### PR TITLE
Edit analysis frequency to speed up CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,9 +5,9 @@ name: CodeQL
 on:
   push:
     branches: [ master ]
-  pull_request:
+  # pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    # branches: [ master ]
   schedule:
     # 10:16 on Fridays
     - cron: '16 10 * * 5'


### PR DESCRIPTION
For now, suggest not running CodeQL scanning on every commit on Pull Requests. The analysis is still run on master, and can be checked before releases are run.