### PR TITLE
Implement unit conversion for a wider range of units

### DIFF
--- a/resqpy/olio/data/unit_registry.txt
+++ b/resqpy/olio/data/unit_registry.txt
@@ -51,6 +51,7 @@ month = year / 12
 # Volume
 cm3 = cm**3
 ft3 = foot**3
+m3 = m**3
 poreunits = cm3 / (cm3 * 100) = pu
 percent = 0.01 = %
 bbl = (m**3) * 0.1234

--- a/resqpy/olio/data/unit_registry.txt
+++ b/resqpy/olio/data/unit_registry.txt
@@ -51,7 +51,8 @@ month = year / 12
 # Volume
 cm3 = cm**3
 ft3 = foot**3
-pu = cm3 / (cm3 * 100)  # pore units
+poreunits = cm3 / (cm3 * 100) = pu
+percent = 0.01 = %
 bbl = (m**3) * 0.1234
 
 # Force

--- a/resqpy/olio/data/unit_registry.txt
+++ b/resqpy/olio/data/unit_registry.txt
@@ -1,0 +1,96 @@
+# Pint units definition file
+
+#### PREFIXES ####
+
+nano- =  1e-9  = n-
+micro- = 1e-6  = µ- = u-
+milli- = 1e-3  = m-
+centi- = 1e-2  = c-
+deci- =  1e-1  = d-
+deca- =  1e+1  = da- = deka-
+hecto- = 1e2   = h-
+kilo- =  1e3   = k-
+mega- =  1e6   = M-
+giga- =  1e9   = G-
+tera- =  1e12  = T-
+
+
+#### BASE UNITS ####
+
+meter = [length] = m = metre
+second = [time] = s = sec
+gram = [mass] = g
+kelvin = [temperature]; offset: 0 = K = degK = °K = degree_Kelvin = degreeK  # older names supported for compatibility
+radian = [] = rad
+count = []
+
+# Derived dimensions
+[area] = [length] ** 2
+[volume] = [length] ** 3
+[velocity] = [length] / [time] = [speed]
+[acceleration] = [velocity] / [time]
+
+#### CONSTANTS ####
+
+pi     = 3.1415926535897932384626433832795028841971693993751 = π  # pi
+tau    = 2 * pi = τ                                               # Far more beautiful than pi
+tansec = 4.8481368111333441675396429478852851658848753880815e-6   # tangent of 1 arc-second ~ arc_second/radian
+ln10   = 2.3025850929940456840179914546843642076011014886288      # natural logarithm of 10
+
+#### UNITS ####
+
+# Time
+minute = 60 * second = min
+hour = 60 * minute = hr
+day = 24 * hour = d
+week = 7 * day
+fortnight = 2 * week
+year = 365.25 * day = a = yr = julian_year
+month = year / 12
+
+# Volume
+cm3 = cm**3
+ft3 = foot**3
+pu = cm3 / (cm3 * 100)  # pore units
+bbl = (m**3) * 0.1234
+
+# Force
+[force] = [mass] * [acceleration]
+newton = kilogram * meter / second ** 2 = N
+
+# Pressure
+[pressure] = [force] / [area]
+pascal = newton / meter ** 2 = Pa
+
+# Viscosity
+[viscosity] = [pressure] * [time]
+poise = 0.1 * Pa * second = P
+
+# Petrophysical
+gAPI = [radioactivity] = gapi = _ = GAPI
+
+# Permeability
+darcy = 10**-12 * m**2 = D
+
+
+#### UNIT GROUPS ####
+
+@group USCSLengthInternational
+    inch = yard / 36 = in = international_inch = inches = international_inches
+    foot = yard / 3 = ft = international_foot = feet = international_feet
+    yard = 0.9144 * meter = yd = international_yard  # since Jul 1959
+    mile = 1760 * yard = mi = international_mile
+
+    square_inch = inch ** 2 = sq_in = square_inches
+    square_foot = foot ** 2 = sq_ft = square_feet
+    square_yard = yard ** 2 = sq_yd
+    square_mile = mile ** 2 = sq_mi
+
+    cubic_inch = in ** 3 = cu_in
+    cubic_foot = ft ** 3 = cu_ft = cubic_feet
+    cubic_yard = yd ** 3 = cu_yd
+@end
+
+@group USCSLengthSurvey
+    survey_foot = 1200 / 3937 * meter = sft = ft[US]
+@end

