### PR TITLE
WIP: UUID keys in model

### DIFF
--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -2978,7 +2978,7 @@ class Model():
 
       uuid = rqet.uuid_in_part_name(part_name)
       try:
-         del uuid_part_dict[bu.uuid_as_int(uuid)]
+         del self.uuid_part_dict[bu.uuid_as_int(uuid)]
       except:
          pass
 

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -1,6 +1,6 @@
 """model.py: Main resqml interface module handling epc packing & unpacking and xml structures."""
 
-version = '8th June 2021'
+version = '15th June 2021'
 
 import logging
 log = logging.getLogger(__name__)
@@ -154,6 +154,7 @@ class Model():
       self.grid_root = None      # extracted from tree as speed optimization (useful for single grid models), for 'main' grid
       self.time_series = None    # extracted as speed optimization (single time series only for now)
       self.parts_forest = {}     # dictionary keyed on part_name; mapping to (content_type, uuid, xml_tree)
+      self.uuid_part_dict = {}   # dictionary keyed on uuid.int; mapping to part_name
       self.rels_present = False
       self.rels_forest = {}      # dictionary keyed on part_name; mapping to (uuid, xml_tree)
       self.other_forest = {}     # dictionary keyed on part_name; mapping to (content_type, xml_tree); used for docProps
@@ -551,6 +552,7 @@ class Model():
                elif uuid_from_tree is not None:
                   assert bu.matching_uuids(part_uuid, uuid_from_tree)
                self.parts_forest[part_name] = (part_type, part_uuid, part_tree)
+               self._set_uuid_to_part(part_name)
                if self.crs_root is None and part_type == 'obj_LocalDepth3dCrs':   # randomly assign first crs as primary crs for model
                   self.crs_root = part_tree.getroot()
 
@@ -588,6 +590,10 @@ class Model():
          not usually called directly
       """
 
+      try:
+         self._del_uuid_to_part(part_name)
+      except:
+         pass
       try:
          del self.parts_forest[part_name]
       except:
@@ -633,6 +639,7 @@ class Model():
       for part in deletion_list:
          log.debug('removing part due to lack of xml tree etc.: ' + str(part))
          if tidy_main_tree: self.remove_part_from_main_tree(part)
+         self._del_uuid_to_part(part)
          del self.parts_forest[part]
       deletion_list = []
       for part, info in self.rels_forest.items():
@@ -718,6 +725,7 @@ class Model():
                      self.rels_forest[name] = (part_uuid, None)
                   else:
                      self.parts_forest[name] = (None, part_uuid, None)
+                     self._set_uuid_to_part(name)
          with epc.open('[Content_Types].xml') as main_xml:
             self.main_tree = rqet.parse(main_xml)
             self.main_root = self.main_tree.getroot()
@@ -845,10 +853,16 @@ class Model():
 
       if type_of_interest and type_of_interest[0].isupper(): type_of_interest = 'obj_' + type_of_interest
 
+      if uuid is not None:
+         part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
+         if part_name is None or (type_of_interest is not None and (self.parts_forest[part_name][0] != type_of_interest)):
+            return []
+         return [part_name]
+
       parts_list = []
       for part_name in self.parts_forest:
-         if ((type_of_interest is None or self.parts_forest[part_name][0] == type_of_interest) and
-             (uuid is None or bu.matching_uuids(uuid, self.parts_forest[part_name][1]))): parts_list.append(part_name)
+         if type_of_interest is None or self.parts_forest[part_name][0] == type_of_interest:
+            parts_list.append(part_name)
       return parts_list
 
 
@@ -883,10 +897,7 @@ class Model():
       :meta common:
       """
 
-      if uuid is None: return None
-      parts_list = self.parts_list_of_type(uuid = uuid)
-      if not parts_list: return None
-      return parts_list[0]
+      return self.uuid_part_dict.get(bu.uuid_as_int(uuid))
 
 
    def root_for_uuid(self, uuid):
@@ -1072,6 +1083,10 @@ class Model():
       returns:
          uuid.UUID for the specified part
 
+      note:
+         this method will fail with an exception if the part is not in this model; a quicker alternative
+         to this method is simply to extract the uuid from the part name using olio.xml_et.uuid_in_part_name()
+
       :meta common:
       """
 
@@ -1095,10 +1110,29 @@ class Model():
       :meta common:
       """
 
