### PR TITLE
Leaving model attribute set in PropertyCollection.set_support()

### DIFF
--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -226,7 +226,7 @@ class PropertyCollection():
       if support_uuid is None:
          if self.support_uuid is not None:
             log.warning('clearing supporting representation for property collection')
-         self.model = None
+#         self.model = None
          self.support = None
          self.support_root = None
          self.support_uuid = None


### PR DESCRIPTION
The PropertyCollection.set_support() method clears the supporting representation for multi-support or no support property collections.  This change causes the model attribute of the PropertyCollection to remain unchanged in those circumstances (previously it was also cleared).