### PR TITLE
Implement simple base class

### DIFF
--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -11,7 +11,7 @@ import resqpy.olio.xml_et as rqet
 logger = logging.getLogger(__name__)
 
 
-class BaseResqml(metaclass=ABCMeta):
+class BaseResqpy(metaclass=ABCMeta):
     """Base class for generic RESQML objects
     
     Implements generic attributes such as uuid, root, part, title, originator.
@@ -21,7 +21,7 @@ class BaseResqml(metaclass=ABCMeta):
     
     Example use::
 
-        class AnotherResqmlObject(BaseResqml):
+        class AnotherResqmlObject(BaseResqpy):
             
             _content_type = 'obj_anotherresqmlobjectrepresentation'
 

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -91,7 +91,7 @@ class BaseResqml(metaclass=ABCMeta):
         self.title = rqet.find_nested_tags_text(self.root, ['Citation', 'Title'])
         self.originator = rqet.find_nested_tags_text(self.root, ['Citation', 'Originator'])
 
-    def create_xml(self, title=None, originator=None, ext_uuid=None, add_as_part=True):
+    def create_xml(self, title=None, originator=None, add_as_part=True):
         """Write citation block to XML
         
         Args:
@@ -107,8 +107,6 @@ class BaseResqml(metaclass=ABCMeta):
         """
 
         assert self.uuid is not None
-
-        if ext_uuid is None: ext_uuid = self.model.h5_uuid()
 
         # Create the root node
         node = self.model.new_obj_node(self._content_type)

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -91,7 +91,7 @@ class BaseResqpy(metaclass=ABCMeta):
         self.title = rqet.find_nested_tags_text(self.root, ['Citation', 'Title'])
         self.originator = rqet.find_nested_tags_text(self.root, ['Citation', 'Originator'])
 
-    def create_xml(self, title=None, originator=None, add_as_part=True):
+    def create_xml(self, title=None, originator=None, add_as_part=False):
         """Write citation block to XML
         
         Args:
@@ -112,16 +112,17 @@ class BaseResqpy(metaclass=ABCMeta):
         node = self.model.new_obj_node(self._content_type)
         node.attrib['uuid'] = str(self.uuid)
 
-        if add_as_part:
-            self.model.add_part(self._content_type, self.uuid, node)
-            assert self.root is not None   
-
         # Citation block
         if title: self.title = title
         if originator: self.originator = originator
         self.model.create_citation(
             root=node, title=self.title, originator=self.originator
         )
+        
+        if add_as_part:
+            self.model.add_part(self._content_type, self.uuid, node)
+            assert self.root is not None
+        
         return node
 
     # Generic magic methods

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -63,6 +63,7 @@ class BaseResqpy(metaclass=ABCMeta):
     def part(self):
         """Part corresponding to self.uuid"""
 
+        # TODO: create directly from self._content_type
         if self.uuid is None:
             raise ValueError('Cannot get part if uuid is None')
         return self.model.part_for_uuid(self.uuid)
@@ -74,18 +75,12 @@ class BaseResqpy(metaclass=ABCMeta):
         if self.uuid is None:
             raise ValueError('Cannot get root if uuid is None')
         return self.model.root_for_uuid(self.uuid)
-    
-    @root.setter
-    def root(self, value):
-        """Update self.uuid to match new root. Ensure root is added as a part"""
-
-        new_uuid = rqet.uuid_for_part_root(value)
-        if new_uuid is None:
-            raise ValueError("Cannot set uuid to be None")
-        self.uuid = new_uuid
 
     def load_from_xml(self):
-        """Load citation block from XML"""
+        """Load citation block from XML.
+        
+        Note: derived classes should extend this to load other XML and HDF attributes
+        """
 
         # Citation block
         self.title = rqet.find_nested_tags_text(self.root, ['Citation', 'Title'])
@@ -118,7 +113,7 @@ class BaseResqpy(metaclass=ABCMeta):
         self.model.create_citation(
             root=node, title=self.title, originator=self.originator
         )
-        
+
         if add_as_part:
             self.model.add_part(self._content_type, self.uuid, node)
             assert self.root is not None

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -101,7 +101,9 @@ class BaseResqml(metaclass=ABCMeta):
                 default is to use the login name
             add_as_part (boolean, default True): if True, the newly created xml node is added as a part
                 in the model
