### PR TITLE
WIP: changes to accept any hdf5 internal paths

### DIFF
--- a/resqpy/olio/uuid.py
+++ b/resqpy/olio/uuid.py
@@ -3,7 +3,7 @@
 # NB: at present the code does not enforce multiprocessor safe generation of unique identifiers
 # it calls uuid.uuid1() to generate new uuids, ie. using version 1 of the iso standard options
 
-version = '15th June 2021'
+version = '25th August 2021'
 
 # import logging
 # log = logging.getLogger(__name__)
@@ -19,17 +19,17 @@ max_version_string_length = 10
 def switch_on_test_mode(seed = 0):
    """Causes subsequent calls to new_uid() to produce integer sequence starting from successor to seed.
 
-      argument:
-         seed (integer, default 0): The predecessor to the first uuid returned by subsequent calls to
-            new_uuid()
+   arguments:
+      seed (integer, default 0): The predecessor to the first uuid returned by subsequent calls to
+         new_uuid()
 
-      returns:
-         None
+   returns:
+      None
 
-      notes:
-         call switch_off_test_mode() to reactivate normal behaviour;
-         uuids generated whilst in test mode do not adhere to the iso standard;
-         test mode is intended to allow replicatable behaviour for testing purposes
+   notes:
+      call switch_off_test_mode() to reactivate normal behaviour;
+      uuids generated whilst in test mode do not adhere to the iso standard;
+      test mode is intended to allow replicatable behaviour for testing purposes
    """
 
    global test_mode
@@ -41,8 +41,8 @@ def switch_on_test_mode(seed = 0):
 def switch_off_test_mode():
    """Subsequent calls to new_uid() will produce standard uuid values (default behaviour).
 
-      note:
-         this function will have no effect unless switch_on_test_mode() has previously been called
+   note:
+      this function will have no effect unless switch_on_test_mode() has previously been called
    """
 
    global test_mode
@@ -52,13 +52,13 @@ def switch_off_test_mode():
 def new_uuid():
    """Returns a new uuid based on the time (to 100ns) & MAC address option of the iso standard.
 
-      returns:
-         uuid.UUID object
+   returns:
+      uuid.UUID object
 
-      notes:
-         at present, the multi-processor safe functionality is not deployed, so multiple processors
-         sharing the same MAC address could generate the same uuid simultaneously;
-         an integer sequence is generated when in test mode
+   notes:
+      at present, the multi-processor safe functionality is not deployed, so multiple processors
+      sharing the same MAC address could generate the same uuid simultaneously;
+      an integer sequence is generated when in test mode
    """
 
    global test_latest_int
@@ -72,11 +72,11 @@ def new_uuid():
 def string_from_uuid(uuid_obj):
    """Returns standard hexadecimal string for uuid; same as str(uuid_obj).
 
-      argument:
-         uuid_obj (uuid.UUID object): the uuid which is required in hexadecimal string format
+   arguments:
+      uuid_obj (uuid.UUID object): the uuid which is required in hexadecimal string format
 
-      returns:
-         string (40 characters: 36 lowercase hexadecimals and 4 hyphens)
+   returns:
+      string (40 characters: 36 lowercase hexadecimals and 4 hyphens)
    """
 
    return str(uuid_obj)
@@ -85,38 +85,45 @@ def string_from_uuid(uuid_obj):
 def uuid_from_string(uuid_str):
    """Returns a uuid object for the given uuid string; hyphens are ignored.
 
-      argument:
-         uuid_str (string): the hexadecimal representation of the 128 bit uuid integer;
-            hyphens are ignored
+   arguments:
+      uuid_str (string): the hexadecimal representation of the 128 bit uuid integer;
+         hyphens are ignored
 
-      returns:
-         uuid.UUID object
+   returns:
+      uuid.UUID object
 
-      notes:
-         if a uuid.UUID object is passed by accident, it is returned;
-         if the string starts with an underscore, it is skipped (to cater for a fesapi quirk)
+   notes:
+      if a uuid.UUID object is passed by accident, it is returned;
+      if the string starts with an underscore, the underscore is skipped (to cater for a fesapi quirk);
+      any tail beyond the uuid string is ignored
    """
 
    if uuid_str is None:
       return None
    if isinstance(uuid_str, uuid.UUID):
       return uuid_str  # resilience to accidentally passing a uuid object
