### PR TITLE
commenting out posting of unit test results message in CI script

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -70,8 +70,8 @@ jobs:
           name: Unit Test Results (Python ${{ matrix.python-version }})
           path: pytest.xml
 
-      - name: Publish Unit Test Results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      # - name: Publish Unit Test Results
+      #   if: always()
+      #   uses: EnricoMi/publish-unit-test-result-action@v1
         # with:
         #   files: *.xml


### PR DESCRIPTION
This change removes the posting of messages for individual unit tests during CI processing.  "All tests" result is still obvious.