-    
+
+        Returns:
+            node: the newly created root node
         """
 
         assert self.uuid is not None
@@ -114,9 +116,7 @@ class BaseResqml(metaclass=ABCMeta):
 
         if add_as_part:
             self.model.add_part(self._content_type, self.uuid, node)
-        # self.root = node
-
-        assert self.root is not None
+            assert self.root is not None   
 
         # Citation block
         if title: self.title = title
@@ -124,6 +124,7 @@ class BaseResqml(metaclass=ABCMeta):
         self.model.create_citation(
             root=node, title=self.title, originator=self.originator
         )
+        return node
 
     # Generic magic methods
 

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -1,0 +1,162 @@
+"""Base class for generic resqml objects """
+
+import logging
+import warnings
+from abc import ABCMeta, abstractmethod
+
+import resqpy.olio.uuid as bu
+import resqpy.olio.xml_et as rqet
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseResqml(metaclass=ABCMeta):
+    """Base class for generic RESQML objects
+    
+    Implements generic attributes such as uuid, root, part, title, originator.
+
+    Implements generic magic methods, such as pretty printing and testing for
+    equality.
+    
+    Example use::
+
+        class AnotherResqmlObject(BaseResqml):
+            
+            _content_type = 'obj_anotherresqmlobjectrepresentation'
+
+    """
+
+    @property
+    @abstractmethod
+    def _content_type(self):
+        """Definition of which RESQML object the class represents.
+        
+        Subclasses must overwrite this abstract attribute.
+        """
+        raise NotImplementedError
+
+    def __init__(self, model, uuid=None, title=None, originator=None):
+        """Load an existing resqml object, or create new.
+
+        Args:
+            model (resqpy.model.Model): Parent model
+            uuid (str, optional): Load from existing uuid (if given), else create new.
+            title (str, optional): Citation title
+            originator (str, optional): Creator of object. By default, uses user id.
+        """
+        self.model = model
+        self.title = title
+        self.originator = originator
+
+        if uuid is None:
+            self.uuid = bu.new_uuid()
+            logger.debug(f"Created new uuid for object {self}")
+        else:
+            self.uuid = uuid
+            logger.debug(f"Loading existing object {self}")
+            self.load_from_xml()
+    
+    # Define attributes self.part and self.root, using uuid as the primary key
+
+    @property
+    def part(self):
+        """Part corresponding to self.uuid"""
+
+        if self.uuid is None:
+            raise ValueError('Cannot get part if uuid is None')
+        return self.model.part_for_uuid(self.uuid)
+
+    @property
+    def root(self):
+        """Node corresponding to self.uuid"""
+
+        if self.uuid is None:
+            raise ValueError('Cannot get root if uuid is None')
+        return self.model.root_for_uuid(self.uuid)
+    
+    @root.setter
+    def root(self, value):
+        """Update self.uuid to match new root. Ensure root is added as a part"""
+
+        new_uuid = rqet.uuid_for_part_root(value)
+        if new_uuid is None:
+            raise ValueError("Cannot set uuid to be None")
+        self.uuid = new_uuid
+
+    def load_from_xml(self):
+        """Load citation block from XML"""
+
+        # Citation block
+        self.title = rqet.find_nested_tags_text(self.root, ['Citation', 'Title'])
+        self.originator = rqet.find_nested_tags_text(self.root, ['Citation', 'Originator'])
+
+    def create_xml(self, title=None, originator=None, ext_uuid=None, add_as_part=True):
+        """Write citation block to XML
+        
+        Args:
+            title (string): used as the citation Title text; should usually refer to the well name in a
+                human readable way
+            originator (string, optional): the name of the human being who created the deviation survey part;
+                default is to use the login name
+            add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+                in the model
+    
+        """
+
+        assert self.uuid is not None
+
+        if ext_uuid is None: ext_uuid = self.model.h5_uuid()
+
+        # Create the root node
+        node = self.model.new_obj_node(self._content_type)
+        node.attrib['uuid'] = str(self.uuid)
+
+        if add_as_part:
+            self.model.add_part(self._content_type, self.uuid, node)
+        # self.root = node
+
+        assert self.root is not None
+
+        # Citation block
+        if title: self.title = title
+        if originator: self.originator = originator
+        self.model.create_citation(
+            root=node, title=self.title, originator=self.originator
+        )
+
+    # Generic magic methods
+
+    def __eq__(self, other):
+        """Implements equals operator. By default, compare objects using uuid"""
+        return self.uuid is not None and self.uuid == getattr(other, "uuid", None)
+
+    def __ne__(self, other):
+        """Implements not equal operator"""
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        """String representation"""
+        return f"{self.__class__.__name__}(uuid={self.uuid}, title={self.title})"
+
+    def _repr_html_(self):
+        """IPython / Jupyter representation"""
+        
+        keys_to_display = ('uuid', 'title', 'originator')
+        html =  f"<h3>{self.__class__.__name__}</h3>\n"
+        for key in keys_to_display:
+            html += f"<strong>{key}</strong>: {getattr(self, key)}<br>\n"
+        return html
+
+    # Include some aliases for root, but raise warnings if they are used
+    # TODO: remove these aliases for self.node
+
+    @property
+    def root_node(self):
+        warnings.warn("Attribute 'root_node' is deprecated. Use 'root'", DeprecationWarning)
+        return self.root
+
+    @property
+    def node(self):
+        warnings.warn("Attribute 'node' is deprecated. Sse 'root'", DeprecationWarning)
+        return self.root

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -128,7 +128,8 @@ class BaseResqml(metaclass=ABCMeta):
 
     def __eq__(self, other):
         """Implements equals operator. By default, compare objects using uuid"""
-        return self.uuid is not None and self.uuid == getattr(other, "uuid", None)
+        other_uuid = getattr(other, "uuid", None)
+        return isinstance(other, self.__class__) and bu.matching_uuids(self.uuid, other_uuid)
 
     def __ne__(self, other):
         """Implements not equal operator"""

--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -124,6 +124,25 @@ def find_nested_tags(root, tag_list):
    return find_nested_tags(head, tag_list[1:])
 
 
+def find_nested_tags_cast(root, tag_list, dtype=None):
+   """Return value of nested tags as desired dtype.
+   
+   Follows a list of tags in a nested xml hierarchy, returning the stripped text
+   of the node at the deepest level.
+   """
+
+   cast_func = {
+      int: node_int,
+      float: node_float,
+      bool: node_bool,
+      str: node_text,
+      None: lambda x: x,
+   }[dtype]
+
+   node = find_nested_tags(root, tag_list)
+   return cast_func(node)
+
+
 def find_nested_tags_text(root, tag_list):
    """Follows a list of tags in a nested xml hierarchy, returning the stripped text of the node at the deepest level."""
 

--- a/resqpy/organize.py
+++ b/resqpy/organize.py
@@ -111,7 +111,8 @@ class OrganizationFeature(BaseResqpy):
          all(
             self.feature_name == other.feature_name,
             self.organization_kind == other.organization_kind,
-            (equivalent_extra_metadata(self, other) or not check_extra_metadata))
+            (equivalent_extra_metadata(self, other) or not check_extra_metadata)
+         )
       )
 
    def __eq__(self, other):

--- a/resqpy/organize.py
+++ b/resqpy/organize.py
@@ -17,7 +17,7 @@ import warnings
 import resqpy.olio.xml_et as rqet
 import resqpy.olio.uuid as bu
 from resqpy.olio.xml_namespaces import curly_namespace as ns
-from resqpy.olio.base import BaseResqml
+from resqpy.olio.base import BaseResqpy
 
 
 def extract_has_occurred_during(parent_node, tag = 'HasOccuredDuring'):  # RESQML Occured (stet)
@@ -84,7 +84,7 @@ def _alias_for_attribute(attribute_name):
    return property(fget, fset)
 
 
-class OrganizationFeature(BaseResqml):
+class OrganizationFeature(BaseResqpy):
    """Class for generic RESQML Organization Feature objects."""
 
    _content_type = "OrganizationFeature"

--- a/resqpy/organize.py
+++ b/resqpy/organize.py
@@ -17,6 +17,7 @@ import warnings
 import resqpy.olio.xml_et as rqet
 import resqpy.olio.uuid as bu
 from resqpy.olio.xml_namespaces import curly_namespace as ns
+from resqpy.olio.base import BaseResqml
 
 
 def extract_has_occurred_during(parent_node, tag = 'HasOccuredDuring'):  # RESQML Occured (stet)
@@ -71,74 +72,70 @@ def create_xml_has_occurred_during(model, parent_node, hod_pair, tag = 'HasOccur
    model.create_ref_node('ChronoTop', model.title_for_root(chrono_top_root), top_chrono_uuid, root = hod_node)
 
 
+def _alias_for_attribute(attribute_name):
+   """Return an attribute that is a direct alias for an existing attribute"""
 
-class OrganizationFeature():
+   def fget(self):
+      return getattr(self, attribute_name)
+   
+   def fset(self, value):
+      return setattr(self, attribute_name, value)
+
+   return property(fget, fset)
+
+
+class OrganizationFeature(BaseResqml):
    """Class for generic RESQML Organization Feature objects."""
 
-   def __init__(self, parent_model, root_node=None, uuid=None, extract_from_xml=True, feature_name=None, organization_kind=None):
-      """Initialises an organization feature object."""
+   _content_type = "OrganizationFeature"
+   feature_name = _alias_for_attribute("title")
 
-      self.model = parent_model
-      self.uuid = uuid
-      self.feature_name = None
-      self.organization_kind = None
+   def __init__(self, parent_model, root_node=None, uuid=None, feature_name=None,
+                organization_kind=None, originator=None):
+      """Initialises an organization feature object."""
 
       if root_node is not None:
          warnings.warn("root_node parameter is deprecated, use uuid instead", DeprecationWarning)
-         self.root_node = root_node
-      else:
-         self.root_node = self.model.root_for_uuid(self.uuid)
+         uuid = rqet.uuid_for_part_root(root_node)
 
-      if extract_from_xml and self.root_node is not None:
-         self.uuid = self.root_node.attrib['uuid']
-         self.feature_name = rqet.find_nested_tags_text(self.root_node, ['Citation', 'Title'])
-         self.organization_kind = rqet.find_tag_text(self.root_node, 'OrganizationKind')
-      else:
-         self.uuid = bu.new_uuid()
-         self.feature_name = feature_name
-         if organization_kind not in ['earth model', 'fluid', 'stratigraphic', 'structural']:
-            raise ValueError(organization_kind)
-         self.organization_kind = organization_kind
-
+      self.organization_kind = organization_kind
+      super().__init__(model=parent_model, uuid=uuid, title=feature_name, originator=originator)
+   
 
    def is_equivalent(self, other, check_extra_metadata = True):
       """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, OrganizationFeature): return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid): return True