-   if len(uuid_str) < 36:
+   try:
+      if uuid_str[0] == '_':  # tolerate one of the fesapi quirks
+         if len(uuid_str) < 37:
+            return None
+         return uuid.UUID(uuid_str[1:37])
+      else:
+         if len(uuid_str) < 36:
+            return None
+         return uuid.UUID(uuid_str[:36])
+   except Exception:
+      # could log or raise an error or warning?
       return None
-   if uuid_str[0] == '_':  # tolerate one of the fesapi quirks
-      return uuid.UUID(uuid_str[1:])
-   else:
-      return uuid.UUID(uuid_str)
 
 
 def uuid_as_bytes(uuid_obj):
    """Returns the uuid as a 16 byte bytes sequence; same as uuid_obj.bytes.
 
-      argument:
-         uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
+   arguments:
+      uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
 
-      returns:
-         bytes (16 bytes long)
+   returns:
+      bytes (16 bytes long)
    """
 
    if uuid_obj is None:
@@ -129,11 +136,11 @@ def uuid_as_bytes(uuid_obj):
 def uuid_as_int(uuid_obj):
    """Returns the uuid as a 128 bit int; same as uuid_obj.int.
 
-      argument:
-         uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
+   arguments:
+      uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
 
-      returns:
-         bytes (16 bytes long)
+   returns:
+      bytes (16 bytes long)
    """
 
    if uuid_obj is None:
@@ -146,14 +153,14 @@ def uuid_as_int(uuid_obj):
 def matching_uuids(uuid_a, uuid_b):
    """Returns True if the 2 uuid objects are for the same id; False otherwise.
 
-      arguments:
-         uuid_a, uuid_b (uuid.UUID objects): the two uuids to be compared
+   arguments:
+      uuid_a, uuid_b (uuid.UUID objects): the two uuids to be compared
 
-      returns:
-         boolean: True if the two uuids are the same; False otherwise
+   returns:
+      boolean: True if the two uuids are the same; False otherwise
 
-      note:
-         this function is resilient to uuids being passed in hexadecimal string format
+   note:
+      this function is resilient to uuids being passed in hexadecimal string format
    """
 
    if isinstance(uuid_a, str):
@@ -168,17 +175,17 @@ def matching_uuids(uuid_a, uuid_b):
 def version_string(uuid_obj):
    """Returns an integer string rendering of the time element of the uuid.
 
-      argument:
-         uuid_obj (uuid.UUID): the uuid for which a string representation of the time component is required
+   arguments:
+      uuid_obj (uuid.UUID): the uuid for which a string representation of the time component is required
 
-      returns:
-         string (of digits)
+   returns:
+      string (of digits)
 
-      notes:
-         this function has nothing to do with the uuid.version attribute, it is used to populate the version
-         field of a resqml citation block;
-         the time component of the uuid is the number of 100ns periods that have elapsed since October 1582
-         (when the Gregorian calendar was adopted), as a 60 bit integer
+   notes:
+      this function has nothing to do with the uuid.version attribute, it is used to populate the version
+      field of a resqml citation block;
+      the time component of the uuid is the number of 100ns periods that have elapsed since October 1582
+      (when the Gregorian calendar was adopted), as a 60 bit integer
    """
 
    if isinstance(uuid_obj, str):

--- a/resqpy/olio/write_hdf5.py
+++ b/resqpy/olio/write_hdf5.py
@@ -1,6 +1,6 @@
 """write_hdf5.py: Class to write a resqml hdf5 file."""
 
-version = '14th May 2021'
+version = '25th August 2021'
 
 # Nexus is a registered trademark of the Halliburton Company
 