--- a/resqpy/olio/weights_and_measures.py
+++ b/resqpy/olio/weights_and_measures.py
@@ -22,19 +22,25 @@ def convert(value, from_unit, to_unit):
    """Convert a value between any two compatible units
    
    Args:
-      value (float): value in old units
+      value (float or array): value in old units
       from_unit (str): old units
       to_unit (str): desired units
 
    Returns:
-      float: converted unit
+      float or array: converted unit
    """
+   return value * conversion_factor(from_unit, to_unit)
+
+
+@lru_cache()   # Memoized for speed
+def conversion_factor(from_unit, to_unit):
+   """Return a numerical factor to convert between compatible units"""
+
    s1, u1 = parse_unit(from_unit)
    s2, u2 = parse_unit(to_unit)
-
-   quantity_from = Q_(value * s1, u1)
-   quantity_to = quantity_from.to(u2)
-   return quantity_to.magnitude / s2
+   quantity_from = Q_(s1, u1)
+   quantity_to = quantity_from.to(u2) / s2
+   return quantity_to.magnitude
 
 
 def parse_unit(unit_string):

--- a/resqpy/olio/weights_and_measures.py
+++ b/resqpy/olio/weights_and_measures.py
@@ -12,8 +12,15 @@ from pint import UnitRegistry, set_application_registry
 version = '17th June 2021'
 
 # Shared instance of pint unit registry
+ureg = UnitRegistry(
+   filename=str(Path(__file__).parent / 'data/unit_registry.txt'),
+   preprocessors=(
+      # Preprocessors: see https://github.com/hgrecco/pint/issues/185
+      lambda s: s.replace('%', ' percent '),
+      lambda s: s.replace('p.u.', ' poreunits '),
+   ),
 
-ureg = UnitRegistry(str(Path(__file__).parent / 'data/unit_registry.txt'))
+)
 set_application_registry(ureg)
 Q_ = ureg.Quantity
 

--- a/resqpy/olio/weights_and_measures.py
+++ b/resqpy/olio/weights_and_measures.py
@@ -3,12 +3,19 @@
 from pathlib import Path
 import json
 from functools import lru_cache
+from pint import UnitRegistry, set_application_registry
 
 # Bifrost weights and measures module
 # Temporary version based on pagoda code
 # todo: Replace with RESQML uom based version at a later date
 
 version = '17th June 2021'
+
+# Shared instance of pint unit registry
+
+ureg = UnitRegistry(str(Path(__file__).parent / 'data/unit_registry.txt'))
+set_application_registry(ureg)
+Q_ = ureg.Quantity
 
 # physical constants
 feet_to_metres = 0.3048

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     h5py
     lxml
     lasio
+    pint
 
 [options.package_data]
 # Include resqpy/olio/data/*.json

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,33 @@
+"""Unit tests for pint unit registry"""
+
+import math as maths
+
+import pint
+import pytest
+
+from resqpy.olio.weights_and_measures import Q_, ureg
+
+
+@pytest.mark.parametrize("unit", [
+    "m",
+    "metres",
+    "ft",
+    "ft[US]",
+])
+def test_units_are_understood(unit):
+    Q_(1, unit)
+
+
+def test_undefined_units_raise_error():
+    with pytest.raises(pint.UndefinedUnitError):
+        Q_(1, 'foobar')
+
+
+@pytest.mark.parametrize("unit_from, unit_to, factor", [
+    ("m", "ft", 3.28084),
+    ("ft", "ft[US]", 0.999998),
+])
+def test_unit_conversion(unit_from, unit_to, factor):
+    old = Q_(1, unit_from)
+    new = old.to(unit_to)
+    assert maths.isclose(new.magnitude, factor, rel_tol=1e-5)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -16,7 +16,7 @@ from resqpy.olio.weights_and_measures import Q_, ureg
     "ft[US]",
 ])
 def test_units_are_understood(unit):
