### PR TITLE
Fix docs version numbers, explicit docs dependencies

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,4 @@
+---
 # Configuration for CodeCov
 # See https://docs.codecov.io/docs/codecov-yaml
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,4 +12,4 @@ coverage:
 
 comment:
   # Only post a comment if coverage changes
-  require_changes: yes
+  require_changes: true

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-      
+
       # Post in-line comments for any issues found
       # Do not run if coming from a forked repo
       # See https://github.com/marketplace/actions/lint-action
@@ -38,7 +38,7 @@ jobs:
         uses: wearerequired/lint-action@v1
         with:
           flake8: true
-      
+
       # Alternative step that works with forked repo
       - name: Run flake8 (pure)
         if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,20 +1,24 @@
+---
+
 # .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF
+# Optional additional formats
 formats:
    - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
+# Python environment
+# Equivalent to: pip install resqpy[docs]
 python:
    version: 3.8
    install:
-   - requirements: docs/requirements.txt
+      - method: pip
+        path: .
+        extra_requirements:
+           - docs

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -23,8 +23,8 @@ Ways of contributing
 * Documentation or test improvements
 * Publicity and support
 
-Making a Pull Request
----------------------
+Development environment setup
+-----------------------------
 
 1. Clone the repo
 
@@ -83,7 +83,8 @@ Checklist for pull requests
 Code Style
 ----------
 
-Please try to write code according to the python style guide (PEP8), which
+Please try to write code according to the
+`PEP8 python style guide <https://www.python.org/dev/peps/pep-0008/>`_, which
 defines conventions such as variable naming and capitalisation. A consistent
 style makes it much easier for other developers to read and understand your
 code.
@@ -158,15 +159,18 @@ There are several command line options that can be appended:
 Static analysis
 ^^^^^^^^^^^^^^^
 
-We use flake8 to scan for obvious code errors. This is part of the CI tests, and
-can also be ran locally with:
+We use `flake8 <https://flake8.pycqa.org/en/latest/user/invocation.html>`_ to
+scan for obvious code errors. This is automatically run part as part of the CI
+tests, and can also be ran locally with:
 
 .. code:: bash
 
     flake8 .
 
-The configuration of which `error codes <https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3>`_
-are checked by default is stored in `setup.cfg <https://github.com/bp/resqpy/blob/master/setup.cfg>`_.
+The configuration of which
+`error codes <https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3>`_
+are checked by default is configured in the repo in
+`setup.cfg <https://github.com/bp/resqpy/blob/master/setup.cfg>`_.
 
 By default in resqpy:
 
@@ -178,12 +182,6 @@ You can test for PEP8 compliance by running flake8 with further error codes:
 .. code:: bash
 
     flake8 . –select=F,E2,E3,E4,E7
-
-Links:
-
--	`PEP8 Style Guide <https://www.python.org/dev/peps/pep-0008/>`_
--	`Flake8 reference <https://flake8.pycqa.org/en/latest/user/invocation.html>`_
--	`Flake8 error codes <https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3>`_
 
 Documentation
 -------------

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -35,6 +35,7 @@ Making a Pull Request
    .. code-block:: bash
 
       git clone <url from GitHub>
+      cd resqpy
 
 2. Set up a python environment
 
@@ -52,6 +53,10 @@ Making a Pull Request
    .. code-block:: bash
 
       pip install --editable .[tests,docs]
+
+   Be sure to execute the above command from the top level of the repository.
+   The full stop ``.`` instructs pip to find the python package in the current
+   working directory.
     
 3. Make a Pull Request
 

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -45,13 +45,13 @@ Making a Pull Request
       conda create -n resqpy python=3.7
       conda activate resqpy
         
-   You should then make an “editable” installation of the package into your local environment. This will
-   also install required dependencies, including extra packages required to running
-   unit tests.
+   You should then make an “editable” installation of the package into your
+   local environment. This will also install required dependencies, including
+   extra packages required for running unit tests and building documentation.
 
    .. code-block:: bash
 
-      pip install --editable .[tests]
+      pip install --editable .[tests,docs]
     
 3. Make a Pull Request
 
@@ -179,6 +179,18 @@ Links:
 -	`PEP8 Style Guide <https://www.python.org/dev/peps/pep-0008/>`_
 -	`Flake8 reference <https://flake8.pycqa.org/en/latest/user/invocation.html>`_
 -	`Flake8 error codes <https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3>`_
+
+Documentation
+-------------
+
+The docs are built automatically when code is merged into master, and are hosted
+at `readthedocs <https://resqpy.readthedocs.io/>`_. You can also build the docs
+locally, providing you have installed all required dependencies as described
+above:
+
+.. code:: bash
+
+   sphinx-build docs docs/html
 
 Get in touch
 ------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,10 +13,8 @@
 
 # -- Path setup --------------------------------------------------------------
 
-# Point to the current working copy of resqml
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..',)))
+# Do not do sys.path surgery
+# Instead, resqpy package should be pip-installed in the python environment
 
 # Mock imports for things not available
 # autodoc_mock_imports = ["h5py"]
@@ -31,7 +29,7 @@ author = 'BP'
 # See https://github.com/pypa/setuptools_scm/#usage-from-sphinx
 try:
     from importlib import metadata
-    release = metadata.version('myproject')
+    release = metadata.version('resqpy')
 except Exception:
     release = '0.0.0-version-not-available'
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-numpy
-pandas
-h5py
-lxml
-lasio
-autoclasstoc

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ tests =
     pytest-cov
     flake8
 docs = 
+    sphinx
     autoclasstoc
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ tests =
     pytest
     pytest-cov
     flake8
+docs = 
+    autoclasstoc
 
 [tool:pytest]
 addopts = -ra


### PR DESCRIPTION
The docs do not currently show the version number correctly when hyperlinks are copied and pasted around. I think this is because the `resqpy` package is not properly pip-installed when the docs are build - this should fix that issue.

Also suggest including the documentation dependencies explicitly in the package requirements (i.e. in `setup.cfg`), so that a developer can install everything needed with:

```
pip install .[tests,docs]
```