### PR TITLE
Use autoclasstoc to separate out "high level" and "low level" methods

### DIFF
--- a/docs/_templates/custom-class-template.rst
+++ b/docs/_templates/custom-class-template.rst
@@ -6,6 +6,6 @@
    :members:
    :show-inheritance:
    :inherited-members:
-   :special-members: __call__, __add__, __mul__
+   :special-members: __init__
 
    .. autoclasstoc::

--- a/docs/_templates/custom-class-template.rst
+++ b/docs/_templates/custom-class-template.rst
@@ -8,27 +8,4 @@
    :inherited-members:
    :special-members: __call__, __add__, __mul__
 
-   {% block methods %}
-   {% if methods %}
-   .. rubric:: {{ _('Methods') }}
-
-   .. autosummary::
-      :nosignatures:
-   {% for item in methods %}
-      {%- if not item.startswith('_') %}
-      ~{{ name }}.{{ item }}
-      {%- endif -%}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: {{ _('Attributes') }}
-
-   .. autosummary::
-   {% for item in attributes %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+   .. autoclasstoc::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ version = '.'.join(release.split('.')[:2])
 
 # -- General configuration ---------------------------------------------------
 
-autoclass_content = "both"  # include both class docstring and __init__
+autoclass_content = "class"  # Alternatively, "both" to include init method
 # autodoc_default_options = {
 #     'members': None,
 #     'inherited-members': None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,33 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 
+# -- Options custom autoclasstoc sections ------------------------------------
+
+# See https://autoclasstoc.readthedocs.io/en/latest/advanced_usage.html
+
+from autoclasstoc import Section, is_method, PublicMethods
+
+class HighLevelSection(PublicMethods):
+    key = 'high-level-methods'
+    title = "High-Level Methods:"
+
+    def predicate(self, name, attr, meta):
+        always_include = ['__init__']
+        return super().predicate(name, attr, meta) and ('high-level' in meta or name in always_include)
+
+class OtherMethods(PublicMethods):
+    key = 'other-methods'
+    title = "Methods:"
+
+    def predicate(self, name, attr, meta):
+        return super().predicate(name, attr, meta) and not name.startswith('on_')
+
+autoclasstoc_sections = [
+        'public-attrs',
+        'high-level-methods',
+        'other-methods',
+]
+
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = 'sphinx_rtd_theme'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode',     # Add a link to the Python source code for classes, functions etc.
+    'sphinx.ext.viewcode',
+    'autoclasstoc',
 ]
 
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,23 +74,23 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 from autoclasstoc import PublicMethods
 
-class HighLevelSection(PublicMethods):
-    key = "high-level-methods"
-    title = "High-Level Methods:"
+class CommomMethods(PublicMethods):
+    key = "common-methods"
+    title = "Commonly Used Methods:"
 
     def predicate(self, name, attr, meta):
-        return super().predicate(name, attr, meta) and 'high-level' in meta
+        return super().predicate(name, attr, meta) and 'common' in meta
 
 class OtherMethods(PublicMethods):
     key = "other-methods"
     title = "Methods:"
 
     def predicate(self, name, attr, meta):
