### PR TITLE
Add version to packaging config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ build
 dist
 *.egg-info
 
+# Dynamically-generated version
+resqpy/version.py
+
 # XSD files
 resqml/olio/data/Properties.xsd
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,12 @@ pytest.xml
 docs/_build
 docs/_autosummary
 docs/html
+
+# Build artifacts
+build
+dist
 *.egg-info
 
 # XSD files
 resqml/olio/data/Properties.xsd
 
-# Build artifacts
-/resqml.egg-info/
-**/*.pyc

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: 3.8
    install:
    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,8 +27,16 @@ project = 'resqpy'
 copyright = '2021, BP'
 author = 'BP'
 
-release = 'PreRelease'
-version = 'PreRelease'
+# Version from git tag
+# See https://github.com/pypa/setuptools_scm/#usage-from-sphinx
+try:
+    from importlib import metadata
+    release = metadata.version('myproject')
+except Exception:
+    release = '0.0.0-version-not-available'
+
+# Take major/minor
+version = '.'.join(release.split('.')[:2])
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 # PEP 517-compliant build configuration
-# To build resqpy package, run: python -m build
+
+# To build resqpy package, run:
+# >>> pip install build
+# >>> python -m build
 
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
+# PEP 517-compliant build configuration
+# To build resqpy package, run: python -m build
+
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"
+
+# Get version number from git tag
+# See https://github.com/pypa/setuptools_scm/
+[tool.setuptools_scm]
+write_to = "resqpy/version.py"

--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -21,5 +21,11 @@
     well
     olio
 
-
 """
+
+try:
+    # Version dynamically extracted from git tags when package is built
+    from .version import version as __version__
+
+except ImportError:
+    __version__ = "0.0.0-version-not-available"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
 packages = find:
 include_package_data = True
 python_requires = >=3.6
+setup_requires = setuptools_scm[toml]
 install_requires = 
     numpy
     pandas


### PR DESCRIPTION
This updates the build config to **version** the build according to the latest git tag.

Git tags are used as the single source of truth of the version. The version will then appear in several places:
- The built python package (i.e. when `python -m build` is run, the wheel file has the version in the name)
- The `resqpy.__version__` attribute
- The top right and bottom left of https://resqpy.readthedocs.io/

Closes #2 

References:

- https://packaging.python.org/guides/single-sourcing-package-version/
- https://github.com/pypa/setuptools_scm/