### PR TITLE
Modify pytest to fail if internal Deprecation warnings are raised

### DIFF
--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -5234,7 +5234,7 @@ class RegularGrid(Grid):
          self.make_regular_points_cached()
 
       if crs_uuid is None:
-         new_crs = rqc.Crs()
+         new_crs = rqc.Crs(parent_model)
          self.crs_uuid = new_crs.uuid
          self.crs_root = new_crs.create_xml(reuse = True)
       else:

--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -33,6 +33,7 @@ import resqpy.olio.write_hdf5 as rwh5
 import resqpy.olio.trademark as tm
 from resqpy.olio.xml_namespaces import curly_namespace as ns
 
+import resqpy.crs as rqc
 import resqpy.property as rprop
 import resqpy.fault as rqf
 
@@ -5233,11 +5234,12 @@ class RegularGrid(Grid):
          self.make_regular_points_cached()
 
       if crs_uuid is None:
-         self.crs_root = parent_model.create_crs(add_as_part = True)
-         self.crs_uuid = bu.uuid_from_string(self.crs_root.attrib['uuid'])
+         new_crs = rqc.Crs()
+         self.crs_uuid = new_crs.uuid
+         self.crs_root = new_crs.create_xml(reuse = True)
       else:
-         self.crs_root = parent_model.root_for_uuid(crs_uuid)
          self.crs_uuid = crs_uuid
+         self.crs_root = parent_model.root_for_uuid(crs_uuid)
 
       if self.uuid is None:
          self.uuid = bu.new_uuid()

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -2493,7 +2493,6 @@ class Model():
 
    def create_crs(self,
                   add_as_part = True,
-                  root = None,
                   title = 'cell grid local CRS',
                   epsg_code = None,
                   originator = None,
@@ -2509,8 +2508,6 @@ class Model():
       arguments:
          add_as_part (boolean, default True): if True the newly created crs node is added to the model
             as a part
-         root (optional, usually None): if not None, the newly created crs node is appended as a child
-            of this node
          title (string): used as the Title text in the citation node
          epsg_code (integer): EPSG code of the parent coordinate reference system that this crs sits within;
             used for both projected and vertical frames of reference; if None then unknown settings are used
@@ -2540,7 +2537,7 @@ class Model():
                     z_inc_down = z_inc_down,
                     epsg_code = epsg_code)
 
-      crs_node = crs.create_xml(add_as_part = add_as_part, root = root, title = title, originator = originator)
+      crs_node = crs.create_xml(add_as_part = add_as_part, title = title, originator = originator)
 
       if self.crs_uuid is None:
          self.crs_uuid = crs.uuid

--- a/resqpy/rq_import.py
+++ b/resqpy/rq_import.py
@@ -1,6 +1,6 @@
 """rq_import.py: Module to import a nexus corp grid & properties, or vdb, or vdb ensemble into resqml format."""
 
-version = '18th June 2021'
+version = '5th August 2021'
 
 # Nexus is a registered trademark of the Halliburton Company
 
@@ -248,25 +248,15 @@ def import_nexus(
    # create coodinate reference system (crs) in model and set references in grid object
    log.debug('creating coordinate reference system')
    crs_uuids = model.uuids(obj_type = 'LocalDepth3dCrs')
-   if mode == 'w' or len(crs_uuids) == 0:
-      crs_node = model.create_crs(add_as_part = True,
-                                  x_offset = local_origin[0],
-                                  y_offset = local_origin[1],
-                                  z_offset = local_origin[2],
-                                  xy_units = resqml_xy_units,
-                                  z_units = resqml_z_units,
-                                  z_inc_down = resqml_z_inc_down)
-      crs_uuid = bu.uuid_from_string(crs_node.attrib['uuid'])
-   else:
-      new_crs = rqc.Crs(model,
-                        x_offset = local_origin[0],
-                        y_offset = local_origin[1],
-                        z_offset = local_origin[2],
-                        xy_units = resqml_xy_units,
-                        z_units = resqml_z_units,
-                        z_inc_down = resqml_z_inc_down)
-      new_crs.create_xml(reuse = True)
-      crs_uuid = new_crs.uuid
+   new_crs = rqc.Crs(model,
+                     x_offset = local_origin[0],
+                     y_offset = local_origin[1],
+                     z_offset = local_origin[2],
+                     xy_units = resqml_xy_units,
+                     z_units = resqml_z_units,
+                     z_inc_down = resqml_z_inc_down)
+   new_crs.create_xml(reuse = True)
+   crs_uuid = new_crs.uuid
 
    grid = grid_from_cp(model,
                        cp_array,

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ addopts = -ra
 junit_family = xunit2
 testpaths = tests/
 filterwarnings =
+    # Error on internal deprecation warnings
+    error::DeprecationWarning:.*resqpy.*
     # Ignore warnings that are entirely from 3rd party libs outside our control
     ignore:.*importing the ABCs from 'collections'.*:DeprecationWarning:.*pyreadline.*
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*pywintypes.*


### PR DESCRIPTION
This change makes pytest fail if a respy-internal DeprecationWarning is raised within the test suite. This should help us ensure that we are not calling any soon-to-be-deprecated functions from within the other functions.