### PR TITLE
Merging timeseries

### DIFF
--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -376,19 +376,21 @@ def time_series_from_list(timestamp_list, parent_model = None):
       time_series.add_timestamp(timestamp)
    return time_series
 
-def merge_timeseries_from_uuid(model, timeseries_uuid_iter, reverse=False):
-   """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). reverse=True returns a timeseries object in ascending order. Reverse=None returns a timeseries without timestamps being sorted. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
-    #assert(False)
+def merge_timeseries_from_uuid(model, timeseries_uuid_iter):
+   """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). The new timeseries is sorted in ascending order. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
+   
+   reverse=False 
+
    alltimestamps=set({})
    timeserieslist=[]
    for timeseries_uuid in timeseries_uuid_iter:
        timeseriesroot=model.root(uuid=timeseries_uuid)
        assert(rqet.node_type(timeseriesroot) == 'obj_TimeSeries')
        
-       #singlets=model.part_for_uuid(timeseries_uuid)
        singlets=TimeSeries(model, time_series_root=timeseriesroot)
        timeserieslist.append(singlets)
-       alltimestamps.update( set(singlets.timestamps) )
+       #alltimestamps.update( set(singlets.timestamps) )
+       alltimestamps.update( set(singlets.datetimes()) )
    
    if reverse is None:
       sortedtimestamps=sorted(list(alltimestamps), reverse=reverse)

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -247,6 +247,18 @@ class TimeSeries():
       duration = TimeDuration(days = days)
       self.extend_by_duration(duration)
 
+   def datetimes(self):
+      """Returns a list of python-datetime objects """
+      datetimes=[]
+        
+      for timestamp in self.timestamps:
+         datetime_timestamp=timestamp
+         if timestamp.endswith('Z'): datetime_timestamp = timestamp[:-1]
+         datetimes.append(dt.datetime.fromisoformat(datetime_timestamp))
+        
+        
+
+      return datetimes
 
    def create_xml(self, add_as_part = True, root = None,
                   title = 'time series', originator = None):
@@ -363,6 +375,25 @@ def time_series_from_list(timestamp_list, parent_model = None):
       timestamp = cleaned_timestamp(raw_timestamp)
       time_series.add_timestamp(timestamp)
    return time_series
