### PR TITLE
Add CodeCov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Python version](https://img.shields.io/pypi/pyversions/resqpy)
 [![PyPI](https://img.shields.io/pypi/v/resqpy)](https://badge.fury.io/py/resqpy)
 ![Status](https://img.shields.io/pypi/status/resqpy)
+[![codecov](https://codecov.io/gh/bp/resqpy/branch/master/graph/badge.svg)](https://codecov.io/gh/bp/resqpy)
 
 ## Introduction
 


### PR DESCRIPTION
An easier way to see our coverage, avoids having to remember the URL of the CodeCov website:

![image](https://user-images.githubusercontent.com/71127464/121182347-e7699400-c85a-11eb-81cd-eb3f39f77e8b.png)
