### PR TITLE
Enable max-complexity CI checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ filterwarnings =
 [flake8]
 # count = True
 # statistics = True
+max-complexity = 50  # Should aim for max complexity of 10
 show_source = True
 exclude =  .git, __pycache__, .ipynb_checkpoints
 # error code reference: https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3
@@ -71,6 +72,8 @@ select =
     E9
     # Deprecation
     W60
+    # Complexity
+    C
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority
     F401,

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,24 +55,21 @@ filterwarnings =
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*pywintypes.*
 
 [flake8]
-# count = True
-# statistics = True
-max-complexity = 50  # Should aim for max complexity of 10
+# Standard max-complexity limit is 10
+max-complexity = 50  
 show_source = True
 exclude =  .git, __pycache__, .ipynb_checkpoints
 # error code reference: https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3
 select =
     # Logical errors
     F,
-    # Indentation
-    E101, E112, E113, W19
-    # Statements
-    E71, E72, E73, E74
-    # Runtime
-    E9
-    # Deprecation
-    W60
-    # Complexity
+    # Unexpected Indentation
+    E101, E112, E113, W19,
+    # Statement errors
+    E71, E72, E73, E74,
+    # Runtime & Deprecation errors
+    E9, W60,
+    # Cyclomatic Complexity
     C
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority


### PR DESCRIPTION
Supports #131 , but does not fully close.

Implements a very generous cyclometric complexity limit, 5 times greater than the recommended limit.

This change makes our static analysis bot comment on any functions that are too complex, according to the cyclomatic complexity threshold set in `setup.cfg`. See the "files changed" tab:

![image](https://user-images.githubusercontent.com/71127464/124747719-20f4f400-df1a-11eb-8063-a2012d7b8ded.png)
