### PR TITLE
WIP: support for geologic time series; closes issue #213

### DIFF
--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -7,7 +7,8 @@ version = '10th September 2021'
 # At present, no time zone information is handled
 
 # This module differentiates between 'human timeframe' and 'geologic timeframe' time series, though RESQML does
-# not make such a distinction explicitly
+# not make such a distinction explicitly; the code here uses presence of YearOffset xml data to imply a time
+# series on a geological timeframe
 
 import logging
 

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -222,10 +222,11 @@ class AnyTimeSeries(BaseResqpy):
          dt_node = rqet.SubElement(time_node, ns['resqml2'] + 'DateTime')
          dt_node.set(ns['xsi'] + 'type', ns['xsd'] + 'dateTime')
          if self.timeframe == 'geologic':
+            assert isinstance(self.timestamps[index], int)
             dt_node.text = '0000-01-01T00:00:00Z'
             yo_node = rqet.SubElement(time_node, ns['resqml2'] + 'YearOffset')
             yo_node.set(ns['xsi'] + 'type', ns['xsd'] + 'long')
-            yo_node.text = str(self.timestamps(index))
+            yo_node.text = str(self.timestamps[index])
          else:
             dt_node.text = self.timestamp(index)
 
@@ -585,9 +586,11 @@ def time_series_from_list(timestamp_list, parent_model = None, title = None):
    assert (len(timestamp_list) > 0)
    sorted_timestamps = sorted(timestamp_list)
    if isinstance(sorted_timestamps[0], int):
+      sorted_timestamps = sorted([-t if t > 0 else t for t in timestamp_list])
       time_series = GeologicTimeSeries(parent_model = parent_model, title = title)
       time_series.timestamps = sorted_timestamps
    else:
+      sorted_timestamps = sorted(timestamp_list)
       time_series = TimeSeries(parent_model = parent_model,
                                first_timestamp = cleaned_timestamp(sorted_timestamps[0]),
                                title = title)


### PR DESCRIPTION
This change adds a new resqpy class, GeologicTimeSeries, which is designed to be used for RESQML TimeSeries objects which are on a geological timeframe.

Note that initial code changes were accidentally merged directly into master (sorry!)

Resolves issue #213 