### PR TITLE
Pin sphinx_rtd_theme version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ tests =
     yapf
 docs = 
     sphinx
-    sphinx_rtd_theme
+    sphinx_rtd_theme<1.0.0
     autoclasstoc
 
 [tool:pytest]


### PR DESCRIPTION
Closes #227 

From experimentation:

- Pinning an older version of `sphinx-rtd-theme` seems to fix the issue
- Removing the `autoclasstoc` extension does _not_ fix the issue
- Changing the theme to "classic" does _not_ seem to fix the issue