+
+def merge_timeseries_from_uuid(model, timeseries_uuid_iter, reverse=False):
+   """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). reverse=True returns a timeseries object in ascending order. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
+    #assert(False)
+   alltimestamps=set({})
+   timeserieslist=[]
+   for timeseries_uuid in timeseries_uuid_iter:
+       timeseriesroot=model.root(uuid=timeseries_uuid)
+       assert(rqet.node_type(timeseriesroot) == 'obj_TimeSeries')
+       
+       #singlets=model.part_for_uuid(timeseries_uuid)
+       singlets=TimeSeries(model, time_series_root=timeseriesroot)
+       timeserieslist.append(singlets)
+       alltimestamps.update( set(singlets.timestamps) )
+   
+   sortedtimestamps=sorted(list(alltimestamps), reverse=reverse)
+   new_time_series=time_series_from_list(sortedtimestamps, parent_model=model)
+   new_time_series_uuid=new_time_series.uuid
+   return (new_time_series, new_time_series_uuid, timeserieslist)
 
 
 def time_series_from_nexus_summary(summary_file, parent_model = None):

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -249,16 +249,7 @@ class TimeSeries():
 
    def datetimes(self):
       """Returns a list of python-datetime objects """
-      datetimes=[]
-        
-      for timestamp in self.timestamps:
-         datetime_timestamp=timestamp
-         if timestamp.endswith('Z'): datetime_timestamp = timestamp[:-1]
-         datetimes.append(dt.datetime.fromisoformat(datetime_timestamp))
-        
-        
-
-      return datetimes
+      return [dt.datetime.fromisoformat(t.rstrip('z')) for t in self.timestamps]
 
    def create_xml(self, add_as_part = True, root = None,
                   title = 'time series', originator = None):

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -377,7 +377,7 @@ def time_series_from_list(timestamp_list, parent_model = None):
    return time_series
 
 def merge_timeseries_from_uuid(model, timeseries_uuid_iter, reverse=False):
-   """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). reverse=True returns a timeseries object in ascending order. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
+   """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). reverse=True returns a timeseries object in ascending order. Reverse=None returns a timeseries without timestamps being sorted. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
     #assert(False)
    alltimestamps=set({})
    timeserieslist=[]
@@ -390,7 +390,11 @@ def merge_timeseries_from_uuid(model, timeseries_uuid_iter, reverse=False):
        timeserieslist.append(singlets)
        alltimestamps.update( set(singlets.timestamps) )
    
-   sortedtimestamps=sorted(list(alltimestamps), reverse=reverse)
+   if reverse is None:
+      sortedtimestamps=sorted(list(alltimestamps), reverse=reverse)
+   else:
+      sortedtimestamps=list(alltimestamps) #do not sort the timestamps
+    
    new_time_series=time_series_from_list(sortedtimestamps, parent_model=model)
    new_time_series_uuid=new_time_series.uuid
    return (new_time_series, new_time_series_uuid, timeserieslist)

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -383,10 +383,7 @@ def merge_timeseries_from_uuid(model, timeseries_uuid_iter):
        #alltimestamps.update( set(singlets.timestamps) )
        alltimestamps.update( set(singlets.datetimes()) )
    
-   if reverse is None:
-      sortedtimestamps=sorted(list(alltimestamps), reverse=reverse)
-   else:
-      sortedtimestamps=list(alltimestamps) #do not sort the timestamps
+   sortedtimestamps=sorted(list(alltimestamps), reverse=reverse)
     
    new_time_series=time_series_from_list(sortedtimestamps, parent_model=model)
    new_time_series_uuid=new_time_series.uuid

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,0 +1,46 @@
+import pytest
+
+import resqpy.time_series as rqts
+
+from resqpy import model as makemodel
+
+#reversemode=True
+
+#@pytest.mark.parametrize("reversemode", [True, False])
+def test_merge_timeseries(reverse=False):
+    model=makemodel.Model(create_basics=True)
+
+    timestamps1=['2020-01-01T00:00:00Z', '2015-01-01T00:00:00Z']
+    timestamps2=['2021-01-01T00:00:00Z', '2014-01-01T00:00:00Z']
+
+    #sortedtimestamps=sorted(timestamps1 + timestamps2, reverse=reverse)
+
+    timeseries1=rqts.time_series_from_list(timestamps1, parent_model=model)
+    timeseries1.set_model(model)
+    timeseries1.create_xml()
+    timeseries2=rqts.time_series_from_list(timestamps2, parent_model=model)
+    timeseries2.set_model(model)
+    timeseries2.create_xml()
+    
+
+    sortedtimestamps=sorted(timeseries1.datetimes() + timeseries2.datetimes())
+    #print(timeseries1)
+
+    #print(model.roots(obj_type='obj_TimeSeries'))
+
+    timeseries_uuids=(timeseries1.uuid, timeseries2.uuid)
+
+    newts, newtsuuid, timeserieslist = rqts.merge_timeseries_from_uuid(model, timeseries_uuids)
+
+    assert len(newts.timestamps) == len(timeseries1.timestamps) + len(timeseries2.timestamps)
+
+    for idx, timestamp in enumerate(newts.datetimes()):
+        #print(timestamp, sortedtimestamps)
+        assert timestamp==sortedtimestamps[idx]
+
+    return True
+
+if __name__ == "__main__":
+
+    for reversemode in [True, False]:
+        assert test_merge_timeseries(reverse=reversemode)


### PR DESCRIPTION
New timeseries functions to merge together several timeseries into one sorted timeseries and return the resulting timeseries object. Also created a convenience routine to return datetime objects which may entail slicing off the "+Z" timezone character from the timestamps. 

This works only based off of timeseries uuids.

I created tests in tests/test_timeseries.py, but I'm not sure how to configure the CI workflow to run them automatically