### PR TITLE
Handle PEP 517 pathlike inputs

### DIFF
--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -10,9 +10,11 @@ log.debug('model.py version ' + version)
 import os
 import copy
 import getpass
+import pathlib
 import shutil
 import warnings
 import zipfile as zf
+from typing import Union, Optional, Iterable, TypeVar
 
 import numpy as np
 import h5py
@@ -29,6 +31,7 @@ import resqpy.grid as grr
 import resqpy.fault as rqf
 
 use_version_string = False
+PathLike = TypeVar("PathLike", str, bytes, pathlib.Path)  # PEP 519
 
 
 def _pl(i, e = False):
@@ -55,13 +58,13 @@ class Model():
    """
 
    def __init__(self,
-                epc_file = None,
-                full_load = True,
-                epc_subdir = None,
-                new_epc = False,
-                create_basics = None,
-                create_hdf5_ext = None,
-                copy_from = None):
+                epc_file: Optional[PathLike] = None,
+                full_load: bool = True,
+                epc_subdir: Optional[Union[str, Iterable]] = None,
+                new_epc: bool = False,
+                create_basics: Optional[bool] = None,
+                create_hdf5_ext: Optional[bool] = None,
+                copy_from: Optional[PathLike] = None):
       """Create an empty model; load it from epc_file if given.
 
       Note:
@@ -71,7 +74,7 @@ class Model():
          immediately
 
       Arguments:
-         epc_file (string, optional): if present, and new_epc is False and copy_from is None, the name
+         epc_file (path-like, optional): if present, and new_epc is False and copy_from is None, the name
             of an existing epc file which is opened, unzipped and parsed to determine the list of parts
             and relationships comprising the model; if present, and new_epc is True or copy_from is
             specified, the name of a new file to be created - any existing file (and .h5 paired hdf5
@@ -93,7 +96,7 @@ class Model():
             and epc_file is not None, then an hdf5 external part is created, equivalent to calling the
             create_hdf5_ext() method; an empty hdf5 file is also created; if None, defaults to same
             value as new_epc
-         copy_from: (string, optional): if present, and epc_file is also present, then the epc file
+         copy_from: (path-like, optional): if present, and epc_file is also present, then the epc file
             named in copy_from, together with its paired h5 file, are copied to epc_file (overwriting
             any previous instances) before epc_file is opened; this argument is primarily to facilitate
             repeated testing of code that modifies the resqml dataset, eg. by appending new parts
@@ -103,6 +106,10 @@ class Model():
 
       :meta common:
       """
+      if epc_file:
+         epc_file = str(epc_file)
+      if copy_from:
+         copy_from = str(copy_from)
 
       if epc_file and not epc_file.endswith('.epc'):
          epc_file += '.epc'
@@ -3400,7 +3407,7 @@ class Model():
          pass
 
 
-def new_model(epc_file):
+def new_model(epc_file: PathLike):
    """Returns a new, empty Model object with basics and hdf5 ext part set up."""
 
    return Model(epc_file = epc_file, new_epc = True, create_basics = True, create_hdf5_ext = True)


### PR DESCRIPTION
A very minor enhancement - allowing resqpy models to be created from pathlike objects, rather than just strings.

Closes #165 