### PR TITLE
Fixing timeseries merging

### DIFF
--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -304,7 +304,7 @@ class TimeSeries():
 
    def datetimes(self):
       """Returns a list of python-datetime objects """
-      return [dt.datetime.fromisoformat(t.rstrip('z')) for t in self.timestamps]
+      return [dt.datetime.fromisoformat(t.rstrip('Z')) for t in self.timestamps]
 
    def create_xml(self, add_as_part = True, root = None,
                   title = 'time series', originator = None):

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -7,7 +7,7 @@ from resqpy import model as makemodel
 #reversemode=True
 
 #@pytest.mark.parametrize("reversemode", [True, False])
-def test_merge_timeseries(reverse=False):
+def test_merge_timeseries():
     model=makemodel.Model(create_basics=True)
 
     timestamps1=['2020-01-01T00:00:00Z', '2015-01-01T00:00:00Z']
@@ -40,7 +40,3 @@ def test_merge_timeseries(reverse=False):
 
     return True
 
-if __name__ == "__main__":
-
-    for reversemode in [True, False]:
-        assert test_merge_timeseries(reverse=reversemode)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -13,7 +13,6 @@ def test_merge_timeseries():
     timestamps1=['2020-01-01T00:00:00Z', '2015-01-01T00:00:00Z']
     timestamps2=['2021-01-01T00:00:00Z', '2014-01-01T00:00:00Z']
 
-    #sortedtimestamps=sorted(timestamps1 + timestamps2, reverse=reverse)
 
     timeseries1=rqts.time_series_from_list(timestamps1, parent_model=model)
     timeseries1.set_model(model)
@@ -24,9 +23,6 @@ def test_merge_timeseries():
     
 
     sortedtimestamps=sorted(timeseries1.datetimes() + timeseries2.datetimes())
-    #print(timeseries1)
-
-    #print(model.roots(obj_type='obj_TimeSeries'))
 
     timeseries_uuids=(timeseries1.uuid, timeseries2.uuid)
 
@@ -35,8 +31,26 @@ def test_merge_timeseries():
     assert len(newts.timestamps) == len(timeseries1.timestamps) + len(timeseries2.timestamps)
 
     for idx, timestamp in enumerate(newts.datetimes()):
-        #print(timestamp, sortedtimestamps)
         assert timestamp==sortedtimestamps[idx]
+    
 
+    #Now test duplication doesn't create duplicate timestamps during merge, I want a unique set of merged timestamps
+    
+    timestamps3=[timestamp for timestamp in timestamps1]
+    timeseries3=rqts.time_series_from_list(timestamps3, parent_model=model)
+    timeseries3.set_model(model)
+    timeseries3.create_xml()
+    
+    timeseries_uuids=(timeseries1.uuid, timeseries2.uuid, timeseries3.uuid)
+    
+
+    newts2, _, _ = rqts.merge_timeseries_from_uuid(model, timeseries_uuids)
+
+    assert len(newts.timestamps) == len(newts2.timestamps)
+    
+    for idx, timestamp in enumerate(newts2.datetimes()):
+        assert timestamp==sortedtimestamps[idx]
+    
+    
     return True
 


### PR DESCRIPTION
There was a bug in previous PR https://github.com/bp/resqpy/pull/32

Fixed to strip uppercase z from timestamp strings instead of lowercase. 

Also added more tests to check that merging timeseries does not return duplicate timestamps. 