-      if part_name not in self.parts_forest: return None
-      obj_type = self.parts_forest[part_name][0]
+      part_info = self.parts_forest.get(part_name)
+      if part_info is None: return None
+      obj_type = part_info[0]
       if obj_type is None or not strip_obj or not obj_type.startswith('obj_'): return obj_type
       return obj_type[4:]
+
+
+   def type_of_uuid(self, uuid, strip_obj = False):
+      """Returns content type for the uuid.
+
+      arguments:
+         uuid (uuid.UUID or str): the uuid for which the type is required
+         strip_obj (boolean, default False): if True, the leading 'obj_' is removed
+            from the returned string
+
+      returns:
+         string being the type (resqml object class) for the named part
+
+      :meta common:
+      """
+
+      part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
+      return self.type_of_part(part_name, strip_obj = strip_obj)
 
 
    def tree_for_part(self, part_name, is_rels = None):
@@ -1878,6 +1912,7 @@ class Model():
          self.other_forest[part_name] = (content_type, part_tree)
       else:
          self.parts_forest[part_name] = (content_type, uuid, part_tree)
+         self._set_uuid_to_part(part_name)
       main_ref = rqet.SubElement(self.main_root, ns['content_types'] + 'Override')
       main_ref.set('PartName', part_name)
       main_ref.set('ContentType', ct)
@@ -1894,7 +1929,7 @@ class Model():
 
 
    def patch_root_for_part(self, part, root):
-      """Updates the xml tree for the part without chaning the uuid."""
+      """Updates the xml tree for the part without changing the uuid."""
 
       content_type, uuid, part_tree = self.parts_forest[part]
       assert bu.matching_uuids(uuid, rqet.uuid_for_part_root(root))
@@ -1905,6 +1940,7 @@ class Model():
    def remove_part(self, part_name, remove_relationship_part = True):
       """Removes a part from the parts forest; optionally remove corresponding rels part and other relationships."""
 
+      self._del_uuid_to_part(part_name)
       self.parts_forest.pop(part_name)
       if remove_relationship_part:
          if 'docProps' in part_name:
@@ -2928,6 +2964,23 @@ class Model():
       for timestamp, index in reversed(sort_list):
          results.append(parts_list[index])
       return results
+
+
+   def _set_uuid_to_part(self, part_name):
+      """Adds an entry to the dictionary mapping from uuid to part name."""
+
+      uuid = rqet.uuid_in_part_name(part_name)
+      self.uuid_part_dict[bu.uuid_as_int(uuid)] = part_name
+
+
+   def _del_uuid_to_part(self, part_name):
+      """Deletes an entry from the dictionary mapping from uuid to part name."""
+
+      uuid = rqet.uuid_in_part_name(part_name)
+      try:
+         del uuid_part_dict[bu.uuid_as_int(uuid)]
+      except:
+         pass
 
 
 

--- a/resqpy/olio/uuid.py
+++ b/resqpy/olio/uuid.py
@@ -3,7 +3,7 @@
 # NB: at present the code does not enforce multiprocessor safe generation of unique identifiers
 # it calls uuid.uuid1() to generate new uuids, ie. using version 1 of the iso standard options
 
-version = '24th November 2020'
+version = '15th June 2021'
 
 # import logging
 # log = logging.getLogger(__name__)
