### PR TITLE
Surface upheaval

### DIFF
--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -4436,7 +4436,7 @@ class Grid():
          geom.text = '\n'
 
          # the remainder of this function is populating the geometry node
-         self.model.create_crs_reference(self.crs_root, root = geom)
+         self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
          k_dir = rqet.SubElement(geom, ns['resqml2'] + 'KDirection')
          k_dir.set(ns['xsi'] + 'type', ns['resqml2'] + 'KDirection')

--- a/resqpy/grid_surface.py
+++ b/resqpy/grid_surface.py
@@ -1323,7 +1323,7 @@ def populate_blocked_well_from_trajectory(blocked_well, grid, active_only = Fals
       log.debug('skin single layer tactics disabled')
 
    grid_crs = rqc.Crs(grid.model, uuid = grid.crs_uuid)
-   if bu.matching_uuids(rqet.uuid_for_part_root(blocked_well.trajectory.crs_root)), grid.crs_uuid):
+   if bu.matching_uuids(rqet.uuid_for_part_root(blocked_well.trajectory.crs_root), grid.crs_uuid):
       trajectory = blocked_well.trajectory
    else:
       # create a temporary orphanage model (in memory only) to host a copy of the trajectory for crs alignment

--- a/resqpy/grid_surface.py
+++ b/resqpy/grid_surface.py
@@ -1,6 +1,6 @@
 """grid_surface.py: Functions relating to intsection of resqml grid with surface or trajectory objects."""
 
-version = '10th June 2021'
+version = '24th June 2021'
 
 import logging
 log = logging.getLogger(__name__)
@@ -9,9 +9,11 @@ log.debug('grid_surface.py version ' + version)
 import numpy as np
 import pandas as pd
 
+import resqpy.olio.xml_et as rqet
 import resqpy.olio.vector_utilities as vec
 import resqpy.olio.intersection as meet
 import resqpy.olio.box_utilities as bx
+import resqpy.olio.uuid as bu
 
 import resqpy.model as rq
 import resqpy.crs as rqc