-    ureg.parse_units(unit)
+    bwam.parse_unit(unit)
 
 
 @pytest.mark.skip("Not ready yet")
@@ -26,14 +26,23 @@ def test_all_uoms_understood():
 
     for uom in all_uoms:
         try:
-            ureg.parse_units(uom)
+            bwam.parse_unit(uom)
         except Exception as e:
             raise ValueError(f"Cannot handle uom '{uom}'") from e
 
 
 def test_undefined_units_raise_error():
     with pytest.raises(pint.UndefinedUnitError):
-        Q_(1, 'foobar')
+        bwam.parse_unit('foobar')
+
+
+def test_strip_scaling_prefix():
+    assert bwam.strip_scaling_prefix("ft") == (1, "ft")
+    assert bwam.strip_scaling_prefix("100 ft") == (100, "ft")
+    assert bwam.strip_scaling_prefix("1/32 ft") == (1/32, "ft")
+    assert bwam.strip_scaling_prefix("1e9 ft") == (1e9, "ft")
+    assert bwam.strip_scaling_prefix("1.2 ft") == (1.2, "ft")
+
 
 
 @pytest.mark.parametrize("unit_from, unit_to, factor", [
@@ -45,10 +54,12 @@ def test_undefined_units_raise_error():
     ("p.u.", "%", 1),
 ])
 def test_unit_conversion(unit_from, unit_to, factor):
-    old = Q_(1, unit_from)
-    
-    new = old.to(ureg.parse_units(unit_to))
-    assert maths.isclose(new.magnitude, factor, rel_tol=1e-5)
+
+    ratio = bwam.convert(1, unit_from, unit_to)
+    assert maths.isclose(ratio, factor, rel_tol=1e-5)
 
     # NB this does not work:    new = old.to(unit_to)    
-    # Looks like we should always first use ureg.parse_units()
+    # Looks like we should always first use ureg.parse_units(), or Q_(unit)
+
+    # Also note, some units contain magnitudes (aka numerical prefixes)
+    # So, it seems best to use Q_(unit) to get a quantity, as that allows numerical prefixes

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -5,6 +5,7 @@ import math as maths
 import pint
 import pytest
 
+import resqpy.olio.weights_and_measures as bwam
 from resqpy.olio.weights_and_measures import Q_, ureg
 
 
@@ -15,7 +16,19 @@ from resqpy.olio.weights_and_measures import Q_, ureg
     "ft[US]",
 ])
 def test_units_are_understood(unit):
-    Q_(1, unit)
+    ureg.parse_units(unit)
+
+
+@pytest.mark.skip("Not ready yet")
+def test_all_uoms_understood():
+    all_uoms = bwam.properties_data()['uoms']
+    assert len(all_uoms) > 100
+
+    for uom in all_uoms:
+        try:
+            ureg.parse_units(uom)
+        except Exception as e:
+            raise ValueError(f"Cannot handle uom '{uom}'") from e
 
 
 def test_undefined_units_raise_error():
@@ -26,8 +39,16 @@ def test_undefined_units_raise_error():
 @pytest.mark.parametrize("unit_from, unit_to, factor", [
     ("m", "ft", 3.28084),
     ("ft", "ft[US]", 0.999998),
+    ("pu", "v/v", 0.01),
+    ("%", "v/v", 0.01),
+    ("pu", "%", 1),
+    ("p.u.", "%", 1),
 ])
 def test_unit_conversion(unit_from, unit_to, factor):
     old = Q_(1, unit_from)
-    new = old.to(unit_to)
+    
+    new = old.to(ureg.parse_units(unit_to))
     assert maths.isclose(new.magnitude, factor, rel_tol=1e-5)
+
+    # NB this does not work:    new = old.to(unit_to)    
+    # Looks like we should always first use ureg.parse_units()


### PR DESCRIPTION
Adds a pint unit registry, that can be used to convert between a wide range of units.

Eventually, should be able to handle a large set of units, including all valid resqml uoms.