@@ -116,8 +116,24 @@ def uuid_as_bytes(uuid_obj):
          bytes (16 bytes long)
    """
 
+   if uuid_obj is None: return None
    if isinstance(uuid_obj, str): uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
    return uuid_obj.bytes
+
+
+def uuid_as_int(uuid_obj):
+   """Returns the uuid as a 128 bit int; same as uuid_obj.int.
+
+      argument:
+         uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
+
+      returns:
+         bytes (16 bytes long)
+   """
+
+   if uuid_obj is None: return None
+   if isinstance(uuid_obj, str): uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
+   return uuid_obj.int
 
 
 def matching_uuids(uuid_a, uuid_b):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,8 +26,8 @@ def test_model(tmp_path):
    model = rq.Model(epc)
    assert model is not None
    assert len(model.uuids(obj_type = 'MdDatum')) == 2
-   datum_part_1 = model.part(obj_type = 'MdDatum', title = '1', title_mode = 'endswith')
-   datum_part_2 = model.part(obj_type = 'MdDatum', title = '2', title_mode = 'endswith')
+   datum_part_1 = model.part(obj_type = 'MdDatum', title = '1', title_mode = 'ends')
+   datum_part_2 = model.part(obj_type = 'MdDatum', title = '2', title_mode = 'ends')
    assert datum_part_1 is not None and datum_part_2 is not None and datum_part_1 != datum_part_2
    datum_uuid_1 = rqet.uuid_in_part_name(datum_part_1)
    datum_uuid_2 = rqet.uuid_in_part_name(datum_part_2)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,12 +19,12 @@ def test_model(tmp_path):
    md_datum_1.create_xml(title = 'Datum 1')
    md_datum_2 = rqw.MdDatum(model, location = (3.0, 0.0, -50.0), crs_root = crs_root)
    md_datum_2.create_xml(title = 'Datum 2')
-   assert len(model.uuids(obj_type = 'MdDatum)) == 2
+   assert len(model.uuids(obj_type = 'MdDatum')) == 2
    model.store_epc()
 
    model = rq.Model(epc)
    assert model is not None
-   assert len(model.uuids(obj_type = 'MdDatum)) == 2
+   assert len(model.uuids(obj_type = 'MdDatum')) == 2
    datum_part_1 = model.part(obj_type = 'MdDatum', title = '1', title_mode = 'endswith')
    datum_part_2 = model.part(obj_type = 'MdDatum', title = '2', title_mode = 'endswith')
    assert datum_part_1 is not None and datum_part_2 is not None and datum_part_1 != datum_part_2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,36 @@
+import pytest
+import os
+
+import resqpy.model as rq
+import resqpy.crs as rqc
+import resqpy.olio.xml_et as rqet
+import resqpy.olio.uuid as bu
+
+def test_model(tmp_path):
+
+   epc = os.path.join(tmp_path, 'model.epc')
+   model = rq.new_model(epc)
+   assert model is not None
+   crs = rqc.Crs()
+   crs_root = crs.create_xml()
+   model.store_epc()
+   assert os.path.exists(epc)
+   md_datum_1 = rqw.MdDatum(model, location = (0.0, 0.0, -50.0), crs_root = crs_root)
+   md_datum_1.create_xml(title = 'Datum 1')
+   md_datum_2 = rqw.MdDatum(model, location = (3.0, 0.0, -50.0), crs_root = crs_root)
+   md_datum_2.create_xml(title = 'Datum 2')
+   assert len(model.uuids(obj_type = 'MdDatum)) == 2
+   model.store_epc()
+
+   model = rq.Model(epc)
+   assert model is not None
+   assert len(model.uuids(obj_type = 'MdDatum)) == 2
+   datum_part_1 = model.part(obj_type = 'MdDatum', title = '1', title_mode = 'endswith')
+   datum_part_2 = model.part(obj_type = 'MdDatum', title = '2', title_mode = 'endswith')
+   assert datum_part_1 is not None and datum_part_2 is not None and datum_part_1 != datum_part_2
+   datum_uuid_1 = rqet.uuid_in_part_name(datum_part_1)
+   datum_uuid_2 = rqet.uuid_in_part_name(datum_part_2)
+   assert not bu.matching_uuids(datum_uuid_1, datum_uuid_2)
+   p1 = model.uuid_part_dict[bu.uuid_as_int(datum_uuid_1)]
+   p2 = model.uuid_part_dict[bu.uuid_as_int(datum_uuid_2)]
+   assert p1 == datum_part_1 and p2 == datum_part_2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,7 +12,7 @@ def test_model(tmp_path):
    epc = os.path.join(tmp_path, 'model.epc')
    model = rq.new_model(epc)
    assert model is not None
-   crs = rqc.Crs()
+   crs = rqc.Crs(model)
    crs_root = crs.create_xml()
    model.store_epc()
    assert os.path.exists(epc)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,6 +3,7 @@ import os
 
 import resqpy.model as rq
 import resqpy.crs as rqc
+import resqpy.well as rqw
 import resqpy.olio.xml_et as rqet
 import resqpy.olio.uuid as bu
 


### PR DESCRIPTION
This change adds code to the Model class to maintain a second dictionary kept in sync with parts_forest. The new dictionary maps from uuid (as int) to part name and should hopefully speed up the lookup of objects when starting from a uuid.