### PR TITLE
setting grid geometry from points property; resolves issue #223

### DIFF
--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -1618,11 +1618,11 @@ class Grid(BaseResqpy):
             if active_collection is None:
                active_collection = property_collection
                assert active_collection is not None
-            active_part = property_collection.singleton(property_kind = 'active',
-                                                        indexable = 'cells',
-                                                        continuous = False,
-                                                        realization = realization,
-                                                        time_index = time_index)
+            active_part = active_collection.singleton(property_kind = 'active',
+                                                      indexable = 'cells',
+                                                      continuous = False,
+                                                      realization = realization,
+                                                      time_index = time_index)
             assert active_part is not None, 'failed to identify active property to use for grid inactive mask'
             active_property_uuid = active_collection.uuid_for_part(active_part)
          active = rprop.Property(self.model, uuid = active_property_uuid)
@@ -5257,8 +5257,9 @@ class Grid(BaseResqpy):
                                                          self.model.root_for_uuid(self.parent_grid_uuid),
                                                          'sourceObject')
 
-      if write_active and self.active_property_uuid is not None and self.model.part(
-            uuid = self.active_property_uuid) is None:
+      if (write_active and self.active_property_uuid is not None and
+          self.model.part(uuid = self.active_property_uuid) is None):
+         # TODO: replace following with call to rprop.write_hdf5_and_create_xml_for_active_property()
          active_collection = rprop.PropertyCollection()
          active_collection.set_support(support = self)
          active_collection.create_xml(None,

--- a/resqpy/olio/rq_print.py
+++ b/resqpy/olio/rq_print.py
@@ -284,9 +284,11 @@ def print_TimeSeries(model, node, detail_level = 0):
    print('number of timestamps: ' + str(rqet.count_tag(node, 'Time')))
    if not detail_level:
       return
-   time_series = rts.TimeSeries(model, uuid = node.attrib['uuid'])
+   time_series = rts.any_time_series(model, uuid = node.attrib['uuid'])
    for index in range(time_series.number_of_timestamps()):
-      if index:
+      if time_series.timeframe == 'geologic':
+         print(f'{index:>5d}  {time_series.timestamp(index)}')
+      elif index:
          print('{0:>5d}  {1} {2:>5d}'.format(index, rts.simplified_timestamp(time_series.timestamp(index)),
                                              time_series.step_days(index)))
       else:
@@ -405,7 +407,7 @@ def print_Property(model, node, detail_level = 0):
             print('   time series part not found!')
             log.warning('missing time series part: ' + str(time_series_part))
          else:
-            time_series = rts.TimeSeries(model, uuid = time_series_uuid)
+            time_series = rts.any_time_series(model, uuid = time_series_uuid)
             print('   number of timestamps in series: ' + str(time_series.number_of_timestamps()))
          if time_index is not None and time_series is not None:
             print('timestamp for this part: ' + str(rts.simplified_timestamp(time_series.timestamp(time_index))))

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -5931,3 +5931,28 @@ def return_cell_indices(i, cell_indices):
       return np.nan
    else:
       return cell_indices[i]
+
+
+def write_hdf5_and_create_xml_for_active_property(model,
+                                                  active_property_array,
+                                                  support_uuid,
+                                                  title = 'ACTIVE',
+                                                  realization = None,
+                                                  time_series_uuid = None,
+                                                  time_index = None):
+   """Writes hdf5 data and creates xml for an active cell property; returns uuid."""
+
+   active = Property.from_array(parent_model = model,
+                                cached_array = active_property_array,
+                                source_info = None,
+                                keyword = title,
+                                support_uuid = support_uuid,
+                                property_kind = 'active',
+                                local_property_kind_uuid = None,
+                                indexable_element = 'cells',
+                                discrete = True,
+                                time_series_uuid = time_series_uuid,
+                                time_index = time_index,
+                                realization = realization,
+                                find_local_property_kind = True)
+   return active.uuid

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -1,6 +1,6 @@
 """time_series.py: RESQML time series class."""
 
-version = '13th September 2021'
+version = '16th September 2021'
 
 # Nexus is a registered trademark of the Halliburton Company
 
@@ -740,9 +740,9 @@ def geologic_time_str(years):
    assert isinstance(years, int)
    years = abs(years)  # positive and negative values are both interpreted as the same: years before present
    if years < 10000000 and years % 1000000:
-      stamp = f'{float(-years) / 1.0e6:.3f}Ma'
+      stamp = f'{float(-years) / 1.0e6:.3f} Ma'
    else:
-      stamp = f'{-years // 1000000}Ma'
+      stamp = f'{-years // 1000000} Ma'
    return stamp
 
 

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -387,7 +387,10 @@ def test_points_properties(tmp_path):
    r = ensemble_size // 2
    ti = time_series_size // 2
    a = nc.single_array_ref(realization = r, time_index = ti)
-   grid.set_cached_points_from_property(property_collection = nc, realization = r, time_index = ti)
+   grid.set_cached_points_from_property(property_collection = nc,
+                                        realization = r,
+                                        time_index = ti,
+                                        set_inactive = False)
    assert_array_almost_equal(grid.points_cached, nc.single_array_ref(realization = r, time_index = ti))
 
    # check that 5 dimensional numpy arrays can be set up, each covering realisations for a single time index
@@ -419,5 +422,8 @@ def test_points_properties(tmp_path):
    # check that the cached points for the faulted grid can be populated from a points property
    r = faulted_ensemble_size // 2
    ti = time_series_size - 1
-   f_grid.set_cached_points_from_property(property_collection = fnc, realization = r, time_index = ti)
+   f_grid.set_cached_points_from_property(property_collection = fnc,
+                                          realization = r,
+                                          time_index = ti,
+                                          set_inactive = False)
    assert_array_almost_equal(f_grid.points_cached, fnc.single_array_ref(realization = r, time_index = ti))

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 
 import resqpy.model as rq
 import resqpy.grid as grr
@@ -381,6 +382,14 @@ def test_points_properties(tmp_path):
                                             time_series_uuid = ts_uuid)
    assert nc.number_of_parts() == ensemble_size * time_series_size
 
+   # check that the cached points for the grid can be populated from a points property
+   grid.make_regular_points_cached()
+   r = ensemble_size // 2
+   ti = time_series_size // 2
+   a = nc.single_array_ref(realization = r, time_index = ti)
+   grid.set_cached_points_from_property(property_collection = nc, realization = r, time_index = ti)
+   assert_array_almost_equal(grid.points_cached, nc.single_array_ref(realization = r, time_index = ti))
+
    # check that 5 dimensional numpy arrays can be set up, each covering realisations for a single time index
    for ti in range(time_series_size):
       tnc = rqp.selective_version_of_collection(nc, time_index = ti)
@@ -406,3 +415,9 @@ def test_points_properties(tmp_path):
                                              points = True,
                                              time_series_uuid = ts_uuid)
    assert fnc.number_of_parts() == faulted_ensemble_size * time_series_size
+
+   # check that the cached points for the faulted grid can be populated from a points property
+   r = faulted_ensemble_size // 2
+   ti = time_series_size - 1
+   f_grid.set_cached_points_from_property(property_collection = fnc, realization = r, time_index = ti)
+   assert_array_almost_equal(f_grid.points_cached, fnc.single_array_ref(realization = r, time_index = ti))


### PR DESCRIPTION
This change provides a Grid method for overwriting the cached points (geometry) from an instance of a points property.  The property may have multiple realizations and/or time indices as usual.  This is primarily to support basin modelling or other geological processes affecting the geometry of strata.