@@ -35,18 +35,18 @@ class H5Register():
    def register_dataset(self, object_uuid, group_tail, a, dtype = None):
       """Register an array to be included as a dataset in the hdf5 file.
 
-         arguments:
-            object_uuid (uuid.UUID): the uuid of the object (part) that this array is for
-            group_tail (string): the remainder of the hdf5 internal path (following RESQML and
-               uuid elements)
-            a (numpy array): the dataset (array) to be registered for writing
-            dtype (type or string): the type of the individual elements within the dataset
+      arguments:
+         object_uuid (uuid.UUID): the uuid of the object (part) that this array is for
+         group_tail (string): the remainder of the hdf5 internal path (following RESQML and
+            uuid elements)
+         a (numpy array): the dataset (array) to be registered for writing
+         dtype (type or string): the type of the individual elements within the dataset
 
-         returns:
-            None
+      returns:
+         None
 
-         note:
-            several arrays might belong to the same object
+      note:
+         several arrays might belong to the same object
       """
 
       #     print('registering dataset with uuid ' + str(object_uuid) + ' and group tail ' + group_tail)
@@ -64,14 +64,14 @@ class H5Register():
    def write_fp(self, fp):
       """Write or append to an hdf5 file, writing the pre-registered datasets (arrays).
 
-         arguments:
-            fp: an already open h5py._hl.files.File object
+      arguments:
+         fp: an already open h5py._hl.files.File object
 
-         returns:
-            None
+      returns:
+         None
 
-         note:
-            the file handle fp must have been opened with mode 'w' or 'a'
+      note:
+         the file handle fp must have been opened with mode 'w' or 'a'
       """
 
       # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
@@ -92,15 +92,15 @@ class H5Register():
    def write(self, file = None, mode = 'w', release_after = True):
       """Create or append to an hdf5 file, writing the pre-registered datasets (arrays).
 
-         arguments:
-            file: either a string being the file path, or an already open h5py._hl.files.File object;
-               if None (recommended), the file is opened through the model object's hdf5 management
-               functions
-            mode (string, default 'w'): the mode to open the file in; only relevant if file is a path;
-               must be 'w' or 'a' for (over)write or append
+      arguments:
+         file: either a string being the file path, or an already open h5py._hl.files.File object;
+            if None (recommended), the file is opened through the model object's hdf5 management
+            functions
+         mode (string, default 'w'): the mode to open the file in; only relevant if file is a path;
+            must be 'w' or 'a' for (over)write or append
 
-         returns:
-            None
+      returns:
+         None
       """
 
       # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
@@ -123,29 +123,30 @@ class H5Register():
 def copy_h5(file_in, file_out, uuid_inclusion_list = None, uuid_exclusion_list = None, mode = 'w'):
    """Create a copy of an hdf5, optionally including or excluding arrays with specified uuids.
 
-      arguments:
-         file_in (string): path of existing hdf5 file to be duplicated
-         file_out (string): path of output hdf5 file to be created or appended to (see mode)
-         uuid_inclusion_list (list of uuid.UUID, optional): if present, the uuids to be included
-            in the output file
-         uuid_exclusion_list (list of uuid.UUID, optional): if present, the uuids to be excluded
-            from the output file
-         mode (string, default 'w'): mode to open output file with; must be 'w' or 'a' for
-            (over)write or append respectively
+   arguments:
+      file_in (string): path of existing hdf5 file to be duplicated
+      file_out (string): path of output hdf5 file to be created or appended to (see mode)
+      uuid_inclusion_list (list of uuid.UUID, optional): if present, the uuids to be included
+         in the output file
+      uuid_exclusion_list (list of uuid.UUID, optional): if present, the uuids to be excluded
+         from the output file
+      mode (string, default 'w'): mode to open output file with; must be 'w' or 'a' for
+         (over)write or append respectively
 
-      returns:
-         number of hdf5 groups (uuid's) copied
+   returns:
+      number of hdf5 groups (uuid's) copied
 
-      note:
-         at most one of uuid_inclusion_list and uuid_exclusion_list should be passed;
-         if neither are passed, all the datasets (arrays) in the input file are copied to the
-         output file
+   notes:
+      at most one of uuid_inclusion_list and uuid_exclusion_list should be passed;
+      if neither are passed, all the datasets (arrays) in the input file are copied to the
+      output file
    """
 
    #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
    assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
    assert uuid_inclusion_list is None or uuid_exclusion_list is None,  \
       'inclusion and exclusion lists both specified for hdf5 copy; at most one allowed'
