### PR TITLE
Add Pillow as dependency

### DIFF
--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -18,7 +18,9 @@
     rq_import
     surface
     time_series
+    tomography
     well
+    weights_and_measures
     olio
 
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     h5py
     lxml
     lasio
+    Pillow
 
 [options.package_data]
 # Include resqpy/olio/data/*.json

--- a/tests/test_tomography.py
+++ b/tests/test_tomography.py
@@ -1,0 +1,6 @@
+
+# TODO: write some proper tests for this module
+# For now as a minimum, check module imports ok
+
+def test_tomography_import():
+    import resqpy.tomography


### PR DESCRIPTION
I noticed `resqpy.tomography` imports `PIL`, which is not available in the project's dependencies. This will lead to an import error if the module is used in a fresh environment.

This PR tries to fix that by adding the library to the main list of dependencies. An alternative could be to add it as an optional extra, under "extras_requires".

It looks like the Python Imaging Library `PIL` is no longer maintained, and `Pillow` is the actively used fork, so suggesting putting that into our dependencies.

I've added `resqpy.tomography` to the TOC too, as presumably we want this to appear in the docs.

I believe it's not used in any unit tests, and is missing from the documentation table of contents, which is why the CI suite did not pick this up.