### PR TITLE
Add badges and links to docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # resqpy: Python API for working with RESQML models
 
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bp/resqpy/blob/master/LICENSE)
+[![Python CI](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bp/resqpy/blob/master/LICENSE)
 [![Python CI](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml)
+[![PyPI](https://badge.fury.io/py/resqpy.svg)](https://badge.fury.io/py/resqpy)
 [![Documentation Status](https://readthedocs.org/projects/resqpy/badge/?version=latest)](https://resqpy.readthedocs.io/en/latest/?badge=latest)
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bp/resqpy/blob/master/LICENSE)
 [![Python CI](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml)
+[![Documentation Status](https://readthedocs.org/projects/resqpy/badge/?version=latest)](https://resqpy.readthedocs.io/en/latest/?badge=latest)
 
 ## Introduction
 
 This repository contains pure python modules which provide a programming
 interface (API) for reading, writing, and modifying reservoir models in the
 RESQML format.
+
+See the full documentation [here](https://resqpy.readthedocs.io).
 
 ### Current capabilities
 
@@ -37,14 +40,6 @@ object and more fully cover the options permitted by the RESQML standard.
 
 Modification functionality at the moment focuses on changes to grid geometry.
 
-### Documentation
-
-Build locally with:
-
-```bash
-sphinx-build docs docs/html
-```
-
 ### Installation
 
 Install from source in "editable" mode with:
@@ -64,7 +59,7 @@ pip install -e /path/to/repo/
 
 ### Unit tests
 
-Run locally with:
+Run the test suite locally with:
 
 ```bash
 pytest tests/


### PR DESCRIPTION
Finishes the roll-out of the automatically generated documentation, by providing hyperlinks and status badges on the README.

Documentation is stored in the `docs/` directory; more content can be added here over time.

Closes #3 