@@ -277,7 +279,7 @@ def generate_untorn_surface_for_layer_interface(grid, k0 = 0, ref_k_faces = 'top
       messed up.
    """
 
-   surf = rqs.Surface(grid.model, extract_from_xml = False)
+   surf = rqs.Surface(grid.model)
    kp = 1 if ref_k_faces == 'base' else 0
    mesh = grid.horizon_points(ref_k0 = k0, heal_faults = True, kp = kp)
    if border is None or border <= 0.0:
@@ -328,7 +330,7 @@ def generate_torn_surface_for_layer_interface(grid, k0 = 0, ref_k_faces = 'top',
       single patch regardless.
    """
 
-   surf = rqs.Surface(grid.model, extract_from_xml = False)
+   surf = rqs.Surface(grid.model)
    kp = 1 if ref_k_faces == 'base' else 0
    mesh = grid.split_horizon_points(ref_k0 = k0, kp = kp)
    surf.set_from_torn_mesh(mesh, quad_triangles = quad_triangles)
@@ -379,7 +381,7 @@ def generate_torn_surface_for_x_section(grid, axis, ref_slice0 = 0, plus_face = 
    else:
       x_sect_mesh = grid.split_gap_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
 
-   surf = rqs.Surface(grid.model, extract_from_xml = False)
+   surf = rqs.Surface(grid.model)
    surf.set_from_torn_mesh(x_sect_mesh, quad_triangles = quad_triangles)
 
    return surf
@@ -426,7 +428,7 @@ def generate_untorn_surface_for_x_section(grid, axis, ref_slice0 = 0, plus_face 
 
    log.debug(f'x_sect_mesh.shape: {x_sect_mesh.shape}; grid.extent_kji: {grid.extent_kji}')
 
-   surf = rqs.Surface(grid.model, extract_from_xml = False)
+   surf = rqs.Surface(grid.model)
    surf.set_from_irregular_mesh(x_sect_mesh, quad_triangles = quad_triangles)
 
    return surf
@@ -676,7 +678,7 @@ def find_first_intersection_of_trajectory_with_cell_surface(trajectory, grid, kj
    """Searches along the trajectory from a starting point until the first intersection with the cell's surface is encountered."""
 
    cp = grid.corner_points(kji0)
-   cell_surface = rqs.Surface(grid.model, extract_from_xml = False)
+   cell_surface = rqs.Surface(grid.model)
    cell_surface.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
    t, p = cell_surface.triangles_and_points()
    triangles = p[t]
@@ -720,7 +722,7 @@ def point_is_within_cell(xyz, grid, kji0, cell_surface = None, false_on_pinchout
    if false_on_pinchout and grid.pinched_out(kji0, cache_pinchout_array = False): return False
    if cell_surface is None:
       cp = grid.corner_points(kji0)
-      cell_surface = rqs.Surface(grid.model, extract_from_xml = False)
+      cell_surface = rqs.Surface(grid.model)
       cell_surface.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = True)
    t, p = cell_surface.triangles_and_points()
    triangles = p[t]
@@ -763,7 +765,7 @@ def create_column_face_mesh_and_surface(grid, col_ji0, axis, polarity, quad_tria
 
    if not as_single_layer and grid.k_gaps:
       col_face_mesh = None
-      col_face_surface = rqs.Surface(grid.model, extract_from_xml = False)
+      col_face_surface = rqs.Surface(grid.model)
       mesh = np.empty((1, grid.nk, 2, 2, 3))
       mesh[0, :, 0, 0, :] = points[grid.k_raw_index_array, pillar_index_pair[0], :]
       mesh[0, :, 1, 0, :] = points[grid.k_raw_index_array, pillar_index_pair[1], :]
@@ -784,7 +786,7 @@ def create_column_face_mesh_and_surface(grid, col_ji0, axis, polarity, quad_tria
          col_face_xyz[1] = points[:, pillar_index_pair[1]]
       col_face_mesh = rqs.Mesh(grid.model, xyz_values = col_face_xyz, crs_uuid = grid.crs_uuid)
       title = 'column face for j0,i0: ' + str(col_ji0[0]) + ',' + str(col_ji0[1]) + ' face ' + 'KJI'[axis] + '-+'[polarity]
-      col_face_surface = rqs.Surface(grid.model, extract_from_xml = False, mesh = col_face_mesh,
+      col_face_surface = rqs.Surface(grid.model, mesh = col_face_mesh,
                                      quad_triangles = quad_triangles, title = title)
 
    return col_face_mesh, col_face_surface
@@ -1136,14 +1138,14 @@ def generate_surface_for_blocked_well_cells(blocked_well, combined = True, activ
          composite_cp[cell_p] = cp
          cell_p += 1
       else:
-         cs = rqs.Surface(blocked_well.model, extract_from_xml = False)
+         cs = rqs.Surface(blocked_well.model)
          cs.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
          surface_list.append(cs)
 
    if cell_p == 0 and len(surface_list) == 0: return None
 
    if combined:
-      cs = rqs.Surface(blocked_well.model, extract_from_xml = False)
+      cs = rqs.Surface(blocked_well.model)
       cs.set_to_multi_cell_faces_from_corner_points(composite_cp[:cell_p])
       return cs
 
@@ -1163,8 +1165,8 @@ def trajectory_grid_overlap(trajectory, grid, lazy = False):
    traj_box[0] = np.amin(trajectory.control_points, axis = 0)
    traj_box[1] = np.amax(trajectory.control_points, axis = 0)
    grid_box = grid.xyz_box(lazy = lazy, local = True)
-   if trajectory.crs_root is not grid.crs_root:
-      t_crs = rqc.Crs(trajectory.model, crs_root = trajectory.crs_root)
+   if not bu.matching_uuids(rqet.uuid_for_part_root(trajectory.crs_root), grid.crs_uuid):
+      t_crs = rqc.Crs(trajectory.model, uuid = rqet.uuid_for_part_root(trajectory.crs_root))
       g_crs = rqc.Crs(grid.model, uuid = grid.crs_uuid)
       t_crs.convert_array_to(g_crs, traj_box)
    return bx.boxes_overlap(traj_box, grid_box)
@@ -1321,7 +1323,7 @@ def populate_blocked_well_from_trajectory(blocked_well, grid, active_only = Fals
       log.debug('skin single layer tactics disabled')
 
    grid_crs = rqc.Crs(grid.model, uuid = grid.crs_uuid)
-   if blocked_well.trajectory.crs_root is grid.crs_root:
+   if bu.matching_uuids(rqet.uuid_for_part_root(blocked_well.trajectory.crs_root)), grid.crs_uuid):
       trajectory = blocked_well.trajectory
    else:
       # create a temporary orphanage model (in memory only) to host a copy of the trajectory for crs alignment
@@ -1329,7 +1331,7 @@ def populate_blocked_well_from_trajectory(blocked_well, grid, active_only = Fals
       model = rq.Model(create_basics = True)
       trajectory = rqw.Trajectory(model, blocked_well.trajectory.root_node, hdf5_source_model = blocked_well.trajectory.model)
       assert trajectory is not None
-      traj_crs = rqc.Crs(blocked_well.model, crs_root = blocked_well.trajectory.crs_root)
+      traj_crs = rqc.Crs(blocked_well.model, uuid = rqet.uuid_for_part_root(blocked_well.trajectory.crs_root))
       traj_crs.convert_array_to(grid_crs, trajectory.control_points)   # trajectory xyz converted in situ to grid's crs
       trajectory.crs_root = model.duplicate_node(grid.crs_root)
       # note: any represented interpretation object will not be present in the temporary model

--- a/resqpy/lines.py
+++ b/resqpy/lines.py
@@ -514,7 +514,7 @@ class Polyline(_BasePolyline):
         geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
         geom.text = '\n'
 
-        self.model.create_crs_reference(self.crs_root, root = geom)
+        self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
         points = rqet.SubElement(geom, ns['resqml2'] + 'Points')
         points.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
@@ -616,9 +616,8 @@ class PolylineSet(_BasePolyline):
 
                 self.crs_root = self.model.referenced_node(rqet.find_tag(geometry_node, 'LocalCrs'))
                 assert self.crs_root is not None # Required field
-                uuid_str = self.crs_root.attrib['uuid']
-                crs_uuid = bu.uuid_from_string(uuid_str)
-                assert crs_uuid is not None # Required field
+                self.crs_uuid = rqet.uuid_for_part_root(self.crs_root)
+                assert self.crs_uuid is not None # Required field
 
                 closed_node = rqet.find_tag(patch_node, 'ClosedPolylines')
                 assert closed_node is not None # Required field
@@ -637,7 +636,8 @@ class PolylineSet(_BasePolyline):
                 assert len(self.count_perpol) == len(closed_array)
                 assert np.sum(self.count_perpol) == len(self.coordinates)
 
-                subpolys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates, crs_uuid, self.crs_root, self.rep_int_root)
+                subpolys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates,
+                                                     self.crs_uuid, self.crs_root, self.rep_int_root)
                 # Check we have the right number of polygons
                 assert len(subpolys) == len(self.count_perpol)
 
@@ -652,7 +652,7 @@ class PolylineSet(_BasePolyline):
             for poly in polylines:
                 crs_list.append(poly.crs_uuid)
             crs_set = set(crs_list)
-            assert len(crs_set) == 1, 'More than one CRS found in input polylines - only handling the first'
+            assert len(crs_set) == 1, 'More than one CRS found in input polylines for polyline set'
             for crs_uuid in crs_set:
                 self.crs_uuid = crs_uuid
                 self.crs_root = self.model.root_for_uuid(self.crs_uuid)
@@ -683,7 +683,7 @@ class PolylineSet(_BasePolyline):
             self.count_perpol = np.array(self.count_perpol)
             if self.crs_root is None: # If no crs_uuid is provided, assume the main model crs is valid
                 self.crs_root = self.model.crs_root
-                self.crs_uuid = self.crs_root.attrib['uuid']
+                self.crs_uuid = rqet.uuid_for_part_root(self.crs_root)
             self.polys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates,
                                                    self.crs_uuid, self.crs_root, self.rep_int_root)
 
@@ -836,7 +836,7 @@ class PolylineSet(_BasePolyline):
         geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
         geom.text = '\n'
 
-        self.model.create_crs_reference(self.crs_root, root = geom)
+        self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
         points = rqet.SubElement(geom, ns['resqml2'] + 'Points')
         points.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -2305,21 +2305,28 @@ class Model():
       return crs_node
 
 
-   def create_crs_reference(self, crs_root, root = None):
+   def create_crs_reference(self, crs_root = None, root = None, crs_uuid = None):
       """Creates a node refering to an existing crs node and optionally adds as child of root.
 
       arguments:
-         crs_root: the root xml node for the coordinate reference system being referenced
+         crs_root: DEPRECATED, use uuid instead; the root xml node for the coordinate reference system being referenced
          root: the xml node to which the new reference node is to appended as a child (ie. the xml node
             for the object that is referring to the crs)
+         crs_uuid: the uuid of the crs
 
       returns:
          newly created crs reference xml node
       """
 
+      if crs_uuid is None:
+         warnings.warn('use of crs_root is deprecated in Model.create_crs_reference(); use crs_uuid instead')
+         crs_uuid = rqet.uuid_for_part_root(crs_root)
+      else:
+         crs_root = self.root_for_uuid(crs_uuid)
+      assert crs_root is not None
+
       return self.create_ref_node('LocalCrs', rqet.find_nested_tags_text(crs_root, ['Citation', 'Title']),
-                                  bu.uuid_from_string(crs_root.attrib['uuid']),
-                                  content_type = 'obj_LocalDepth3dCrs', root = root)
+                                  crs_uuid, content_type = 'obj_LocalDepth3dCrs', root = root)
 
 
    def create_md_datum_reference(self, md_datum_root, root = None):

--- a/resqpy/rq_import.py
+++ b/resqpy/rq_import.py
@@ -953,12 +953,12 @@ def add_surfaces(epc_file,                       # existing resqml model
       log.info('surface ' + short_name + ' processing file: ' + surf_file + ' using format: ' + surface_file_format)
       if rq_class == 'surface':
          if surface_file_format == 'GOCAD-Tsurf':
-            surface = rqs.Surface(model, extract_from_xml = False,
+            surface = rqs.Surface(model,
                                   tsurf_file = surf_file,
                                   surface_role = surface_role,
                                   quad_triangles = quad_triangles)
          else:
-            surface = rqs.Surface(model, extract_from_xml = False,
+            surface = rqs.Surface(model,
                                   mesh_file = surf_file, mesh_format = surface_file_format,
                                   surface_role = surface_role,
                                   quad_triangles = quad_triangles)
@@ -986,7 +986,7 @@ def add_surfaces(epc_file,                       # existing resqml model
          surface.set_represented_interpretation_root(interp_root)
 
       surface.create_xml(ext_uuid, add_as_part = True, add_relationships = True,
-                         crs_root = crs_root, root = None,
+                         crs_uuid = rqet.uuid_for_part_root(crs_root),
                          title = short_name + ' sourced from ' + surf_file,
                          originator = None)
 

--- a/resqpy/surface.py
+++ b/resqpy/surface.py
@@ -947,6 +947,7 @@ class Surface(_BaseSurface):
       # todo: if crs_root is None, attempt to derive from surface patch crs uuid (within patch loop, below)
       if crs_uuid is None:
          crs_root = self.model.crs_root     # maverick use of model's default crs
+         crs_uuid = rqet.uuid_for_part_root(crs_root)
       else:
          crs_root = self.model.root_for_uuid(crs_uuid)
 
@@ -1007,7 +1008,7 @@ class Surface(_BaseSurface):
          geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
          geom.text = '\n'
 
-         self.model.create_crs_reference(crs_root, root = geom)
+         self.model.create_crs_reference(crs_uuid = crs_uuid, root = geom)
 
          points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
          points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
@@ -1368,9 +1369,11 @@ class PointSet(_BaseSurface):
       if crs_root is None:
          if self.crs_uuid is None:
             crs_root = self.model.crs_root     # maverick use of model's default crs
-            self.crs_uuid = bu.uuid_from_string(crs_root.attrib['uuid'])
+            self.crs_uuid = rqet.uuid_for_part_root(crs_root)
          else:
             crs_root = self.model.root_for_part(self.model.part_for_uuid(self.crs_uuid))
+      else:
+         self.crs_uuid = rqet.uuid_for_part_root(crs_root)
 
       if self.represented_interpretation_root is not None:
          interp_root = self.represented_interpretation_root
@@ -1399,7 +1402,7 @@ class PointSet(_BaseSurface):
          geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
          geom.text = '\n'
 
-         self.model.create_crs_reference(crs_root, root = geom)
+         self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
          points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
          points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')

--- a/resqpy/surface.py
+++ b/resqpy/surface.py
@@ -1254,7 +1254,7 @@ class PointSet(_BaseSurface):
          assert hdf5_path, 'missing internal hdf5 path in goemetry xml for point set patch'
          self.patch_ref_list.append((ext_uuid, hdf5_path, point_count))
          patch_index += 1
-      ref_node = rqet.find_tag(self.root_node, 'RepresentedInterpretation')
+      ref_node = rqet.find_tag(self.root, 'RepresentedInterpretation')
       if ref_node is not None:
          interp_root = self.model.referenced_node(ref_node)
          self.set_represented_interpretation_root(interp_root)
@@ -1646,10 +1646,6 @@ class Mesh(_BaseSurface):
    def load_from_xml(self):
       root_node = self.root
       assert root_node is not None
-      assert rqet.node_type(root_node) == 'obj_Grid2dRepresentation'
-      self.root_node = root_node
-      self.uuid = self.root_node.attrib['uuid']
-      self.title = rqet.citation_title_for_node(root_node)
       self.surface_role = rqet.find_tag_text(root_node, 'SurfaceRole')
       ref_node = rqet.find_tag(root_node, 'RepresentedInterpretation')
       if ref_node is not None:

--- a/resqpy/surface.py
+++ b/resqpy/surface.py
@@ -1544,10 +1544,11 @@ class Mesh(_BaseSurface):
       self.ref_z_h5_key_pair = None
       # note: in this class, z values for ref&z meshes are held in the full_array (xy data will be duplicated in memory)
       self.crs_uuid = crs_uuid
-      self.crs_root = None if crs_uuid is None else self.model.root_for_uuid(self.crs_uuid)
       self.represented_interpretation_root = None
 
       super().__init__(model = parent_model, uuid = uuid, title = title, originator = originator, root_node = root_node)
+
+      self.crs_root = None if self.crs_uuid is None else self.model.root_for_uuid(self.crs_uuid)
 
       if self.root is not None:
          pass
@@ -1662,7 +1663,6 @@ class Mesh(_BaseSurface):
       assert geom_node is not None, 'geometry missing in mesh xml'
       self.crs_uuid = rqet.find_nested_tags_text(geom_node, ['LocalCrs', 'UUID'])
       assert self.crs_uuid is not None, 'crs reference missing in mesh geometry xml'
-      self.crs_root = self.model.root_for_uuid(self.crs_uuid)
       point_node = rqet.find_tag(geom_node, 'Points')
       assert point_node is not None, 'missing Points node in mesh geometry xml'
       flavour = rqet.node_type(point_node)

--- a/resqpy/surface.py
+++ b/resqpy/surface.py
@@ -1910,7 +1910,7 @@ class Mesh(_BaseSurface):
       geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
       geom.text = '\n'
 
-      self.model.create_crs_reference(crs_root, root = geom)
+      self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
       p_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
       p_node.text = '\n'
@@ -2065,7 +2065,7 @@ class Mesh(_BaseSurface):
       if add_as_part:
          self.model.add_part('obj_Grid2dRepresentation', self.uuid, g2d_node)
          if add_relationships:
-            self.model.create_reciprocal_relationship(g2d_node, 'destinationObject', crs_root, 'sourceObject')
+            self.model.create_reciprocal_relationship(g2d_node, 'destinationObject', self.crs_root, 'sourceObject')
             if self.represented_interpretation_root is not None:
                self.model.create_reciprocal_relationship(g2d_node, 'destinationObject',
                                                          self.represented_interpretation_root, 'sourceObject')

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -193,6 +193,7 @@ class MdDatum():
 
       crs_root = self.crs_root
       assert crs_root is not None
+      crs_uuid = rqet.uuid_for_part_root(crs_root)
 
       datum = self.model.new_obj_node('MdDatum')
 
@@ -209,7 +210,7 @@ class MdDatum():
       md_ref.set(ns['xsi'] + 'type', ns['resqml2'] + 'MdReference')
       md_ref.text = md_reference
 
-      self.model.create_crs_reference(crs_root, root = datum)
+      self.model.create_crs_reference(crs_uuid = crs_uuid, root = datum)
 
       if root is not None: root.append(datum)
       if add_as_part:
@@ -1244,9 +1245,9 @@ class Trajectory():
          # note: resqml standard allows trajectory to be in different crs to md datum
          #       however, this module often uses the md datum crs, if the trajectory has been imported
          if self.crs_root is None:
-            self.model.create_crs_reference(self.md_datum.crs_root, root = geom)
+            self.model.create_crs_reference(crs_uuid = self.md_datum.crs_uuid, root = geom)
          else:
-            self.model.create_crs_reference(self.crs_root, root = geom)
+            self.model.create_crs_reference(crs_uuid = rqet.uuid_for_part_root(self.crs_root), root = geom)
 
          kc_node = rqet.SubElement(geom, ns['resqml2'] + 'KnotCount')
          kc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -8,7 +8,7 @@ def test_surface(tmp_model):
     title = 'Mountbatten'
     model = tmp_model
     surf = resqpy.surface.Surface(
-        parent_model=model, extract_from_xml=False, title=title
+        parent_model=model, title=title
     )
     surf.create_xml()
 


### PR DESCRIPTION
Bringing resqpy surface classes in line with BaseResqpy and uuid way of working.  This will be a breaking change, removing the extraneous extract_from_xml arguments and also unused parent node argument to create_xml() methods.