+   checking_uuid = uuid_inclusion_list is not None or uuid_exclusion_list is not None
    assert mode in ['w', 'a']
    copy_count = 0
    with h5py.File(file_out, mode) as fp_out:
@@ -164,21 +165,59 @@ def copy_h5(file_in, file_out, uuid_inclusion_list = None, uuid_exclusion_list =
          else:
             main_group_out = fp_out['RESQML']
          for group in main_group_in:
-            uuid = bu.uuid_from_string(group)
-            if uuid is None:
-               log.warning('RESQML group name in hdf5 file is not a uuid, skipping: ' + str(group))
-               continue
-            if uuid_inclusion_list is not None:
-               if uuid not in uuid_inclusion_list:
-                  continue
-            elif uuid_exclusion_list is not None:
-               if uuid in uuid_exclusion_list:
-                  continue
+            if checking_uuid:
+               uuid = bu.uuid_from_string(group)
+               if uuid_inclusion_list is not None:
+                  if uuid not in uuid_inclusion_list:
+                     if uuid is None:
+                        log.warning('RESQML group name in hdf5 file does not start with a uuid, skipping: ' +
+                                    str(group))
+                     continue
+               else:  # uuid_exclusion_list is not None
+                  if uuid in uuid_exclusion_list:
+                     continue
+                  if uuid is None:  # will still be copied
+                     log.warning('RESQML group name in hdf5 file does not start with a uuid: ' + str(group))
             if group in main_group_out:
                log.warning('not copying hdf5 data due to pre-existence for: ' + str(group))
                continue
             log.debug('copying hdf5 data for uuid: ' + group)
             main_group_in.copy(group, main_group_out, expand_soft = True, expand_external = True, expand_refs = True)
+            copy_count += 1
+   return copy_count
+
+
+def copy_h5_path_list(file_in, file_out, hdf5_path_list, mode = 'w'):
+   """Create a copy of some hdf5 datasets (or groups), identified as a list of hdf5 internal paths.
+
+   arguments:
+      file_in (string): path of existing hdf5 file to be copied from
+      file_out (string): path of output hdf5 file to be created or appended to (see mode)
+      hdf5_path_list (list of string): the hdf5 internal paths of the datasets (or groups) to be copied
+      mode (string, default 'w'): mode to open output file with; must be 'w' or 'a' for
+         (over)write or append respectively
+
+   returns:
+      number of hdf5 datasets (or groups) copied
+   """
+
+   #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
+   assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
+   assert hdf5_path_list is not None
+   assert mode in ['w', 'a']
+   copy_count = 0
+   with h5py.File(file_out, mode) as fp_out:
+      assert fp_out is not None, 'failed to open output hdf5 file: ' + file_out
+      with h5py.File(file_in, 'r') as fp_in:
+         assert fp_in is not None, 'failed to open input hdf5 file: ' + file_in
+         for path in hdf5_path_list:
+            group = fp_in[path]
+            assert group is not None
+            if group in fp_out:
+               log.warning('not copying hdf5 data due to pre-existence for: ' + str(group))
+               continue
+            log.debug('copying hdf5 data for: ' + group)
+            fp_in.copy(group, fp_out, expand_soft = True, expand_external = True, expand_refs = True)
             copy_count += 1
    return copy_count
 


### PR DESCRIPTION
Parts of the resqpy code assume that hdf5 internal paths have a certain structure, namely /RESQML/uuid/array_name...

That structure is not part of the RESQML standard, so this change is to make resqpy accept any hdf5 internal paths (as stored in the xml) when reading a RESQML dataset.
