### PR TITLE
Well log creation and conversion

### DIFF
--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -3033,9 +3033,9 @@ class Model():
          hv.extension('bokeh')
 
          # Plot
-         hv.Graph.from_networkx(g, nx.layout.spring_layout)\
-            .opts(tools=['hover'], width=600, height=600,
-                  node_color='resqml_type', cmap='Category10')
+         hv.Graph.from_networkx(g, nx.layout.spring_layout).opts(
+            tools=['hover'], node_color='resqml_type', cmap='Category10'
+         )
 
       Args:
          uuids_subset (iterable): If present, only consider uuids in this list.

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -792,6 +792,15 @@ class PropertyCollection():
 
       return list(self.dict.keys())
 
+   def uuids(self):
+      """Return list of uuids in this collection.
+
+      returns:
+         list of uuids being the members of this collection; there is one uuid per property array
+
+      :meta common:
+      """
+      return [self.model.uuid_for_part(p) for p in self.dict.keys()]
 
    def selective_parts_list(self,
                             realization = None,
@@ -3927,7 +3936,7 @@ class WellLogCollection(PropertyCollection):
             print(log.title)
       """
       
-      return (WellLog(collection=self, part=part) for part in self.parts())
+      return (WellLog(collection=self, uuid=uuid) for uuid in self.uuids())
 
    def to_df(self, include_units=False):
       """ Return pandas dataframe of log data
@@ -4010,19 +4019,20 @@ class WellLogCollection(PropertyCollection):
 class WellLog:
    """ Thin wrapper class around RESQML properties for well logs """
 
-   def __init__(self, collection, part):
+   def __init__(self, collection, uuid):
       """ Create a well log from a part name """
 
       self.collection: PropertyCollection = collection
       self.model = collection.model
-      self.part = part
+      self.uuid = uuid
 
+      part = self.model.part_for_uuid(uuid)
       indexable = self.collection.indexable_for_part(part)
       if indexable != 'nodes':
          raise NotImplementedError('well frame related property does not have nodes as indexable element')
 
       #: Name of log
-      self.title = self.model.citation_title_for_part(part)  # make this title
+      self.title = self.model.citation_title_for_part(part)
 
       #: Unit of measure
       self.uom = self.collection.uom_for_part(part)
@@ -4034,7 +4044,8 @@ class WellLog:
          may return 2D numpy array with shape (num_depths, num_columns).
       """
 
-      return self.collection.cached_part_array_ref(self.part)
+      part = self.model.part_for_uuid(self.uuid)
+      return self.collection.cached_part_array_ref(part)
 
 
 

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -3897,7 +3897,7 @@ class WellLogCollection(PropertyCollection):
 
       # Add to the "import list"
       self.add_cached_array_to_imported_list(
-         cached_array=data,
+         cached_array=np.array(data),
          source_info='',
          # TODO: put the curve.descr somewhere
          keyword=title,
@@ -3984,12 +3984,14 @@ class WellLogCollection(PropertyCollection):
       # todo: include datum information in description
       las.append_curve('MD', md_values, unit=md_unit)
 
-      for log in self.iter_logs():
-         name = log.title
-         unit = log.uom
-         values = log.values()
+      for well_log in self.iter_logs():
+         name = well_log.title
+         unit = well_log.uom
+         values = well_log.values()
          if values.ndim > 1:
             raise NotImplementedError('Multidimensional logs not yet supported in pandas')
+         assert len(values) > 0
+         log.debug(f"Writing log {name} of length {len(values)} and shape {values.shape}")
          las.append_curve(name, values, unit=unit, descr=None)
       return las
 

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -4216,6 +4216,13 @@ class WellLogCollection(PropertyCollection):
    def add_log(self, title, data, unit, discrete=False, case_sensitive_units=False, realization=None, write=True):
       """Add a well log to the collection, and optionally save to HDF / XML
       
+      Note:
+         If write=False, the data are not written to the model and are saved to be written later.
+         To write the data, you can subsequently call::
+
+            logs.write_hdf5_for_imported_list()
+            logs.create_xml_for_imported_list_and_add_parts_to_model()
+
       Args:
          title (str): Name of log, typically the mnemonic
          data (array-like): log data to write. Must have same length as frame MDs
@@ -4223,6 +4230,7 @@ class WellLogCollection(PropertyCollection):
          discrete (bool): by default False, i.e. continuous
          case_sensitive_units (bool): If True, consider case when parsing units.
          realization (int): If given, assign data to a realisation.
+         write (bool): If True, write XML and HDF5.
 
       Returns:
          uuids: list of uuids of newly added properties. Only returned if write=True.

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -3610,42 +3610,17 @@ def add_las_to_trajectory(las: lasio.LASFile, trajectory, realization=None,
    # Create a WellLogCollection in which to put logs
    collection = rqp.WellLogCollection(frame=well_frame, realization=realization)
 
-   # Step 1. Read in data from each curve in turn (skipping first curve which has depths)
+   # Read in data from each curve in turn (skipping first curve which has depths)
    for curve in las.curves[1:]:
-
-      # Steps to load in array data:
-      # 1. read array of data into a numpy array (already performed by las.curves[])
-      # 2. add to the "import list"
-      # 3. write imported list arrays to hdf5 file
-      # 4. create resqml xml nodes for imported list arrays and add as parts to model
-      # 5. include newly added parts in collection
-
-      # Infer valid RESQML properties
-      # TODO: Store orginal unit somewhere if it's not a valid RESQML unit
-      uom = rqp.validate_uom_from_string(curve.unit, case_sensitive=case_sensitive_units)
-      property_kind, facet_type, facet = rqp.infer_property_kind(curve.mnemonic, uom)
-
-      assert len(curve.data) == well_frame.node_count
-
-      # Step 2. add to the "import list"
-      collection.add_cached_array_to_imported_list(
-         cached_array=curve.data,
-         source_info='',
-         # TODO: put the curve.descr somewhere
-         keyword=curve.mnemonic,  # ': '.join([curve.mnemonic, curve.descr]),
-         discrete=False,
-         uom=uom,
-         property_kind=property_kind,
-         facet_type=facet_type,
-         facet=facet,
-         realization=realization,
+      
+      collection.add_log(
+         title=curve.mnemonic,
+         data=curve.data,
+         unit=curve.unit,
+         case_sensitive_units=case_sensitive_units,
+         realization=realization
       )
-
-   # Step 3. write imported list arrays to hdf5 file
-   collection.write_hdf5_for_imported_list()
-   # Step 4. create resqml xml nodes for imported list arrays and add as parts to model
-   # And step 5. include newly added parts in collection
-   collection.create_xml_for_imported_list_and_add_parts_to_model()
+      # TODO: for speed, only write on last log
 
    return collection, well_frame
 

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -1460,10 +1460,7 @@ class WellboreFrame:
       if interp_uuid is None:
          self.wellbore_interpretation = None
       else:
-         wellbore_interp_part = self.model.part_for_uuid(interp_uuid)
-         self.wellbore_interpretation = rqo.WellboreInterpretation(
-            self.model, root_node = self.model.root_for_part(wellbore_interp_part)
-         )
+         self.wellbore_interpretation = rqo.WellboreInterpretation(self.model, uuid=interp_uuid)
 
       # Set wellboreframe title
       self.title = rqet.citation_title_for_node(self.root_node)

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -1412,15 +1412,19 @@ class WellboreFrame:
 
       #: All logs associated with the wellbore frame; an instance of :class:`resqpy.property.WellLogCollection`
       self.logs = None
-
+      
       if frame_root is not None:
          self.load_from_xml(frame_root)
       elif trajectory is not None and mds is not None and len(mds) > 1:
          self.node_count = len(mds)
          self.node_mds = np.array(mds)
          assert self.node_mds is not None and self.node_mds.ndim == 1
-
+          
       if self.uuid is None: self.uuid = bu.new_uuid()
+
+      # UUID needs to have been created before LogCollection can be made
+      # TODO: Figure out when this should be created, and how it is kept in sync when new logs are created
+      self.logs = rqp.WellLogCollection(frame=self)
 
 
    def load_from_xml(self, node):

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -3619,9 +3619,12 @@ def add_las_to_trajectory(las: lasio.LASFile, trajectory, realization=None,
          data=curve.data,
          unit=curve.unit,
          case_sensitive_units=case_sensitive_units,
-         realization=realization
+         realization=realization,
+         write=False,
       )
-      # TODO: for speed, only write on last log
+      collection.write_hdf5_for_imported_list()
+      collection.create_xml_for_imported_list_and_add_parts_to_model()
+
 
    return collection, well_frame
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def example_model_with_well(example_model_and_crs):
 
    # Create a measured depth datum
    datum = MdDatum(
-      parent_model=model, crs_root=crs.crs_root, location=(0, 0, -elevation), md_reference='kelly bushing'
+      parent_model=model, crs_root=crs.root, location=(0, 0, -elevation), md_reference='kelly bushing'
    )
    datum.create_xml()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from resqpy.model import Model, new_model
 from resqpy.organize import WellboreFeature, WellboreInterpretation
-from resqpy.well import Trajectory, MdDatum
+from resqpy.well import Trajectory, MdDatum, WellboreFrame
 from resqpy.crs import Crs
 
 
@@ -78,3 +78,22 @@ def example_model_with_well(example_model_and_crs):
    return model, well_interp, datum, traj
 
 
+@pytest.fixture
+def example_model_with_logs(example_model_with_well):
+
+   model, well_interp, datum, traj = example_model_with_well
+
+   frame = WellboreFrame(
+      model,
+      trajectory=traj,
+      represented_interp=well_interp,
+      mds=[1,2,3,4],
+   )
+   frame.write_hdf5()
+   frame.create_xml(title='Log run A')
+
+   log_collection = frame.logs
+   log_collection.add_log("GR", [1,2,1,2], 'gAPI')
+   log_collection.add_log("NPHI", [0.1, 0.1, np.NaN, np.NaN], 'v/v')
+
+   return model, well_interp, datum, traj, frame, log_collection

--- a/tests/test_well.py
+++ b/tests/test_well.py
@@ -22,7 +22,7 @@ def test_MdDatum(example_model_and_crs):
       md_reference='mean low water',
    )
    datum = resqpy.well.MdDatum(
-      parent_model=model, crs_root=crs.crs_root, **data
+      parent_model=model, crs_root=crs.root, **data
    )
    uuid = datum.uuid
 
@@ -128,7 +128,7 @@ def test_Trajectory_add_well_feature_and_interp(example_model_and_crs):
    wellname = "Hullabaloo"
    model, crs = example_model_and_crs
    datum = resqpy.well.MdDatum(
-      parent_model=model, crs_root=crs.crs_root, location=(0, 0, -100), md_reference='kelly bushing'
+      parent_model=model, crs_root=crs.root, location=(0, 0, -100), md_reference='kelly bushing'
    )
    datum.create_xml()
    traj = resqpy.well.Trajectory(parent_model=model, md_datum=datum, well_name=wellname)


### PR DESCRIPTION
Adds a method `WellLogCollection.add_log`, to enable well logs to be created from scratch and saved to disk.

Supporting changes:
- Unit tests, including for previous functionality for export of logs as pandas or lasio.LasFile
- rename of `log.name` to `log.title`
- rename of `WellLogCollection.logs()` to `WellLogCollection.iter_logs()`
- Update of a few other tests, to stop using deprecated keywords (and thus reduce number of pytest warnings).