-        return super().predicate(name, attr, meta) and 'high-level' not in meta
+        return super().predicate(name, attr, meta) and 'common' not in meta
 
 autoclasstoc_sections = [
         "public-attrs",
-        "high-level-methods",
+        "common-methods",
         "other-methods",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,27 +72,26 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 # See https://autoclasstoc.readthedocs.io/en/latest/advanced_usage.html
 
-from autoclasstoc import Section, is_method, PublicMethods
+from autoclasstoc import PublicMethods
 
 class HighLevelSection(PublicMethods):
-    key = 'high-level-methods'
+    key = "high-level-methods"
     title = "High-Level Methods:"
 
     def predicate(self, name, attr, meta):
-        always_include = ['__init__']
-        return super().predicate(name, attr, meta) and ('high-level' in meta or name in always_include)
+        return super().predicate(name, attr, meta) and 'high-level' in meta
 
 class OtherMethods(PublicMethods):
-    key = 'other-methods'
+    key = "other-methods"
     title = "Methods:"
 
     def predicate(self, name, attr, meta):
-        return super().predicate(name, attr, meta) and not name.startswith('on_')
+        return super().predicate(name, attr, meta) and 'high-level' not in meta
 
 autoclasstoc_sections = [
-        'public-attrs',
-        'high-level-methods',
-        'other-methods',
+        "public-attrs",
+        "high-level-methods",
+        "other-methods",
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ pandas
 h5py
 lxml
 lasio
+autoclasstoc

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -11,6 +11,7 @@ import copy
 import shutil
 import numpy as np
 import h5py
+import warnings
 import zipfile as zf
 # import xml.etree.ElementTree as et
 # from lxml import etree as et
@@ -168,7 +169,7 @@ class Model():
              extra = {}, related_uuid = None, epc_subdir = None, sort_by = None):
       """Returns a list of parts matching all of the arguments passed.
 
-      arguments:
+      Arguments:
          parts_list (list of strings, optional): if present, an 'input' list of parts to be filtered;
             if None then all the parts in the model are considered
          obj_type (string, optional): if present, only parts of this resqml type will be included
@@ -188,15 +189,25 @@ class Model():
             subdirectory path of the epc are included in the filtered list
          sort_by (string, optional): one of 'newest', 'oldest', 'title', 'uuid', 'type'
 
-      returns:
+      Returns:
          a list of strings being the names of parts which match all filter arguments
 
-      example calls:
-         a full list of parts in the model: model.parts()
-         a list of IjkGrid parts: model.parts(obj_type = 'IjkGridRepresentation')
-         a list containing the part name for a uuid: model.parts(uuid = 'a869e7cc-5d30-4b31-8502-c74b1d87c777')
-         a list of IjkGrid parts with titles beginning LGR, sorted by title:
-            model.parts(obj_type = 'IjkGridRepresentation', title = 'LGR', title_mode = 'starts', sort_by = 'title')
+      Examples:
+         a full list of parts in the model::
+         
+            model.parts()
+
+         a list of IjkGrid parts::
+            
+            model.parts(obj_type = 'IjkGridRepresentation')
+
+         a list containing the part name for a uuid::
+         
+            model.parts(uuid = 'a869e7cc-5d30-4b31-8502-c74b1d87c777')
+
+         a list of IjkGrid parts with titles beginning LGR, sorted by title::
+            
+            model.parts(obj_type='IjkGridRepresentation', title='LGR', title_mode='starts', sort_by='title')
       
       :meta high-level:
       """
@@ -633,23 +644,23 @@ class Model():
    def load_epc(self, epc_file, full_load = True, epc_subdir = None, copy_from = None):
       """Load xml parts of model from epc file (HDF5 arrays are not loaded).
 
-         arguments:
-            epc_file (string): the path of the epc file
-            full_load (boolean): if True (recommended), the xml for each part is parsed and stored
-               in a tree structure in memory; if False, only the list of parts is loaded
-            epc_subdir (string or list of strings, optional): if present, only parts in the top
-               level directory within the epc structure, or in the specified subdirectory(ies) are
-               included in the load
-            copy_from (string, optional): if present, the .epc and .h5 are copied from this source
-               to epc_file (and paired .h5) prior to opening epc_file; any previous files named
-               as epc_file will be overwritten
+      Arguments:
+         epc_file (string): the path of the epc file
+         full_load (boolean): if True (recommended), the xml for each part is parsed and stored
+            in a tree structure in memory; if False, only the list of parts is loaded
+         epc_subdir (string or list of strings, optional): if present, only parts in the top
+            level directory within the epc structure, or in the specified subdirectory(ies) are
+            included in the load
+         copy_from (string, optional): if present, the .epc and .h5 are copied from this source
+            to epc_file (and paired .h5) prior to opening epc_file; any previous files named
+            as epc_file will be overwritten
 
-         returns:
-            None
+      Returns:
+         None
 
-         note:
-            when copy_from is specified, the entire contents of the source dataset are copied,
-            regardless of the epc_subdir setting which only affects the subsequent load into memory
+      Note:
+         when copy_from is specified, the entire contents of the source dataset are copied,
+         regardless of the epc_subdir setting which only affects the subsequent load into memory
 
       :meta high-level:
       """
@@ -741,21 +752,21 @@ class Model():
    def store_epc(self, epc_file = None, main_xml_name = '[Content_Types].xml', only_if_modified = False):
       """Write xml parts of model to epc file (HDF5 arrays are not written here).
 
-         arguments:
-            epc_file (string): the name of the output epc file to be written (any existing file will be
-               overwritten)
-            main_xml_name (string, do not pass): this argument should not be passed as the resqml standard
-               requires the default value; (the argument exists in code because the resqml standard value
-               is based on a slight misunderstanding of the opc standard, so could perhaps change in
-               future versions of resqml)
-            only_if_modified (boolean, default False): if True, the epc file is only written if the model
-               is flagged as having been modified (at least one part added or removed)
+      Arguments:
+         epc_file (string): the name of the output epc file to be written (any existing file will be
+            overwritten)
+         main_xml_name (string, do not pass): this argument should not be passed as the resqml standard
+            requires the default value; (the argument exists in code because the resqml standard value
+            is based on a slight misunderstanding of the opc standard, so could perhaps change in
+            future versions of resqml)
+         only_if_modified (boolean, default False): if True, the epc file is only written if the model
+            is flagged as having been modified (at least one part added or removed)
 
-         returns:
-            None
+      Returns:
+         None
 
-         note:
-            the main tree, parts forest and rels forest must all be up to date before calling this method
+      Note:
+         the main tree, parts forest and rels forest must all be up to date before calling this method
 
       :meta high-level:
       """
@@ -1020,10 +1031,11 @@ class Model():
    def external_parts_list(self):
       """Returns a list of part names for external part references.
 
-      returns:
+      Returns:
          list of strings being the part names for external part references
 
-      notes:
+      Note:
+
          in practice, external part references are only used for hdf5 files;
          furthermore, all current datasets have adopted the practice of using
          a single hdf5 file for a given epc file
@@ -1266,21 +1278,21 @@ class Model():
    def root_for_ijk_grid(self, uuid = None, title = None):
       """Return root for IJK Grid part.
 
-         arguments:
-            uuid (uuid.UUID, optional): if present, the uuid of the ijk grid part for which the root is required;
-               if None, a single ijk grid part is expected and the root for that part is returned
-            title (string, optional): if present, the citation title for the grid; defaults to 'ROOT' if more
-               than one ijk grid present and no uuid supplied
+      arguments:
+         uuid (uuid.UUID, optional): if present, the uuid of the ijk grid part for which the root is required;
+            if None, a single ijk grid part is expected and the root for that part is returned
+         title (string, optional): if present, the citation title for the grid; defaults to 'ROOT' if more
+            than one ijk grid present and no uuid supplied
 
-         returns:
-            root node in xml tree for the ijk grid part in this model
+      returns:
+         root node in xml tree for the ijk grid part in this model
 
-         notes:
-            if uuid and title are both supplied, they must match in the corresponding grid part;
-            if a title but no uuid is given, the first ijk grid encountered that has a matching title will be returned;
-            if neither title nor uuid are given, the first ijk grid with title 'ROOT' will be returned, unless there is
-            only one grid part in which case the root npde for that part is returned regardless;
-            failure to find a matching grid part results in an assertion exception
+      notes:
+         if uuid and title are both supplied, they must match in the corresponding grid part;
+         if a title but no uuid is given, the first ijk grid encountered that has a matching title will be returned;
+         if neither title nor uuid are given, the first ijk grid with title 'ROOT' will be returned, unless there is
+         only one grid part in which case the root npde for that part is returned regardless;
+         failure to find a matching grid part results in an assertion exception
       """
 
       if title is not None: title = title.strip().upper()
@@ -1786,6 +1798,8 @@ class Model():
 
       note:
          not usually called directly
+
+      :meta private:
       """
 
       assert(self.main_tree is None)
@@ -2038,7 +2052,7 @@ class Model():
          originator (string, optional): the name of the human being who created the object
             which this citation is for; default is to use the login name
 
-      returns;
+      returns:
          newly created citation xml node
       """
 
@@ -2082,7 +2096,7 @@ class Model():
    def title_for_root(self, root = None):
       """Returns the Title text from the Citation within the given root node.
 
-      argument:
+      arguments:
          root: the xml node for the object for which the citation title is required
 
       returns:
@@ -2099,7 +2113,7 @@ class Model():
    def title_for_part(self, part_name):   # duplicate functionality to citation_title_for_part()
       """Returns the Title text from the Citation for the given main part name (not for rels).
 
-      argument:
+      arguments:
          part_name (string): the name of the part for which the citation title is required
 
       returns:
@@ -2113,7 +2127,7 @@ class Model():
    def create_unknown(self, root = None):
       """Creates an Unknown node and optionally adds as child of root.
 
-      argument:
+      arguments:
          root (optional): if present, the newly created Unknown node is appended as a child
             of this xml node
 
@@ -2204,7 +2218,8 @@ class Model():
       returns:
          newly created coordinate reference system xml node
       """
-
+      
+      warnings.warn("model.create_crs is Deprecated, will be removed", DeprecationWarning)
       crs = rqc.Crs(self, x_offset = x_offset, y_offset = y_offset, z_offset = z_offset,
                     rotation = areal_rotation_radians, xy_units = xy_units, z_units = z_units,
                     z_inc_down = z_inc_down, epsg_code = epsg_code)

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -40,7 +40,27 @@ class Model():
                 new_epc = False, create_basics = None, create_hdf5_ext = None, copy_from = None):
       """Create an empty model; load it from epc_file if given.
 
-      arguments:
+      Examples:
+
+         To open an existing dataset::
+
+            Model(epc_file = 'filename.epc')
+
+         To create a new, empty model ready to populate::
+
+            Model(epc_file = 'new_file.epc', new_epc = True, create_basics = True, create_hdf5_ext = True)
+
+         To copy an existing dataset then open the new copy::
+
+            Model(epc_file = 'new_file.epc', copy_from = 'existing.epc')
+
+      Note:
+
+         if epc_file is given and the other arguments indicate that it will be a new dataset (new_epc is True
+         or copy_from is given) then any existing .epc and .h5 file(s) with this name will be deleted
+         immediately
+
+      Arguments:
          epc_file (string, optional): if present, and new_epc is False and copy_from is None, the name
             of an existing epc file which is opened, unzipped and parsed to determine the list of parts
             and relationships comprising the model; if present, and new_epc is True or copy_from is
@@ -68,21 +88,9 @@ class Model():
             any previous instances) before epc_file is opened; this argument is primarily to facilitate
             repeated testing of code that modifies the resqml dataset, eg. by appending new parts
 