-      if self.feature_name != other.feature_name or self.organization_kind != other.organization_kind: return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other): return False
-      return True
-
+      return isinstance(other, OrganizationFeature) and any(
+         self is other,
+         bu.matching_uuids(self.uuid, other.uuid),
+         all(
+            self.feature_name == other.feature_name,
+            self.organization_kind == other.organization_kind,
+            (equivalent_extra_metadata(self, other) or not check_extra_metadata))
+      )
 
    def __eq__(self, other):
       return self.is_equivalent(other)
 
-
-   def __ne__(self, other):
-      return not self.is_equivalent(other)
-
+   def load_from_xml(self):
+       super().load_from_xml()
+       self.organization_kind = rqet.find_tag_text(self.root_node, 'OrganizationKind')
 
    def create_xml(self, add_as_part = True, originator = None):
       """Creates an organization feature xml node from this organization feature object."""
 
-      ofn = self.model.new_obj_node('OrganizationFeature')
+      # Create node with citation block
+      ofn = super().create_xml(add_as_part=False, originator=originator)
 
-      if self.uuid is None:
-         self.uuid = bu.uuid_from_string(ofn.attrib['uuid'])
-      else:
-         ofn.attrib['uuid'] = str(self.uuid)
-
-      self.model.create_citation(root = ofn, title = self.feature_name, originator = originator)
-
+      # Extra element for organization_kind
+      if self.organization_kind not in ['earth model', 'fluid', 'stratigraphic', 'structural']:
+            raise ValueError(self.organization_kind)
       kind_node = rqet.SubElement(ofn, ns['resqml2'] + 'OrganizationKind')
       kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'OrganizationKind')
       kind_node.text = self.organization_kind
 
       if add_as_part:
          self.model.add_part('obj_OrganizationFeature', self.uuid, ofn)
