### PR TITLE
Add CI pipeline to make release

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,0 +1,50 @@
+name: Publish release
+
+on:
+  push:
+    tags:
+      - 'v*' # On push events with tags matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build setuptools wheel twine
+
+    - name: Build
+      run: python -m build
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Build package
+        path: dist/
+
+    # - name: Publish to PyPI
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: twine upload dist/*
+
+    # - name: Create GitHub Release
+    #   uses: ncipollo/release-action@v1
+    #   with:
+    #     name: Release ${{ github.ref }}
+    #     tag: ${{ github.ref }}
+    #     artifacts: "dist/"
+    #     body: |
+    #       Changes in this Release
+    #     token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -57,7 +57,7 @@ jobs:
       run: pytest
 
   publish:
-    name: Make release and publish
+    name: Publish to PyPI
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
@@ -73,22 +73,11 @@ jobs:
           name: dist-artifact
           path: dist/
 
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          name: Release ${{ github.ref }}
-          tag: ${{ github.ref }}
-          artifacts: "dist/"
-          body: |
-            Changes in this Release
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to Test PyPI
-        # TODO: Move to prod PyPI
+      - name: Upload to PyPI
         env:
-          TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m pip install --upgrade pip
           pip install twine
-          twine upload --repository testpypi dist/*
+          twine upload dist/*

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build and test package
+    name: Build distribution
     runs-on: ubuntu-latest
     steps:
 
@@ -25,20 +25,40 @@ jobs:
         pip install build setuptools wheel
         python -m build
 
-    - name: Run tests on built package
-      run: |
-        pip install --no-index --find-links=build/ resqpy[tests]
-        pytest
-
     - name: Save build artifacts
       uses: actions/upload-artifact@v2
       with:
         name: dist-artifact
         path: dist/
 
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Get build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: dist-artifact
+        path: dist/
+
+    - name: Install from build
+      run: |
+        python -m pip install --upgrade pip
+        pip install resqpy[tests] --no-index --find-links=build/
+
+    - name: Run tests
+      run: pytest
+
   publish:
     name: Make release and publish
-    needs: build
+    needs: [build, test]
     runs-on: ubuntu-latest
     steps:
 
@@ -56,18 +76,21 @@ jobs:
       - name: print directory structure
         run: ls -R ./dist
 
-    # - name: Publish to PyPI
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: twine upload dist/*
+      # - name: Publish to PyPI
+      #   env:
+      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install twine
+      #     twine upload dist/*
 
-    # - name: Create GitHub Release
-    #   uses: ncipollo/release-action@v1
-    #   with:
-    #     name: Release ${{ github.ref }}
-    #     tag: ${{ github.ref }}
-    #     artifacts: "dist/"
-    #     body: |
-    #       Changes in this Release
-    #     token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Create GitHub Release
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     name: Release ${{ github.ref }}
+      #     tag: ${{ github.ref }}
+      #     artifacts: "dist/"
+      #     body: |
+      #       Changes in this Release
+      #     token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -6,8 +6,8 @@ on:
       - 'v*' # On push events with tags matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  publish:
-    name: Publish release
+  build:
+    name: Build and test package
     runs-on: ubuntu-latest
     steps:
 
@@ -19,19 +19,42 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install build dependencies
+    - name: Build
       run: |
         python -m pip install --upgrade pip
-        pip install build setuptools wheel twine
+        pip install build setuptools wheel
+        python -m build
 
-    - name: Build
-      run: python -m build
+    - name: Run tests on built package
+      run: |
+        pip install --no-index --find-links=build/ resqpy[tests]
+        pytest
 
-    - name: Upload build artifacts
+    - name: Save build artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: Build package
+        name: dist-artifact
         path: dist/
+
+  publish:
+    name: Make release and publish
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Get build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-artifact
+          path: dist/
+
+      - name: print directory structure
+        run: ls -R ./dist
 
     # - name: Publish to PyPI
     #   env:

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -73,24 +73,22 @@ jobs:
           name: dist-artifact
           path: dist/
 
-      - name: print directory structure
-        run: ls -R ./dist
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref }}
+          tag: ${{ github.ref }}
+          artifacts: "dist/"
+          body: |
+            Changes in this Release
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Publish to PyPI
-      #   env:
-      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install twine
-      #     twine upload dist/*
-
-      # - name: Create GitHub Release
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     name: Release ${{ github.ref }}
-      #     tag: ${{ github.ref }}
-      #     artifacts: "dist/"
-      #     body: |
-      #       Changes in this Release
-      #     token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to Test PyPI
+        # TODO: Move to prod PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+          twine upload --repository testpypi dist/*

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     
-    - name: Install dependencies
+    - name: Install from source
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install ".[tests]"

--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,12 @@ pytest.xml
 docs/_build
 docs/_autosummary
 docs/html
+
+# Build artifacts
+build
+dist
 *.egg-info
 
 # XSD files
 resqml/olio/data/Properties.xsd
 
-# Build artifacts
-/resqml.egg-info/
-**/*.pyc

--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ pytest tests/
 To make a release at a given commit, simply make a git tag:
 
 ```bash
-git tag v0.0.0
-git push origin v0.0.0
+# Make a tag
+git tag -a v0.0.1 -m "Incremental release with some bugfixes"
+
+# Push tag to github
+git push origin v0.0.1
 ```
 
 The tag must have the prefix `v` and have the form `MAJOR.MINOR.PATCH`.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,20 @@ Run locally with:
 ```bash
 pytest tests/
 ```
+
+### Making a release
+
+To make a release at a given commit, simply make a git tag:
+
+```bash
+git tag v0.0.0
+git push origin v0.0.0
+```
+
+The tag must have the prefix `v` and have the form `MAJOR.MINOR.PATCH`.
+
+Following [semantic versioning](https://semver.org/), increment the:
+
+- MAJOR version when you make incompatible API changes,
+- MINOR version when you add functionality in a backwards compatible manner, and
+- PATCH version when you make backwards compatible bug fixes.


### PR DESCRIPTION
Adds a CI workflow for making new releases, and adds instructions to the README on how to trigger a release.

There are three sequential jobs, that will be triggered by a git tag:
- Build a python distribution (`python -m build`)
- Run pytest against the installed distribution (_not_ against the source repo)
- Publish to PyPI

Closes #9 

Links:

- CI with Github Actions: https://docs.github.com/en/actions
- PEP517-compliant builds: https://www.python.org/dev/peps/pep-0517/
- Publishing distributions: https://packaging.python.org/tutorials/packaging-projects/