-      returns:
-         the newly created Model object
+      Returns:
+         The newly created Model object
 
-      example calls:
-         to open an existing dataset:
-            Model(epc_file = 'filename.epc')
-         to create a new, empty model ready to populate:
-            Model(epc_file = 'new_file.epc', new_epc = True, create_basics = True, create_hdf5_ext = True)
-         to copy an existing dataset then open the new copy:
-            Model(epc_file = 'new_file.epc', copy_from = 'existing.epc')
-
-      notes:
-         if epc_file is given and the other arguments indicate that it will be a new dataset (new_epc is True
-         or copy_from is given) then any existing .epc and .h5 file(s) with this name will be deleted
-         immediately
       """
 
       if epc_file and not epc_file.endswith('.epc'): epc_file += '.epc'
@@ -125,6 +133,8 @@ class Model():
 
       note:
          not usually called directly (semi-private)
+
+      :meta private:
       """
 
       self.epc_file = None

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -187,6 +187,8 @@ class Model():
          a list containing the part name for a uuid: model.parts(uuid = 'a869e7cc-5d30-4b31-8502-c74b1d87c777')
          a list of IjkGrid parts with titles beginning LGR, sorted by title:
             model.parts(obj_type = 'IjkGridRepresentation', title = 'LGR', title_mode = 'starts', sort_by = 'title')
