### PR TITLE
Permissive comparisons in further volume tests

### DIFF
--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -58,6 +58,7 @@ def test_array_volume():
    v2 = vol.tetra_volumes(cp, off_hand = False)
    # following is a stringent test requiring that exactly the same mathematical operations have been performed
    assert_array_almost_equal(v1, v2)
+
    # the random changes to corner points should have left the volumes within a certain range
    assert np.all(v1 >= 0.0), 'negative volume(s) returned by array function'
    assert np.all(v1 <= 27.0), 'exaggerated volume(s) returned by array function'
@@ -65,11 +66,12 @@ def test_array_volume():
    translate = (random(cp.size // 8) * 3.23478).reshape((cp.shape[0], cp.shape[1], cp.shape[2], 1, 1, 1, 3))
    cp[:] -= translate
    v2 = vol.tetra_volumes(cp, off_hand = False)
-   assert np.all(np.isclose(v1, v2)), 'volumes have changed with translation'
+   assert_array_almost_equal(v1, v2)
+
    # test handedness inversion
    cp[:, :, :, :, :, :, 0] *= -1.0
    v1 = vol.tetra_volumes_slow(cp, off_hand = True)
    v2 = vol.tetra_volumes(cp, off_hand = True)
-   assert np.all(v1 == v2), 'some differences in volumes arrays computed by different array functions'
+   assert_array_almost_equal(v1 == v2)
    assert np.all(v1 >= 0.0), 'negative volume(s) returned by array function'
    assert np.all(v1 <= 27.0), 'exaggerated volume(s) returned by array function'

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -72,6 +72,6 @@ def test_array_volume():
    cp[:, :, :, :, :, :, 0] *= -1.0
    v1 = vol.tetra_volumes_slow(cp, off_hand = True)
    v2 = vol.tetra_volumes(cp, off_hand = True)
-   assert_array_almost_equal(v1 == v2)
+   assert_array_almost_equal(v1, v2)
    assert np.all(v1 >= 0.0), 'negative volume(s) returned by array function'
    assert np.all(v1 <= 27.0), 'exaggerated volume(s) returned by array function'


### PR DESCRIPTION
Fixes an intermittent failure in the unit tests.

Currently one test has a random element without a fixed seed, and fails approximately half of the time.