### PR TITLE
Re-add weights_and_measures to API docs

### DIFF
--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -18,6 +18,7 @@
     rq_import
     surface
     time_series
+    weights_and_measures
     well
     olio
 


### PR DESCRIPTION
Something I missed when moving this module from the `resqpy.olio` subdirectory!