+      
+      :meta high-level:
       """
 
       if not parts_list: parts_list = self.list_of_parts()
@@ -638,6 +640,8 @@ class Model():
          note:
             when copy_from is specified, the entire contents of the source dataset are copied,
             regardless of the epc_subdir setting which only affects the subsequent load into memory
+
+      :meta high-level:
       """
 
       def exclude(name, epc_subdir):
@@ -742,6 +746,8 @@ class Model():
 
          note:
             the main tree, parts forest and rels forest must all be up to date before calling this method
+
+      :meta high-level:
       """
 
 #      for prefix, uri in ns.items():
@@ -1358,6 +1364,8 @@ class Model():
          a Model by using this method which will return a shared object from this list, instantiating a new
          object and adding it to the list when necessary; an assertion exception will be raised if a
          suitable grid part is not present in the model
+
+      :meta high-level:
       """
 
       if uuid is None and (title is None or title.upper() == 'ROOT'):
@@ -1608,6 +1616,8 @@ class Model():
 
       returns:
          None
+
+      :meta high-level:
       """
 
       if self.h5_currently_open_root is not None:
@@ -2797,6 +2807,8 @@ class Model():
 
       Yields:
          wellbore: instance of :class:`resqpy.organize.WellboreInterpretation`
+
+      :meta high-level:
       """
       import resqpy.organize  # Imported here to avoid circular imports
 
@@ -2812,6 +2824,8 @@ class Model():
 
       Yields:
          trajectory: instance of :class:`resqpy.well.Trajectory`
+
+      :meta high-level:
       """
       import resqpy.well  # Imported here to avoid circular imports
 

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -94,7 +94,7 @@ class Model():
       Returns:
          The newly created Model object
 
-      :meta high-level:
+      :meta common:
       """
 
       if epc_file and not epc_file.endswith('.epc'): epc_file += '.epc'
