### PR TITLE
Explicit python version support, set development status

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,8 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: expand to [2.7, 3.5, 3.6, 3.7, 3.8]
-        python-version: [3.7]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python CI](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml)
 ![Python version](https://img.shields.io/pypi/pyversions/resqpy)
 [![PyPI](https://img.shields.io/pypi/v/resqpy)](https://badge.fury.io/py/resqpy)
+![Status](https://img.shields.io/pypi/status/resqpy)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # resqpy: Python API for working with RESQML models
 
-[![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bp/resqpy/blob/master/LICENSE)
-[![Python CI](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml)
-[![PyPI](https://badge.fury.io/py/resqpy.svg)](https://badge.fury.io/py/resqpy)
+[![License](https://img.shields.io/pypi/l/resqpy)](https://github.com/bp/resqpy/blob/master/LICENSE)
 [![Documentation Status](https://readthedocs.org/projects/resqpy/badge/?version=latest)](https://resqpy.readthedocs.io/en/latest/?badge=latest)
+[![Python CI](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/bp/resqpy/actions/workflows/ci-tests.yml)
+![Python version](https://img.shields.io/pypi/pyversions/resqpy)
+[![PyPI](https://img.shields.io/pypi/v/resqpy)](https://badge.fury.io/py/resqpy)
 
 ## Introduction
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,14 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/bp/resqpy
 classifiers =
-    Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Development Status :: 4 - Beta
+    # Development Status :: 5 - Production/Stable
     Topic :: Scientific/Engineering
     Topic :: System :: Filesystems
     Topic :: Scientific/Engineering :: Information Analysis


### PR DESCRIPTION
Tested which python versions are supported: tests pass with 3.6+, but fail for 2.7 and 3.5. 

So, adding the list of supported versions to:
- CI tests (matrix strategy)
- PyPI classifier listing
- Badge on README front page

Also added a `Development Status :: 4 - Beta` classifier to `setup.cgf`, which is listed on the PyPI pacakge and will appear as a README badge. 

Other options for this classifier could be:

```
Development Status :: 1 - Planning
Development Status :: 2 - Pre-Alpha
Development Status :: 3 - Alpha
Development Status :: 4 - Beta
Development Status :: 5 - Production/Stable
Development Status :: 6 - Mature
Development Status :: 7 - Inactive
```