### PR TITLE
Optimising consolidation

### DIFF
--- a/resqpy/derived_model.py
+++ b/resqpy/derived_model.py
@@ -3427,11 +3427,17 @@ def gather_ensemble(case_epc_list, new_epc_file, consolidate = True, shared_grid
                composite_model.force_consolidation_uuid_equivalence(grid_uuid, host_grid_uuids[host_index])
                grid_relatives = case_model.parts(related_uuid = grid_uuid)
                t_props = 0.0
+               composite_h5_file_name = composite_model.h5_file_name()
+               composite_h5_uuid = composite_model.h5_uuid()
+               case_h5_file_name = case_model.h5_file_name()
                for part in grid_relatives:
                   if 'Property' in part:
                      t_p_start = time()
                      composite_model.copy_part_from_other_model(case_model, part, realization = r,
-                                                                consolidate = True, force = shared_time_series)
+                                                                consolidate = True, force = shared_time_series,
+                                                                self_h5_file_name = composite_h5_file_name,
+                                                                h5_uuid = composite_h5_uuid,
+                                                                other_h5_file_name = case_h5_file_name)
                      t_props += time() - t_p_start
                log.info(f'time props: {t_props:.3f} sec')  # debug
          else:

--- a/resqpy/derived_model.py
+++ b/resqpy/derived_model.py
@@ -3402,7 +3402,7 @@ def gather_ensemble(case_epc_list, new_epc_file, consolidate = True, shared_grid
             for ts_uuid in case_model.uuids(obj_type = 'TimeSeries'):
                ts_title = case_model.title(uuid = ts_uuid)
                ts_index = host_ts_titles.index(ts_title)
-               host_ts_uuid = host_ts_uuids(ts_index)
+               host_ts_uuid = host_ts_uuids[ts_index]
                composite_model.force_consolidation_uuid_equivalence(ts_uuid, host_ts_uuid)
          if shared_grids:
             for grid_uuid in case_model.uuids(obj_type = 'IjkGridRepresentation'):
@@ -3420,11 +3420,11 @@ def gather_ensemble(case_epc_list, new_epc_file, consolidate = True, shared_grid
                      host_index = host_grid_shapes.index(grid_extent)
                assert host_index is not None, 'failed to match grids when gathering ensemble'
                composite_model.force_consolidation_uuid_equivalence(grid_uuid, host_grid_uuids[host_index])
-            grid_relatives = case_model.parts(related_uuid = grid_uuid)
-            for part in grid_relatives:
-               if 'Property' in part:
-                  composite_model.copy_part_from_other_model(case_model, part, realization = r,
-                                                             consolidate = True, force = shared_time_series)
+               grid_relatives = case_model.parts(related_uuid = grid_uuid)
+               for part in grid_relatives:
+                  if 'Property' in part:
+                     composite_model.copy_part_from_other_model(case_model, part, realization = r,
+                                                                consolidate = True, force = shared_time_series)
          else:
             composite_model.copy_all_parts_from_other_model(case_model, realization = r, consolidate = consolidate)
 

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -2616,7 +2616,7 @@ class Model():
       self.consolidation.force_uuid_equivalence(immigrant_uuid, resident_uuid)
 
 
-   def copy_part_from_other_model(self, other_model, part, realization = None, consolidate = True):
+   def copy_part_from_other_model(self, other_model, part, realization = None, consolidate = True, force = False):
       """Fully copies part in from another model, with referenced parts, hdf5 data and relationships.
 
       arguments:
@@ -2626,6 +2626,8 @@ class Model():
             will be set to this value, instead of the value in use in the other model if any
          consolidate (boolean, default True): if True and an equivalent part already exists in
             this model, do not duplicate but instead note uuids as equivalent
+         force (boolean, default False): if True, the part itself is copied without much checking
+            and all references are required to be handled by an entry in the consolidation object
 
       notes:
          if the part name already exists in this model, no action is taken;
@@ -2657,7 +2659,7 @@ class Model():
          log.error('failed to copy part (missing in source model?): ' + str(part))
          return
 
-      if consolidate:
+      if consolidate and not force:
          if self.consolidation is None: self.consolidation = cons.Consolidation(self)
          resident_uuid = self.consolidation.equivalent_uuid_for_part(part, immigrant_model = other_model)
       else:
@@ -2693,6 +2695,7 @@ class Model():
             self.create_reciprocal_relationship(root_node, 'mlToExternalPartProxy', ext_node, 'externalPartProxyToMl')
 
          # recursively copy in referenced parts where they don't already exist in this model
+         # TODO: optimise in some way when force is True
          for ref_node in rqet.list_obj_references(root_node):
             resident_referred_node = None
             if consolidate:

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -2819,8 +2819,13 @@ class Model():
       if consolidate:
          other_parts_list = cons.sort_parts_list(other_model, other_parts_list)
 
+      self_h5_file_name = self.h5_file_name(file_must_exist = False)
+      self_h5_uuid = self.h5_uuid()
+      other_h5_file_name = other_model.h5_file_name()
       for part in other_parts_list:
-         self.copy_part_from_other_model(other_model, part, realization = realization, consolidate = consolidate)
+         self.copy_part_from_other_model(other_model, part, realization = realization, consolidate = consolidate,
+                                         self_h5_file_name = self_h5_file_name, h5_uuid = self_h5_uuid,
+                                         other_h5_file_name = other_h5_file_name)
 
       if consolidate and self.consolidation is not None:
          self.consolidation.check_map_integrity()

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -2685,7 +2685,8 @@ class Model():
       log.debug('copying part: ' + str(part))
 
       uuid = rqet.uuid_in_part_name(part)
-      assert self.part_for_uuid(uuid) is None, 'part copying failure: uuid exists for different part!'
+      if not force:
+         assert self.part_for_uuid(uuid) is None, 'part copying failure: uuid exists for different part!'
 
       # duplicate xml tree and add as a part
       other_root = other_model.root_for_part(part, is_rels = False)
@@ -2741,6 +2742,7 @@ class Model():
                else:
                   referred_part = rqet.part_name_for_part_root(referred_node)
                   if other_model.type_of_part(referred_part) == 'obj_EpcExternalPartReference': continue
+                  if referred_part in self.list_of_parts(): continue
                   self.copy_part_from_other_model(other_model, referred_part, consolidate = consolidate)
 
          resident_uuid = uuid

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -13,7 +13,7 @@ import numpy as np
 import h5py
 import warnings
 import zipfile as zf
-from time import time as tim  # debug
+
 # import xml.etree.ElementTree as et
 # from lxml import etree as et
 
@@ -2678,8 +2678,6 @@ class Model():
 
       # todo: double check behaviour around equivalent CRSes, especially any default crs in model
 
-      t_start = tim()
-
       assert other_model is not None
       if other_model is self: return
       assert part is not None
@@ -2790,7 +2788,6 @@ class Model():
             if source_flag: sd_a, sd_b = 'sourceObject', 'destinationObject'
             else: sd_b, sd_a = 'sourceObject', 'destinationObject'
             self.create_reciprocal_relationship(root_node, sd_a, related_node, sd_b)
-      log.debug(f'cpfom: done; {tim() - t_start:.3f}s')
 
 
    def copy_all_parts_from_other_model(self, other_model, realization = None, consolidate = True):


### PR DESCRIPTION
BOOTs Maps workflow is taking too long to consolidate large ensembles (time grows worse than linear with number of realisations). This change aims to provide some speedup when the calling code has some 'knowledge' about the ensemble.