@@ -210,7 +210,7 @@ class Model():
             
             model.parts(obj_type='IjkGridRepresentation', title='LGR', title_mode='starts', sort_by='title')
       
-      :meta high-level:
+      :meta common:
       """
 
       if not parts_list: parts_list = self.list_of_parts()
@@ -663,7 +663,7 @@ class Model():
          when copy_from is specified, the entire contents of the source dataset are copied,
          regardless of the epc_subdir setting which only affects the subsequent load into memory
 
-      :meta high-level:
+      :meta common:
       """
 
       def exclude(name, epc_subdir):
@@ -769,7 +769,7 @@ class Model():
       Note:
          the main tree, parts forest and rels forest must all be up to date before calling this method
 
-      :meta high-level:
+      :meta common:
       """
 
 #      for prefix, uri in ns.items():
@@ -1388,7 +1388,7 @@ class Model():
          object and adding it to the list when necessary; an assertion exception will be raised if a
          suitable grid part is not present in the model
 
-      :meta high-level:
+      :meta common:
       """
 
       if uuid is None and (title is None or title.upper() == 'ROOT'):
@@ -1640,7 +1640,7 @@ class Model():
       returns:
          None
 
-      :meta high-level:
+      :meta common:
       """
 
       if self.h5_currently_open_root is not None:
@@ -2832,7 +2832,7 @@ class Model():
       Yields:
          wellbore: instance of :class:`resqpy.organize.WellboreInterpretation`
 
-      :meta high-level:
+      :meta common:
       """
       import resqpy.organize  # Imported here to avoid circular imports
 
@@ -2849,7 +2849,7 @@ class Model():
       Yields:
          trajectory: instance of :class:`resqpy.well.Trajectory`
 
-      :meta high-level:
+      :meta common:
       """
       import resqpy.well  # Imported here to avoid circular imports
 

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -35,13 +35,9 @@ def _pl(i, e = False):
 
 
 class Model():
-   """Class for RESQML (v2) based models."""
-
-   def __init__(self, epc_file = None, full_load = True, epc_subdir = None,
-                new_epc = False, create_basics = None, create_hdf5_ext = None, copy_from = None):
-      """Create an empty model; load it from epc_file if given.
-
-      Examples:
+   """Class for RESQML (v2) based models.
+   
+   Examples:
 
          To open an existing dataset::
 
@@ -54,6 +50,12 @@ class Model():
          To copy an existing dataset then open the new copy::
 
             Model(epc_file = 'new_file.epc', copy_from = 'existing.epc')
+   
+   """
+
+   def __init__(self, epc_file = None, full_load = True, epc_subdir = None,
+                new_epc = False, create_basics = None, create_hdf5_ext = None, copy_from = None):
+      """Create an empty model; load it from epc_file if given.
 
       Note:
 

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -94,6 +94,7 @@ class Model():
       Returns:
          The newly created Model object
 
+      :meta high-level:
       """
 
       if epc_file and not epc_file.endswith('.epc'): epc_file += '.epc'
@@ -136,8 +137,6 @@ class Model():
 
       note:
          not usually called directly (semi-private)
-
-      :meta private:
       """
 
       self.epc_file = None
@@ -1800,8 +1799,6 @@ class Model():
 
       note:
          not usually called directly
-
-      :meta private:
       """
 
       assert(self.main_tree is None)

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -3792,9 +3792,9 @@ def well_name(well_object, model = None):
    """Returns the 'best' citation title from the object or related well objects.
 
    arguments:
-      well_object (Trajectory, WellboreInterpretation, WellboreFeature, BlockedWell, WellboreMarkerFrame,
-         WellboreFrame, DeviationSurvey or MdDatum object; or uuid or root for one of those): object for which
-         a well name is required
+      well_object (object, uuid or root): Object for which a well name is required. Can be a
+         Trajectory, WellboreInterpretation, WellboreFeature, BlockedWell, WellboreMarkerFrame,
+         WellboreFrame, DeviationSurvey or MdDatum object
       model (model.Model, optional): required if passing a uuid or root; not recommended otherwise
 
    returns:


### PR DESCRIPTION
Closes #16 

Uses the autoclasstoc library to enhance our Sphinx documentation with customised sections when listing out methods of a class: https://autoclasstoc.readthedocs.io/en/latest/index.html

Enables us to separate out high- and low-level methods in the docs, to make it a bit more tractable when the table gets very long. The enables us to promote a method to a special "High-level methods" section by including `:meta high-level:` at the end of the docstring.

The new-style documentation can be previewed here:
https://resqpy.readthedocs.io/en/split-docs/