-
-      self.root_node = ofn
 
       return ofn
 

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -57,7 +57,7 @@ import resqpy.olio.write_hdf5 as rwh5
 import resqpy.olio.keyword_files as kf
 import resqpy.olio.wellspec_keywords as wsk
 from resqpy.olio.xml_namespaces import curly_namespace as ns
-from resqpy.olio.base import BaseResqml
+from resqpy.olio.base import BaseResqpy
 
 
 valid_md_reference_list = ["ground level", "kelly bushing", "mean sea level", "derrick floor", "casing flange",
@@ -222,7 +222,7 @@ class MdDatum():
       return datum
 
 
-class DeviationSurvey(BaseResqml):
+class DeviationSurvey(BaseResqpy):
    """Class for RESQML wellbore deviation survey.
 
    RESQML documentation:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -31,7 +31,7 @@ def test_base_save_and_load(example_model):
     originator = 'Scruffian'
     model, crs = example_model
     dummy1 = DummyObj(model=model, title=title, originator=originator)
-    dummy1.create_xml()
+    dummy1.create_xml(add_as_part=True)
 
     # Load a new object
     dummy2 = DummyObj(model=model, uuid=dummy1.uuid)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,6 @@
-from resqpy.olio.base import BaseResqml
+from resqpy.olio.base import BaseResqpy
 
-class DummyObj(BaseResqml):
+class DummyObj(BaseResqpy):
     _content_type = 'DummyResqmlInterpretation'
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,7 @@ def test_base_creation(example_model):
     assert dummy.part is None
 
     # After creating XML, root and part should exist
-    dummy.create_xml()
+    dummy.create_xml(add_as_part=True)
     assert dummy.root is not None
     assert dummy.part is not None
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,69 @@
+from resqpy.olio.base import BaseResqml
+
+class DummyObj(BaseResqml):
+    _content_type = 'DummyResqmlInterpretation'
+
+
+def test_base_creation(example_model):
+
+    # Setup new object
+    title = 'Wondermuffin'
+    model, crs = example_model
+    dummy = DummyObj(model=model, title=title)
+
+    # UUID should exist, but not root or part
+    assert dummy.uuid is not None
+    assert dummy.root is None
+    assert dummy.part is None
+
+    # After creating XML, root and part should exist
+    dummy.create_xml()
+    assert dummy.root is not None
+    assert dummy.part is not None
+
+
+def test_base_save_and_load(example_model):
+
+    # Create and save a DummyObj
+    title = 'feefifofum'
+    originator = 'Scruffian'
+    model, crs = example_model
+    dummy1 = DummyObj(model=model, title=title, originator=originator)
+    dummy1.create_xml()
+
+    # Load a new object
+    dummy2 = DummyObj(model=model, uuid=dummy1.uuid)
+
+    # Properties should match
+    assert dummy2.uuid == dummy1.uuid
+    assert dummy2.root is not None
+    assert dummy2.title == title
+    assert dummy2.originator == originator
+
+
+def test_base_comparison(example_model):
+
+    # Setup new object
+    model, crs = example_model
+    dummy1 = DummyObj(model=model)
+    dummy2 = DummyObj(model=model, uuid=dummy1.uuid)  # Same UUID
+    dummy3 = DummyObj(model=model, title='hello')     # Different UUID
+
+    # Comparison should work by UUID
+    assert dummy1 == dummy2
+    assert dummy1 != dummy3
+
+    
+def test_base_repr(example_model):
+
+    model, crs = example_model
+    dummy = DummyObj(model=model)
+
+    # Check repr method produces a string
+    rep = repr(dummy)
+    assert isinstance(rep, str)
+    assert len(rep) > 0
+
+    # Check HTML can be generated
+    html = dummy._repr_html_()
+    assert len(html) > 0

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,6 @@
+import resqpy.olio.uuid as bu
 from resqpy.olio.base import BaseResqpy
+
 
 class DummyObj(BaseResqpy):
     _content_type = 'DummyResqmlInterpretation'
@@ -35,7 +37,7 @@ def test_base_save_and_load(example_model):
     dummy2 = DummyObj(model=model, uuid=dummy1.uuid)
 
     # Properties should match
-    assert dummy2.uuid == dummy1.uuid
+    assert bu.matching_uuids(dummy2.uuid, dummy1.uuid)
     assert dummy2.root is not None
     assert dummy2.title == title
     assert dummy2.originator == originator


### PR DESCRIPTION
A second, simpler attempt to implement a simple Base Class for resqml objects, that handles the generic stuff like:

- Standardising on using `uuid` as the primary key
- Setting citation title and orginator attributes
- Pretty display methods, including HTML ipython

Closes #20
Closes #19

Similar to #44 , but with fewer changes for a first step.

In future, could be extended to implement loading and saving simple (not nested) properties to XML and HDF5