### PR TITLE
yapf change from 3 to 4 space indentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,10 +26,10 @@ author = 'BP'
 # Version from git tag
 # See https://github.com/pypa/setuptools_scm/#usage-from-sphinx
 try:
-   from importlib import metadata
-   release = metadata.version('resqpy')
+    from importlib import metadata
+    release = metadata.version('resqpy')
 except Exception:
-   release = '0.0.0-version-not-available'
+    release = '0.0.0-version-not-available'
 
 # Take major/minor
 version = '.'.join(release.split('.')[:2])
@@ -51,11 +51,11 @@ autodoc_member_order = 'bysource'
 # napoleon_numpy_docstring = False  # Force consistency, leave only Google
 
 extensions = [
-   'sphinx.ext.autodoc',
-   'sphinx.ext.autosummary',
-   'sphinx.ext.napoleon',
-   'sphinx.ext.viewcode',
-   'autoclasstoc',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'autoclasstoc',
 ]
 
 templates_path = ['_templates']
@@ -70,25 +70,25 @@ from autoclasstoc import PublicMethods
 
 
 class CommomMethods(PublicMethods):
-   key = "common-methods"
-   title = "Commonly Used Methods:"
+    key = "common-methods"
+    title = "Commonly Used Methods:"
 
-   def predicate(self, name, attr, meta):
-      return super().predicate(name, attr, meta) and 'common' in meta
+    def predicate(self, name, attr, meta):
+        return super().predicate(name, attr, meta) and 'common' in meta
 
 
 class OtherMethods(PublicMethods):
-   key = "other-methods"
-   title = "Methods:"
+    key = "other-methods"
+    title = "Methods:"
 
-   def predicate(self, name, attr, meta):
-      return super().predicate(name, attr, meta) and 'common' not in meta
+    def predicate(self, name, attr, meta):
+        return super().predicate(name, attr, meta) and 'common' not in meta
 
 
 autoclasstoc_sections = [
-   "public-attrs",
-   "common-methods",
-   "other-methods",
+    "public-attrs",
+    "common-methods",
+    "other-methods",
 ]
 
 # -- Options for HTML output -------------------------------------------------
@@ -99,7 +99,7 @@ html_theme = 'sphinx_rtd_theme'
 # See https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
 html_static_path = ['_static']
 html_context = {
-   'css_files': [
-      '_static/theme_overrides.css',  # override wide tables in RTD theme
-   ],
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+    ],
 }

--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -27,8 +27,8 @@
 """
 
 try:
-   # Version dynamically extracted from git tags when package is built
-   from .version import version as __version__  # type: ignore
+    # Version dynamically extracted from git tags when package is built
+    from .version import version as __version__  # type: ignore
 
 except ImportError:
-   __version__ = "0.0.0-version-not-available"
+    __version__ = "0.0.0-version-not-available"

--- a/resqpy/crs.py
+++ b/resqpy/crs.py
@@ -27,34 +27,34 @@ PointType = Union[Tuple[float, float, float], List[float], np.ndarray]
 
 
 class Crs(BaseResqpy):
-   """ Coordinate reference system object """
+    """ Coordinate reference system object """
 
-   @property
-   def resqml_type(self):
-      return 'LocalTime3dCrs' if hasattr(self, 'time_units') and self.time_units else 'LocalDepth3dCrs'
+    @property
+    def resqml_type(self):
+        return 'LocalTime3dCrs' if hasattr(self, 'time_units') and self.time_units else 'LocalDepth3dCrs'
 
-   valid_axis_orders = ("easting northing", "northing easting", "westing southing", "southing westing",
-                        "northing westing", "westing northing")
+    valid_axis_orders = ("easting northing", "northing easting", "westing southing", "southing westing",
+                         "northing westing", "westing northing")
 
-   def __init__(
-         self,
-         parent_model: 'rq.Model',
-         crs_root = None,  # deprecated
-         uuid: Optional[uuid.UUID] = None,
-         x_offset: float = 0.0,
-         y_offset: float = 0.0,
-         z_offset: float = 0.0,
-         rotation: float = 0.0,
-         xy_units: str = 'm',
-         z_units: str = 'm',
-         z_inc_down: bool = True,
-         axis_order: str = 'easting northing',
-         time_units: Optional[str] = None,
-         epsg_code: Optional[str] = None,
-         title: Optional[str] = None,
-         originator: Optional[str] = None,
-         extra_metadata: Optional[Dict[str, str]] = None):
-      """Create a new coordinate reference system object.
+    def __init__(
+            self,
+            parent_model: 'rq.Model',
+            crs_root = None,  # deprecated
+            uuid: Optional[uuid.UUID] = None,
+            x_offset: float = 0.0,
+            y_offset: float = 0.0,
+            z_offset: float = 0.0,
+            rotation: float = 0.0,
+            xy_units: str = 'm',
+            z_units: str = 'm',
+            z_inc_down: bool = True,
+            axis_order: str = 'easting northing',
+            time_units: Optional[str] = None,
+            epsg_code: Optional[str] = None,
+            title: Optional[str] = None,
+            originator: Optional[str] = None,
+            extra_metadata: Optional[Dict[str, str]] = None):
+        """Create a new coordinate reference system object.
 
       arguments:
          parent_model (model.Model): the model to which the new Crs object will belong
@@ -94,242 +94,243 @@ class Crs(BaseResqpy):
       :meta common:
       """
 
-      self.xy_units = xy_units
-      self.z_units = z_units
-      self.time_units = time_units  # if None, z values are depth; if not None, z values are time (from seismic)
-      self.z_inc_down = z_inc_down
-      self.x_offset = x_offset
-      self.y_offset = y_offset
-      self.z_offset = z_offset
-      self.rotation = rotation  # radians
-      self.axis_order = axis_order
-      self.epsg_code = epsg_code
-      # following are derived attributes, set below
-      self.rotated = None
-      self.rotation_matrix = None
-      self.reverse_rotation_matrix = None
+        self.xy_units = xy_units
+        self.z_units = z_units
+        self.time_units = time_units  # if None, z values are depth; if not None, z values are time (from seismic)
+        self.z_inc_down = z_inc_down
+        self.x_offset = x_offset
+        self.y_offset = y_offset
+        self.z_offset = z_offset
+        self.rotation = rotation  # radians
+        self.axis_order = axis_order
+        self.epsg_code = epsg_code
+        # following are derived attributes, set below
+        self.rotated = None
+        self.rotation_matrix = None
+        self.reverse_rotation_matrix = None
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = crs_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = crs_root)
 
-      assert self.axis_order in self.valid_axis_orders, 'invalid CRS axis order: ' + str(axis_order)
+        assert self.axis_order in self.valid_axis_orders, 'invalid CRS axis order: ' + str(axis_order)
 
-      self.rotated = (not maths.isclose(self.rotation, 0.0, abs_tol = 1e-8) and
-                      not maths.isclose(self.rotation, 2.0 * maths.pi, abs_tol = 1e-8))
-      if self.rotated:
-         self.rotation_matrix = vec.rotation_matrix_3d_axial(2, maths.degrees(self.rotation))
-         self.reverse_rotation_matrix = vec.rotation_matrix_3d_axial(2, maths.degrees(-self.rotation))
+        self.rotated = (not maths.isclose(self.rotation, 0.0, abs_tol = 1e-8) and
+                        not maths.isclose(self.rotation, 2.0 * maths.pi, abs_tol = 1e-8))
+        if self.rotated:
+            self.rotation_matrix = vec.rotation_matrix_3d_axial(2, maths.degrees(self.rotation))
+            self.reverse_rotation_matrix = vec.rotation_matrix_3d_axial(2, maths.degrees(-self.rotation))
 
-      self.null_transform = (maths.isclose(self.x_offset, 0.0, abs_tol = 1e-8) and
-                             maths.isclose(self.y_offset, 0.0, abs_tol = 1e-8) and
-                             maths.isclose(self.z_offset, 0.0, abs_tol = 1e-8) and not self.rotated)
+        self.null_transform = (maths.isclose(self.x_offset, 0.0, abs_tol = 1e-8) and
+                               maths.isclose(self.y_offset, 0.0, abs_tol = 1e-8) and
+                               maths.isclose(self.z_offset, 0.0, abs_tol = 1e-8) and not self.rotated)
 
-   def _load_from_xml(self):
-      root_node = self.root
-      flavour = rqet.node_type(root_node)
-      assert flavour in ['obj_LocalDepth3dCrs', 'obj_LocalTime3dCrs']
-      if flavour == 'obj_LocalTime3dCrs':
-         self.time_units = rqet.find_tag_text(root_node, 'TimeUom')
-         assert self.time_units
-      else:
-         self.time_units = None
-      self.xy_units = rqet.find_tag_text(root_node, 'ProjectedUom')
-      self.axis_order = rqet.find_tag_text(root_node, 'ProjectedAxisOrder')
-      self.z_units = rqet.find_tag_text(root_node, 'VerticalUom')
-      self.z_inc_down = rqet.find_tag_bool(root_node, 'ZIncreasingDownward')
-      self.x_offset = rqet.find_tag_float(root_node, 'XOffset')
-      self.y_offset = rqet.find_tag_float(root_node, 'YOffset')
-      self.z_offset = rqet.find_tag_float(root_node, 'ZOffset')
-      self.rotation = rqet.find_tag_float(root_node, 'ArealRotation')  # todo: extract uom attribute from this node
-      parent_xy_crs = rqet.find_tag(root_node, 'ProjectedCrs')
-      if parent_xy_crs is not None and rqet.node_type(parent_xy_crs) == 'ProjectedCrsEpsgCode':
-         self.epsg_code = rqet.find_tag_text(parent_xy_crs, 'EpsgCode')  # should be an integer?
-      else:
-         self.epsg_code = None
+    def _load_from_xml(self):
+        root_node = self.root
+        flavour = rqet.node_type(root_node)
+        assert flavour in ['obj_LocalDepth3dCrs', 'obj_LocalTime3dCrs']
+        if flavour == 'obj_LocalTime3dCrs':
+            self.time_units = rqet.find_tag_text(root_node, 'TimeUom')
+            assert self.time_units
+        else:
+            self.time_units = None
+        self.xy_units = rqet.find_tag_text(root_node, 'ProjectedUom')
+        self.axis_order = rqet.find_tag_text(root_node, 'ProjectedAxisOrder')
+        self.z_units = rqet.find_tag_text(root_node, 'VerticalUom')
+        self.z_inc_down = rqet.find_tag_bool(root_node, 'ZIncreasingDownward')
+        self.x_offset = rqet.find_tag_float(root_node, 'XOffset')
+        self.y_offset = rqet.find_tag_float(root_node, 'YOffset')
+        self.z_offset = rqet.find_tag_float(root_node, 'ZOffset')
+        self.rotation = rqet.find_tag_float(root_node, 'ArealRotation')  # todo: extract uom attribute from this node
+        parent_xy_crs = rqet.find_tag(root_node, 'ProjectedCrs')
+        if parent_xy_crs is not None and rqet.node_type(parent_xy_crs) == 'ProjectedCrsEpsgCode':
+            self.epsg_code = rqet.find_tag_text(parent_xy_crs, 'EpsgCode')  # should be an integer?
+        else:
+            self.epsg_code = None
 
-   def is_right_handed_xyz(self) -> bool:
-      """Returns True if the xyz axes are right handed; False if left handed."""
+    def is_right_handed_xyz(self) -> bool:
+        """Returns True if the xyz axes are right handed; False if left handed."""
 
-      return self.axis_order in ["northing easting", "southing westing", "westing northing"] == self.z_inc_down
+        return self.axis_order in ["northing easting", "southing westing", "westing northing"] == self.z_inc_down
 
-   def global_to_local(self, xyz: PointType, global_z_inc_down: bool = True) -> Tuple[float, float, float]:
-      """Convert a single xyz point from the parent coordinate reference system to this one."""
+    def global_to_local(self, xyz: PointType, global_z_inc_down: bool = True) -> Tuple[float, float, float]:
+        """Convert a single xyz point from the parent coordinate reference system to this one."""
 
-      x, y, z = xyz
-      if self.x_offset != 0.0:
-         x -= self.x_offset
-      if self.y_offset != 0.0:
-         y -= self.y_offset
-      if global_z_inc_down != self.z_inc_down:
-         z = -z
-      if self.z_offset != 0.0:
-         z -= self.z_offset
-      if self.rotated:
-         (x, y, z) = vec.rotate_vector(self.rotation_matrix, np.array((x, y, z)))
-      return (x, y, z)
+        x, y, z = xyz
+        if self.x_offset != 0.0:
+            x -= self.x_offset
+        if self.y_offset != 0.0:
+            y -= self.y_offset
+        if global_z_inc_down != self.z_inc_down:
+            z = -z
+        if self.z_offset != 0.0:
+            z -= self.z_offset
+        if self.rotated:
+            (x, y, z) = vec.rotate_vector(self.rotation_matrix, np.array((x, y, z)))
+        return (x, y, z)
 
-   def global_to_local_array(self, xyz: np.ndarray, global_z_inc_down: bool = True):
-      """Convert in situ a numpy array of xyz points from the parent coordinate reference system to this one."""
+    def global_to_local_array(self, xyz: np.ndarray, global_z_inc_down: bool = True):
+        """Convert in situ a numpy array of xyz points from the parent coordinate reference system to this one."""
 
-      if self.x_offset != 0.0:
-         xyz[..., 0] -= self.x_offset
-      if self.y_offset != 0.0:
-         xyz[..., 1] -= self.y_offset
-      if global_z_inc_down != self.z_inc_down:
-         z = np.negative(xyz[..., 2])
-         xyz[..., 2] = z
-      if self.z_offset != 0.0:
-         xyz[..., 2] -= self.z_offset
-      if self.rotated:
-         a = vec.rotate_array(self.rotation_matrix, xyz)
-         xyz[:] = a
+        if self.x_offset != 0.0:
+            xyz[..., 0] -= self.x_offset
+        if self.y_offset != 0.0:
+            xyz[..., 1] -= self.y_offset
+        if global_z_inc_down != self.z_inc_down:
+            z = np.negative(xyz[..., 2])
+            xyz[..., 2] = z
+        if self.z_offset != 0.0:
+            xyz[..., 2] -= self.z_offset
+        if self.rotated:
+            a = vec.rotate_array(self.rotation_matrix, xyz)
+            xyz[:] = a
 
-   def local_to_global(self, xyz: PointType, global_z_inc_down: bool = True) -> Tuple[float, float, float]:
-      """Convert a single xyz point from this coordinate reference system to the parent one."""
+    def local_to_global(self, xyz: PointType, global_z_inc_down: bool = True) -> Tuple[float, float, float]:
+        """Convert a single xyz point from this coordinate reference system to the parent one."""
 
-      if self.rotated:
-         (x, y, z) = vec.rotate_vector(self.reverse_rotation_matrix, np.array(xyz))
-      else:
-         (x, y, z) = xyz
-      if self.x_offset != 0.0:
-         x += self.x_offset
-      if self.y_offset != 0.0:
-         y += self.y_offset
-      if self.z_offset != 0.0:
-         z += self.z_offset
-      if global_z_inc_down != self.z_inc_down:
-         z = -z
-      return (x, y, z)
+        if self.rotated:
+            (x, y, z) = vec.rotate_vector(self.reverse_rotation_matrix, np.array(xyz))
+        else:
+            (x, y, z) = xyz
+        if self.x_offset != 0.0:
+            x += self.x_offset
+        if self.y_offset != 0.0:
+            y += self.y_offset
+        if self.z_offset != 0.0:
+            z += self.z_offset
+        if global_z_inc_down != self.z_inc_down:
+            z = -z
+        return (x, y, z)
 
-   def local_to_global_array(self, xyz: np.ndarray, global_z_inc_down: bool = True):
-      """Convert in situ a numpy array of xyz points from this coordinate reference system to the parent one."""
+    def local_to_global_array(self, xyz: np.ndarray, global_z_inc_down: bool = True):
+        """Convert in situ a numpy array of xyz points from this coordinate reference system to the parent one."""
 
-      if self.rotated:
-         a = vec.rotate_array(self.reverse_rotation_matrix, xyz)
-         xyz[:] = a
-      if self.x_offset != 0.0:
-         xyz[..., 0] += self.x_offset
-      if self.y_offset != 0.0:
-         xyz[..., 1] += self.y_offset
-      if self.z_offset != 0.0:
-         xyz[..., 2] += self.z_offset
-      if global_z_inc_down != self.z_inc_down:
-         z = np.negative(xyz[..., 2])
-         xyz[..., 2] = z
+        if self.rotated:
+            a = vec.rotate_array(self.reverse_rotation_matrix, xyz)
+            xyz[:] = a
+        if self.x_offset != 0.0:
+            xyz[..., 0] += self.x_offset
+        if self.y_offset != 0.0:
+            xyz[..., 1] += self.y_offset
+        if self.z_offset != 0.0:
+            xyz[..., 2] += self.z_offset
+        if global_z_inc_down != self.z_inc_down:
+            z = np.negative(xyz[..., 2])
+            xyz[..., 2] = z
 
-   def has_same_epsg_code(self, other_crs: 'Crs') -> bool:
-      """Returns True if either of the crs'es has a null EPSG code, or if they are the same."""
-      return self.epsg_code is None or other_crs.epsg_code is None or self.epsg_code == other_crs.epsg_code
+    def has_same_epsg_code(self, other_crs: 'Crs') -> bool:
+        """Returns True if either of the crs'es has a null EPSG code, or if they are the same."""
+        return self.epsg_code is None or other_crs.epsg_code is None or self.epsg_code == other_crs.epsg_code
 
-   def is_equivalent(self, other_crs: 'Crs') -> bool:
-      """Returns True if this crs is effectively the same as the other crs."""
+    def is_equivalent(self, other_crs: 'Crs') -> bool:
+        """Returns True if this crs is effectively the same as the other crs."""
 
-      log.debug('testing crs equivalence')
-      if other_crs is None:
-         return False
-      if self is other_crs:
-         return True
-      if bu.matching_uuids(self.uuid, other_crs.uuid):
-         return True
-      if self.xy_units != other_crs.xy_units or self.z_units != other_crs.z_units:
-         return False
-      if self.z_inc_down != other_crs.z_inc_down:
-         return False
-      if (self.time_units is not None or other_crs.time_units is not None) and self.time_units != other_crs.time_units:
-         return False
-      if not self.has_same_epsg_code(other_crs):
-         return False
-      if self.null_transform and other_crs.null_transform:
-         return True
-      if (maths.isclose(self.x_offset, other_crs.x_offset, abs_tol = 1e-4) and
-          maths.isclose(self.y_offset, other_crs.y_offset, abs_tol = 1e-4) and
-          maths.isclose(self.z_offset, other_crs.z_offset, abs_tol = 1e-4) and
-          maths.isclose(self.rotation, other_crs.rotation, abs_tol = 1e-4)):
-         return True
-      # todo: handle and check rotation units; modularly equivalent rotations
-      return False
+        log.debug('testing crs equivalence')
+        if other_crs is None:
+            return False
+        if self is other_crs:
+            return True
+        if bu.matching_uuids(self.uuid, other_crs.uuid):
+            return True
+        if self.xy_units != other_crs.xy_units or self.z_units != other_crs.z_units:
+            return False
+        if self.z_inc_down != other_crs.z_inc_down:
+            return False
+        if (self.time_units is not None or
+                other_crs.time_units is not None) and self.time_units != other_crs.time_units:
+            return False
+        if not self.has_same_epsg_code(other_crs):
+            return False
+        if self.null_transform and other_crs.null_transform:
+            return True
+        if (maths.isclose(self.x_offset, other_crs.x_offset, abs_tol = 1e-4) and
+                maths.isclose(self.y_offset, other_crs.y_offset, abs_tol = 1e-4) and
+                maths.isclose(self.z_offset, other_crs.z_offset, abs_tol = 1e-4) and
+                maths.isclose(self.rotation, other_crs.rotation, abs_tol = 1e-4)):
+            return True
+        # todo: handle and check rotation units; modularly equivalent rotations
+        return False
 
-   def convert_to(self, other_crs: 'Crs', xyz: PointType) -> Tuple[float, float, float]:
-      """Converts a single xyz point from this coordinate reference system to the other.
-
-      :meta common:
-      """
-
-      if self is other_crs:
-         return _as_xyz_tuple(xyz)
-      assert self.has_same_epsg_code(other_crs)
-      xyz = self.local_to_global(xyz)
-      xyz = (wam.convert_lengths(xyz[0], self.xy_units,
-                                 other_crs.xy_units), wam.convert_lengths(xyz[1], self.xy_units, other_crs.xy_units),
-             wam.convert_lengths(xyz[2], self.z_units, other_crs.z_units))
-      xyz = other_crs.global_to_local(xyz)
-      return _as_xyz_tuple(xyz)
-
-   def convert_array_to(self, other_crs: 'Crs', xyz: np.ndarray):
-      """Converts in situ a numpy array of xyz points from this coordinate reference system to the other.
+    def convert_to(self, other_crs: 'Crs', xyz: PointType) -> Tuple[float, float, float]:
+        """Converts a single xyz point from this coordinate reference system to the other.
 
       :meta common:
       """
 
-      if self.is_equivalent(other_crs):
-         return
-      assert self.has_same_epsg_code(other_crs)
-      self.local_to_global_array(xyz)
-      if self.xy_units == self.z_units and other_crs.xy_units == other_crs.z_units:
-         wam.convert_lengths(xyz, self.xy_units, other_crs.xy_units)
-      else:
-         wam.convert_lengths(xyz[..., :2], self.xy_units, other_crs.xy_units)
-         wam.convert_lengths(xyz[..., 2], self.z_units, other_crs.z_units)
-      other_crs.global_to_local_array(xyz)
-      return xyz
+        if self is other_crs:
+            return _as_xyz_tuple(xyz)
+        assert self.has_same_epsg_code(other_crs)
+        xyz = self.local_to_global(xyz)
+        xyz = (wam.convert_lengths(xyz[0], self.xy_units,
+                                   other_crs.xy_units), wam.convert_lengths(xyz[1], self.xy_units, other_crs.xy_units),
+               wam.convert_lengths(xyz[2], self.z_units, other_crs.z_units))
+        xyz = other_crs.global_to_local(xyz)
+        return _as_xyz_tuple(xyz)
 
-   def convert_from(self, other_crs: 'Crs', xyz: PointType) -> Tuple[float, float, float]:
-      """Converts a single xyz point from the other coordinate reference system to this one.
+    def convert_array_to(self, other_crs: 'Crs', xyz: np.ndarray):
+        """Converts in situ a numpy array of xyz points from this coordinate reference system to the other.
 
       :meta common:
       """
 
-      if self is other_crs:
-         return _as_xyz_tuple(xyz)
-      assert self.has_same_epsg_code(other_crs)
-      xyz = other_crs.local_to_global(xyz)
-      xyz = (wam.convert_lengths(xyz[0], other_crs.xy_units,
-                                 self.xy_units), wam.convert_lengths(xyz[1], other_crs.xy_units, self.xy_units),
-             wam.convert_lengths(xyz[2], other_crs.z_units, self.z_units))
-      xyz = self.global_to_local(xyz)
-      return _as_xyz_tuple(xyz)
+        if self.is_equivalent(other_crs):
+            return
+        assert self.has_same_epsg_code(other_crs)
+        self.local_to_global_array(xyz)
+        if self.xy_units == self.z_units and other_crs.xy_units == other_crs.z_units:
+            wam.convert_lengths(xyz, self.xy_units, other_crs.xy_units)
+        else:
+            wam.convert_lengths(xyz[..., :2], self.xy_units, other_crs.xy_units)
+            wam.convert_lengths(xyz[..., 2], self.z_units, other_crs.z_units)
+        other_crs.global_to_local_array(xyz)
+        return xyz
 
-   def convert_array_from(self, other_crs: 'Crs', xyz: np.ndarray):
-      """Converts in situ a numpy array of xyz points from the other coordinate reference system to this one.
+    def convert_from(self, other_crs: 'Crs', xyz: PointType) -> Tuple[float, float, float]:
+        """Converts a single xyz point from the other coordinate reference system to this one.
 
       :meta common:
       """
 
-      if self.is_equivalent(other_crs):
-         return
-      assert self.has_same_epsg_code(other_crs)
-      other_crs.local_to_global_array(xyz)
-      if self.xy_units == self.z_units and other_crs.xy_units == other_crs.z_units:
-         wam.convert_lengths(xyz, other_crs.xy_units, self.xy_units)
-      else:
-         wam.convert_lengths(xyz[..., :2], other_crs.xy_units, self.xy_units)
-         wam.convert_lengths(xyz[..., 2], other_crs.z_units, self.z_units)
-      self.global_to_local_array(xyz)
-      return xyz
+        if self is other_crs:
+            return _as_xyz_tuple(xyz)
+        assert self.has_same_epsg_code(other_crs)
+        xyz = other_crs.local_to_global(xyz)
+        xyz = (wam.convert_lengths(xyz[0], other_crs.xy_units,
+                                   self.xy_units), wam.convert_lengths(xyz[1], other_crs.xy_units, self.xy_units),
+               wam.convert_lengths(xyz[2], other_crs.z_units, self.z_units))
+        xyz = self.global_to_local(xyz)
+        return _as_xyz_tuple(xyz)
 
-   def create_xml(
-         self,
-         title: Optional[str] = None,
-         originator: Optional[str] = None,
-         extra_metadata: Optional[Dict[str, str]] = None,
-         add_as_part: bool = True,
-         root = None,  # deprecated
-         reuse: bool = True):
-      """Creates a Coordinate Reference System xml node and optionally adds as a part in the parent model.
+    def convert_array_from(self, other_crs: 'Crs', xyz: np.ndarray):
+        """Converts in situ a numpy array of xyz points from the other coordinate reference system to this one.
+
+      :meta common:
+      """
+
+        if self.is_equivalent(other_crs):
+            return
+        assert self.has_same_epsg_code(other_crs)
+        other_crs.local_to_global_array(xyz)
+        if self.xy_units == self.z_units and other_crs.xy_units == other_crs.z_units:
+            wam.convert_lengths(xyz, other_crs.xy_units, self.xy_units)
+        else:
+            wam.convert_lengths(xyz[..., :2], other_crs.xy_units, self.xy_units)
+            wam.convert_lengths(xyz[..., 2], other_crs.z_units, self.z_units)
+        self.global_to_local_array(xyz)
+        return xyz
+
+    def create_xml(
+            self,
+            title: Optional[str] = None,
+            originator: Optional[str] = None,
+            extra_metadata: Optional[Dict[str, str]] = None,
+            add_as_part: bool = True,
+            root = None,  # deprecated
+            reuse: bool = True):
+        """Creates a Coordinate Reference System xml node and optionally adds as a part in the parent model.
 
       arguments:
          title (string, optional): used as the Title text in the citation node
@@ -356,95 +357,95 @@ class Crs(BaseResqpy):
       :meta common:
       """
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
 
-      crs = super().create_xml(add_as_part = False,
-                               title = title,
-                               originator = originator,
-                               extra_metadata = extra_metadata)
+        crs = super().create_xml(add_as_part = False,
+                                 title = title,
+                                 originator = originator,
+                                 extra_metadata = extra_metadata)
 
-      xoffset = rqet.SubElement(crs, ns['resqml2'] + 'XOffset')
-      xoffset.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-      xoffset.text = '{0:5.3f}'.format(self.x_offset)
+        xoffset = rqet.SubElement(crs, ns['resqml2'] + 'XOffset')
+        xoffset.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+        xoffset.text = '{0:5.3f}'.format(self.x_offset)
 
-      yoffset = rqet.SubElement(crs, ns['resqml2'] + 'YOffset')
-      yoffset.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-      yoffset.text = '{0:5.3f}'.format(self.y_offset)
+        yoffset = rqet.SubElement(crs, ns['resqml2'] + 'YOffset')
+        yoffset.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+        yoffset.text = '{0:5.3f}'.format(self.y_offset)
 
-      zoffset = rqet.SubElement(crs, ns['resqml2'] + 'ZOffset')
-      zoffset.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-      zoffset.text = '{0:6.4f}'.format(self.z_offset)
+        zoffset = rqet.SubElement(crs, ns['resqml2'] + 'ZOffset')
+        zoffset.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+        zoffset.text = '{0:6.4f}'.format(self.z_offset)
 
-      rotation = rqet.SubElement(crs, ns['resqml2'] + 'ArealRotation')
-      rotation.set('uom', 'rad')
-      rotation.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleMeasure')
-      rotation.text = '{0:8.6f}'.format(self.rotation)
+        rotation = rqet.SubElement(crs, ns['resqml2'] + 'ArealRotation')
+        rotation.set('uom', 'rad')
+        rotation.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleMeasure')
+        rotation.text = '{0:8.6f}'.format(self.rotation)
 
-      if self.axis_order is None:
-         axes = 'easting northing'
-      else:
-         axes = self.axis_order.lower()
-      axis_order = rqet.SubElement(crs, ns['resqml2'] + 'ProjectedAxisOrder')
-      axis_order.set(ns['xsi'] + 'type', ns['eml'] + 'AxisOrder2d')
-      axis_order.text = axes
+        if self.axis_order is None:
+            axes = 'easting northing'
+        else:
+            axes = self.axis_order.lower()
+        axis_order = rqet.SubElement(crs, ns['resqml2'] + 'ProjectedAxisOrder')
+        axis_order.set(ns['xsi'] + 'type', ns['eml'] + 'AxisOrder2d')
+        axis_order.text = axes
 
-      xy_uom = rqet.SubElement(crs, ns['resqml2'] + 'ProjectedUom')
-      xy_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
-      xy_uom.text = wam.rq_length_unit(self.xy_units)
+        xy_uom = rqet.SubElement(crs, ns['resqml2'] + 'ProjectedUom')
+        xy_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
+        xy_uom.text = wam.rq_length_unit(self.xy_units)
 
-      z_uom = rqet.SubElement(crs, ns['resqml2'] + 'VerticalUom')
-      z_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
-      z_uom.text = wam.rq_length_unit(self.z_units)
+        z_uom = rqet.SubElement(crs, ns['resqml2'] + 'VerticalUom')
+        z_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
+        z_uom.text = wam.rq_length_unit(self.z_units)
 
-      if self.time_units is not None:
-         t_uom = rqet.SubElement(crs, ns['resqml2'] + 'TimeUom')
-         t_uom.set(ns['xsi'] + 'type', ns['eml'] + 'TimeUom')  # todo: check this
-         t_uom.text = self.time_units
+        if self.time_units is not None:
+            t_uom = rqet.SubElement(crs, ns['resqml2'] + 'TimeUom')
+            t_uom.set(ns['xsi'] + 'type', ns['eml'] + 'TimeUom')  # todo: check this
+            t_uom.text = self.time_units
 
-      z_sense = rqet.SubElement(crs, ns['resqml2'] + 'ZIncreasingDownward')
-      z_sense.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-      z_sense.text = str(self.z_inc_down).lower()
+        z_sense = rqet.SubElement(crs, ns['resqml2'] + 'ZIncreasingDownward')
+        z_sense.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+        z_sense.text = str(self.z_inc_down).lower()
 
-      xy_crs = rqet.SubElement(crs, ns['resqml2'] + 'ProjectedCrs')
-      xy_crs.text = rqet.null_xml_text
-      if self.epsg_code is None:
-         xy_crs.set(ns['xsi'] + 'type', ns['eml'] + 'ProjectedUnknownCrs')
-         self.model.create_unknown(root = xy_crs)
-      else:
-         xy_crs.set(ns['xsi'] + 'type', ns['eml'] + 'ProjectedCrsEpsgCode')
-         epsg_node = rqet.SubElement(xy_crs, ns['resqml2'] + 'EpsgCode')
-         epsg_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         epsg_node.text = str(self.epsg_code)
+        xy_crs = rqet.SubElement(crs, ns['resqml2'] + 'ProjectedCrs')
+        xy_crs.text = rqet.null_xml_text
+        if self.epsg_code is None:
+            xy_crs.set(ns['xsi'] + 'type', ns['eml'] + 'ProjectedUnknownCrs')
+            self.model.create_unknown(root = xy_crs)
+        else:
+            xy_crs.set(ns['xsi'] + 'type', ns['eml'] + 'ProjectedCrsEpsgCode')
+            epsg_node = rqet.SubElement(xy_crs, ns['resqml2'] + 'EpsgCode')
+            epsg_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            epsg_node.text = str(self.epsg_code)
 
-      z_crs = rqet.SubElement(crs, ns['resqml2'] + 'VerticalCrs')
-      if self.epsg_code is None:
-         z_crs.set(ns['xsi'] + 'type', ns['eml'] + 'VerticalUnknownCrs')
-         z_crs.text = rqet.null_xml_text
-         self.model.create_unknown(root = z_crs)
-      else:  # not sure if this is appropriate for the vertical crs
-         z_crs.set(ns['xsi'] + 'type', ns['eml'] + 'VerticalCrsEpsgCode')
-         epsg_node = rqet.SubElement(xy_crs, ns['resqml2'] + 'EpsgCode')
-         epsg_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         epsg_node.text = str(self.epsg_code)
+        z_crs = rqet.SubElement(crs, ns['resqml2'] + 'VerticalCrs')
+        if self.epsg_code is None:
+            z_crs.set(ns['xsi'] + 'type', ns['eml'] + 'VerticalUnknownCrs')
+            z_crs.text = rqet.null_xml_text
+            self.model.create_unknown(root = z_crs)
+        else:  # not sure if this is appropriate for the vertical crs
+            z_crs.set(ns['xsi'] + 'type', ns['eml'] + 'VerticalCrsEpsgCode')
+            epsg_node = rqet.SubElement(xy_crs, ns['resqml2'] + 'EpsgCode')
+            epsg_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            epsg_node.text = str(self.epsg_code)
 
-      if root is not None:
-         root.append(crs)
-      if add_as_part:
-         self.model.add_part('obj_' + self.resqml_type, bu.uuid_from_string(crs.attrib['uuid']), crs)
-      if self.model.crs_uuid is None:
-         self.model.crs_uuid = self.uuid  # mark's as 'main' (ie. first) crs for model
+        if root is not None:
+            root.append(crs)
+        if add_as_part:
+            self.model.add_part('obj_' + self.resqml_type, bu.uuid_from_string(crs.attrib['uuid']), crs)
+        if self.model.crs_uuid is None:
+            self.model.crs_uuid = self.uuid  # mark's as 'main' (ie. first) crs for model
 
-      return crs
+        return crs
 
-   @property
-   def crs_root(self):
-      """DEPRECATED. Alias for root"""
-      warnings.warn("Attribute 'crs_root' is deprecated. Use 'root'", DeprecationWarning)
-      return self.root
+    @property
+    def crs_root(self):
+        """DEPRECATED. Alias for root"""
+        warnings.warn("Attribute 'crs_root' is deprecated. Use 'root'", DeprecationWarning)
+        return self.root
 
 
 def _as_xyz_tuple(xyz):
-   """Coerce into 3-tuple of floats"""
+    """Coerce into 3-tuple of floats"""
 
-   return tuple(float(xyz[0]), float(xyz[1]), float(xyz[2]))
+    return tuple(float(xyz[0]), float(xyz[1]), float(xyz[2]))

--- a/resqpy/derived_model.py
+++ b/resqpy/derived_model.py
@@ -36,29 +36,29 @@ import resqpy.rq_import as rqi
 
 
 def _pl(n, use_es = False):
-   if n == 1:
-      return ''
-   elif use_es:
-      return 'es'
-   else:
-      return 's'
+    if n == 1:
+        return ''
+    elif use_es:
+        return 'es'
+    else:
+        return 's'
 
 
 def _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization, inherit_all_realizations):
-   collection = None
-   if inherit_properties:
-      source_collection = source_grid.extract_property_collection()
-      if source_collection is not None:
-         #  do not inherit the inactive property array by this mechanism
-         collection = rqp.GridPropertyCollection()
-         collection.set_grid(grid)
-         collection.extend_imported_list_copying_properties_from_other_grid_collection(
-            source_collection, realization = inherit_realization, copy_all_realizations = inherit_all_realizations)
-   return collection
+    collection = None
+    if inherit_properties:
+        source_collection = source_grid.extract_property_collection()
+        if source_collection is not None:
+            #  do not inherit the inactive property array by this mechanism
+            collection = rqp.GridPropertyCollection()
+            collection.set_grid(grid)
+            collection.extend_imported_list_copying_properties_from_other_grid_collection(
+                source_collection, realization = inherit_realization, copy_all_realizations = inherit_all_realizations)
+    return collection
 
 
 def zone_layer_ranges_from_array(zone_array, min_k0 = 0, max_k0 = None, use_dominant_zone = False):
-   """Returns a list of (zone_min_k0, zone_max_k0, zone_index) derived from zone_array.
+    """Returns a list of (zone_min_k0, zone_max_k0, zone_index) derived from zone_array.
 
    arguments:
       zone_array (3D numpy int array or masked array): array holding zone index value per cell
@@ -80,60 +80,60 @@ def zone_layer_ranges_from_array(zone_array, min_k0 = 0, max_k0 = None, use_domi
       cells to a different zone!
    """
 
-   def dominant_zone(zone_array):
-      # modifies data in zone_array such that each layer has a single (most common) value
-      for k in range(zone_array.shape[0]):
-         unique_zones = np.unique(zone_array[k])
-         if len(unique_zones) <= 1:
-            continue
-         dominant = unique_zones[0]
-         dominant_count = np.count_nonzero(zone_array[k] == dominant)
-         for contender in unique_zones[1:]:
-            contender_count = np.count_nonzero(zone_array[k] == contender)
-            if contender_count > dominant_count:
-               dominant = contender
-               dominant_count = contender_count
-         zone_array[k] = dominant
-         log.info('layer ' + str(k + 1) + ' (1 based) zone set to most common value ' + str(dominant))
+    def dominant_zone(zone_array):
+        # modifies data in zone_array such that each layer has a single (most common) value
+        for k in range(zone_array.shape[0]):
+            unique_zones = np.unique(zone_array[k])
+            if len(unique_zones) <= 1:
+                continue
+            dominant = unique_zones[0]
+            dominant_count = np.count_nonzero(zone_array[k] == dominant)
+            for contender in unique_zones[1:]:
+                contender_count = np.count_nonzero(zone_array[k] == contender)
+                if contender_count > dominant_count:
+                    dominant = contender
+                    dominant_count = contender_count
+            zone_array[k] = dominant
+            log.info('layer ' + str(k + 1) + ' (1 based) zone set to most common value ' + str(dominant))
 
-   if max_k0 is None:
-      max_k0 = zone_array.shape[0] - 1
-   if use_dominant_zone:
-      dominant_zone(zone_array)
-   zone_list = np.unique(zone_array)
-   log.debug('list of zones: ' + str(zone_list))
-   assert len(zone_list) > 0, 'no zone values present (all cells inactive?)'
-   zone_layer_range_list = []  # list of (zone_min_k0, zone_max_k0, zone)
-   for zone in zone_list:
-      single_zone_mask = (zone_array == zone)
-      zone_min_k0 = None
-      zone_max_k0 = None
-      for k0 in range(min_k0, max_k0 + 1):
-         if np.any(single_zone_mask[k0]):
-            zone_min_k0 = k0
-            break
-      if zone_min_k0 is None:
-         log.warning('no active cells for zone ' + str(zone) + ' in layer range ' + str(min_k0 + 1) + ' to ' +
-                     str(max_k0 + 1))
-         continue
-      for k0 in range(max_k0, min_k0 - 1, -1):
-         if np.any(single_zone_mask[k0]):
-            zone_max_k0 = k0
-            break
-      # require all active cells in zone layer range to be for this zone
-      for k0 in range(zone_min_k0, zone_max_k0 + 1):
-         assert np.all(single_zone_mask[k0]), 'unacceptable zone variation with layer ' + str(k0 + 1)
-      zone_layer_range_list.append((zone_min_k0, zone_max_k0, zone))
-   assert len(zone_layer_range_list) > 0, 'no zone layer ranges derived from zone array'
-   zone_layer_range_list.sort()
-   for zone_i in range(1, len(zone_layer_range_list)):
-      assert zone_layer_range_list[zone_i][0] > zone_layer_range_list[
-         zone_i - 1][1], 'overlapping zone layer ranges'  # todo: add more info
-      if zone_layer_range_list[zone_i][0] > zone_layer_range_list[zone_i - 1][1] + 1:
-         log.warning('gap in zonal layer ranges, missing layer(s) being arbitrarily assigned to zone below'
-                    )  # todo: add more info to log
-         zone_layer_range_list[zone_i][0] = zone_layer_range_list[zone_i - 1][1] + 1
-   return zone_layer_range_list
+    if max_k0 is None:
+        max_k0 = zone_array.shape[0] - 1
+    if use_dominant_zone:
+        dominant_zone(zone_array)
+    zone_list = np.unique(zone_array)
+    log.debug('list of zones: ' + str(zone_list))
+    assert len(zone_list) > 0, 'no zone values present (all cells inactive?)'
+    zone_layer_range_list = []  # list of (zone_min_k0, zone_max_k0, zone)
+    for zone in zone_list:
+        single_zone_mask = (zone_array == zone)
+        zone_min_k0 = None
+        zone_max_k0 = None
+        for k0 in range(min_k0, max_k0 + 1):
+            if np.any(single_zone_mask[k0]):
+                zone_min_k0 = k0
+                break
+        if zone_min_k0 is None:
+            log.warning('no active cells for zone ' + str(zone) + ' in layer range ' + str(min_k0 + 1) + ' to ' +
+                        str(max_k0 + 1))
+            continue
+        for k0 in range(max_k0, min_k0 - 1, -1):
+            if np.any(single_zone_mask[k0]):
+                zone_max_k0 = k0
+                break
+        # require all active cells in zone layer range to be for this zone
+        for k0 in range(zone_min_k0, zone_max_k0 + 1):
+            assert np.all(single_zone_mask[k0]), 'unacceptable zone variation with layer ' + str(k0 + 1)
+        zone_layer_range_list.append((zone_min_k0, zone_max_k0, zone))
+    assert len(zone_layer_range_list) > 0, 'no zone layer ranges derived from zone array'
+    zone_layer_range_list.sort()
+    for zone_i in range(1, len(zone_layer_range_list)):
+        assert zone_layer_range_list[zone_i][0] > zone_layer_range_list[
+            zone_i - 1][1], 'overlapping zone layer ranges'  # todo: add more info
+        if zone_layer_range_list[zone_i][0] > zone_layer_range_list[zone_i - 1][1] + 1:
+            log.warning('gap in zonal layer ranges, missing layer(s) being arbitrarily assigned to zone below'
+                       )  # todo: add more info to log
+            zone_layer_range_list[zone_i][0] = zone_layer_range_list[zone_i - 1][1] + 1
+    return zone_layer_range_list
 
 
 def add_zone_by_layer_property(epc_file,
@@ -146,7 +146,7 @@ def add_zone_by_layer_property(epc_file,
                                title = 'ZONE',
                                realization = None,
                                extra_metadata = {}):
-   """Adds a discrete zone property (and local property kind) with indexable element of layers.
+    """Adds a discrete zone property (and local property kind) with indexable element of layers.
 
    arguments:
       epc_file (string): file name to load resqml model from and to update with the zonal property
@@ -173,65 +173,66 @@ def add_zone_by_layer_property(epc_file,
       numpy vector of zone numbers (by layer), uuid of newly created property
    """
 
-   assert zone_by_layer_vector is not None or zone_by_cell_property_uuid is not None
-   assert zone_by_layer_vector is None or zone_by_cell_property_uuid is None
+    assert zone_by_layer_vector is not None or zone_by_cell_property_uuid is not None
+    assert zone_by_layer_vector is None or zone_by_cell_property_uuid is None
 
-   model = rq.Model(epc_file)
+    model = rq.Model(epc_file)
 
-   if grid_uuid is None:
-      grid = model.grid()
-      grid_uuid = grid.uuid
-   else:
-      grid = model.grid_for_uuid_from_grid_list(grid_uuid)
-      if grid is None:
-         grid = grr.any_grid(model, uuid = grid_uuid, find_properties = True)
-   assert grid is not None, 'failed to establish grid object'
+    if grid_uuid is None:
+        grid = model.grid()
+        grid_uuid = grid.uuid
+    else:
+        grid = model.grid_for_uuid_from_grid_list(grid_uuid)
+        if grid is None:
+            grid = grr.any_grid(model, uuid = grid_uuid, find_properties = True)
+    assert grid is not None, 'failed to establish grid object'
 
-   if zone_by_layer_vector is not None:
-      assert len(
-         zone_by_layer_vector) == grid.nk, 'length of zone by layer vector does not match number of layers in grid'
-      zone_by_layer = np.array(zone_by_layer_vector, dtype = int)
-   elif zone_by_cell_property_uuid is not None:
-      pc = grid.property_collection
-      zone_by_cell_array = pc.single_array_ref(uuid = zone_by_cell_property_uuid)
-      assert zone_by_cell_array is not None, 'zone by cell property array not found for uuid: ' + str(
-         zone_by_cell_property_uuid)
-      zone_range_list = zone_layer_ranges_from_array(zone_by_cell_array, use_dominant_zone = use_dominant_zone)
-      assert zone_range_list is not None and len(zone_range_list) > 0, 'failed to convert zone by cell to zone by layer'
-      zone_by_layer = np.full((grid.nk,), null_value, dtype = int)
-      for min_k0, max_k0, zone_index in zone_range_list:
-         assert 0 <= min_k0 <= max_k0 < grid.nk, 'zonal layer limits out of range for grid (probable bug)'
-         zone_by_layer[min_k0:max_k0 + 1] = zone_index
-   else:
-      raise Exception('code failure')
+    if zone_by_layer_vector is not None:
+        assert len(
+            zone_by_layer_vector) == grid.nk, 'length of zone by layer vector does not match number of layers in grid'
+        zone_by_layer = np.array(zone_by_layer_vector, dtype = int)
+    elif zone_by_cell_property_uuid is not None:
+        pc = grid.property_collection
+        zone_by_cell_array = pc.single_array_ref(uuid = zone_by_cell_property_uuid)
+        assert zone_by_cell_array is not None, 'zone by cell property array not found for uuid: ' + str(
+            zone_by_cell_property_uuid)
+        zone_range_list = zone_layer_ranges_from_array(zone_by_cell_array, use_dominant_zone = use_dominant_zone)
+        assert zone_range_list is not None and len(
+            zone_range_list) > 0, 'failed to convert zone by cell to zone by layer'
+        zone_by_layer = np.full((grid.nk,), null_value, dtype = int)
+        for min_k0, max_k0, zone_index in zone_range_list:
+            assert 0 <= min_k0 <= max_k0 < grid.nk, 'zonal layer limits out of range for grid (probable bug)'
+            zone_by_layer[min_k0:max_k0 + 1] = zone_index
+    else:
+        raise Exception('code failure')
 
-   assert zone_by_layer.ndim == 1 and zone_by_layer.size == grid.nk
+    assert zone_by_layer.ndim == 1 and zone_by_layer.size == grid.nk
 
-   if use_local_property_kind:
-      property_kind = 'zone'
-      zone_pk = grr.establish_zone_property_kind(model)
-      local_property_kind_uuid = zone_pk.uuid
-      model.store_epc(only_if_modified = True)
-   else:
-      property_kind = 'discrete'
-      local_property_kind_uuid = None
+    if use_local_property_kind:
+        property_kind = 'zone'
+        zone_pk = grr.establish_zone_property_kind(model)
+        local_property_kind_uuid = zone_pk.uuid
+        model.store_epc(only_if_modified = True)
+    else:
+        property_kind = 'discrete'
+        local_property_kind_uuid = None
 
-   model.h5_release()
+    model.h5_release()
 
-   property_uuid = add_one_grid_property_array(epc_file,
-                                               zone_by_layer,
-                                               property_kind,
-                                               grid_uuid = grid.uuid,
-                                               source_info = 'zone defined by layer',
-                                               title = title,
-                                               discrete = True,
-                                               null_value = null_value,
-                                               indexable_element = 'layers',
-                                               realization = realization,
-                                               local_property_kind_uuid = local_property_kind_uuid,
-                                               extra_metadata = extra_metadata)
+    property_uuid = add_one_grid_property_array(epc_file,
+                                                zone_by_layer,
+                                                property_kind,
+                                                grid_uuid = grid.uuid,
+                                                source_info = 'zone defined by layer',
+                                                title = title,
+                                                discrete = True,
+                                                null_value = null_value,
+                                                indexable_element = 'layers',
+                                                realization = realization,
+                                                local_property_kind_uuid = local_property_kind_uuid,
+                                                extra_metadata = extra_metadata)
 
-   return zone_by_layer, property_uuid
+    return zone_by_layer, property_uuid
 
 
 def add_one_grid_property_array(epc_file,
@@ -256,7 +257,7 @@ def add_one_grid_property_array(epc_file,
                                 points = False,
                                 extra_metadata = {},
                                 new_epc_file = None):
-   """Adds a grid property from a numpy array to an existing resqml dataset.
+    """Adds a grid property from a numpy array to an existing resqml dataset.
 
    arguments:
       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
@@ -296,71 +297,71 @@ def add_one_grid_property_array(epc_file,
       uuid.UUID of newly created property object
    """
 
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
 
-   # open up model and establish grid object
-   model = rq.Model(epc_file)
-   if grid_uuid is None:
-      grid = model.grid()
-      grid_uuid = grid.uuid
-   else:
-      grid = model.grid_for_uuid_from_grid_list(grid_uuid)
-      if grid is None:
-         grid = grr.any_grid(model, uuid = grid_uuid, find_properties = False)
-   assert grid is not None, 'failed to establish grid object'
+    # open up model and establish grid object
+    model = rq.Model(epc_file)
+    if grid_uuid is None:
+        grid = model.grid()
+        grid_uuid = grid.uuid
+    else:
+        grid = model.grid_for_uuid_from_grid_list(grid_uuid)
+        if grid is None:
+            grid = grr.any_grid(model, uuid = grid_uuid, find_properties = False)
+    assert grid is not None, 'failed to establish grid object'
 
-   if not discrete:
-      string_lookup_uuid = None
+    if not discrete:
+        string_lookup_uuid = None
 
-   # create an empty property collection and add the new array to its 'imported' list
-   gpc = rqp.GridPropertyCollection()
-   gpc.set_grid(grid)
-   gpc.add_cached_array_to_imported_list(a,
-                                         source_info,
-                                         title,
-                                         discrete = discrete,
-                                         uom = uom,
-                                         time_index = time_index,
-                                         null_value = null_value,
-                                         property_kind = property_kind,
-                                         local_property_kind_uuid = local_property_kind_uuid,
-                                         facet_type = facet_type,
-                                         facet = facet,
-                                         realization = realization,
-                                         indexable_element = indexable_element,
-                                         count = count_per_element,
-                                         const_value = const_value,
-                                         points = points)
+    # create an empty property collection and add the new array to its 'imported' list
+    gpc = rqp.GridPropertyCollection()
+    gpc.set_grid(grid)
+    gpc.add_cached_array_to_imported_list(a,
+                                          source_info,
+                                          title,
+                                          discrete = discrete,
+                                          uom = uom,
+                                          time_index = time_index,
+                                          null_value = null_value,
+                                          property_kind = property_kind,
+                                          local_property_kind_uuid = local_property_kind_uuid,
+                                          facet_type = facet_type,
+                                          facet = facet,
+                                          realization = realization,
+                                          indexable_element = indexable_element,
+                                          count = count_per_element,
+                                          const_value = const_value,
+                                          points = points)
 
-   # write or re-write model
-   model.h5_release()
-   if new_epc_file:
-      grid_title = rqet.citation_title_for_node(grid.root)
-      uuid_list = write_grid(new_epc_file,
-                             grid,
-                             property_collection = gpc,
-                             grid_title = grid_title,
-                             mode = 'w',
-                             time_series_uuid = time_series_uuid,
-                             string_lookup_uuid = string_lookup_uuid,
-                             extra_metadata = extra_metadata)
-   else:
-      # add arrays to hdf5 file holding source grid geometry
-      uuid_list = write_grid(epc_file,
-                             grid,
-                             property_collection = gpc,
-                             mode = 'a',
-                             geometry = False,
-                             time_series_uuid = time_series_uuid,
-                             string_lookup_uuid = string_lookup_uuid,
-                             extra_metadata = extra_metadata)
+    # write or re-write model
+    model.h5_release()
+    if new_epc_file:
+        grid_title = rqet.citation_title_for_node(grid.root)
+        uuid_list = write_grid(new_epc_file,
+                               grid,
+                               property_collection = gpc,
+                               grid_title = grid_title,
+                               mode = 'w',
+                               time_series_uuid = time_series_uuid,
+                               string_lookup_uuid = string_lookup_uuid,
+                               extra_metadata = extra_metadata)
+    else:
+        # add arrays to hdf5 file holding source grid geometry
+        uuid_list = write_grid(epc_file,
+                               grid,
+                               property_collection = gpc,
+                               mode = 'a',
+                               geometry = False,
+                               time_series_uuid = time_series_uuid,
+                               string_lookup_uuid = string_lookup_uuid,
+                               extra_metadata = extra_metadata)
 
-   if uuid_list is None or len(uuid_list) == 0:
-      return None
-   return uuid_list[0]
+    if uuid_list is None or len(uuid_list) == 0:
+        return None
+    return uuid_list[0]
 
 
 def add_one_blocked_well_property(epc_file,
@@ -384,7 +385,7 @@ def add_one_blocked_well_property(epc_file,
                                   points = False,
                                   extra_metadata = {},
                                   new_epc_file = None):
-   """Adds a blocked well property from a numpy array to an existing resqml dataset.
+    """Adds a blocked well property from a numpy array to an existing resqml dataset.
 
    arguments:
       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
@@ -421,46 +422,46 @@ def add_one_blocked_well_property(epc_file,
       uuid.UUID of newly created property object
    """
 
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
 
-   # open up model and establish grid object
-   model = rq.Model(epc_file)
+    # open up model and establish grid object
+    model = rq.Model(epc_file)
 
-   blocked_well = rqw.BlockedWell(model, uuid = blocked_well_uuid)
-   assert blocked_well is not None, f'no blocked well object found with uuid {blocked_well_uuid}'
+    blocked_well = rqw.BlockedWell(model, uuid = blocked_well_uuid)
+    assert blocked_well is not None, f'no blocked well object found with uuid {blocked_well_uuid}'
 
-   if not discrete:
-      string_lookup_uuid = None
+    if not discrete:
+        string_lookup_uuid = None
 
-   # create an empty property collection and add the new array to its 'imported' list
-   bwpc = rqp.PropertyCollection()
-   bwpc.set_support(support = blocked_well, model = model)
-   bwpc.add_cached_array_to_imported_list(a,
-                                          source_info,
-                                          title,
-                                          discrete = discrete,
-                                          uom = uom,
-                                          time_index = time_index,
-                                          null_value = null_value,
-                                          property_kind = property_kind,
-                                          local_property_kind_uuid = local_property_kind_uuid,
-                                          facet_type = facet_type,
-                                          facet = facet,
-                                          realization = realization,
-                                          indexable_element = indexable_element,
-                                          count = count_per_element,
-                                          points = points)
-   bwpc.write_hdf5_for_imported_list()
-   uuid_list = bwpc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = time_series_uuid,
-                                                                        string_lookup_uuid = string_lookup_uuid,
-                                                                        property_kind_uuid = local_property_kind_uuid,
-                                                                        extra_metadata = extra_metadata)
-   assert len(uuid_list) == 1
-   model.store_epc()
-   return uuid_list[0]
+    # create an empty property collection and add the new array to its 'imported' list
+    bwpc = rqp.PropertyCollection()
+    bwpc.set_support(support = blocked_well, model = model)
+    bwpc.add_cached_array_to_imported_list(a,
+                                           source_info,
+                                           title,
+                                           discrete = discrete,
+                                           uom = uom,
+                                           time_index = time_index,
+                                           null_value = null_value,
+                                           property_kind = property_kind,
+                                           local_property_kind_uuid = local_property_kind_uuid,
+                                           facet_type = facet_type,
+                                           facet = facet,
+                                           realization = realization,
+                                           indexable_element = indexable_element,
+                                           count = count_per_element,
+                                           points = points)
+    bwpc.write_hdf5_for_imported_list()
+    uuid_list = bwpc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = time_series_uuid,
+                                                                         string_lookup_uuid = string_lookup_uuid,
+                                                                         property_kind_uuid = local_property_kind_uuid,
+                                                                         extra_metadata = extra_metadata)
+    assert len(uuid_list) == 1
+    model.store_epc()
+    return uuid_list[0]
 
 
 def add_wells_from_ascii_file(epc_file,
@@ -478,7 +479,7 @@ def add_wells_from_ascii_file(epc_file,
                               drilled = False,
                               z_inc_down = True,
                               new_epc_file = None):
-   """Adds new md datum, trajectory, interpretation and feature objects for each well in a tabular ascii file..
+    """Adds new md datum, trajectory, interpretation and feature objects for each well in a tabular ascii file..
 
    arguments:
       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
@@ -513,47 +514,47 @@ def add_wells_from_ascii_file(epc_file,
       generally affect computations
    """
 
-   assert trajectory_file and os.path.exists(trajectory_file)
-   if md_domain:
-      assert md_domain in ['driller', 'logger']
+    assert trajectory_file and os.path.exists(trajectory_file)
+    if md_domain:
+        assert md_domain in ['driller', 'logger']
 
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
 
-   # open up model
-   if new_epc_file:
-      model = rq.Model(new_epc_file, copy_from = epc_file)
-   else:
-      model = rq.Model(epc_file)
+    # open up model
+    if new_epc_file:
+        model = rq.Model(new_epc_file, copy_from = epc_file)
+    else:
+        model = rq.Model(epc_file)
 
-   # sort out the coordinate reference system
-   if crs_uuid is None:
-      crs_uuid = rqet.uuid_for_part_root(model.crs_root)
-   if crs_uuid is None:
-      if z_inc_down is None:
-         z_inc_down = True
-      crs_root = rqcrs.Crs(model, xy_units = length_uom, z_units = length_uom, z_inc_down = z_inc_down)
-      crs_uuid = rqet.uuid_for_part_root(crs_root)
+    # sort out the coordinate reference system
+    if crs_uuid is None:
+        crs_uuid = rqet.uuid_for_part_root(model.crs_root)
+    if crs_uuid is None:
+        if z_inc_down is None:
+            z_inc_down = True
+        crs_root = rqcrs.Crs(model, xy_units = length_uom, z_units = length_uom, z_inc_down = z_inc_down)
+        crs_uuid = rqet.uuid_for_part_root(crs_root)
 
-   # add all the well related objects to the model, based on data in the ascii file
-   (feature_list, interpretation_list, trajectory_list, md_datum_list) =  \
-      rqw.add_wells_from_ascii_file(model, crs_uuid, trajectory_file, comment_character = comment_character,
-                                    space_separated_instead_of_csv = space_separated_instead_of_csv,
-                                    well_col = well_col, md_col = md_col, x_col = x_col, y_col = y_col, z_col = z_col,
-                                    length_uom = length_uom, md_domain = md_domain, drilled = drilled)
+    # add all the well related objects to the model, based on data in the ascii file
+    (feature_list, interpretation_list, trajectory_list, md_datum_list) =  \
+       rqw.add_wells_from_ascii_file(model, crs_uuid, trajectory_file, comment_character = comment_character,
+                                     space_separated_instead_of_csv = space_separated_instead_of_csv,
+                                     well_col = well_col, md_col = md_col, x_col = x_col, y_col = y_col, z_col = z_col,
+                                     length_uom = length_uom, md_domain = md_domain, drilled = drilled)
 
-   assert len(feature_list) == len(interpretation_list) == len(trajectory_list) == len(md_datum_list)
-   count = len(feature_list)
+    assert len(feature_list) == len(interpretation_list) == len(trajectory_list) == len(md_datum_list)
+    count = len(feature_list)
 
-   log.info('features, interpretations, trajectories and md data added for ' + str(count) + ' well' + _pl(count))
+    log.info('features, interpretations, trajectories and md data added for ' + str(count) + ' well' + _pl(count))
 
-   # write or re-write model
-   model.h5_release()
-   model.store_epc()
+    # write or re-write model
+    model.h5_release()
+    model.store_epc()
 
-   return count
+    return count
 
 
 def zonal_grid(epc_file,
@@ -567,7 +568,7 @@ def zonal_grid(epc_file,
                inactive_laissez_faire = True,
                new_grid_title = None,
                new_epc_file = None):
-   """Extends an existing model with a new version of the source grid converted to a single, thick, layer per zone.
+    """Extends an existing model with a new version of the source grid converted to a single, thick, layer per zone.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -598,224 +599,226 @@ def zonal_grid(epc_file,
       single layer grid is generated; zone_layer_range_list will take precendence if present
    """
 
-   def fetch_zone_array(grid, zone_title = None, zone_uuid = None, masked = True):
-      properties = grid.extract_property_collection()
-      assert properties is not None and properties.number_of_parts() > 0, 'no properties found in relation to grid'
-      properties = rqp.selective_version_of_collection(properties, continuous = False)
-      assert properties is not None and properties.number_of_parts() > 0,  \
-         'no discreet properties found in relation to grid'
-      if zone_title:
-         properties = rqp.selective_version_of_collection(properties,
-                                                          citation_title = zone_title)  # could make case insensitive?
-         assert properties is not None and properties.number_of_parts() > 0,  \
-            'no discreet property found with title ' + zone_title
-      if zone_uuid:
-         if isinstance(zone_uuid, str):
-            zone_uuid = bu.uuid_from_string(zone_uuid)
-         zone_uuid_str = str(zone_uuid)
-         if zone_title:
-            postamble = ' (and title ' + zone_title + ')'
-         else:
-            postamble = ''
-         assert zone_uuid in properties.uuids(), 'no property found with uuid ' + zone_uuid_str + postamble
-         part_name = grid.model.part(uuid = zone_uuid)
-      else:
-         part_name = properties.singleton()
-      return properties.cached_part_array_ref(part_name, masked = masked)  # .copy() needed?
+    def fetch_zone_array(grid, zone_title = None, zone_uuid = None, masked = True):
+        properties = grid.extract_property_collection()
+        assert properties is not None and properties.number_of_parts() > 0, 'no properties found in relation to grid'
+        properties = rqp.selective_version_of_collection(properties, continuous = False)
+        assert properties is not None and properties.number_of_parts() > 0,  \
+           'no discreet properties found in relation to grid'
+        if zone_title:
+            properties = rqp.selective_version_of_collection(
+                properties, citation_title = zone_title)  # could make case insensitive?
+            assert properties is not None and properties.number_of_parts() > 0,  \
+               'no discreet property found with title ' + zone_title
+        if zone_uuid:
+            if isinstance(zone_uuid, str):
+                zone_uuid = bu.uuid_from_string(zone_uuid)
+            zone_uuid_str = str(zone_uuid)
+            if zone_title:
+                postamble = ' (and title ' + zone_title + ')'
+            else:
+                postamble = ''
+            assert zone_uuid in properties.uuids(), 'no property found with uuid ' + zone_uuid_str + postamble
+            part_name = grid.model.part(uuid = zone_uuid)
+        else:
+            part_name = properties.singleton()
+        return properties.cached_part_array_ref(part_name, masked = masked)  # .copy() needed?
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model (or one named ROOT)
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
-   if source_grid.grid_representation == 'IjkBlockGrid':
-      source_grid.make_regular_points_cached()
-   assert model is not None
-   single_layer_mode = (not zone_title and not zone_uuid)
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model (or one named ROOT)
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
+    if source_grid.grid_representation == 'IjkBlockGrid':
+        source_grid.make_regular_points_cached()
+    assert model is not None
+    single_layer_mode = (not zone_title and not zone_uuid)
 
-   if k0_min is None:
-      k0_min = 0
-   else:
-      assert k0_min >= 0 and k0_min < source_grid.nk
-   if k0_max is None:
-      k0_max = source_grid.nk - 1
-   else:
-      assert k0_max >= 0 and k0_max < source_grid.nk and k0_max >= k0_min
+    if k0_min is None:
+        k0_min = 0
+    else:
+        assert k0_min >= 0 and k0_min < source_grid.nk
+    if k0_max is None:
+        k0_max = source_grid.nk - 1
+    else:
+        assert k0_max >= 0 and k0_max < source_grid.nk and k0_max >= k0_min
 
-   if not single_layer_mode:  # process zone array
-      if zone_layer_range_list is None:
-         zone_array = fetch_zone_array(source_grid, zone_title, zone_uuid)
-         zone_layer_range_list = zone_layer_ranges_from_array(zone_array,
-                                                              k0_min,
-                                                              k0_max,
-                                                              use_dominant_zone = use_dominant_zone)
-      zone_count = len(zone_layer_range_list)
-      # above is list of (zone_min_k0, zone_max_k0, zone) sorted by zone_min_k0
-      log.info('following layer ranges are based on top layer being numbered 1 (simulator protocol)')
-      for (zone_min_k0, zone_max_k0, zone) in zone_layer_range_list:
-         log.info('zone id {0:1d} covers layers {1:1d} to {2:1d}'.format(zone, zone_min_k0 + 1, zone_max_k0 + 1))
-   else:
-      zone_layer_range_list = [(k0_min, k0_max, 0)]
-      zone_count = 1
-   assert zone_count > 0, 'unexpected lack of zones'
+    if not single_layer_mode:  # process zone array
+        if zone_layer_range_list is None:
+            zone_array = fetch_zone_array(source_grid, zone_title, zone_uuid)
+            zone_layer_range_list = zone_layer_ranges_from_array(zone_array,
+                                                                 k0_min,
+                                                                 k0_max,
+                                                                 use_dominant_zone = use_dominant_zone)
+        zone_count = len(zone_layer_range_list)
+        # above is list of (zone_min_k0, zone_max_k0, zone) sorted by zone_min_k0
+        log.info('following layer ranges are based on top layer being numbered 1 (simulator protocol)')
+        for (zone_min_k0, zone_max_k0, zone) in zone_layer_range_list:
+            log.info('zone id {0:1d} covers layers {1:1d} to {2:1d}'.format(zone, zone_min_k0 + 1, zone_max_k0 + 1))
+    else:
+        zone_layer_range_list = [(k0_min, k0_max, 0)]
+        zone_count = 1
+    assert zone_count > 0, 'unexpected lack of zones'
 
-   # create a new, empty grid object
-   is_regular = grr.is_regular_grid(source_grid.root) and single_layer_mode
-   if is_regular:
-      dxyz_dkji = source_grid.block_dxyz_dkji.copy()
-      dxyz_dkji[0] *= k0_max - k0_min + 1
-      grid = grr.RegularGrid(model,
-                             extent_kji = (1, source_grid.nj, source_grid.ni),
-                             dxyz_dkji = dxyz_dkji,
-                             origin = source_grid.block_origin,
-                             crs_uuid = source_grid.crs_uuid,
-                             set_points_cached = False)
-   else:
-      grid = grr.Grid(model)
-      # inherit attributes from source grid
-      grid.grid_representation = 'IjkGrid'
-      grid.extent_kji = np.array((zone_count, source_grid.nj, source_grid.ni), dtype = 'int')
-      grid.nk, grid.nj, grid.ni = zone_count, source_grid.nj, source_grid.ni
-      grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
-      grid.crs_root = source_grid.crs_root
-      grid.crs_uuid = source_grid.crs_uuid
+    # create a new, empty grid object
+    is_regular = grr.is_regular_grid(source_grid.root) and single_layer_mode
+    if is_regular:
+        dxyz_dkji = source_grid.block_dxyz_dkji.copy()
+        dxyz_dkji[0] *= k0_max - k0_min + 1
+        grid = grr.RegularGrid(model,
+                               extent_kji = (1, source_grid.nj, source_grid.ni),
+                               dxyz_dkji = dxyz_dkji,
+                               origin = source_grid.block_origin,
+                               crs_uuid = source_grid.crs_uuid,
+                               set_points_cached = False)
+    else:
+        grid = grr.Grid(model)
+        # inherit attributes from source grid
+        grid.grid_representation = 'IjkGrid'
+        grid.extent_kji = np.array((zone_count, source_grid.nj, source_grid.ni), dtype = 'int')
+        grid.nk, grid.nj, grid.ni = zone_count, source_grid.nj, source_grid.ni
+        grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
+        grid.crs_root = source_grid.crs_root
+        grid.crs_uuid = source_grid.crs_uuid
 
-   grid.k_direction_is_down = source_grid.k_direction_is_down
-   grid.grid_is_right_handed = source_grid.grid_is_right_handed
-   grid.pillar_shape = source_grid.pillar_shape
+    grid.k_direction_is_down = source_grid.k_direction_is_down
+    grid.grid_is_right_handed = source_grid.grid_is_right_handed
+    grid.pillar_shape = source_grid.pillar_shape
 
-   # aggregate inactive cell mask depending on laissez faire argument
-   if source_grid.inactive is None:
-      log.debug('setting inactive mask to None')
-      grid.inactive = None
-   elif single_layer_mode:
-      if inactive_laissez_faire:
-         log.debug('setting inactive mask using all mode (laissez faire)')
-         grid.inactive = np.all(source_grid.inactive[k0_min:k0_max + 1], axis = 0).reshape(grid.extent_kji)
-      else:
-         log.debug('setting inactive mask using any mode (strict)')
-         grid.inactive = np.any(source_grid.inactive[k0_min:k0_max + 1], axis = 0).reshape(grid.extent_kji)
-   else:
-      grid.inactive = np.zeros(grid.extent_kji, dtype = bool)
-      for zone_i in range(zone_count):
-         zk0_min, zk0_max, _ = zone_layer_range_list[zone_i]
-         if inactive_laissez_faire:
-            grid.inactive[zone_i] = np.all(source_grid.inactive[zk0_min:zk0_max + 1], axis = 0)
-         else:
-            grid.inactive[zone_i] = np.any(source_grid.inactive[zk0_min:zk0_max + 1], axis = 0)
+    # aggregate inactive cell mask depending on laissez faire argument
+    if source_grid.inactive is None:
+        log.debug('setting inactive mask to None')
+        grid.inactive = None
+    elif single_layer_mode:
+        if inactive_laissez_faire:
+            log.debug('setting inactive mask using all mode (laissez faire)')
+            grid.inactive = np.all(source_grid.inactive[k0_min:k0_max + 1], axis = 0).reshape(grid.extent_kji)
+        else:
+            log.debug('setting inactive mask using any mode (strict)')
+            grid.inactive = np.any(source_grid.inactive[k0_min:k0_max + 1], axis = 0).reshape(grid.extent_kji)
+    else:
+        grid.inactive = np.zeros(grid.extent_kji, dtype = bool)
+        for zone_i in range(zone_count):
+            zk0_min, zk0_max, _ = zone_layer_range_list[zone_i]
+            if inactive_laissez_faire:
+                grid.inactive[zone_i] = np.all(source_grid.inactive[zk0_min:zk0_max + 1], axis = 0)
+            else:
+                grid.inactive[zone_i] = np.any(source_grid.inactive[zk0_min:zk0_max + 1], axis = 0)
 
-   if not is_regular:
+    if not is_regular:
 
-      # rework the grid geometry
-      source_grid.cache_all_geometry_arrays()
-      # determine cell geometry is defined
-      if hasattr(source_grid, 'array_cell_geometry_is_defined'):
-         grid.array_cell_geometry_is_defined = np.empty(grid.extent_kji, dtype = bool)
-         if single_layer_mode:
-            grid.array_cell_geometry_is_defined[0] = np.logical_and(source_grid.array_cell_geometry_is_defined[k0_min],
-                                                                    source_grid.array_cell_geometry_is_defined[k0_max])
-         else:
+        # rework the grid geometry
+        source_grid.cache_all_geometry_arrays()
+        # determine cell geometry is defined
+        if hasattr(source_grid, 'array_cell_geometry_is_defined'):
+            grid.array_cell_geometry_is_defined = np.empty(grid.extent_kji, dtype = bool)
+            if single_layer_mode:
+                grid.array_cell_geometry_is_defined[0] = np.logical_and(
+                    source_grid.array_cell_geometry_is_defined[k0_min],
+                    source_grid.array_cell_geometry_is_defined[k0_max])
+            else:
+                for zone_i in range(zone_count):
+                    zk0_min, zk0_max, _ = zone_layer_range_list[zone_i]
+                    grid.array_cell_geometry_is_defined[zone_i] = np.logical_and(
+                        source_grid.array_cell_geometry_is_defined[zk0_min],
+                        source_grid.array_cell_geometry_is_defined[zk0_max])
+                    # could attempt to pick up some corner points from K-neighbouring cells
+            grid.geometry_defined_for_all_cells_cached = np.all(grid.array_cell_geometry_is_defined)
+        else:
+            grid.geometry_defined_for_all_cells_cached = source_grid.geometry_defined_for_all_cells_cached
+        # copy info for pillar geometry is defined
+        grid.geometry_defined_for_all_pillars_cached = source_grid.geometry_defined_for_all_pillars_cached
+        if hasattr(source_grid, 'array_pillar_geometry_is_defined'):
+            grid.array_pillar_geometry_is_defined = source_grid.array_pillar_geometry_is_defined.copy()
+        # get reference to points for source grid geometry
+        source_points = source_grid.points_ref()
+        # slice top and base points
+        points_shape = list(source_points.shape)
+        points_shape[0] = zone_count + 1  # nk + 1
+        grid.points_cached = np.zeros(points_shape)
+        if grid.geometry_defined_for_all_cells_cached:
+            if single_layer_mode:
+                grid.points_cached[0] = source_points[k0_min]
+                grid.points_cached[1] = source_points[k0_max + 1]  # base face
+            else:
+                for zone_i in range(zone_count):
+                    if zone_i == 0:
+                        grid.points_cached[0] = source_points[zone_layer_range_list[zone_i][0]]
+                    grid.points_cached[zone_i + 1] = source_points[
+                        zone_layer_range_list[zone_i][1]]  # or could use 0th element of tuple for zone_i+1
+        elif not grid.has_split_coordinate_lines:
+            log.debug('scanning columns (unsplit pillars) for reference geometry')
+            # fill in geometry: todo: replace with array operations if possible
             for zone_i in range(zone_count):
-               zk0_min, zk0_max, _ = zone_layer_range_list[zone_i]
-               grid.array_cell_geometry_is_defined[zone_i] = np.logical_and(
-                  source_grid.array_cell_geometry_is_defined[zk0_min],
-                  source_grid.array_cell_geometry_is_defined[zk0_max])
-               # could attempt to pick up some corner points from K-neighbouring cells
-         grid.geometry_defined_for_all_cells_cached = np.all(grid.array_cell_geometry_is_defined)
-      else:
-         grid.geometry_defined_for_all_cells_cached = source_grid.geometry_defined_for_all_cells_cached
-      # copy info for pillar geometry is defined
-      grid.geometry_defined_for_all_pillars_cached = source_grid.geometry_defined_for_all_pillars_cached
-      if hasattr(source_grid, 'array_pillar_geometry_is_defined'):
-         grid.array_pillar_geometry_is_defined = source_grid.array_pillar_geometry_is_defined.copy()
-      # get reference to points for source grid geometry
-      source_points = source_grid.points_ref()
-      # slice top and base points
-      points_shape = list(source_points.shape)
-      points_shape[0] = zone_count + 1  # nk + 1
-      grid.points_cached = np.zeros(points_shape)
-      if grid.geometry_defined_for_all_cells_cached:
-         if single_layer_mode:
-            grid.points_cached[0] = source_points[k0_min]
-            grid.points_cached[1] = source_points[k0_max + 1]  # base face
-         else:
+                zk0_min, zk0_max = zone_layer_range_list[zone_i][0:2]
+                for j in range(grid.nj):
+                    for i in range(grid.ni):
+                        if zone_i == 0:
+                            for k in range(zk0_min, zk0_max + 1):
+                                if source_grid.array_cell_geometry_is_defined[k, j, i]:
+                                    grid.points_cached[0, j:j + 2, i:i + 2] = source_points[k, j:j + 2, i:i + 2]
+                                    break
+                        for k in range(zk0_max, zk0_min - 1, -1):
+                            if source_grid.array_cell_geometry_is_defined[k, j, i]:
+                                grid.points_cached[zone_i + 1, j:j + 2, i:i + 2] = source_points[k + 1, j:j + 2,
+                                                                                                 i:i + 2]
+                                grid.array_cell_geometry_is_defined[zone_i, j, i] = True
+                                break
+        else:
+            log.debug('scanning columns (split pillars) for reference geometry')
+            if not hasattr(source_grid, 'pillars_for_column'):
+                source_grid.create_column_pillar_mapping()
+            grid.pillars_for_column = source_grid.pillars_for_column.copy()
             for zone_i in range(zone_count):
-               if zone_i == 0:
-                  grid.points_cached[0] = source_points[zone_layer_range_list[zone_i][0]]
-               grid.points_cached[zone_i + 1] = source_points[zone_layer_range_list[zone_i]
-                                                              [1]]  # or could use 0th element of tuple for zone_i+1
-      elif not grid.has_split_coordinate_lines:
-         log.debug('scanning columns (unsplit pillars) for reference geometry')
-         # fill in geometry: todo: replace with array operations if possible
-         for zone_i in range(zone_count):
-            zk0_min, zk0_max = zone_layer_range_list[zone_i][0:2]
-            for j in range(grid.nj):
-               for i in range(grid.ni):
-                  if zone_i == 0:
-                     for k in range(zk0_min, zk0_max + 1):
-                        if source_grid.array_cell_geometry_is_defined[k, j, i]:
-                           grid.points_cached[0, j:j + 2, i:i + 2] = source_points[k, j:j + 2, i:i + 2]
-                           break
-                  for k in range(zk0_max, zk0_min - 1, -1):
-                     if source_grid.array_cell_geometry_is_defined[k, j, i]:
-                        grid.points_cached[zone_i + 1, j:j + 2, i:i + 2] = source_points[k + 1, j:j + 2, i:i + 2]
-                        grid.array_cell_geometry_is_defined[zone_i, j, i] = True
-                        break
-      else:
-         log.debug('scanning columns (split pillars) for reference geometry')
-         if not hasattr(source_grid, 'pillars_for_column'):
-            source_grid.create_column_pillar_mapping()
-         grid.pillars_for_column = source_grid.pillars_for_column.copy()
-         for zone_i in range(zone_count):
-            zk0_min, zk0_max = zone_layer_range_list[zone_i][0:2]
-            for j in range(grid.nj):
-               for i in range(grid.ni):
-                  if grid.inactive[zone_i, j, i]:
-                     continue
-                  if zone_i == 0:
-                     for k in range(zk0_min, zk0_max + 1):
-                        if source_grid.array_cell_geometry_is_defined[k, j, i]:
-                           for jp in range(2):
-                              for ip in range(2):
-                                 pillar = grid.pillars_for_column[j, i, jp, ip]
-                                 grid.points_cached[0, pillar] = source_points[k, pillar]
-                           break
-                  for k in range(zk0_max + 1, zk0_min - 1, -1):
-                     if source_grid.array_cell_geometry_is_defined[k, j, i]:
-                        for jp in range(2):
-                           for ip in range(2):
-                              pillar = grid.pillars_for_column[j, i, jp, ip]
-                              grid.points_cached[zone_i + 1, pillar] = source_points[k + 1, pillar]
-                        grid.array_cell_geometry_is_defined[zone_i, j, i] = True
-                        break
-      if grid.has_split_coordinate_lines:
-         grid.split_pillar_indices_cached = source_grid.split_pillar_indices_cached.copy()
-         grid.cols_for_split_pillars = source_grid.cols_for_split_pillars.copy()
-         grid.cols_for_split_pillars_cl = source_grid.cols_for_split_pillars_cl.copy()
-         grid.split_pillars_count = source_grid.split_pillars_count
+                zk0_min, zk0_max = zone_layer_range_list[zone_i][0:2]
+                for j in range(grid.nj):
+                    for i in range(grid.ni):
+                        if grid.inactive[zone_i, j, i]:
+                            continue
+                        if zone_i == 0:
+                            for k in range(zk0_min, zk0_max + 1):
+                                if source_grid.array_cell_geometry_is_defined[k, j, i]:
+                                    for jp in range(2):
+                                        for ip in range(2):
+                                            pillar = grid.pillars_for_column[j, i, jp, ip]
+                                            grid.points_cached[0, pillar] = source_points[k, pillar]
+                                    break
+                        for k in range(zk0_max + 1, zk0_min - 1, -1):
+                            if source_grid.array_cell_geometry_is_defined[k, j, i]:
+                                for jp in range(2):
+                                    for ip in range(2):
+                                        pillar = grid.pillars_for_column[j, i, jp, ip]
+                                        grid.points_cached[zone_i + 1, pillar] = source_points[k + 1, pillar]
+                                grid.array_cell_geometry_is_defined[zone_i, j, i] = True
+                                break
+        if grid.has_split_coordinate_lines:
+            grid.split_pillar_indices_cached = source_grid.split_pillar_indices_cached.copy()
+            grid.cols_for_split_pillars = source_grid.cols_for_split_pillars.copy()
+            grid.cols_for_split_pillars_cl = source_grid.cols_for_split_pillars_cl.copy()
+            grid.split_pillars_count = source_grid.split_pillars_count
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      if single_layer_mode:
-         preamble = 'single layer'
-      else:
-         preamble = 'zonal'
-      new_grid_title = preamble + ' version of ' + str(rqet.citation_title_for_node(source_grid.root))
+    if new_grid_title is None or len(new_grid_title) == 0:
+        if single_layer_mode:
+            preamble = 'single layer'
+        else:
+            preamble = 'zonal'
+        new_grid_title = preamble + ' version of ' + str(rqet.citation_title_for_node(source_grid.root))
 
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, grid_title = new_grid_title, mode = 'w')
-   else:
-      #      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']), 'Coordinates')
-      write_grid(epc_file, grid, ext_uuid = None, grid_title = new_grid_title, mode = 'a')
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, grid_title = new_grid_title, mode = 'w')
+    else:
+        #      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']), 'Coordinates')
+        write_grid(epc_file, grid, ext_uuid = None, grid_title = new_grid_title, mode = 'a')
 
-   return grid
+    return grid
 
 
 def single_layer_grid(epc_file,
@@ -825,7 +828,7 @@ def single_layer_grid(epc_file,
                       inactive_laissez_faire = True,
                       new_grid_title = None,
                       new_epc_file = None):
-   """Extends an existing model with a new version of the source grid converted to a single, thick, layer.
+    """Extends an existing model with a new version of the source grid converted to a single, thick, layer.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -846,13 +849,13 @@ def single_layer_grid(epc_file,
       new grid object (grid.Grid) with a single layer representation of the source grid
    """
 
-   return zonal_grid(epc_file,
-                     source_grid = source_grid,
-                     k0_min = k0_min,
-                     k0_max = k0_max,
-                     inactive_laissez_faire = inactive_laissez_faire,
-                     new_grid_title = new_grid_title,
-                     new_epc_file = new_epc_file)
+    return zonal_grid(epc_file,
+                      source_grid = source_grid,
+                      k0_min = k0_min,
+                      k0_max = k0_max,
+                      inactive_laissez_faire = inactive_laissez_faire,
+                      new_grid_title = new_grid_title,
+                      new_epc_file = new_epc_file)
 
 
 def interpolated_grid(epc_file,
@@ -865,7 +868,7 @@ def interpolated_grid(epc_file,
                       inherit_all_realizations = False,
                       new_grid_title = None,
                       new_epc_file = None):
-   """Extends an existing model with a new grid geometry linearly interpolated between the two source_grids.
+    """Extends an existing model with a new grid geometry linearly interpolated between the two source_grids.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to
@@ -895,254 +898,256 @@ def interpolated_grid(epc_file,
       as the first argument (unless a new epc file is required, sharing the hdf5 file)
    """
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert grid_a is not None and grid_b is not None, 'at least one source grid is missing'
-   assert grid_a.grid_representation == 'IjkGrid' and grid_b.grid_representation == 'IjkGrid'
-   assert 0.0 <= a_to_b_0_to_1 <= 1.0, 'interpolation factor outside range 0.0 to 1.0'
-   assert tuple(grid_a.extent_kji) == tuple(grid_b.extent_kji), 'source grids have different extents'
-   assert grid_a.k_direction_is_down == grid_b.k_direction_is_down, 'source grids have different k directions'
-   assert grid_a.grid_is_right_handed == grid_b.grid_is_right_handed, 'source grids have different ijk handedness'
-   assert grid_a.pillar_shape == grid_b.pillar_shape, 'source grids have different resqml pillar shapes'
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert grid_a is not None and grid_b is not None, 'at least one source grid is missing'
+    assert grid_a.grid_representation == 'IjkGrid' and grid_b.grid_representation == 'IjkGrid'
+    assert 0.0 <= a_to_b_0_to_1 <= 1.0, 'interpolation factor outside range 0.0 to 1.0'
+    assert tuple(grid_a.extent_kji) == tuple(grid_b.extent_kji), 'source grids have different extents'
+    assert grid_a.k_direction_is_down == grid_b.k_direction_is_down, 'source grids have different k directions'
+    assert grid_a.grid_is_right_handed == grid_b.grid_is_right_handed, 'source grids have different ijk handedness'
+    assert grid_a.pillar_shape == grid_b.pillar_shape, 'source grids have different resqml pillar shapes'
 
-   b_weight = a_to_b_0_to_1
-   a_weight = 1.0 - b_weight
+    b_weight = a_to_b_0_to_1
+    a_weight = 1.0 - b_weight
 
-   model = grid_a.model
+    model = grid_a.model
 
-   if not bu.matching_uuids(grid_a.crs_uuid, grid_b.crs_uuid):
-      crs_a = rqcrs.Crs(grid_a.model, uuid = grid_a.crs_uuid)
-      crs_b = rqcrs.Crs(grid_b.model, uuid = grid_b.crs_uuid)
-      assert crs_a.is_equivalent(crs_b), 'end point grids for interpolation have different coordinate reference systems'
+    if not bu.matching_uuids(grid_a.crs_uuid, grid_b.crs_uuid):
+        crs_a = rqcrs.Crs(grid_a.model, uuid = grid_a.crs_uuid)
+        crs_b = rqcrs.Crs(grid_b.model, uuid = grid_b.crs_uuid)
+        assert crs_a.is_equivalent(
+            crs_b), 'end point grids for interpolation have different coordinate reference systems'
 
-   log.info('loading geometry for two source grids')
-   grid_a.cache_all_geometry_arrays()
-   grid_b.cache_all_geometry_arrays()
+    log.info('loading geometry for two source grids')
+    grid_a.cache_all_geometry_arrays()
+    grid_b.cache_all_geometry_arrays()
 
-   assert grid_a.geometry_defined_for_all_cells() and grid_b.geometry_defined_for_all_cells(
-   ), 'geometry not defined for all cells'
-   #  assert grid_a.geometry_defined_for_all_pillars() and grid_b.geometry_defined_for_all_pillars(), 'geometry not defined for all pillars'
+    assert grid_a.geometry_defined_for_all_cells() and grid_b.geometry_defined_for_all_cells(
+    ), 'geometry not defined for all cells'
+    #  assert grid_a.geometry_defined_for_all_pillars() and grid_b.geometry_defined_for_all_pillars(), 'geometry not defined for all pillars'
 
-   if not grid_a.has_split_coordinate_lines and not grid_b.has_split_coordinate_lines:
-      work_from_pillars = True
-   elif (grid_a.has_split_coordinate_lines and grid_b.has_split_coordinate_lines and
-         grid_a.points_cached.shape == grid_b.points_cached.shape and
-         grid_a.split_pillar_indices_cached.shape == grid_b.split_pillar_indices_cached.shape and
-         grid_a.cols_for_split_pillars.shape == grid_b.cols_for_split_pillars.shape and
-         grid_a.cols_for_split_pillars_cl.shape == grid_b.cols_for_split_pillars_cl.shape and
-         np.all(grid_a.split_pillar_indices_cached == grid_b.split_pillar_indices_cached) and
-         np.all(grid_a.cols_for_split_pillars == grid_b.cols_for_split_pillars) and
-         np.all(grid_a.cols_for_split_pillars_cl == grid_b.cols_for_split_pillars_cl)):
-      work_from_pillars = True
-   else:
-      work_from_pillars = False
+    if not grid_a.has_split_coordinate_lines and not grid_b.has_split_coordinate_lines:
+        work_from_pillars = True
+    elif (grid_a.has_split_coordinate_lines and grid_b.has_split_coordinate_lines and
+          grid_a.points_cached.shape == grid_b.points_cached.shape and
+          grid_a.split_pillar_indices_cached.shape == grid_b.split_pillar_indices_cached.shape and
+          grid_a.cols_for_split_pillars.shape == grid_b.cols_for_split_pillars.shape and
+          grid_a.cols_for_split_pillars_cl.shape == grid_b.cols_for_split_pillars_cl.shape and
+          np.all(grid_a.split_pillar_indices_cached == grid_b.split_pillar_indices_cached) and
+          np.all(grid_a.cols_for_split_pillars == grid_b.cols_for_split_pillars) and
+          np.all(grid_a.cols_for_split_pillars_cl == grid_b.cols_for_split_pillars_cl)):
+        work_from_pillars = True
+    else:
+        work_from_pillars = False
 
-   if work_from_pillars:
-      log.info('interpolating between compatible pillar grids')
-   else:
-      log.warning('interpolating between corner points due to pillar incompatibilities')
+    if work_from_pillars:
+        log.info('interpolating between compatible pillar grids')
+    else:
+        log.warning('interpolating between corner points due to pillar incompatibilities')
 
-   # create a new, empty grid object
-   grid = grr.Grid(model)
+    # create a new, empty grid object
+    grid = grr.Grid(model)
 
-   # inherit attributes from source grid
-   grid.grid_representation = 'IjkGrid'
-   grid.extent_kji = grid_a.extent_kji.copy()
-   grid.nk, grid.nj, grid.ni = grid.extent_kji
-   grid.k_direction_is_down = grid_a.k_direction_is_down
-   grid.grid_is_right_handed = grid_a.grid_is_right_handed
-   grid.pillar_shape = grid_a.pillar_shape
-   grid.has_split_coordinate_lines = (grid_a.has_split_coordinate_lines or grid_b.has_split_coordinate_lines)
-   # inherit the coordinate reference system used by the grid geometry
-   grid.crs_root = grid_a.crs_root
-   grid.crs_uuid = grid_a.crs_uuid
+    # inherit attributes from source grid
+    grid.grid_representation = 'IjkGrid'
+    grid.extent_kji = grid_a.extent_kji.copy()
+    grid.nk, grid.nj, grid.ni = grid.extent_kji
+    grid.k_direction_is_down = grid_a.k_direction_is_down
+    grid.grid_is_right_handed = grid_a.grid_is_right_handed
+    grid.pillar_shape = grid_a.pillar_shape
+    grid.has_split_coordinate_lines = (grid_a.has_split_coordinate_lines or grid_b.has_split_coordinate_lines)
+    # inherit the coordinate reference system used by the grid geometry
+    grid.crs_root = grid_a.crs_root
+    grid.crs_uuid = grid_a.crs_uuid
 
-   if grid_a.inactive is None or grid_b.inactive is None:
-      grid.inactive = None
-   else:
-      grid.inactive = np.logical_and(grid_a.inactive, grid_b.inactive)
+    if grid_a.inactive is None or grid_b.inactive is None:
+        grid.inactive = None
+    else:
+        grid.inactive = np.logical_and(grid_a.inactive, grid_b.inactive)
 
-   grid.geometry_defined_for_all_cells_cached = True
-   grid.array_cell_geometry_is_defined = np.ones(tuple(grid.extent_kji), dtype = bool)
-   grid.geometry_defined_for_all_pillars_cached = True
+    grid.geometry_defined_for_all_cells_cached = True
+    grid.array_cell_geometry_is_defined = np.ones(tuple(grid.extent_kji), dtype = bool)
+    grid.geometry_defined_for_all_pillars_cached = True
 
-   if work_from_pillars:
-      grid.points_cached = grid_a.points_cached * a_weight + grid_b.points_cached * b_weight
-      grid.has_split_coordinate_lines = grid_a.has_split_coordinate_lines
-      if grid.has_split_coordinate_lines:
-         grid.split_pillar_indices_cached = grid_a.split_pillar_indices_cached.copy()
-         grid.cols_for_split_pillars = grid_a.cols_for_split_pillars.copy()
-         grid.cols_for_split_pillars_cl = grid_a.cols_for_split_pillars_cl.copy()
-         grid.split_pillars_count = grid_a.split_pillars_count
-   else:
-      grid.pillar_shape = 'curved'  # following fesapi approach of non-parametric pillars even if they are in fact straight
-      cp_a = grid_a.corner_points(cache_cp_array = True)
-      cp_b = grid_b.corner_points(cache_cp_array = True)
-      assert cp_a.shape == cp_b.shape
-      grid_cp = cp_a * a_weight + cp_b * b_weight
-      if grid.nk > 1:
-         z_gap = grid_cp[1:, :, :, 0, :, :, :] - grid_cp[:-1, :, :, 1, :, :, :]
-         max_gap = np.max(np.abs(z_gap))
-         log.info('maximum vertical void distance after corner point interpolation: {0:.3f} {1}'.format(
-            max_gap, grid_a.z_units()))
-         # close vertical voids (includes shifting x & y)
-         if max_gap > 0.0:
-            log.debug('closing vertical voids')
-            z_gap *= 0.5
-            grid_cp[1:, :, :, 0, :, :, :] -= z_gap
-            grid_cp[:-1, :, :, 1, :, :, :] += z_gap
-      # reduce cp array extent in k
-      log.debug('reducing k extent of interpolated corner point array (sharing points vertically)')
-      k_reduced_cp_array = np.zeros((grid.nk + 1, grid.nj, grid.ni, 2, 2, 3))  # (nk+1, nj, ni, jp, ip, xyz)
-      k_reduced_cp_array[0, :, :, :, :, :] = grid_cp[0, :, :, 0, :, :, :]
-      k_reduced_cp_array[-1, :, :, :, :, :] = grid_cp[-1, :, :, 1, :, :, :]
-      if grid.nk > 1:
-         k_reduced_cp_array[1:-1, :, :, :, :, :] = grid_cp[:-1, :, :, 1, :, :, :]
-      # create primary pillar reference indices as one of four column corners around pillar, active column preferred
-      log.debug('creating primary pillar reference neighbourly indices')
-      primary_pillar_jip = np.zeros((grid.nj + 1, grid.ni + 1, 2), dtype = 'int')  # (nj + 1, ni + 1, jp:ip)
-      primary_pillar_jip[-1, :, 0] = 1
-      primary_pillar_jip[:, -1, 1] = 1
-      # build extra pillar references for split pillars
-      extras_count = np.zeros((grid.nj + 1, grid.ni + 1), dtype = 'int')  # count (0 to 3) of extras for pillar
-      extras_list_index = np.zeros((grid.nj + 1, grid.ni + 1), dtype = 'int')  # index in list of 1st extra for pillar
-      extras_list = []  # list of (jp, ip)
-      extras_use = np.negative(np.ones((grid.nj, grid.ni, 2, 2), dtype = 'int'))  # (j, i, jp, ip); -1 means use primary
-      log.debug('building extra pillar references for split pillars')
-      # loop over pillars
-      for j in range(grid.nj + 1):
-         for i in range(grid.ni + 1):
-            primary_jp = primary_pillar_jip[j, i, 0]
-            primary_ip = primary_pillar_jip[j, i, 1]
-            p_col_j = j - primary_jp
-            p_col_i = i - primary_ip
-            # loop over 4 columns surrounding this pillar
-            for jp in range(2):
-               col_j = j - jp
-               if col_j < 0 or col_j >= grid.nj:
-                  continue  # no column this side of pillar in j
-               for ip in range(2):
-                  col_i = i - ip
-                  if col_i < 0 or col_i >= grid.ni:
-                     continue  # no column this side of pillar in i
-                  if jp == primary_jp and ip == primary_ip:
-                     continue  # this column is the primary for this pillar
-                  discrepancy = np.max(
-                     np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
-                            k_reduced_cp_array[:, p_col_j, p_col_i, primary_jp, primary_ip, :]))
-                  if discrepancy <= split_tolerance:
-                     continue  # data for this column's corner aligns with primary
-                  for e in range(extras_count[j, i]):
-                     eli = extras_list_index[j, i] + e
-                     pillar_j_extra = j - extras_list[eli][0]
-                     pillar_i_extra = i - extras_list[eli][1]
-                     discrepancy = np.max(
-                        np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
-                               k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, extras_list[eli][0],
-                                                  extras_list[eli][1], :]))
-                     if discrepancy <= split_tolerance:  # data for this corner aligns with existing extra
-                        extras_use[col_j, col_i, jp, ip] = e
-                        break
-                  if extras_use[col_j, col_i, jp, ip] >= 0:  # reusing an existing extra for this pillar
-                     continue
-                  # add this corner as an extra
-                  if extras_count[j, i] == 0:  # create entry point for this pillar in extras
-                     extras_list_index[j, i] = len(extras_list)
-                  extras_list.append((jp, ip))
-                  extras_use[col_j, col_i, jp, ip] = extras_count[j, i]
-                  extras_count[j, i] += 1
-      if len(extras_list) == 0:
-         grid.has_split_coordinate_lines = False
-      log.debug('number of extra pillars: ' + str(len(extras_list)))
-      # create points array as used in resqml
-      log.debug('creating points array as used in resqml format')
-      if grid.has_split_coordinate_lines:
-         points_array = np.zeros((grid.nk + 1, (grid.nj + 1) * (grid.ni + 1) + len(extras_list), 3))
-         index = 0
-         # primary pillars
-         for pillar_j in range(grid.nj + 1):
-            for pillar_i in range(grid.ni + 1):
-               (jp, ip) = primary_pillar_jip[pillar_j, pillar_i]
-               points_array[:, index, :] = k_reduced_cp_array[:, pillar_j - jp, pillar_i - ip, jp, ip, :]
-               index += 1
-         # add extras for split pillars
-         for pillar_j in range(grid.nj + 1):
-            for pillar_i in range(grid.ni + 1):
-               for e in range(extras_count[pillar_j, pillar_i]):
-                  eli = extras_list_index[pillar_j, pillar_i] + e
-                  (jp, ip) = extras_list[eli]
-                  pillar_j_extra = pillar_j - jp
-                  pillar_i_extra = pillar_i - ip
-                  points_array[:, index, :] = k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, jp, ip, :]
-                  index += 1
-         assert index == (grid.nj + 1) * (grid.ni + 1) + len(extras_list)
-      else:  # unsplit pillars
-         points_array = np.zeros((grid.nk + 1, grid.nj + 1, grid.ni + 1, 3))
-         for j in range(grid.nj + 1):
+    if work_from_pillars:
+        grid.points_cached = grid_a.points_cached * a_weight + grid_b.points_cached * b_weight
+        grid.has_split_coordinate_lines = grid_a.has_split_coordinate_lines
+        if grid.has_split_coordinate_lines:
+            grid.split_pillar_indices_cached = grid_a.split_pillar_indices_cached.copy()
+            grid.cols_for_split_pillars = grid_a.cols_for_split_pillars.copy()
+            grid.cols_for_split_pillars_cl = grid_a.cols_for_split_pillars_cl.copy()
+            grid.split_pillars_count = grid_a.split_pillars_count
+    else:
+        grid.pillar_shape = 'curved'  # following fesapi approach of non-parametric pillars even if they are in fact straight
+        cp_a = grid_a.corner_points(cache_cp_array = True)
+        cp_b = grid_b.corner_points(cache_cp_array = True)
+        assert cp_a.shape == cp_b.shape
+        grid_cp = cp_a * a_weight + cp_b * b_weight
+        if grid.nk > 1:
+            z_gap = grid_cp[1:, :, :, 0, :, :, :] - grid_cp[:-1, :, :, 1, :, :, :]
+            max_gap = np.max(np.abs(z_gap))
+            log.info('maximum vertical void distance after corner point interpolation: {0:.3f} {1}'.format(
+                max_gap, grid_a.z_units()))
+            # close vertical voids (includes shifting x & y)
+            if max_gap > 0.0:
+                log.debug('closing vertical voids')
+                z_gap *= 0.5
+                grid_cp[1:, :, :, 0, :, :, :] -= z_gap
+                grid_cp[:-1, :, :, 1, :, :, :] += z_gap
+        # reduce cp array extent in k
+        log.debug('reducing k extent of interpolated corner point array (sharing points vertically)')
+        k_reduced_cp_array = np.zeros((grid.nk + 1, grid.nj, grid.ni, 2, 2, 3))  # (nk+1, nj, ni, jp, ip, xyz)
+        k_reduced_cp_array[0, :, :, :, :, :] = grid_cp[0, :, :, 0, :, :, :]
+        k_reduced_cp_array[-1, :, :, :, :, :] = grid_cp[-1, :, :, 1, :, :, :]
+        if grid.nk > 1:
+            k_reduced_cp_array[1:-1, :, :, :, :, :] = grid_cp[:-1, :, :, 1, :, :, :]
+        # create primary pillar reference indices as one of four column corners around pillar, active column preferred
+        log.debug('creating primary pillar reference neighbourly indices')
+        primary_pillar_jip = np.zeros((grid.nj + 1, grid.ni + 1, 2), dtype = 'int')  # (nj + 1, ni + 1, jp:ip)
+        primary_pillar_jip[-1, :, 0] = 1
+        primary_pillar_jip[:, -1, 1] = 1
+        # build extra pillar references for split pillars
+        extras_count = np.zeros((grid.nj + 1, grid.ni + 1), dtype = 'int')  # count (0 to 3) of extras for pillar
+        extras_list_index = np.zeros((grid.nj + 1, grid.ni + 1), dtype = 'int')  # index in list of 1st extra for pillar
+        extras_list = []  # list of (jp, ip)
+        extras_use = np.negative(np.ones((grid.nj, grid.ni, 2, 2),
+                                         dtype = 'int'))  # (j, i, jp, ip); -1 means use primary
+        log.debug('building extra pillar references for split pillars')
+        # loop over pillars
+        for j in range(grid.nj + 1):
             for i in range(grid.ni + 1):
-               (jp, ip) = primary_pillar_jip[j, i]
-               points_array[:, j, i, :] = k_reduced_cp_array[:, j - jp, i - ip, jp, ip, :]
-      grid.points_cached = points_array
-      # add split pillar arrays to grid object
-      if grid.has_split_coordinate_lines:
-         log.debug('adding split pillar arrays to grid object')
-         split_pillar_indices_list = []
-         cumulative_length_list = []
-         cols_for_extra_pillar_list = []
-         cumulative_length = 0
-         for pillar_j in range(grid.nj + 1):
-            for pillar_i in range(grid.ni + 1):
-               for e in range(extras_count[pillar_j, pillar_i]):
-                  split_pillar_indices_list.append(pillar_j * (grid.ni + 1) + pillar_i)
-                  use_count = 0
-                  for jp in range(2):
-                     j = pillar_j - jp
-                     if j < 0 or j >= grid.nj:
-                        continue
-                     for ip in range(2):
-                        i = pillar_i - ip
-                        if i < 0 or i >= grid.ni:
-                           continue
-                        if extras_use[j, i, jp, ip] == e:
-                           use_count += 1
-                           cols_for_extra_pillar_list.append((j * grid.ni) + i)
-                  assert (use_count > 0)
-                  cumulative_length += use_count
-                  cumulative_length_list.append(cumulative_length)
-         log.debug('number of extra pillars: ' + str(len(split_pillar_indices_list)))
-         assert (len(cumulative_length_list) == len(split_pillar_indices_list))
-         grid.split_pillar_indices_cached = np.array(split_pillar_indices_list, dtype = 'int')
-         log.debug('number of uses of extra pillars: ' + str(len(cols_for_extra_pillar_list)))
-         assert (len(cols_for_extra_pillar_list) == np.count_nonzero(extras_use + 1))
-         assert (len(cols_for_extra_pillar_list) == cumulative_length)
-         grid.cols_for_split_pillars = np.array(cols_for_extra_pillar_list, dtype = 'int')
-         assert (len(cumulative_length_list) == len(extras_list))
-         grid.cols_for_split_pillars_cl = np.array(cumulative_length_list, dtype = 'int')
-         grid.split_pillars_count = len(extras_list)
+                primary_jp = primary_pillar_jip[j, i, 0]
+                primary_ip = primary_pillar_jip[j, i, 1]
+                p_col_j = j - primary_jp
+                p_col_i = i - primary_ip
+                # loop over 4 columns surrounding this pillar
+                for jp in range(2):
+                    col_j = j - jp
+                    if col_j < 0 or col_j >= grid.nj:
+                        continue  # no column this side of pillar in j
+                    for ip in range(2):
+                        col_i = i - ip
+                        if col_i < 0 or col_i >= grid.ni:
+                            continue  # no column this side of pillar in i
+                        if jp == primary_jp and ip == primary_ip:
+                            continue  # this column is the primary for this pillar
+                        discrepancy = np.max(
+                            np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
+                                   k_reduced_cp_array[:, p_col_j, p_col_i, primary_jp, primary_ip, :]))
+                        if discrepancy <= split_tolerance:
+                            continue  # data for this column's corner aligns with primary
+                        for e in range(extras_count[j, i]):
+                            eli = extras_list_index[j, i] + e
+                            pillar_j_extra = j - extras_list[eli][0]
+                            pillar_i_extra = i - extras_list[eli][1]
+                            discrepancy = np.max(
+                                np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
+                                       k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, extras_list[eli][0],
+                                                          extras_list[eli][1], :]))
+                            if discrepancy <= split_tolerance:  # data for this corner aligns with existing extra
+                                extras_use[col_j, col_i, jp, ip] = e
+                                break
+                        if extras_use[col_j, col_i, jp, ip] >= 0:  # reusing an existing extra for this pillar
+                            continue
+                        # add this corner as an extra
+                        if extras_count[j, i] == 0:  # create entry point for this pillar in extras
+                            extras_list_index[j, i] = len(extras_list)
+                        extras_list.append((jp, ip))
+                        extras_use[col_j, col_i, jp, ip] = extras_count[j, i]
+                        extras_count[j, i] += 1
+        if len(extras_list) == 0:
+            grid.has_split_coordinate_lines = False
+        log.debug('number of extra pillars: ' + str(len(extras_list)))
+        # create points array as used in resqml
+        log.debug('creating points array as used in resqml format')
+        if grid.has_split_coordinate_lines:
+            points_array = np.zeros((grid.nk + 1, (grid.nj + 1) * (grid.ni + 1) + len(extras_list), 3))
+            index = 0
+            # primary pillars
+            for pillar_j in range(grid.nj + 1):
+                for pillar_i in range(grid.ni + 1):
+                    (jp, ip) = primary_pillar_jip[pillar_j, pillar_i]
+                    points_array[:, index, :] = k_reduced_cp_array[:, pillar_j - jp, pillar_i - ip, jp, ip, :]
+                    index += 1
+            # add extras for split pillars
+            for pillar_j in range(grid.nj + 1):
+                for pillar_i in range(grid.ni + 1):
+                    for e in range(extras_count[pillar_j, pillar_i]):
+                        eli = extras_list_index[pillar_j, pillar_i] + e
+                        (jp, ip) = extras_list[eli]
+                        pillar_j_extra = pillar_j - jp
+                        pillar_i_extra = pillar_i - ip
+                        points_array[:, index, :] = k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, jp, ip, :]
+                        index += 1
+            assert index == (grid.nj + 1) * (grid.ni + 1) + len(extras_list)
+        else:  # unsplit pillars
+            points_array = np.zeros((grid.nk + 1, grid.nj + 1, grid.ni + 1, 3))
+            for j in range(grid.nj + 1):
+                for i in range(grid.ni + 1):
+                    (jp, ip) = primary_pillar_jip[j, i]
+                    points_array[:, j, i, :] = k_reduced_cp_array[:, j - jp, i - ip, jp, ip, :]
+        grid.points_cached = points_array
+        # add split pillar arrays to grid object
+        if grid.has_split_coordinate_lines:
+            log.debug('adding split pillar arrays to grid object')
+            split_pillar_indices_list = []
+            cumulative_length_list = []
+            cols_for_extra_pillar_list = []
+            cumulative_length = 0
+            for pillar_j in range(grid.nj + 1):
+                for pillar_i in range(grid.ni + 1):
+                    for e in range(extras_count[pillar_j, pillar_i]):
+                        split_pillar_indices_list.append(pillar_j * (grid.ni + 1) + pillar_i)
+                        use_count = 0
+                        for jp in range(2):
+                            j = pillar_j - jp
+                            if j < 0 or j >= grid.nj:
+                                continue
+                            for ip in range(2):
+                                i = pillar_i - ip
+                                if i < 0 or i >= grid.ni:
+                                    continue
+                                if extras_use[j, i, jp, ip] == e:
+                                    use_count += 1
+                                    cols_for_extra_pillar_list.append((j * grid.ni) + i)
+                        assert (use_count > 0)
+                        cumulative_length += use_count
+                        cumulative_length_list.append(cumulative_length)
+            log.debug('number of extra pillars: ' + str(len(split_pillar_indices_list)))
+            assert (len(cumulative_length_list) == len(split_pillar_indices_list))
+            grid.split_pillar_indices_cached = np.array(split_pillar_indices_list, dtype = 'int')
+            log.debug('number of uses of extra pillars: ' + str(len(cols_for_extra_pillar_list)))
+            assert (len(cols_for_extra_pillar_list) == np.count_nonzero(extras_use + 1))
+            assert (len(cols_for_extra_pillar_list) == cumulative_length)
+            grid.cols_for_split_pillars = np.array(cols_for_extra_pillar_list, dtype = 'int')
+            assert (len(cumulative_length_list) == len(extras_list))
+            grid.cols_for_split_pillars_cl = np.array(cumulative_length_list, dtype = 'int')
+            grid.split_pillars_count = len(extras_list)
 
-   collection = _prepare_simple_inheritance(grid, grid_a, inherit_properties, inherit_realization,
-                                            inherit_all_realizations)
+    collection = _prepare_simple_inheritance(grid, grid_a, inherit_properties, inherit_realization,
+                                             inherit_all_realizations)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'interpolated between two grids with factor: ' + str(a_to_b_0_to_1)
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'interpolated between two grids with factor: ' + str(a_to_b_0_to_1)
 
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(grid_a.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(grid_a.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   return grid
+    return grid
 
 
 def extract_box(epc_file = None,
@@ -1155,7 +1160,7 @@ def extract_box(epc_file = None,
                 set_parent_window = None,
                 new_grid_title = None,
                 new_epc_file = None):
-   """Extends an existing model with a new grid extracted as a logical IJK box from the source grid.
+    """Extends an existing model with a new grid extracted as a logical IJK box from the source grid.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -1186,261 +1191,261 @@ def extract_box(epc_file = None,
       in which case the grid and inherited properties are written there instead
    """
 
-   def array_box(a, box):
-      return a[box[0, 0]:box[1, 0] + 1, box[0, 1]:box[1, 1] + 1, box[0, 2]:box[1, 2] + 1].copy()
+    def array_box(a, box):
+        return a[box[0, 0]:box[1, 0] + 1, box[0, 1]:box[1, 1] + 1, box[0, 2]:box[1, 2] + 1].copy()
 
-   def local_col_index(extent, box, col):
-      # return local equivalent natural column index for global column index, or None if outside box
-      j, i = divmod(col, extent[2])
-      j -= box[0, 1]
-      i -= box[0, 2]
-      if j < 0 or i < 0 or j > box[1, 1] - box[0, 1] or i > box[1, 2] - box[0, 2]:
-         return None
-      return j * (box[1, 2] - box[0, 2] + 1) + i
+    def local_col_index(extent, box, col):
+        # return local equivalent natural column index for global column index, or None if outside box
+        j, i = divmod(col, extent[2])
+        j -= box[0, 1]
+        i -= box[0, 2]
+        if j < 0 or i < 0 or j > box[1, 1] - box[0, 1] or i > box[1, 2] - box[0, 2]:
+            return None
+        return j * (box[1, 2] - box[0, 2] + 1) + i
 
-   def local_pillar_index(extent, box, p):
-      # return local equivalent natural pillar index for global pillar index, or None if outside box
-      p_j, p_i = divmod(p, extent[2] + 1)
-      p_j -= box[0, 1]
-      p_i -= box[0, 2]
-      if p_j < 0 or p_i < 0 or p_j > box[1, 1] - box[0, 1] + 1 or p_i > box[1, 2] - box[0, 2] + 1:
-         return None
-      return p_j * (box[1, 2] - box[0, 2] + 2) + p_i
+    def local_pillar_index(extent, box, p):
+        # return local equivalent natural pillar index for global pillar index, or None if outside box
+        p_j, p_i = divmod(p, extent[2] + 1)
+        p_j -= box[0, 1]
+        p_i -= box[0, 2]
+        if p_j < 0 or p_i < 0 or p_j > box[1, 1] - box[0, 1] + 1 or p_i > box[1, 2] - box[0, 2] + 1:
+            return None
+        return p_j * (box[1, 2] - box[0, 2] + 2) + p_i
 
-   def cols_for_pillar(extent, p):
-      # return 4 naturalized column indices for columns surrounding natural pillar index; -1 where beyond edge of ij space
-      cols = np.zeros((4,), dtype = int) - 1
-      p_j, p_i = divmod(p, extent[2] + 1)
-      if p_j > 0 and p_i > 0:
-         cols[0] = (p_j - 1) * extent[2] + p_i - 1
-      if p_j > 0 and p_i < extent[2]:
-         cols[1] = (p_j - 1) * extent[2] + p_i
-      if p_j < extent[1] and p_i > 0:
-         cols[2] = p_j * extent[2] + p_i - 1
-      if p_j < extent[1] and p_i < extent[2]:
-         cols[3] = p_j * extent[2] + p_i
-      return cols
+    def cols_for_pillar(extent, p):
+        # return 4 naturalized column indices for columns surrounding natural pillar index; -1 where beyond edge of ij space
+        cols = np.zeros((4,), dtype = int) - 1
+        p_j, p_i = divmod(p, extent[2] + 1)
+        if p_j > 0 and p_i > 0:
+            cols[0] = (p_j - 1) * extent[2] + p_i - 1
+        if p_j > 0 and p_i < extent[2]:
+            cols[1] = (p_j - 1) * extent[2] + p_i
+        if p_j < extent[1] and p_i > 0:
+            cols[2] = p_j * extent[2] + p_i - 1
+        if p_j < extent[1] and p_i < extent[2]:
+            cols[3] = p_j * extent[2] + p_i
+        return cols
 
-   log.debug('extracting grid for box')
+    log.debug('extracting grid for box')
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if set_parent_window is None:
-      set_parent_window = (new_epc_file is None)
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model (or one named 'ROOT')
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
-   assert model is not None
-   assert box is not None and box.shape == (2, 3)
-   assert np.all(box[1, :] >= box[0, :]) and np.all(box[0, :] >= 0) and np.all(box[1, :] < source_grid.extent_kji)
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if set_parent_window is None:
+        set_parent_window = (new_epc_file is None)
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model (or one named 'ROOT')
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
+    assert model is not None
+    assert box is not None and box.shape == (2, 3)
+    assert np.all(box[1, :] >= box[0, :]) and np.all(box[0, :] >= 0) and np.all(box[1, :] < source_grid.extent_kji)
 
-   if source_grid.grid_representation == 'IjkBlockGrid':
-      source_grid.make_regular_points_cached()
+    if source_grid.grid_representation == 'IjkBlockGrid':
+        source_grid.make_regular_points_cached()
 
-   box_str = bx.string_iijjkk1_for_box_kji0(box)
+    box_str = bx.string_iijjkk1_for_box_kji0(box)
 
-   # create a new, empty grid object
-   grid = grr.Grid(model)
+    # create a new, empty grid object
+    grid = grr.Grid(model)
 
-   # inherit attributes from source grid
-   grid.grid_representation = 'IjkGrid'
-   grid.extent_kji = box[1, :] - box[0, :] + 1
-   if box_inactive is not None:
-      assert box_inactive.shape == tuple(grid.extent_kji)
-   grid.nk, grid.nj, grid.ni = grid.extent_kji[0], grid.extent_kji[1], grid.extent_kji[2]
-   grid.k_direction_is_down = source_grid.k_direction_is_down
-   grid.grid_is_right_handed = source_grid.grid_is_right_handed
-   grid.pillar_shape = source_grid.pillar_shape
-   grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
-   # inherit the coordinate reference system used by the grid geometry
-   grid.crs_root = source_grid.crs_root
-   grid.crs_uuid = source_grid.crs_uuid
+    # inherit attributes from source grid
+    grid.grid_representation = 'IjkGrid'
+    grid.extent_kji = box[1, :] - box[0, :] + 1
+    if box_inactive is not None:
+        assert box_inactive.shape == tuple(grid.extent_kji)
+    grid.nk, grid.nj, grid.ni = grid.extent_kji[0], grid.extent_kji[1], grid.extent_kji[2]
+    grid.k_direction_is_down = source_grid.k_direction_is_down
+    grid.grid_is_right_handed = source_grid.grid_is_right_handed
+    grid.pillar_shape = source_grid.pillar_shape
+    grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
+    # inherit the coordinate reference system used by the grid geometry
+    grid.crs_root = source_grid.crs_root
+    grid.crs_uuid = source_grid.crs_uuid
 
-   # inherit k_gaps for selected layer range
-   if source_grid.k_gaps and box[1, 0] > box[0, 0]:
-      k_gaps = np.count_nonzero(source_grid.k_gap_after_array[box[0, 0]:box[1, 0]])
-      if k_gaps > 0:
-         grid.k_gaps = k_gaps
-         grid.k_gap_after_array = source_grid.k_gap_after_array[box[0, 0]:box[1, 0]].copy()
-         grid.k_raw_index_array = np.empty(grid.nk, dtype = int)
-         k_offset = 0
-         for k in range(grid.nk):
-            grid.k_raw_index_array[k] = k + k_offset
-            if k < grid.nk - 1 and grid.k_gap_after_array[k]:
-               k_offset += 1
-         assert k_offset == k_gaps
+    # inherit k_gaps for selected layer range
+    if source_grid.k_gaps and box[1, 0] > box[0, 0]:
+        k_gaps = np.count_nonzero(source_grid.k_gap_after_array[box[0, 0]:box[1, 0]])
+        if k_gaps > 0:
+            grid.k_gaps = k_gaps
+            grid.k_gap_after_array = source_grid.k_gap_after_array[box[0, 0]:box[1, 0]].copy()
+            grid.k_raw_index_array = np.empty(grid.nk, dtype = int)
+            k_offset = 0
+            for k in range(grid.nk):
+                grid.k_raw_index_array[k] = k + k_offset
+                if k < grid.nk - 1 and grid.k_gap_after_array[k]:
+                    k_offset += 1
+            assert k_offset == k_gaps
 
-   # extract inactive cell mask
-   if source_grid.inactive is None:
-      if box_inactive is None:
-         log.debug('setting inactive mask to None')
-         grid.inactive = None
-      else:
-         log.debug('setting inactive mask to that passed as argument')
-         grid.inactive = box_inactive.copy()
-   else:
-      if box_inactive is None:
-         log.debug('extrating inactive mask')
-         grid.inactive = array_box(source_grid.inactive, box)
-      else:
-         log.debug('setting inactive mask to merge of source grid extraction and mask passed as argument')
-         grid.inactive = np.logical_or(array_box(source_grid.inactive, box), box_inactive)
+    # extract inactive cell mask
+    if source_grid.inactive is None:
+        if box_inactive is None:
+            log.debug('setting inactive mask to None')
+            grid.inactive = None
+        else:
+            log.debug('setting inactive mask to that passed as argument')
+            grid.inactive = box_inactive.copy()
+    else:
+        if box_inactive is None:
+            log.debug('extrating inactive mask')
+            grid.inactive = array_box(source_grid.inactive, box)
+        else:
+            log.debug('setting inactive mask to merge of source grid extraction and mask passed as argument')
+            grid.inactive = np.logical_or(array_box(source_grid.inactive, box), box_inactive)
 
-   # extract the grid geometry
-   source_grid.cache_all_geometry_arrays()
+    # extract the grid geometry
+    source_grid.cache_all_geometry_arrays()
 
-   # determine cell geometry is defined
-   if hasattr(source_grid, 'array_cell_geometry_is_defined'):
-      grid.array_cell_geometry_is_defined = array_box(source_grid.array_cell_geometry_is_defined, box)
-      grid.geometry_defined_for_all_cells_cached = np.all(grid.array_cell_geometry_is_defined)
-   else:
-      grid.geometry_defined_for_all_cells_cached = source_grid.geometry_defined_for_all_cells_cached
+    # determine cell geometry is defined
+    if hasattr(source_grid, 'array_cell_geometry_is_defined'):
+        grid.array_cell_geometry_is_defined = array_box(source_grid.array_cell_geometry_is_defined, box)
+        grid.geometry_defined_for_all_cells_cached = np.all(grid.array_cell_geometry_is_defined)
+    else:
+        grid.geometry_defined_for_all_cells_cached = source_grid.geometry_defined_for_all_cells_cached
 
-   # copy info for pillar geometry is defined
-   grid.geometry_defined_for_all_pillars_cached = source_grid.geometry_defined_for_all_pillars_cached
-   if hasattr(source_grid, 'array_pillar_geometry_is_defined'):
-      grid.array_pillar_geometry_is_defined = array_box(source_grid.array_pillar_geometry_is_defined, box)
-      grid.geometry_defined_for_all_pillars_cached = np.all(grid.array_pillar_geometry_is_defined)
+    # copy info for pillar geometry is defined
+    grid.geometry_defined_for_all_pillars_cached = source_grid.geometry_defined_for_all_pillars_cached
+    if hasattr(source_grid, 'array_pillar_geometry_is_defined'):
+        grid.array_pillar_geometry_is_defined = array_box(source_grid.array_pillar_geometry_is_defined, box)
+        grid.geometry_defined_for_all_pillars_cached = np.all(grid.array_pillar_geometry_is_defined)
 
-   # get reference to points for source grid geometry
-   source_points = source_grid.points_ref()
+    # get reference to points for source grid geometry
+    source_points = source_grid.points_ref()
 
-   pillar_box = box.copy()
-   if source_grid.k_gaps:
-      pillar_box[:, 0] = source_grid.k_raw_index_array[pillar_box[:, 0]]
-   pillar_box[1, :] += 1  # pillar points have extent one greater than cells, in each axis
+    pillar_box = box.copy()
+    if source_grid.k_gaps:
+        pillar_box[:, 0] = source_grid.k_raw_index_array[pillar_box[:, 0]]
+    pillar_box[1, :] += 1  # pillar points have extent one greater than cells, in each axis
 
-   if not source_grid.has_split_coordinate_lines:
-      log.debug('no split pillars in source grid')
-      grid.points_cached = array_box(source_points, pillar_box)  # should work, ie. preserve xyz axis
-   else:
-      source_base_pillar_count = (source_grid.nj + 1) * (source_grid.ni + 1)
-      log.debug('number of base pillars in source grid: ' + str(source_base_pillar_count))
-      log.debug('number of extra pillars in source grid: ' + str(len(source_grid.split_pillar_indices_cached)))
-      base_points = array_box(
-         source_points[:, :source_base_pillar_count, :].reshape(
-            (source_grid.nk_plus_k_gaps + 1, source_grid.nj + 1, source_grid.ni + 1, 3)),
-         pillar_box).reshape(grid.nk_plus_k_gaps + 1, (grid.nj + 1) * (grid.ni + 1), 3)
-      extra_points = np.zeros(
-         (pillar_box[1, 0] - pillar_box[0, 0] + 1, source_points.shape[1] - source_base_pillar_count, 3))
-      spi_array = np.zeros(len(source_grid.split_pillar_indices_cached), dtype = int)
-      local_cols_array = np.zeros(len(source_grid.cols_for_split_pillars), dtype = int)
-      local_cols_cl = np.zeros(len(source_grid.split_pillar_indices_cached), dtype = int)
-      local_index = 0
-      for index in range(len(source_grid.split_pillar_indices_cached)):
-         source_pi = source_grid.split_pillar_indices_cached[index]
-         local_pi = local_pillar_index(source_grid.extent_kji, box, source_pi)
-         if local_pi is None:
-            continue
-         cols = cols_for_pillar(source_grid.extent_kji, source_pi)
-         local_cols = cols_for_pillar(grid.extent_kji, local_pi)
-         if index == 0:
-            start = 0
-         else:
-            start = source_grid.cols_for_split_pillars_cl[index - 1]
-         finish = source_grid.cols_for_split_pillars_cl[index]
-         source_pis = np.zeros((4,), dtype = int)
-         for c_i in range(4):
-            if local_cols[c_i] < 0:
-               source_pis[c_i] = -1
-               continue
-            if cols[c_i] in source_grid.cols_for_split_pillars[start:finish]:
-               source_pis[c_i] = source_base_pillar_count + index
+    if not source_grid.has_split_coordinate_lines:
+        log.debug('no split pillars in source grid')
+        grid.points_cached = array_box(source_points, pillar_box)  # should work, ie. preserve xyz axis
+    else:
+        source_base_pillar_count = (source_grid.nj + 1) * (source_grid.ni + 1)
+        log.debug('number of base pillars in source grid: ' + str(source_base_pillar_count))
+        log.debug('number of extra pillars in source grid: ' + str(len(source_grid.split_pillar_indices_cached)))
+        base_points = array_box(
+            source_points[:, :source_base_pillar_count, :].reshape(
+                (source_grid.nk_plus_k_gaps + 1, source_grid.nj + 1, source_grid.ni + 1, 3)),
+            pillar_box).reshape(grid.nk_plus_k_gaps + 1, (grid.nj + 1) * (grid.ni + 1), 3)
+        extra_points = np.zeros(
+            (pillar_box[1, 0] - pillar_box[0, 0] + 1, source_points.shape[1] - source_base_pillar_count, 3))
+        spi_array = np.zeros(len(source_grid.split_pillar_indices_cached), dtype = int)
+        local_cols_array = np.zeros(len(source_grid.cols_for_split_pillars), dtype = int)
+        local_cols_cl = np.zeros(len(source_grid.split_pillar_indices_cached), dtype = int)
+        local_index = 0
+        for index in range(len(source_grid.split_pillar_indices_cached)):
+            source_pi = source_grid.split_pillar_indices_cached[index]
+            local_pi = local_pillar_index(source_grid.extent_kji, box, source_pi)
+            if local_pi is None:
+                continue
+            cols = cols_for_pillar(source_grid.extent_kji, source_pi)
+            local_cols = cols_for_pillar(grid.extent_kji, local_pi)
+            if index == 0:
+                start = 0
             else:
-               source_pis[c_i] = source_pi
-         unique_source_pis = np.unique(source_pis)
-         unique_count = len(unique_source_pis)
-         unique_index = 0
-         if unique_source_pis[0] == -1:
-            unique_index = 1
-            unique_count -= 1
-         if unique_count <= 0:
-            continue
-         base_points[:, local_pi, :] = source_points[pillar_box[0, 0]:pillar_box[1, 0] + 1,
-                                                     unique_source_pis[unique_index], :]
-         unique_index += 1
-         unique_count -= 1
-         if unique_count <= 0:
-            continue
-         while unique_count > 0:
-            source_pi = unique_source_pis[unique_index]
-            extra_points[:, local_index, :] = source_points[pillar_box[0, 0]:pillar_box[1, 0] + 1, source_pi, :]
-            spi_array[local_index] = local_pi
-            if local_index == 0:
-               lc_index = 0
-            else:
-               lc_index = local_cols_cl[local_index - 1]
+                start = source_grid.cols_for_split_pillars_cl[index - 1]
+            finish = source_grid.cols_for_split_pillars_cl[index]
+            source_pis = np.zeros((4,), dtype = int)
             for c_i in range(4):
-               if source_pis[c_i] == source_pi and local_cols[c_i] >= 0:
-                  local_cols_array[lc_index] = local_cols[c_i]
-                  lc_index += 1
-            local_cols_cl[local_index] = lc_index
-            local_index += 1
+                if local_cols[c_i] < 0:
+                    source_pis[c_i] = -1
+                    continue
+                if cols[c_i] in source_grid.cols_for_split_pillars[start:finish]:
+                    source_pis[c_i] = source_base_pillar_count + index
+                else:
+                    source_pis[c_i] = source_pi
+            unique_source_pis = np.unique(source_pis)
+            unique_count = len(unique_source_pis)
+            unique_index = 0
+            if unique_source_pis[0] == -1:
+                unique_index = 1
+                unique_count -= 1
+            if unique_count <= 0:
+                continue
+            base_points[:, local_pi, :] = source_points[pillar_box[0, 0]:pillar_box[1, 0] + 1,
+                                                        unique_source_pis[unique_index], :]
             unique_index += 1
             unique_count -= 1
-      if local_index == 0:  # there are no split pillars in the box
-         log.debug('box does not inherit any split pillars')
-         grid.points_cached = base_points.reshape(grid.nk_plus_k_gaps + 1, grid.nj + 1, grid.ni + 1, 3)
-         grid.has_split_coordinate_lines = False
-      else:
-         log.debug('number of extra pillars in box: ' + str(local_index))
-         grid.points_cached = np.concatenate((base_points, extra_points[:, :local_index, :]), axis = 1)
-         grid.split_pillar_indices_cached = spi_array[:local_index].copy()
-         grid.cols_for_split_pillars = local_cols_array[:local_cols_cl[local_index - 1]].copy()
-         grid.cols_for_split_pillars_cl = local_cols_cl[:local_index].copy()
-         grid.split_pillars_count = local_index
+            if unique_count <= 0:
+                continue
+            while unique_count > 0:
+                source_pi = unique_source_pis[unique_index]
+                extra_points[:, local_index, :] = source_points[pillar_box[0, 0]:pillar_box[1, 0] + 1, source_pi, :]
+                spi_array[local_index] = local_pi
+                if local_index == 0:
+                    lc_index = 0
+                else:
+                    lc_index = local_cols_cl[local_index - 1]
+                for c_i in range(4):
+                    if source_pis[c_i] == source_pi and local_cols[c_i] >= 0:
+                        local_cols_array[lc_index] = local_cols[c_i]
+                        lc_index += 1
+                local_cols_cl[local_index] = lc_index
+                local_index += 1
+                unique_index += 1
+                unique_count -= 1
+        if local_index == 0:  # there are no split pillars in the box
+            log.debug('box does not inherit any split pillars')
+            grid.points_cached = base_points.reshape(grid.nk_plus_k_gaps + 1, grid.nj + 1, grid.ni + 1, 3)
+            grid.has_split_coordinate_lines = False
+        else:
+            log.debug('number of extra pillars in box: ' + str(local_index))
+            grid.points_cached = np.concatenate((base_points, extra_points[:, :local_index, :]), axis = 1)
+            grid.split_pillar_indices_cached = spi_array[:local_index].copy()
+            grid.cols_for_split_pillars = local_cols_array[:local_cols_cl[local_index - 1]].copy()
+            grid.cols_for_split_pillars_cl = local_cols_cl[:local_index].copy()
+            grid.split_pillars_count = local_index
 
-   if set_parent_window:
-      fine_coarse = fc.FineCoarse(grid.extent_kji, grid.extent_kji, within_coarse_box = box)
-      fine_coarse.set_all_ratios_constant()
-      grid.set_parent(source_grid.uuid, True, fine_coarse)
+    if set_parent_window:
+        fine_coarse = fc.FineCoarse(grid.extent_kji, grid.extent_kji, within_coarse_box = box)
+        fine_coarse.set_all_ratios_constant()
+        grid.set_parent(source_grid.uuid, True, fine_coarse)
 
-   collection = None
-   if inherit_properties:
-      source_collection = source_grid.extract_property_collection()
-      if source_collection is not None:
-         # do not inherit the inactive property array by this mechanism
-         active_collection = rqp.selective_version_of_collection(source_collection, property_kind = 'active')
-         source_collection.remove_parts_list_from_dict(active_collection.parts())
-         inactive_collection = rqp.selective_version_of_collection(
-            source_collection,
-            property_kind = 'code',  # for backward compatibility
-            facet_type = 'what',
-            facet = 'inactive')
-         source_collection.remove_parts_list_from_dict(inactive_collection.parts())
-         collection = rqp.GridPropertyCollection()
-         collection.set_grid(grid)
-         collection.extend_imported_list_copying_properties_from_other_grid_collection(
-            source_collection,
-            box = box,
-            realization = inherit_realization,
-            copy_all_realizations = inherit_all_realizations)
+    collection = None
+    if inherit_properties:
+        source_collection = source_grid.extract_property_collection()
+        if source_collection is not None:
+            # do not inherit the inactive property array by this mechanism
+            active_collection = rqp.selective_version_of_collection(source_collection, property_kind = 'active')
+            source_collection.remove_parts_list_from_dict(active_collection.parts())
+            inactive_collection = rqp.selective_version_of_collection(
+                source_collection,
+                property_kind = 'code',  # for backward compatibility
+                facet_type = 'what',
+                facet = 'inactive')
+            source_collection.remove_parts_list_from_dict(inactive_collection.parts())
+            collection = rqp.GridPropertyCollection()
+            collection.set_grid(grid)
+            collection.extend_imported_list_copying_properties_from_other_grid_collection(
+                source_collection,
+                box = box,
+                realization = inherit_realization,
+                copy_all_realizations = inherit_all_realizations)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'local grid ' + box_str + ' extracted from ' + str(rqet.citation_title_for_node(
-         source_grid.root))
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'local grid ' + box_str + ' extracted from ' + str(
+            rqet.citation_title_for_node(source_grid.root))
 
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   return grid
+    return grid
 
 
 def extract_box_for_well(epc_file = None,
@@ -1464,7 +1469,7 @@ def extract_box_for_well(epc_file = None,
                          set_parent_window = None,
                          new_grid_title = None,
                          new_epc_file = None):
-   """Extends an existing model with a new grid extracted as an IJK box around a well trajectory in the source grid.
+    """Extends an existing model with a new grid extracted as an IJK box around a well trajectory in the source grid.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -1522,248 +1527,249 @@ def extract_box_for_well(epc_file = None,
       are both given, the source grid will be copied to the new epc
    """
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if trajectory_epc == epc_file:
-      trajectory_epc = None
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model (or one named 'ROOT')
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
-   assert model is not None
-   if trajectory_epc is None:
-      traj_model = model
-   else:
-      traj_model = rq.Model(trajectory_epc)
-   assert traj_model is not None
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if trajectory_epc == epc_file:
+        trajectory_epc = None
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model (or one named 'ROOT')
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
+    assert model is not None
+    if trajectory_epc is None:
+        traj_model = model
+    else:
+        traj_model = rq.Model(trajectory_epc)
+    assert traj_model is not None
 
-   if source_grid.grid_representation == 'IjkBlockGrid':
-      source_grid.make_regular_points_cached()
+    if source_grid.grid_representation == 'IjkBlockGrid':
+        source_grid.make_regular_points_cached()
 
-   if min_k0 is None:
-      min_k0 = 0
-   if max_k0 is None:
-      max_k0 = source_grid.nk - 1
-   assert 0 <= min_k0 <= max_k0 < source_grid.nk
-   assert trajectory_uuid is not None or blocked_well_uuid is not None or column_ji0 is not None
-   if radius is None:
-      radius = 0.0  # cells directly penetrated through a k face will still be included
-   assert radius >= 0.0
-   if outer_radius is not None:
-      assert outer_radius >= radius
-   assert active_cells_shape in ['tube', 'prism', 'box']
-   warned = False
-   box = None
-   # prepare cell centre points for testing inclusion
-   centres = source_grid.centre_point(cache_centre_array = True)
-   inclusion_mask = np.zeros(source_grid.extent_kji, dtype = bool)  # intialised to False
-   radius_sqr = radius * radius
-   if outer_radius is not None:
-      outer_radius_sqr = outer_radius * outer_radius
-      outer_inactive_mask = np.zeros(source_grid.extent_kji, dtype = bool)  # intialised to False
-   trajectory = blocked_well = None
-   bw_box = None
-   if trajectory_uuid is not None:
-      # prepare a trajectory object
-      trajectory_root = traj_model.root(obj_type = 'WellboreTrajectoryRepresentation', uuid = trajectory_uuid)
-      assert trajectory_root is not None, 'trajectory object not found for uuid: ' + str(trajectory_uuid)
-      trajectory = rqw.Trajectory(traj_model, uuid = trajectory_uuid)
-      well_name = rqw.well_name(trajectory)
-      traj_crs = rqcrs.Crs(trajectory.model, uuid = trajectory.crs_uuid)
-      grid_crs = rqcrs.Crs(source_grid.model, uuid = source_grid.crs_uuid)
-      # modify in-memory trajectory data to be in the same crs as grid
-      traj_crs.convert_array_to(grid_crs,
-                                trajectory.control_points)  # trajectory xyz points converted in situ to grid's crs
-      trajectory.crs_uuid = source_grid.crs_uuid  # note: tangent vectors might be messed up, if present
-      traj_box = np.empty((2, 3))
-      traj_box[0] = np.amin(trajectory.control_points, axis = 0)
-      traj_box[1] = np.amax(trajectory.control_points, axis = 0)
-      grid_box = source_grid.xyz_box(lazy = False)
-      if not bx.boxes_overlap(traj_box, grid_box):
-         log.error('no overlap of xyz boxes for trajectory and grid for trajectory uuid: ' + str(trajectory.uuid))
-         return None, None
-   elif blocked_well_uuid is not None:
-      bw_root = traj_model.root(obj_type = 'BlockedWellboreRepresentation', uuid = blocked_well_uuid)
-      assert bw_root is not None, 'blocked well object not found for uuid: ' + str(blocked_well_uuid)
-      blocked_well = rqw.BlockedWell(traj_model, uuid = blocked_well_uuid)
-      bw_box = blocked_well.box(grid_uuid = source_grid.uuid)
-      assert bw_box is not None, 'blocked well does not include cells in source grid'
-      assert bw_box[0,
-                    0] <= max_k0 and bw_box[1,
-                                            0] >= min_k0, 'blocked well does not include cells in specified layer range'
-      bw_cells = blocked_well.cell_indices_for_grid_uuid(source_grid.uuid)
-   else:
-      if column_ji0 is None:
-         assert len(column_xy) == 2
-         column_ji0 = source_grid.find_cell_for_point_xy(column_xy[0], column_xy[1])
-         if column_ji0[0] is None or column_ji0[1] is None:
-            log.error('no column found for x, y: ' + str(column_xy[0]) + ', ' + str(column_xy[1]))
-         return None, None
-      assert len(column_ji0) == 2
-      assert 0 <= column_ji0[0] < source_grid.nj and 0 <= column_ji0[1] < source_grid.ni
-      cols_ji0 = np.array(column_ji0, dtype = int).reshape((1, 2))
-      if not well_name:
-         well_name = 'well for global column ' + str(column_ji0[1] + 1) + ', ' + str(column_ji0[0] + 1)
-   # build up mask info
-   # todo: handle base interfaces above k gaps
-   h_or_l = 'layer' if trajectory is None else 'horizon'
-   end_k0 = max_k0 + 1 if trajectory is None else max_k0 + 2
-   for k in range(min_k0, end_k0):
-      if trajectory is None:
-         if blocked_well is None:
-            cols, intersect_points = cols_ji0, centres[k, column_ji0[0], column_ji0[1]].reshape((1, 3))
-         else:
-            selected_cells = np.where(bw_cells[:, 0] == k)[0]
-            cells = bw_cells[selected_cells]
-            cols = cells[:, 1:]
-            intersect_points = centres[cells[:, 0], cells[:, 1], cells[:, 2]]
-      else:
-         if k < source_grid.nk:
-            cols, intersect_points = rgs.find_intersections_of_trajectory_with_layer_interface(
-               trajectory, source_grid, k0 = k, ref_k_faces = 'top', quad_triangles = quad_triangles)
-         else:
-            cols, intersect_points = rgs.find_intersections_of_trajectory_with_layer_interface(
-               trajectory, source_grid, k0 = k - 1, ref_k_faces = 'base', quad_triangles = quad_triangles)
-      if cols is None or len(cols) == 0:
-         if not warned:
-            log.warning(f"no intersection found between well and {h_or_l}(s) such as: {k}")
-            warned = True
-         continue
-      count = cols.shape[0]
-      assert len(intersect_points) == count
-      if count > 1:
-         log.warning(f"{count} intersections found between well and {h_or_l}: {k}")
-      layer_mask = np.zeros((source_grid.nj, source_grid.ni), dtype = bool)  # to be set True within radius
-      if outer_radius is not None:
-         outer_layer_mask = np.ones((source_grid.nj, source_grid.ni),
-                                    dtype = bool)  # to be set False within outer_radius
-      for intersect in range(count):
-         log.debug(f"well intersects {h_or_l} {k} in column j0,i0: {cols[intersect, 0]}, {cols[intersect, 1]}")
-         if radius > 0.0 or outer_radius is not None:
+    if min_k0 is None:
+        min_k0 = 0
+    if max_k0 is None:
+        max_k0 = source_grid.nk - 1
+    assert 0 <= min_k0 <= max_k0 < source_grid.nk
+    assert trajectory_uuid is not None or blocked_well_uuid is not None or column_ji0 is not None
+    if radius is None:
+        radius = 0.0  # cells directly penetrated through a k face will still be included
+    assert radius >= 0.0
+    if outer_radius is not None:
+        assert outer_radius >= radius
+    assert active_cells_shape in ['tube', 'prism', 'box']
+    warned = False
+    box = None
+    # prepare cell centre points for testing inclusion
+    centres = source_grid.centre_point(cache_centre_array = True)
+    inclusion_mask = np.zeros(source_grid.extent_kji, dtype = bool)  # intialised to False
+    radius_sqr = radius * radius
+    if outer_radius is not None:
+        outer_radius_sqr = outer_radius * outer_radius
+        outer_inactive_mask = np.zeros(source_grid.extent_kji, dtype = bool)  # intialised to False
+    trajectory = blocked_well = None
+    bw_box = None
+    if trajectory_uuid is not None:
+        # prepare a trajectory object
+        trajectory_root = traj_model.root(obj_type = 'WellboreTrajectoryRepresentation', uuid = trajectory_uuid)
+        assert trajectory_root is not None, 'trajectory object not found for uuid: ' + str(trajectory_uuid)
+        trajectory = rqw.Trajectory(traj_model, uuid = trajectory_uuid)
+        well_name = rqw.well_name(trajectory)
+        traj_crs = rqcrs.Crs(trajectory.model, uuid = trajectory.crs_uuid)
+        grid_crs = rqcrs.Crs(source_grid.model, uuid = source_grid.crs_uuid)
+        # modify in-memory trajectory data to be in the same crs as grid
+        traj_crs.convert_array_to(grid_crs,
+                                  trajectory.control_points)  # trajectory xyz points converted in situ to grid's crs
+        trajectory.crs_uuid = source_grid.crs_uuid  # note: tangent vectors might be messed up, if present
+        traj_box = np.empty((2, 3))
+        traj_box[0] = np.amin(trajectory.control_points, axis = 0)
+        traj_box[1] = np.amax(trajectory.control_points, axis = 0)
+        grid_box = source_grid.xyz_box(lazy = False)
+        if not bx.boxes_overlap(traj_box, grid_box):
+            log.error('no overlap of xyz boxes for trajectory and grid for trajectory uuid: ' + str(trajectory.uuid))
+            return None, None
+    elif blocked_well_uuid is not None:
+        bw_root = traj_model.root(obj_type = 'BlockedWellboreRepresentation', uuid = blocked_well_uuid)
+        assert bw_root is not None, 'blocked well object not found for uuid: ' + str(blocked_well_uuid)
+        blocked_well = rqw.BlockedWell(traj_model, uuid = blocked_well_uuid)
+        bw_box = blocked_well.box(grid_uuid = source_grid.uuid)
+        assert bw_box is not None, 'blocked well does not include cells in source grid'
+        assert bw_box[0, 0] <= max_k0 and bw_box[
+            1, 0] >= min_k0, 'blocked well does not include cells in specified layer range'
+        bw_cells = blocked_well.cell_indices_for_grid_uuid(source_grid.uuid)
+    else:
+        if column_ji0 is None:
+            assert len(column_xy) == 2
+            column_ji0 = source_grid.find_cell_for_point_xy(column_xy[0], column_xy[1])
+            if column_ji0[0] is None or column_ji0[1] is None:
+                log.error('no column found for x, y: ' + str(column_xy[0]) + ', ' + str(column_xy[1]))
+            return None, None
+        assert len(column_ji0) == 2
+        assert 0 <= column_ji0[0] < source_grid.nj and 0 <= column_ji0[1] < source_grid.ni
+        cols_ji0 = np.array(column_ji0, dtype = int).reshape((1, 2))
+        if not well_name:
+            well_name = 'well for global column ' + str(column_ji0[1] + 1) + ', ' + str(column_ji0[0] + 1)
+    # build up mask info
+    # todo: handle base interfaces above k gaps
+    h_or_l = 'layer' if trajectory is None else 'horizon'
+    end_k0 = max_k0 + 1 if trajectory is None else max_k0 + 2
+    for k in range(min_k0, end_k0):
+        if trajectory is None:
+            if blocked_well is None:
+                cols, intersect_points = cols_ji0, centres[k, column_ji0[0], column_ji0[1]].reshape((1, 3))
+            else:
+                selected_cells = np.where(bw_cells[:, 0] == k)[0]
+                cells = bw_cells[selected_cells]
+                cols = cells[:, 1:]
+                intersect_points = centres[cells[:, 0], cells[:, 1], cells[:, 2]]
+        else:
             if k < source_grid.nk:
-               vectors = centres[k] - intersect_points[intersect].reshape((1, 1, 3))
-               distance_sqr = vectors[..., 0] * vectors[..., 0] + vectors[..., 1] * vectors[..., 1]
-               if radius > 0.0:
-                  layer_mask = np.logical_or(layer_mask, np.less_equal(distance_sqr, radius_sqr))
-               if outer_radius is not None:
-                  outer_layer_mask = np.logical_and(outer_layer_mask, np.greater_equal(distance_sqr, outer_radius_sqr))
-            if k > 0 and (not source_grid.k_gaps or k >= source_grid.nk - 1 or
-                          not source_grid.k_gap_after_array[k - 1]):
-               vectors = centres[k - 1] - intersect_points[intersect].reshape((1, 1, 3))
-               distance_sqr = vectors[..., 0] * vectors[..., 0] + vectors[..., 1] * vectors[..., 1]
-               if radius > 0.0:
-                  layer_mask = np.logical_or(layer_mask, np.less_equal(distance_sqr, radius_sqr))
-               if outer_radius is not None:
-                  outer_layer_mask = np.logical_and(outer_layer_mask, np.greater_equal(distance_sqr, outer_radius_sqr))
-         layer_mask[cols[intersect, 0], cols[intersect, 1]] = True
-      if k <= max_k0:
-         inclusion_mask[k] = layer_mask
-         if outer_radius is not None:
-            outer_inactive_mask[k] = outer_layer_mask
-      if k > min_k0:
-         inclusion_mask[k - 1] = np.logical_or(inclusion_mask[k - 1], layer_mask)
-         if outer_radius is not None:
-            outer_inactive_mask[k - 1] = np.logical_and(outer_inactive_mask[k - 1], outer_layer_mask)
-      log.debug(f"number of columns found in {h_or_l} {k} within radius around well: {np.count_nonzero(layer_mask)}")
-   inc_count = np.count_nonzero(inclusion_mask)
-   if inc_count == 0:
-      log.error('no cells found within search radius around well')
-      return None, None
-   log.info('total number of cells found within radius around well: ' + str(inc_count))
-   # derive box and inactive mask from inclusion mask
-   min_j0 = 0
-   while min_j0 < source_grid.nj - 1 and not np.any(inclusion_mask[:, min_j0, :]):
-      min_j0 += 1
-   max_j0 = source_grid.nj - 1
-   while max_j0 > 0 and not np.any(inclusion_mask[:, max_j0, :]):
-      max_j0 -= 1
-   assert max_j0 >= min_j0
-   min_i0 = 0
-   while min_i0 < source_grid.ni - 1 and not np.any(inclusion_mask[:, :, min_i0]):
-      min_i0 += 1
-   max_i0 = source_grid.ni - 1
-   while max_i0 > 0 and not np.any(inclusion_mask[:, :, max_i0]):
-      max_i0 -= 1
-   assert max_i0 >= min_i0
-   box = np.array([[min_k0, min_j0, min_i0], [max_k0, max_j0, max_i0]], dtype = int)
-   log.info('box for well is: ' + bx.string_iijjkk1_for_box_kji0(box) + ' (simulator protocol)')
-   # prepare inactive mask to merge in for new grid
-   if active_cells_shape in ['tube', 'prism']:
-      if active_cells_shape == 'prism':
-         layer_mask = np.any(inclusion_mask, axis = 0)
-         inclusion_mask[:] = layer_mask
-      box_inactive = np.logical_not(inclusion_mask[min_k0:max_k0 + 1, min_j0:max_j0 + 1, min_i0:max_i0 + 1])
-   else:  # 'box' option: leave all cells active (except where inactive in source grid)
-      box_inactive = None
+                cols, intersect_points = rgs.find_intersections_of_trajectory_with_layer_interface(
+                    trajectory, source_grid, k0 = k, ref_k_faces = 'top', quad_triangles = quad_triangles)
+            else:
+                cols, intersect_points = rgs.find_intersections_of_trajectory_with_layer_interface(
+                    trajectory, source_grid, k0 = k - 1, ref_k_faces = 'base', quad_triangles = quad_triangles)
+        if cols is None or len(cols) == 0:
+            if not warned:
+                log.warning(f"no intersection found between well and {h_or_l}(s) such as: {k}")
+                warned = True
+            continue
+        count = cols.shape[0]
+        assert len(intersect_points) == count
+        if count > 1:
+            log.warning(f"{count} intersections found between well and {h_or_l}: {k}")
+        layer_mask = np.zeros((source_grid.nj, source_grid.ni), dtype = bool)  # to be set True within radius
+        if outer_radius is not None:
+            outer_layer_mask = np.ones((source_grid.nj, source_grid.ni),
+                                       dtype = bool)  # to be set False within outer_radius
+        for intersect in range(count):
+            log.debug(f"well intersects {h_or_l} {k} in column j0,i0: {cols[intersect, 0]}, {cols[intersect, 1]}")
+            if radius > 0.0 or outer_radius is not None:
+                if k < source_grid.nk:
+                    vectors = centres[k] - intersect_points[intersect].reshape((1, 1, 3))
+                    distance_sqr = vectors[..., 0] * vectors[..., 0] + vectors[..., 1] * vectors[..., 1]
+                    if radius > 0.0:
+                        layer_mask = np.logical_or(layer_mask, np.less_equal(distance_sqr, radius_sqr))
+                    if outer_radius is not None:
+                        outer_layer_mask = np.logical_and(outer_layer_mask,
+                                                          np.greater_equal(distance_sqr, outer_radius_sqr))
+                if k > 0 and (not source_grid.k_gaps or k >= source_grid.nk - 1 or
+                              not source_grid.k_gap_after_array[k - 1]):
+                    vectors = centres[k - 1] - intersect_points[intersect].reshape((1, 1, 3))
+                    distance_sqr = vectors[..., 0] * vectors[..., 0] + vectors[..., 1] * vectors[..., 1]
+                    if radius > 0.0:
+                        layer_mask = np.logical_or(layer_mask, np.less_equal(distance_sqr, radius_sqr))
+                    if outer_radius is not None:
+                        outer_layer_mask = np.logical_and(outer_layer_mask,
+                                                          np.greater_equal(distance_sqr, outer_radius_sqr))
+            layer_mask[cols[intersect, 0], cols[intersect, 1]] = True
+        if k <= max_k0:
+            inclusion_mask[k] = layer_mask
+            if outer_radius is not None:
+                outer_inactive_mask[k] = outer_layer_mask
+        if k > min_k0:
+            inclusion_mask[k - 1] = np.logical_or(inclusion_mask[k - 1], layer_mask)
+            if outer_radius is not None:
+                outer_inactive_mask[k - 1] = np.logical_and(outer_inactive_mask[k - 1], outer_layer_mask)
+        log.debug(f"number of columns found in {h_or_l} {k} within radius around well: {np.count_nonzero(layer_mask)}")
+    inc_count = np.count_nonzero(inclusion_mask)
+    if inc_count == 0:
+        log.error('no cells found within search radius around well')
+        return None, None
+    log.info('total number of cells found within radius around well: ' + str(inc_count))
+    # derive box and inactive mask from inclusion mask
+    min_j0 = 0
+    while min_j0 < source_grid.nj - 1 and not np.any(inclusion_mask[:, min_j0, :]):
+        min_j0 += 1
+    max_j0 = source_grid.nj - 1
+    while max_j0 > 0 and not np.any(inclusion_mask[:, max_j0, :]):
+        max_j0 -= 1
+    assert max_j0 >= min_j0
+    min_i0 = 0
+    while min_i0 < source_grid.ni - 1 and not np.any(inclusion_mask[:, :, min_i0]):
+        min_i0 += 1
+    max_i0 = source_grid.ni - 1
+    while max_i0 > 0 and not np.any(inclusion_mask[:, :, max_i0]):
+        max_i0 -= 1
+    assert max_i0 >= min_i0
+    box = np.array([[min_k0, min_j0, min_i0], [max_k0, max_j0, max_i0]], dtype = int)
+    log.info('box for well is: ' + bx.string_iijjkk1_for_box_kji0(box) + ' (simulator protocol)')
+    # prepare inactive mask to merge in for new grid
+    if active_cells_shape in ['tube', 'prism']:
+        if active_cells_shape == 'prism':
+            layer_mask = np.any(inclusion_mask, axis = 0)
+            inclusion_mask[:] = layer_mask
+        box_inactive = np.logical_not(inclusion_mask[min_k0:max_k0 + 1, min_j0:max_j0 + 1, min_i0:max_i0 + 1])
+    else:  # 'box' option: leave all cells active (except where inactive in source grid)
+        box_inactive = None
 
-   if not new_grid_title:
-      if trajectory is not None:
-         new_grid_title = 'local grid extracted for well: ' + str(rqet.citation_title_for_node(trajectory_root))
-      elif blocked_well is not None:
-         new_grid_title = 'local grid extracted for blocked well: ' + str(rqet.citation_title_for_node(bw_root))
-      elif column_ji0 is not None:
-         new_grid_title = 'local grid extracted around column i, j (1 based): ' +  \
-                          str(column_ji0[1] + 1) + ', ' + str(column_ji0[0] + 1)
-      else:  # should not happen
-         new_grid_title = 'local grid extracted for well'
+    if not new_grid_title:
+        if trajectory is not None:
+            new_grid_title = 'local grid extracted for well: ' + str(rqet.citation_title_for_node(trajectory_root))
+        elif blocked_well is not None:
+            new_grid_title = 'local grid extracted for blocked well: ' + str(rqet.citation_title_for_node(bw_root))
+        elif column_ji0 is not None:
+            new_grid_title = 'local grid extracted around column i, j (1 based): ' +  \
+                             str(column_ji0[1] + 1) + ', ' + str(column_ji0[0] + 1)
+        else:  # should not happen
+            new_grid_title = 'local grid extracted for well'
 
-   grid = extract_box(epc_file,
-                      source_grid = source_grid,
-                      box = box,
-                      box_inactive = box_inactive,
-                      inherit_properties = inherit_properties,
-                      inherit_realization = inherit_realization,
-                      inherit_all_realizations = inherit_all_realizations,
-                      set_parent_window = set_parent_window,
-                      new_grid_title = new_grid_title,
-                      new_epc_file = new_epc_file)
+    grid = extract_box(epc_file,
+                       source_grid = source_grid,
+                       box = box,
+                       box_inactive = box_inactive,
+                       inherit_properties = inherit_properties,
+                       inherit_realization = inherit_realization,
+                       inherit_all_realizations = inherit_all_realizations,
+                       set_parent_window = set_parent_window,
+                       new_grid_title = new_grid_title,
+                       new_epc_file = new_epc_file)
 
-   if inherit_well and new_epc_file:
-      newer_model = rq.Model(new_epc_file)
-      if trajectory is None and blocked_well is None:
-         log.info('creating well objects for column')
-         box_column_ji0 = (column_ji0[0] - box[0, 1], column_ji0[1] - box[0, 2])
-         bw = rqw.BlockedWell(newer_model,
-                              grid = grid,
-                              column_ji0 = box_column_ji0,
-                              well_name = well_name,
-                              use_face_centres = True)
-         bw.write_hdf5(create_for_trajectory_if_needed = True)
-         bw.create_xml(create_for_trajectory_if_needed = True, title = well_name)
-      elif blocked_well is not None:
-         log.info('inheriting trajectory for blocked well')
-         newer_model.copy_part_from_other_model(traj_model,
-                                                rqet.part_name_for_part_root(blocked_well.trajectory.root_node))
-      else:
-         log.info('inheriting well trajectory')
-         newer_model.copy_part_from_other_model(
-            traj_model, rqet.part_name_for_part_root(trajectory_root))  # recursively copies referenced parts
-      newer_model.h5_release()
-      newer_model.store_epc()
+    if inherit_well and new_epc_file:
+        newer_model = rq.Model(new_epc_file)
+        if trajectory is None and blocked_well is None:
+            log.info('creating well objects for column')
+            box_column_ji0 = (column_ji0[0] - box[0, 1], column_ji0[1] - box[0, 2])
+            bw = rqw.BlockedWell(newer_model,
+                                 grid = grid,
+                                 column_ji0 = box_column_ji0,
+                                 well_name = well_name,
+                                 use_face_centres = True)
+            bw.write_hdf5(create_for_trajectory_if_needed = True)
+            bw.create_xml(create_for_trajectory_if_needed = True, title = well_name)
+        elif blocked_well is not None:
+            log.info('inheriting trajectory for blocked well')
+            newer_model.copy_part_from_other_model(traj_model,
+                                                   rqet.part_name_for_part_root(blocked_well.trajectory.root_node))
+        else:
+            log.info('inheriting well trajectory')
+            newer_model.copy_part_from_other_model(
+                traj_model, rqet.part_name_for_part_root(trajectory_root))  # recursively copies referenced parts
+        newer_model.h5_release()
+        newer_model.store_epc()
 
-   if outer_radius is not None:
-      if new_epc_file:
-         # TODO: copy source grid and reassign source_grid to new copy
-         outer_epc = new_epc_file
-      else:
-         outer_epc = epc_file
-      # todo: make local property kind, or reuse active local property kind?
-      add_one_grid_property_array(outer_epc,
-                                  outer_inactive_mask,
-                                  'discrete',
-                                  grid_uuid = source_grid.uuid,
-                                  source_info = 'extract box for well outer radius',
-                                  title = 'distant mask for well ' + str(well_name),
-                                  discrete = True,
-                                  uom = source_grid.xy_units())
+    if outer_radius is not None:
+        if new_epc_file:
+            # TODO: copy source grid and reassign source_grid to new copy
+            outer_epc = new_epc_file
+        else:
+            outer_epc = epc_file
+        # todo: make local property kind, or reuse active local property kind?
+        add_one_grid_property_array(outer_epc,
+                                    outer_inactive_mask,
+                                    'discrete',
+                                    grid_uuid = source_grid.uuid,
+                                    source_info = 'extract box for well outer radius',
+                                    title = 'distant mask for well ' + str(well_name),
+                                    discrete = True,
+                                    uom = source_grid.xy_units())
 
-   return grid, box
+    return grid, box
 
 
 def refined_grid(epc_file,
@@ -1777,7 +1783,7 @@ def refined_grid(epc_file,
                  infill_missing_geometry = True,
                  new_grid_title = None,
                  new_epc_file = None):
-   """Generates a refined version of the source grid, optionally inheriting properties.
+    """Generates a refined version of the source grid, optionally inheriting properties.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -1815,294 +1821,295 @@ def refined_grid(epc_file,
       modified as a side-effect of the function (but not written to hdf5 or changed in xml)
    """
 
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if not epc_file:
-      epc_file = source_grid.model.epc_file
-      assert epc_file, 'unable to ascertain epc filename from grid object'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   if set_parent_window is None:
-      set_parent_window = (new_epc_file is None)
-   model = None
-   if new_epc_file:
-      log.debug('creating fresh model for refined grid')
-      model = rq.Model(epc_file = new_epc_file, new_epc = True, create_basics = True, create_hdf5_ext = True)
-   if epc_file:
-      model_in = rq.Model(epc_file)
-      if source_grid is None:
-         if source_grid_uuid is None:
-            log.debug('using default source grid from existing epc')
-            source_grid = model_in.grid()
-         else:
-            log.debug('selecting source grid from existing epc based on uuid')
-            source_grid = grr.Grid(model_in, uuid = source_grid_uuid)
-      else:
-         if source_grid_uuid is not None:
-            assert bu.matching_uuids(source_grid_uuid, source_grid.uuid)
-         grid_uuid = source_grid.uuid
-         log.debug('reloading source grid from existing epc file')
-         source_grid = grr.Grid(model_in, uuid = grid_uuid)
-      if model is None:
-         model = model_in
-   else:
-      model_in = source_grid.model
-   assert model_in is not None
-   assert model is not None
-   assert source_grid is not None
-   assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
-   assert fine_coarse is not None and isinstance(fine_coarse, fc.FineCoarse)
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if not epc_file:
+        epc_file = source_grid.model.epc_file
+        assert epc_file, 'unable to ascertain epc filename from grid object'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    if set_parent_window is None:
+        set_parent_window = (new_epc_file is None)
+    model = None
+    if new_epc_file:
+        log.debug('creating fresh model for refined grid')
+        model = rq.Model(epc_file = new_epc_file, new_epc = True, create_basics = True, create_hdf5_ext = True)
+    if epc_file:
+        model_in = rq.Model(epc_file)
+        if source_grid is None:
+            if source_grid_uuid is None:
+                log.debug('using default source grid from existing epc')
+                source_grid = model_in.grid()
+            else:
+                log.debug('selecting source grid from existing epc based on uuid')
+                source_grid = grr.Grid(model_in, uuid = source_grid_uuid)
+        else:
+            if source_grid_uuid is not None:
+                assert bu.matching_uuids(source_grid_uuid, source_grid.uuid)
+            grid_uuid = source_grid.uuid
+            log.debug('reloading source grid from existing epc file')
+            source_grid = grr.Grid(model_in, uuid = grid_uuid)
+        if model is None:
+            model = model_in
+    else:
+        model_in = source_grid.model
+    assert model_in is not None
+    assert model is not None
+    assert source_grid is not None
+    assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
+    assert fine_coarse is not None and isinstance(fine_coarse, fc.FineCoarse)
 
-   if infill_missing_geometry and (not source_grid.geometry_defined_for_all_cells() or
-                                   not source_grid.geometry_defined_for_all_pillars()):
-      log.debug('attempting infill of geometry missing in source grid')
-      source_grid.set_geometry_is_defined(treat_as_nan = None,
-                                          treat_dots_as_nan = True,
-                                          complete_partial_pillars = True,
-                                          nullify_partial_pillars = False,
-                                          complete_all = True)
-   assert source_grid.geometry_defined_for_all_pillars(), 'refinement requires geometry to be defined for all pillars'
-   assert source_grid.geometry_defined_for_all_cells(), 'refinement requires geometry to be defined for all cells'
+    if infill_missing_geometry and (not source_grid.geometry_defined_for_all_cells() or
+                                    not source_grid.geometry_defined_for_all_pillars()):
+        log.debug('attempting infill of geometry missing in source grid')
+        source_grid.set_geometry_is_defined(treat_as_nan = None,
+                                            treat_dots_as_nan = True,
+                                            complete_partial_pillars = True,
+                                            nullify_partial_pillars = False,
+                                            complete_all = True)
+    assert source_grid.geometry_defined_for_all_pillars(), 'refinement requires geometry to be defined for all pillars'
+    assert source_grid.geometry_defined_for_all_cells(), 'refinement requires geometry to be defined for all cells'
 
-   assert tuple(fine_coarse.coarse_extent_kji) == tuple(source_grid.extent_kji),  \
-          'fine_coarse mapping coarse extent does not match that of source grid'
-   fine_coarse.assert_valid()
+    assert tuple(fine_coarse.coarse_extent_kji) == tuple(source_grid.extent_kji),  \
+           'fine_coarse mapping coarse extent does not match that of source grid'
+    fine_coarse.assert_valid()
 
-   source_grid.cache_all_geometry_arrays()
-   if source_grid.has_split_coordinate_lines:
-      source_grid.create_column_pillar_mapping()
-   source_points = source_grid.points_ref()
-   assert source_points is not None
+    source_grid.cache_all_geometry_arrays()
+    if source_grid.has_split_coordinate_lines:
+        source_grid.create_column_pillar_mapping()
+    source_points = source_grid.points_ref()
+    assert source_points is not None
 
-   if model is not model_in:
-      crs_part = model_in.part_for_uuid(source_grid.crs_uuid)
-      assert crs_part is not None
-      model.copy_part_from_other_model(model_in, crs_part)
+    if model is not model_in:
+        crs_part = model_in.part_for_uuid(source_grid.crs_uuid)
+        assert crs_part is not None
+        model.copy_part_from_other_model(model_in, crs_part)
 
-   # todo: set nan-abled numpy operations?
+    # todo: set nan-abled numpy operations?
 
-   if source_grid.has_split_coordinate_lines:
+    if source_grid.has_split_coordinate_lines:
 
-      source_grid.corner_points(cache_cp_array = True)
-      fnk, fnj, fni = fine_coarse.fine_extent_kji
-      fine_cp = np.empty((fnk, fnj, fni, 2, 2, 2, 3))
-      for ck0 in range(source_grid.nk):
-         fine_k_base = fine_coarse.fine_base_for_coarse_axial(0, ck0)
-         k_ratio = fine_coarse.ratio(0, ck0)
-         k_interp = np.ones((k_ratio + 1,))
-         k_interp[:-1] = fine_coarse.interpolation(0, ck0)
-         for cj0 in range(source_grid.nj):
-            fine_j_base = fine_coarse.fine_base_for_coarse_axial(1, cj0)
-            j_ratio = fine_coarse.ratio(1, cj0)
-            j_interp = np.ones((j_ratio + 1,))
-            j_interp[:-1] = fine_coarse.interpolation(1, cj0)
-            for ci0 in range(source_grid.ni):
-               fine_i_base = fine_coarse.fine_base_for_coarse_axial(2, ci0)
-               i_ratio = fine_coarse.ratio(2, ci0)
-               i_interpolation = fine_coarse.interpolation(2, ci0)
-               i_interp = np.ones((i_ratio + 1,))
-               i_interp[:-1] = fine_coarse.interpolation(2, ci0)
-
-               shared_fine_points = source_grid.interpolated_points((ck0, cj0, ci0), (k_interp, j_interp, i_interp))
-
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 0, 0] =  \
-                  shared_fine_points[:-1, :-1, :-1]
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 0, 1] =  \
-                  shared_fine_points[:-1, :-1, 1:]
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 1, 0] =  \
-                  shared_fine_points[:-1, 1:, :-1]
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 1, 1] =  \
-                  shared_fine_points[:-1, 1:, 1:]
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 0, 0] =  \
-                  shared_fine_points[1:, :-1, :-1]
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 0, 1] =  \
-                  shared_fine_points[1:, :-1, 1:]
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 1, 0] =  \
-                  shared_fine_points[1:, 1:, :-1]
-               fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 1, 1] =  \
-                  shared_fine_points[1:, 1:, 1:]
-
-      grid = rqi.grid_from_cp(model,
-                              fine_cp,
-                              source_grid.crs_uuid,
-                              ijk_handedness = 'right' if source_grid.grid_is_right_handed else 'left')
-
-   else:
-
-      # create a new, empty grid object
-      grid = grr.Grid(model)
-
-      # inherit attributes from source grid
-      grid.grid_representation = 'IjkGrid'
-      grid.extent_kji = fine_coarse.fine_extent_kji
-      grid.nk, grid.nj, grid.ni = grid.extent_kji[0], grid.extent_kji[1], grid.extent_kji[2]
-      grid.k_direction_is_down = source_grid.k_direction_is_down
-      grid.grid_is_right_handed = source_grid.grid_is_right_handed
-      grid.pillar_shape = source_grid.pillar_shape
-      grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
-      grid.split_pillars_count = source_grid.split_pillars_count
-      grid.k_gaps = source_grid.k_gaps
-      if grid.k_gaps:
-         grid.k_gap_after_array = np.zeros((grid.nk - 1,), dtype = bool)
-         grid.k_raw_index_array = np.zeros((grid.nk,), dtype = int)
-         # k gap arrays populated below
-      # inherit the coordinate reference system used by the grid geometry
-      grid.crs_root = source_grid.crs_root
-      grid.crs_uuid = source_grid.crs_uuid
-
-      refined_points = np.empty((grid.nk_plus_k_gaps + 1, grid.nj + 1, grid.ni + 1, 3))
-
-      #      log.debug(f'source grid: {source_grid.extent_kji}; k gaps: {source_grid.k_gaps}')
-      #      log.debug(f'refined grid: {grid.extent_kji}; k gaps: {grid.k_gaps}')
-      fk0 = 0
-      gaps_so_far = 0
-      for ck0 in range(fine_coarse.coarse_extent_kji[0] + 1):
-         end_k = (ck0 == fine_coarse.coarse_extent_kji[0])
-         if end_k:
-            k_ratio = 1
-            k_interpolation = [0.0]
-         else:
+        source_grid.corner_points(cache_cp_array = True)
+        fnk, fnj, fni = fine_coarse.fine_extent_kji
+        fine_cp = np.empty((fnk, fnj, fni, 2, 2, 2, 3))
+        for ck0 in range(source_grid.nk):
+            fine_k_base = fine_coarse.fine_base_for_coarse_axial(0, ck0)
             k_ratio = fine_coarse.ratio(0, ck0)
-            k_interpolation = fine_coarse.interpolation(0, ck0)
-         one_if_gap = 1 if source_grid.k_gaps and ck0 < fine_coarse.coarse_extent_kji[
-            0] - 1 and source_grid.k_gap_after_array[ck0] else 0
-         for flk0 in range(k_ratio + one_if_gap):
-            #            log.debug(f'ck0: {ck0}; fk0: {fk0}; flk0: {flk0}; k_ratio: {k_ratio}; one_if_gap: {one_if_gap}; gaps so far: {gaps_so_far}')
-            if flk0 < k_ratio:
-               k_fraction = k_interpolation[flk0]
-            else:
-               k_fraction = 1.0
-            if grid.k_gaps:
-               if end_k:
-                  k_plane = source_points[source_grid.k_raw_index_array[ck0 - 1] + 1, :, :, :]
-               else:
-                  k_plane = (k_fraction * source_points[source_grid.k_raw_index_array[ck0] + 1, :, :, :] +
-                             (1.0 - k_fraction) * source_points[source_grid.k_raw_index_array[ck0], :, :, :])
-               if flk0 == k_ratio:
-                  grid.k_gap_after_array[fk0 - 1] = True
-               elif fk0 < grid.nk:
-                  grid.k_raw_index_array[fk0] = fk0 + gaps_so_far
-            else:
-               if end_k:
-                  k_plane = source_points[ck0, :, :, :]
-               else:
-                  k_plane = k_fraction * source_points[ck0 + 1, :, :, :] + (1.0 -
-                                                                            k_fraction) * source_points[ck0, :, :, :]
-            fj0 = 0
-            for cj0 in range(fine_coarse.coarse_extent_kji[1] + 1):
-               end_j = (cj0 == fine_coarse.coarse_extent_kji[1])
-               if end_j:
-                  j_ratio = 1
-                  j_interpolation = [0.0]
-               else:
-                  j_ratio = fine_coarse.ratio(1, cj0)
-                  j_interpolation = fine_coarse.interpolation(1, cj0)
-               for flj0 in range(j_ratio):
-                  j_fraction = j_interpolation[flj0]
-                  # note: shape of j_line will be different if there are split pillars in play
-                  if end_j:
-                     j_line = k_plane[cj0, :, :]
-                  else:
-                     j_line = j_fraction * k_plane[cj0 + 1, :, :] + (1.0 - j_fraction) * k_plane[cj0, :, :]
+            k_interp = np.ones((k_ratio + 1,))
+            k_interp[:-1] = fine_coarse.interpolation(0, ck0)
+            for cj0 in range(source_grid.nj):
+                fine_j_base = fine_coarse.fine_base_for_coarse_axial(1, cj0)
+                j_ratio = fine_coarse.ratio(1, cj0)
+                j_interp = np.ones((j_ratio + 1,))
+                j_interp[:-1] = fine_coarse.interpolation(1, cj0)
+                for ci0 in range(source_grid.ni):
+                    fine_i_base = fine_coarse.fine_base_for_coarse_axial(2, ci0)
+                    i_ratio = fine_coarse.ratio(2, ci0)
+                    i_interpolation = fine_coarse.interpolation(2, ci0)
+                    i_interp = np.ones((i_ratio + 1,))
+                    i_interp[:-1] = fine_coarse.interpolation(2, ci0)
 
-                  fi0 = 0
-                  for ci0 in range(fine_coarse.coarse_extent_kji[2] + 1):
-                     end_i = (ci0 == fine_coarse.coarse_extent_kji[2])
-                     if end_i:
-                        i_ratio = 1
-                        i_interpolation = [0.0]
-                     else:
-                        i_ratio = fine_coarse.ratio(2, ci0)
-                        i_interpolation = fine_coarse.interpolation(2, ci0)
-                     for fli0 in range(i_ratio):
-                        i_fraction = i_interpolation[fli0]
-                        if end_i:
-                           p = j_line[ci0, :]
+                    shared_fine_points = source_grid.interpolated_points((ck0, cj0, ci0),
+                                                                         (k_interp, j_interp, i_interp))
+
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 0, 0] =  \
+                       shared_fine_points[:-1, :-1, :-1]
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 0, 1] =  \
+                       shared_fine_points[:-1, :-1, 1:]
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 1, 0] =  \
+                       shared_fine_points[:-1, 1:, :-1]
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 0, 1, 1] =  \
+                       shared_fine_points[:-1, 1:, 1:]
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 0, 0] =  \
+                       shared_fine_points[1:, :-1, :-1]
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 0, 1] =  \
+                       shared_fine_points[1:, :-1, 1:]
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 1, 0] =  \
+                       shared_fine_points[1:, 1:, :-1]
+                    fine_cp[fine_k_base : fine_k_base + k_ratio, fine_j_base : fine_j_base + j_ratio, fine_i_base : fine_i_base + i_ratio, 1, 1, 1] =  \
+                       shared_fine_points[1:, 1:, 1:]
+
+        grid = rqi.grid_from_cp(model,
+                                fine_cp,
+                                source_grid.crs_uuid,
+                                ijk_handedness = 'right' if source_grid.grid_is_right_handed else 'left')
+
+    else:
+
+        # create a new, empty grid object
+        grid = grr.Grid(model)
+
+        # inherit attributes from source grid
+        grid.grid_representation = 'IjkGrid'
+        grid.extent_kji = fine_coarse.fine_extent_kji
+        grid.nk, grid.nj, grid.ni = grid.extent_kji[0], grid.extent_kji[1], grid.extent_kji[2]
+        grid.k_direction_is_down = source_grid.k_direction_is_down
+        grid.grid_is_right_handed = source_grid.grid_is_right_handed
+        grid.pillar_shape = source_grid.pillar_shape
+        grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
+        grid.split_pillars_count = source_grid.split_pillars_count
+        grid.k_gaps = source_grid.k_gaps
+        if grid.k_gaps:
+            grid.k_gap_after_array = np.zeros((grid.nk - 1,), dtype = bool)
+            grid.k_raw_index_array = np.zeros((grid.nk,), dtype = int)
+            # k gap arrays populated below
+        # inherit the coordinate reference system used by the grid geometry
+        grid.crs_root = source_grid.crs_root
+        grid.crs_uuid = source_grid.crs_uuid
+
+        refined_points = np.empty((grid.nk_plus_k_gaps + 1, grid.nj + 1, grid.ni + 1, 3))
+
+        #      log.debug(f'source grid: {source_grid.extent_kji}; k gaps: {source_grid.k_gaps}')
+        #      log.debug(f'refined grid: {grid.extent_kji}; k gaps: {grid.k_gaps}')
+        fk0 = 0
+        gaps_so_far = 0
+        for ck0 in range(fine_coarse.coarse_extent_kji[0] + 1):
+            end_k = (ck0 == fine_coarse.coarse_extent_kji[0])
+            if end_k:
+                k_ratio = 1
+                k_interpolation = [0.0]
+            else:
+                k_ratio = fine_coarse.ratio(0, ck0)
+                k_interpolation = fine_coarse.interpolation(0, ck0)
+            one_if_gap = 1 if source_grid.k_gaps and ck0 < fine_coarse.coarse_extent_kji[
+                0] - 1 and source_grid.k_gap_after_array[ck0] else 0
+            for flk0 in range(k_ratio + one_if_gap):
+                #            log.debug(f'ck0: {ck0}; fk0: {fk0}; flk0: {flk0}; k_ratio: {k_ratio}; one_if_gap: {one_if_gap}; gaps so far: {gaps_so_far}')
+                if flk0 < k_ratio:
+                    k_fraction = k_interpolation[flk0]
+                else:
+                    k_fraction = 1.0
+                if grid.k_gaps:
+                    if end_k:
+                        k_plane = source_points[source_grid.k_raw_index_array[ck0 - 1] + 1, :, :, :]
+                    else:
+                        k_plane = (k_fraction * source_points[source_grid.k_raw_index_array[ck0] + 1, :, :, :] +
+                                   (1.0 - k_fraction) * source_points[source_grid.k_raw_index_array[ck0], :, :, :])
+                    if flk0 == k_ratio:
+                        grid.k_gap_after_array[fk0 - 1] = True
+                    elif fk0 < grid.nk:
+                        grid.k_raw_index_array[fk0] = fk0 + gaps_so_far
+                else:
+                    if end_k:
+                        k_plane = source_points[ck0, :, :, :]
+                    else:
+                        k_plane = k_fraction * source_points[ck0 + 1, :, :, :] + (
+                            1.0 - k_fraction) * source_points[ck0, :, :, :]
+                fj0 = 0
+                for cj0 in range(fine_coarse.coarse_extent_kji[1] + 1):
+                    end_j = (cj0 == fine_coarse.coarse_extent_kji[1])
+                    if end_j:
+                        j_ratio = 1
+                        j_interpolation = [0.0]
+                    else:
+                        j_ratio = fine_coarse.ratio(1, cj0)
+                        j_interpolation = fine_coarse.interpolation(1, cj0)
+                    for flj0 in range(j_ratio):
+                        j_fraction = j_interpolation[flj0]
+                        # note: shape of j_line will be different if there are split pillars in play
+                        if end_j:
+                            j_line = k_plane[cj0, :, :]
                         else:
-                           p = i_fraction * j_line[ci0 + 1, :] + (1.0 - i_fraction) * j_line[ci0, :]
+                            j_line = j_fraction * k_plane[cj0 + 1, :, :] + (1.0 - j_fraction) * k_plane[cj0, :, :]
 
-                        refined_points[fk0 + gaps_so_far, fj0, fi0] = p
+                        fi0 = 0
+                        for ci0 in range(fine_coarse.coarse_extent_kji[2] + 1):
+                            end_i = (ci0 == fine_coarse.coarse_extent_kji[2])
+                            if end_i:
+                                i_ratio = 1
+                                i_interpolation = [0.0]
+                            else:
+                                i_ratio = fine_coarse.ratio(2, ci0)
+                                i_interpolation = fine_coarse.interpolation(2, ci0)
+                            for fli0 in range(i_ratio):
+                                i_fraction = i_interpolation[fli0]
+                                if end_i:
+                                    p = j_line[ci0, :]
+                                else:
+                                    p = i_fraction * j_line[ci0 + 1, :] + (1.0 - i_fraction) * j_line[ci0, :]
 
-                        fi0 += 1
+                                refined_points[fk0 + gaps_so_far, fj0, fi0] = p
 
-                  assert fi0 == fine_coarse.fine_extent_kji[2] + 1
+                                fi0 += 1
 
-                  fj0 += 1
+                        assert fi0 == fine_coarse.fine_extent_kji[2] + 1
 
-            assert fj0 == fine_coarse.fine_extent_kji[1] + 1
+                        fj0 += 1
 
-            if flk0 == k_ratio:
-               gaps_so_far += 1
+                assert fj0 == fine_coarse.fine_extent_kji[1] + 1
+
+                if flk0 == k_ratio:
+                    gaps_so_far += 1
+                else:
+                    fk0 += 1
+
+        assert fk0 == fine_coarse.fine_extent_kji[0] + 1
+        assert grid.nk + gaps_so_far == grid.nk_plus_k_gaps
+
+        grid.points_cached = refined_points
+
+        grid.geometry_defined_for_all_pillars_cached = True
+        grid.geometry_defined_for_all_cells_cached = True
+        grid.array_cell_geometry_is_defined = np.full(tuple(grid.extent_kji), True, dtype = bool)
+
+    # todo: option of re-draping interpolated pillars to surface
+
+    collection = None
+    if inherit_properties:
+        source_collection = source_grid.extract_property_collection()
+        if source_collection is not None:
+            #  do not inherit the inactive property array by this mechanism
+            collection = rqp.GridPropertyCollection()
+            collection.set_grid(grid)
+            collection.extend_imported_list_copying_properties_from_other_grid_collection(
+                source_collection,
+                refinement = fine_coarse,
+                realization = inherit_realization,
+                copy_all_realizations = inherit_all_realizations)
+
+    if set_parent_window:
+        pw_grid_uuid = source_grid.uuid
+        if isinstance(set_parent_window, str):
+            if set_parent_window == 'grandparent':
+                assert fine_coarse.within_coarse_box is None or (np.all(fine_coarse.within_coarse_box[0] == 0) and
+                                                                 np.all(fine_coarse.within_coarse_box[1]) == source_grid.extent_kji - 1),  \
+                   'attempt to set grandparent window for grid when parent window is present'
+                source_fine_coarse = source_grid.parent_window
+                if source_fine_coarse is not None and (source_fine_coarse.within_fine_box is not None or
+                                                       source_fine_coarse.within_coarse_box is not None):
+                    assert source_fine_coarse.fine_extent_kji == source_fine_coarse.coarse_extent_kji, 'parentage involves refinement or coarsening'
+                    if source_fine_coarse.within_coarse_box is not None:
+                        fine_coarse.within_coarse_box = source_fine_coarse.within_coarse_box
+                    else:
+                        fine_coarse.within_coarse_box = source_fine_coarse.within_fine_box
+                    pw_grid_uuid = bu.uuid_from_string(
+                        rqet.find_nested_tags_text(source_grid.root, ['ParentWindow', 'ParentGrid', 'UUID']))
             else:
-               fk0 += 1
+                assert set_parent_window == 'parent', 'set_parent_window value not recognized: ' + set_parent_window
+        grid.set_parent(pw_grid_uuid, True, fine_coarse)
 
-      assert fk0 == fine_coarse.fine_extent_kji[0] + 1
-      assert grid.nk + gaps_so_far == grid.nk_plus_k_gaps
+    # write grid
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'grid refined from ' + str(rqet.citation_title_for_node(source_grid.root))
 
-      grid.points_cached = refined_points
+    model.h5_release()
+    if model is not model_in:
+        model_in.h5_release()
 
-      grid.geometry_defined_for_all_pillars_cached = True
-      grid.geometry_defined_for_all_cells_cached = True
-      grid.array_cell_geometry_is_defined = np.full(tuple(grid.extent_kji), True, dtype = bool)
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   # todo: option of re-draping interpolated pillars to surface
-
-   collection = None
-   if inherit_properties:
-      source_collection = source_grid.extract_property_collection()
-      if source_collection is not None:
-         #  do not inherit the inactive property array by this mechanism
-         collection = rqp.GridPropertyCollection()
-         collection.set_grid(grid)
-         collection.extend_imported_list_copying_properties_from_other_grid_collection(
-            source_collection,
-            refinement = fine_coarse,
-            realization = inherit_realization,
-            copy_all_realizations = inherit_all_realizations)
-
-   if set_parent_window:
-      pw_grid_uuid = source_grid.uuid
-      if isinstance(set_parent_window, str):
-         if set_parent_window == 'grandparent':
-            assert fine_coarse.within_coarse_box is None or (np.all(fine_coarse.within_coarse_box[0] == 0) and
-                                                             np.all(fine_coarse.within_coarse_box[1]) == source_grid.extent_kji - 1),  \
-               'attempt to set grandparent window for grid when parent window is present'
-            source_fine_coarse = source_grid.parent_window
-            if source_fine_coarse is not None and (source_fine_coarse.within_fine_box is not None or
-                                                   source_fine_coarse.within_coarse_box is not None):
-               assert source_fine_coarse.fine_extent_kji == source_fine_coarse.coarse_extent_kji, 'parentage involves refinement or coarsening'
-               if source_fine_coarse.within_coarse_box is not None:
-                  fine_coarse.within_coarse_box = source_fine_coarse.within_coarse_box
-               else:
-                  fine_coarse.within_coarse_box = source_fine_coarse.within_fine_box
-               pw_grid_uuid = bu.uuid_from_string(
-                  rqet.find_nested_tags_text(source_grid.root, ['ParentWindow', 'ParentGrid', 'UUID']))
-         else:
-            assert set_parent_window == 'parent', 'set_parent_window value not recognized: ' + set_parent_window
-      grid.set_parent(pw_grid_uuid, True, fine_coarse)
-
-   # write grid
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'grid refined from ' + str(rqet.citation_title_for_node(source_grid.root))
-
-   model.h5_release()
-   if model is not model_in:
-      model_in.h5_release()
-
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
-
-   return grid
+    return grid
 
 
 def coarsened_grid(epc_file,
@@ -2115,7 +2122,7 @@ def coarsened_grid(epc_file,
                    infill_missing_geometry = True,
                    new_grid_title = None,
                    new_epc_file = None):
-   """Generates a coarsened version of an unsplit source grid, todo: optionally inheriting properties.
+    """Generates a coarsened version of an unsplit source grid, todo: optionally inheriting properties.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -2149,142 +2156,142 @@ def coarsened_grid(epc_file,
       set_parent_window argument will relate the coarsened grid back to the original
    """
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if set_parent_window is None:
-      set_parent_window = (new_epc_file is None)
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model (or one named 'ROOT')
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation == 'IjkGrid'
-   assert model is not None
-   assert fine_coarse is not None and isinstance(fine_coarse, fc.FineCoarse)
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if set_parent_window is None:
+        set_parent_window = (new_epc_file is None)
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model (or one named 'ROOT')
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation == 'IjkGrid'
+    assert model is not None
+    assert fine_coarse is not None and isinstance(fine_coarse, fc.FineCoarse)
 
-   assert not source_grid.has_split_coordinate_lines, 'coarsening only available for unsplit grids: use other functions to heal faults first'
+    assert not source_grid.has_split_coordinate_lines, 'coarsening only available for unsplit grids: use other functions to heal faults first'
 
-   if infill_missing_geometry and (not source_grid.geometry_defined_for_all_cells() or
-                                   not source_grid.geometry_defined_for_all_pillars()):
-      log.debug('attempting infill of geometry missing in source grid')
-      source_grid.set_geometry_is_defined(treat_as_nan = None,
-                                          treat_dots_as_nan = True,
-                                          complete_partial_pillars = True,
-                                          nullify_partial_pillars = False,
-                                          complete_all = True)
+    if infill_missing_geometry and (not source_grid.geometry_defined_for_all_cells() or
+                                    not source_grid.geometry_defined_for_all_pillars()):
+        log.debug('attempting infill of geometry missing in source grid')
+        source_grid.set_geometry_is_defined(treat_as_nan = None,
+                                            treat_dots_as_nan = True,
+                                            complete_partial_pillars = True,
+                                            nullify_partial_pillars = False,
+                                            complete_all = True)
 
-   assert source_grid.geometry_defined_for_all_pillars(), 'coarsening requires geometry to be defined for all pillars'
-   assert source_grid.geometry_defined_for_all_cells(), 'coarsening requires geometry to be defined for all cells'
-   assert not source_grid.k_gaps, 'coarsening of grids with k gaps not currently supported'
+    assert source_grid.geometry_defined_for_all_pillars(), 'coarsening requires geometry to be defined for all pillars'
+    assert source_grid.geometry_defined_for_all_cells(), 'coarsening requires geometry to be defined for all cells'
+    assert not source_grid.k_gaps, 'coarsening of grids with k gaps not currently supported'
 
-   assert tuple(fine_coarse.fine_extent_kji) == tuple(source_grid.extent_kji),  \
-          'fine_coarse mapping fine extent does not match that of source grid'
-   fine_coarse.assert_valid()
+    assert tuple(fine_coarse.fine_extent_kji) == tuple(source_grid.extent_kji),  \
+           'fine_coarse mapping fine extent does not match that of source grid'
+    fine_coarse.assert_valid()
 
-   source_grid.cache_all_geometry_arrays()
-   source_points = source_grid.points_ref().reshape((source_grid.nk + 1), (source_grid.nj + 1) * (source_grid.ni + 1),
-                                                    3)
+    source_grid.cache_all_geometry_arrays()
+    source_points = source_grid.points_ref().reshape((source_grid.nk + 1), (source_grid.nj + 1) * (source_grid.ni + 1),
+                                                     3)
 
-   # create a new, empty grid object
-   grid = grr.Grid(model)
+    # create a new, empty grid object
+    grid = grr.Grid(model)
 
-   # inherit attributes from source grid
-   grid.grid_representation = 'IjkGrid'
-   grid.extent_kji = fine_coarse.coarse_extent_kji
-   grid.nk, grid.nj, grid.ni = grid.extent_kji[0], grid.extent_kji[1], grid.extent_kji[2]
-   grid.k_direction_is_down = source_grid.k_direction_is_down
-   grid.grid_is_right_handed = source_grid.grid_is_right_handed
-   grid.pillar_shape = source_grid.pillar_shape
-   grid.has_split_coordinate_lines = False
-   grid.split_pillars_count = None
-   # inherit the coordinate reference system used by the grid geometry
-   grid.crs_root = source_grid.crs_root
-   grid.crs_uuid = source_grid.crs_uuid
+    # inherit attributes from source grid
+    grid.grid_representation = 'IjkGrid'
+    grid.extent_kji = fine_coarse.coarse_extent_kji
+    grid.nk, grid.nj, grid.ni = grid.extent_kji[0], grid.extent_kji[1], grid.extent_kji[2]
+    grid.k_direction_is_down = source_grid.k_direction_is_down
+    grid.grid_is_right_handed = source_grid.grid_is_right_handed
+    grid.pillar_shape = source_grid.pillar_shape
+    grid.has_split_coordinate_lines = False
+    grid.split_pillars_count = None
+    # inherit the coordinate reference system used by the grid geometry
+    grid.crs_root = source_grid.crs_root
+    grid.crs_uuid = source_grid.crs_uuid
 
-   coarsened_points = np.empty(
-      (grid.nk + 1, (grid.nj + 1) * (grid.ni + 1), 3))  # note: gets reshaped after being populated
+    coarsened_points = np.empty(
+        (grid.nk + 1, (grid.nj + 1) * (grid.ni + 1), 3))  # note: gets reshaped after being populated
 
-   k_ratio_constant = fine_coarse.constant_ratios[0]
-   if k_ratio_constant:
-      k_indices = None
-   else:
-      k_indices = np.empty(grid.nk + 1, dtype = int)
-      k_indices[0] = 0
-      for k in range(grid.nk):
-         k_indices[k + 1] = k_indices[k] + fine_coarse.vector_ratios[0][k]
-      assert k_indices[-1] == source_grid.nk
+    k_ratio_constant = fine_coarse.constant_ratios[0]
+    if k_ratio_constant:
+        k_indices = None
+    else:
+        k_indices = np.empty(grid.nk + 1, dtype = int)
+        k_indices[0] = 0
+        for k in range(grid.nk):
+            k_indices[k + 1] = k_indices[k] + fine_coarse.vector_ratios[0][k]
+        assert k_indices[-1] == source_grid.nk
 
-   for cjp in range(grid.nj + 1):
-      for cji in range(grid.ni + 1):
-         natural_coarse_pillar = cjp * (grid.ni + 1) + cji
-         natural_fine_pillar = fine_coarse.fine_for_coarse_natural_pillar_index(natural_coarse_pillar)
-         if k_ratio_constant:
-            coarsened_points[:, natural_coarse_pillar, :] = source_points[0:source_grid.nk + 1:k_ratio_constant,
-                                                                          natural_fine_pillar, :]
-         else:
-            coarsened_points[:, natural_coarse_pillar, :] = source_points[k_indices, natural_fine_pillar, :]
+    for cjp in range(grid.nj + 1):
+        for cji in range(grid.ni + 1):
+            natural_coarse_pillar = cjp * (grid.ni + 1) + cji
+            natural_fine_pillar = fine_coarse.fine_for_coarse_natural_pillar_index(natural_coarse_pillar)
+            if k_ratio_constant:
+                coarsened_points[:, natural_coarse_pillar, :] = source_points[0:source_grid.nk + 1:k_ratio_constant,
+                                                                              natural_fine_pillar, :]
+            else:
+                coarsened_points[:, natural_coarse_pillar, :] = source_points[k_indices, natural_fine_pillar, :]
 
-   grid.points_cached = coarsened_points.reshape(((grid.nk + 1), (grid.nj + 1), (grid.ni + 1), 3))
+    grid.points_cached = coarsened_points.reshape(((grid.nk + 1), (grid.nj + 1), (grid.ni + 1), 3))
 
-   grid.geometry_defined_for_all_pillars_cached = True
-   grid.geometry_defined_for_all_cells_cached = True
-   grid.array_cell_geometry_is_defined = np.full(tuple(grid.extent_kji), True, dtype = bool)
+    grid.geometry_defined_for_all_pillars_cached = True
+    grid.geometry_defined_for_all_cells_cached = True
+    grid.array_cell_geometry_is_defined = np.full(tuple(grid.extent_kji), True, dtype = bool)
 
-   collection = None
-   if inherit_properties:
-      source_collection = source_grid.extract_property_collection()
-      if source_collection is not None:
-         collection = rqp.GridPropertyCollection()
-         collection.set_grid(grid)
-         collection.extend_imported_list_copying_properties_from_other_grid_collection(
-            source_collection,
-            coarsening = fine_coarse,
-            realization = inherit_realization,
-            copy_all_realizations = inherit_all_realizations)
+    collection = None
+    if inherit_properties:
+        source_collection = source_grid.extract_property_collection()
+        if source_collection is not None:
+            collection = rqp.GridPropertyCollection()
+            collection.set_grid(grid)
+            collection.extend_imported_list_copying_properties_from_other_grid_collection(
+                source_collection,
+                coarsening = fine_coarse,
+                realization = inherit_realization,
+                copy_all_realizations = inherit_all_realizations)
 
-   if set_parent_window:
-      pw_grid_uuid = source_grid.uuid
-      if isinstance(set_parent_window, str):
-         if set_parent_window == 'grandparent':
-            assert fine_coarse.within_fine_box is None or (np.all(fine_coarse.within_fine_box[0] == 0) and
-                                                           np.all(fine_coarse.within_fine_box[1]) == source_grid.extent_kji - 1),  \
-               'attempt to set grandparent window for grid when parent window is present'
-            source_fine_coarse = source_grid.parent_window
-            if source_fine_coarse is not None and (source_fine_coarse.within_fine_box is not None or
-                                                   source_fine_coarse.within_coarse_box is not None):
-               assert source_fine_coarse.fine_extent_kji == source_fine_coarse.coarse_extent_kji, 'parentage involves refinement or coarsening'
-               if source_fine_coarse.within_fine_box is not None:
-                  fine_coarse.within_fine_box = source_fine_coarse.within_fine_box
-               else:
-                  fine_coarse.within_fine_box = source_fine_coarse.within_coarse_box
-               pw_grid_uuid = bu.uuid_from_string(
-                  rqet.find_nested_tags_text(source_grid.root, ['ParentWindow', 'ParentGrid', 'UUID']))
-         else:
-            assert set_parent_window == 'parent', 'set_parent_window value not recognized: ' + set_parent_window
-      grid.set_parent(pw_grid_uuid, False, fine_coarse)
+    if set_parent_window:
+        pw_grid_uuid = source_grid.uuid
+        if isinstance(set_parent_window, str):
+            if set_parent_window == 'grandparent':
+                assert fine_coarse.within_fine_box is None or (np.all(fine_coarse.within_fine_box[0] == 0) and
+                                                               np.all(fine_coarse.within_fine_box[1]) == source_grid.extent_kji - 1),  \
+                   'attempt to set grandparent window for grid when parent window is present'
+                source_fine_coarse = source_grid.parent_window
+                if source_fine_coarse is not None and (source_fine_coarse.within_fine_box is not None or
+                                                       source_fine_coarse.within_coarse_box is not None):
+                    assert source_fine_coarse.fine_extent_kji == source_fine_coarse.coarse_extent_kji, 'parentage involves refinement or coarsening'
+                    if source_fine_coarse.within_fine_box is not None:
+                        fine_coarse.within_fine_box = source_fine_coarse.within_fine_box
+                    else:
+                        fine_coarse.within_fine_box = source_fine_coarse.within_coarse_box
+                    pw_grid_uuid = bu.uuid_from_string(
+                        rqet.find_nested_tags_text(source_grid.root, ['ParentWindow', 'ParentGrid', 'UUID']))
+            else:
+                assert set_parent_window == 'parent', 'set_parent_window value not recognized: ' + set_parent_window
+        grid.set_parent(pw_grid_uuid, False, fine_coarse)
 
-   # write grid
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'grid coarsened from ' + str(rqet.citation_title_for_node(source_grid.root))
+    # write grid
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'grid coarsened from ' + str(rqet.citation_title_for_node(source_grid.root))
 
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   return grid
+    return grid
 
 
 def local_depth_adjustment(epc_file,
@@ -2302,7 +2309,7 @@ def local_depth_adjustment(epc_file,
                            inherit_all_realizations = False,
                            new_grid_title = None,
                            new_epc_file = None):
-   """Applies a local depth adjustment to the grid, adding as a new grid part in the model.
+    """Applies a local depth adjustment to the grid, adding as a new grid part in the model.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -2336,145 +2343,145 @@ def local_depth_adjustment(epc_file,
       new grid object which is a copy of the source grid with the local depth adjustment applied
    """
 
-   def decayed_shift(centre_shift, distance, radius, decay_shape):
-      norm_dist = min(distance / radius, 1.0)  # 0..1
-      if decay_shape == 'linear':
-         return (1.0 - norm_dist) * centre_shift
-      elif decay_shape == 'quadratic':
-         if norm_dist >= 0.5:
-            x = (1.0 - norm_dist)
-            return 2.0 * x * x * centre_shift
-         else:
-            return centre_shift * (1.0 - 2.0 * norm_dist * norm_dist)
-      else:
-         raise ValueError('unrecognized decay shape: ' + decay_shape)
+    def decayed_shift(centre_shift, distance, radius, decay_shape):
+        norm_dist = min(distance / radius, 1.0)  # 0..1
+        if decay_shape == 'linear':
+            return (1.0 - norm_dist) * centre_shift
+        elif decay_shape == 'quadratic':
+            if norm_dist >= 0.5:
+                x = (1.0 - norm_dist)
+                return 2.0 * x * x * centre_shift
+            else:
+                return centre_shift * (1.0 - 2.0 * norm_dist * norm_dist)
+        else:
+            raise ValueError('unrecognized decay shape: ' + decay_shape)
 
-   log.info('adjusting depth')
-   log.debug('centre x: {0:3.1f}; y: {1:3.1f}'.format(centre_x, centre_y))
-   if use_local_coords:
-      log.debug('centre x & y interpreted in local crs')
-   log.debug('radius of influence: {0:3.1f}'.format(radius))
-   log.debug('depth shift at centre: {0:5.3f}'.format(centre_shift))
-   log.debug('decay shape: ' + decay_shape)
-   log.debug('reference layer (k0 protocol): ' + str(ref_k0))
+    log.info('adjusting depth')
+    log.debug('centre x: {0:3.1f}; y: {1:3.1f}'.format(centre_x, centre_y))
+    if use_local_coords:
+        log.debug('centre x & y interpreted in local crs')
+    log.debug('radius of influence: {0:3.1f}'.format(radius))
+    log.debug('depth shift at centre: {0:5.3f}'.format(centre_shift))
+    log.debug('decay shape: ' + decay_shape)
+    log.debug('reference layer (k0 protocol): ' + str(ref_k0))
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation == 'IjkGrid'
-   assert model is not None
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation == 'IjkGrid'
+    assert model is not None
 
-   # take a copy of the grid
-   grid = copy_grid(source_grid, model)
+    # take a copy of the grid
+    grid = copy_grid(source_grid, model)
 
-   # if not use_local_coords, convert centre_x & y into local_coords
-   crs_root = grid.extract_crs_root()
-   assert (crs_root is not None)
-   if not use_local_coords:
-      rotation = abs(float(rqet.node_text(rqet.find_tag(crs_root, 'ArealRotation'))))
-      if rotation > 0.001:
-         log.error('unable to account for rotation in crs: use local coordinates')
-         return
-      centre_x -= float(rqet.node_text(rqet.find_tag(crs_root, 'XOffset')))
-      centre_y -= float(rqet.node_text(rqet.find_tag(crs_root, 'YOffset')))
-   z_inc_down = rqet.bool_from_text(rqet.node_text(rqet.find_tag(crs_root, 'ZIncreasingDownward')))
+    # if not use_local_coords, convert centre_x & y into local_coords
+    crs_root = grid.extract_crs_root()
+    assert (crs_root is not None)
+    if not use_local_coords:
+        rotation = abs(float(rqet.node_text(rqet.find_tag(crs_root, 'ArealRotation'))))
+        if rotation > 0.001:
+            log.error('unable to account for rotation in crs: use local coordinates')
+            return
+        centre_x -= float(rqet.node_text(rqet.find_tag(crs_root, 'XOffset')))
+        centre_y -= float(rqet.node_text(rqet.find_tag(crs_root, 'YOffset')))
+    z_inc_down = rqet.bool_from_text(rqet.node_text(rqet.find_tag(crs_root, 'ZIncreasingDownward')))
 
-   if not z_inc_down:
-      centre_shift = -centre_shift
+    if not z_inc_down:
+        centre_shift = -centre_shift
 
-   # cache geometry in memory; needed prior to writing new coherent set of arrays to hdf5
-   grid.cache_all_geometry_arrays()
-   if grid.has_split_coordinate_lines:
-      reshaped_points = grid.points_cached.copy()
-   else:
-      nkp1, njp1, nip1, xyz = grid.points_cached.shape
-      reshaped_points = grid.points_cached.copy().reshape((nkp1, njp1 * nip1, xyz))
-   assert reshaped_points.ndim == 3 and reshaped_points.shape[2] == 3
-   assert ref_k0 >= 0 and ref_k0 < reshaped_points.shape[0]
+    # cache geometry in memory; needed prior to writing new coherent set of arrays to hdf5
+    grid.cache_all_geometry_arrays()
+    if grid.has_split_coordinate_lines:
+        reshaped_points = grid.points_cached.copy()
+    else:
+        nkp1, njp1, nip1, xyz = grid.points_cached.shape
+        reshaped_points = grid.points_cached.copy().reshape((nkp1, njp1 * nip1, xyz))
+    assert reshaped_points.ndim == 3 and reshaped_points.shape[2] == 3
+    assert ref_k0 >= 0 and ref_k0 < reshaped_points.shape[0]
 
-   log.debug('reshaped_points.shape: ' + str(reshaped_points.shape))
+    log.debug('reshaped_points.shape: ' + str(reshaped_points.shape))
 
-   log.debug('min z before depth adjustment: ' + str(np.nanmin(reshaped_points[:, :, 2])))
+    log.debug('min z before depth adjustment: ' + str(np.nanmin(reshaped_points[:, :, 2])))
 
-   # for each pillar, find x, y for k = reference_layer_k0
-   pillars_adjusted = 0
+    # for each pillar, find x, y for k = reference_layer_k0
+    pillars_adjusted = 0
 
-   # todo: replace with numpy array operations
-   radius_sqr = radius * radius
-   for pillar in range(reshaped_points.shape[1]):
-      x, y, z = tuple(reshaped_points[ref_k0, pillar, :])
-      # find distance of this pillar from the centre
-      dx = centre_x - x
-      dy = centre_y - y
-      distance_sqr = (dx * dx) + (dy * dy)
-      # if this pillar is beyond radius of influence, no action needed
-      if distance_sqr > radius_sqr:
-         continue
-      distance = maths.sqrt(distance_sqr)
-      # compute decayed shift as function of distance
-      shift = decayed_shift(centre_shift, distance, radius, decay_shape)
-      # adjust depth values for pillar in cached array
-      log.debug('adjusting pillar number {0} at x: {1:3.1f}, y: {2:3.1f}, distance: {3:3.1f} by {4:5.3f}'.format(
-         pillar, x, y, distance, shift))
-      reshaped_points[:, pillar, 2] += shift
-      pillars_adjusted += 1
+    # todo: replace with numpy array operations
+    radius_sqr = radius * radius
+    for pillar in range(reshaped_points.shape[1]):
+        x, y, z = tuple(reshaped_points[ref_k0, pillar, :])
+        # find distance of this pillar from the centre
+        dx = centre_x - x
+        dy = centre_y - y
+        distance_sqr = (dx * dx) + (dy * dy)
+        # if this pillar is beyond radius of influence, no action needed
+        if distance_sqr > radius_sqr:
+            continue
+        distance = maths.sqrt(distance_sqr)
+        # compute decayed shift as function of distance
+        shift = decayed_shift(centre_shift, distance, radius, decay_shape)
+        # adjust depth values for pillar in cached array
+        log.debug('adjusting pillar number {0} at x: {1:3.1f}, y: {2:3.1f}, distance: {3:3.1f} by {4:5.3f}'.format(
+            pillar, x, y, distance, shift))
+        reshaped_points[:, pillar, 2] += shift
+        pillars_adjusted += 1
 
-   # if no pillars adjusted: warn and return
-   if pillars_adjusted == 0:
-      log.warning('no pillars adjusted')
-      return
+    # if no pillars adjusted: warn and return
+    if pillars_adjusted == 0:
+        log.warning('no pillars adjusted')
+        return
 
-   log.debug('min z after depth adjustment: ' + str(np.nanmin(reshaped_points[:, :, 2])))
-   if grid.has_split_coordinate_lines:
-      grid.points_cached[:] = reshaped_points
-   else:
-      grid.points_cached[:] = reshaped_points.reshape((nkp1, njp1, nip1, xyz))
+    log.debug('min z after depth adjustment: ' + str(np.nanmin(reshaped_points[:, :, 2])))
+    if grid.has_split_coordinate_lines:
+        grid.points_cached[:] = reshaped_points
+    else:
+        grid.points_cached[:] = reshaped_points.reshape((nkp1, njp1, nip1, xyz))
 
 
 #   model.copy_part(old_uuid, grid.uuid, change_hdf5_refs = True)   # copies the xml, substituting the new uuid in the root node (and in hdf5 refs)
-   log.info(str(pillars_adjusted) + ' pillars adjusted')
+    log.info(str(pillars_adjusted) + ' pillars adjusted')
 
-   # build cell displacement property array(s)
-   if store_displacement:
-      log.debug('generating cell displacement property arrays')
-      displacement_collection = displacement_properties(grid, source_grid)
-   else:
-      displacement_collection = None
+    # build cell displacement property array(s)
+    if store_displacement:
+        log.debug('generating cell displacement property arrays')
+        displacement_collection = displacement_properties(grid, source_grid)
+    else:
+        displacement_collection = None
 
-   collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
-                                            inherit_all_realizations)
-   if collection is None:
-      collection = displacement_collection
-   elif displacement_collection is not None:
-      collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
+    collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
+                                             inherit_all_realizations)
+    if collection is None:
+        collection = displacement_collection
+    elif displacement_collection is not None:
+        collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'grid derived from {0} with local depth shift of {1:3.1f} applied'.format(
-         str(rqet.citation_title_for_node(source_grid.root)), centre_shift)
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'grid derived from {0} with local depth shift of {1:3.1f} applied'.format(
+            str(rqet.citation_title_for_node(source_grid.root)), centre_shift)
 
-   # write model
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    # write model
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   return grid
+    return grid
 
 
 def tilted_grid(epc_file,
@@ -2488,7 +2495,7 @@ def tilted_grid(epc_file,
                 inherit_all_realizations = False,
                 new_grid_title = None,
                 new_epc_file = None):
-   """Extends epc file with a new grid which is a version of the source grid tilted.
+    """Extends epc file with a new grid which is a version of the source grid tilted.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -2514,62 +2521,62 @@ def tilted_grid(epc_file,
       a new grid (grid.Grid object) which is a copy of the source grid tilted in 3D space
    """
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation == 'IjkGrid'
-   assert model is not None
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation == 'IjkGrid'
+    assert model is not None
 
-   # take a copy of the grid
-   grid = copy_grid(source_grid, model)
+    # take a copy of the grid
+    grid = copy_grid(source_grid, model)
 
-   if grid.inactive is not None:
-      log.debug('copied grid inactive shape: ' + str(grid.inactive.shape))
+    if grid.inactive is not None:
+        log.debug('copied grid inactive shape: ' + str(grid.inactive.shape))
 
-   # tilt the grid
-   grid.cache_all_geometry_arrays()  # probably already cached anyway
-   vec.tilt_points(pivot_xyz, azimuth, dip, grid.points_cached)
+    # tilt the grid
+    grid.cache_all_geometry_arrays()  # probably already cached anyway
+    vec.tilt_points(pivot_xyz, azimuth, dip, grid.points_cached)
 
-   # build cell displacement property array(s)
-   if store_displacement:
-      displacement_collection = displacement_properties(grid, source_grid)
-   else:
-      displacement_collection = None
+    # build cell displacement property array(s)
+    if store_displacement:
+        displacement_collection = displacement_properties(grid, source_grid)
+    else:
+        displacement_collection = None
 
-   collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
-                                            inherit_all_realizations)
-   if collection is None:
-      collection = displacement_collection
-   elif displacement_collection is not None:
-      collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
+    collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
+                                             inherit_all_realizations)
+    if collection is None:
+        collection = displacement_collection
+    elif displacement_collection is not None:
+        collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'tilted version ({0:4.2f} degree dip) of '.format(abs(dip)) + str(
-         rqet.citation_title_for_node(source_grid.root))
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'tilted version ({0:4.2f} degree dip) of '.format(abs(dip)) + str(
+            rqet.citation_title_for_node(source_grid.root))
 
-   # write model
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    # write model
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   return grid
+    return grid
 
 
 def unsplit_grid(epc_file,
@@ -2579,7 +2586,7 @@ def unsplit_grid(epc_file,
                  inherit_all_realizations = False,
                  new_grid_title = None,
                  new_epc_file = None):
-   """Extends epc file with a new grid which is a version of the source grid with all faults healed.
+    """Extends epc file with a new grid which is a version of the source grid with all faults healed.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -2604,62 +2611,62 @@ def unsplit_grid(epc_file,
       to smooth the adjustments away from the line of the fault, use the global_fault_throw_scaling() function first
    """
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation == 'IjkGrid'
-   assert model is not None
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation == 'IjkGrid'
+    assert model is not None
 
-   assert source_grid.has_split_coordinate_lines, 'source grid is unfaulted'
+    assert source_grid.has_split_coordinate_lines, 'source grid is unfaulted'
 
-   # take a copy of the grid
-   grid = copy_grid(source_grid, model)
+    # take a copy of the grid
+    grid = copy_grid(source_grid, model)
 
-   if grid.inactive is not None:
-      log.debug('copied grid inactive shape: ' + str(grid.inactive.shape))
+    if grid.inactive is not None:
+        log.debug('copied grid inactive shape: ' + str(grid.inactive.shape))
 
-   # heal faults in the grid
-   grid.cache_all_geometry_arrays()  # probably already cached anyway
-   unsplit = source_grid.unsplit_points_ref()
-   grid.points_cached = unsplit.copy()
-   assert grid.points_cached.shape == (grid.nk + 1, grid.nj + 1, grid.ni + 1, 3), 'unsplit points have incorrect shape'
+    # heal faults in the grid
+    grid.cache_all_geometry_arrays()  # probably already cached anyway
+    unsplit = source_grid.unsplit_points_ref()
+    grid.points_cached = unsplit.copy()
+    assert grid.points_cached.shape == (grid.nk + 1, grid.nj + 1, grid.ni + 1, 3), 'unsplit points have incorrect shape'
 
-   grid.has_split_coordinate_lines = False
-   delattr(grid, 'split_pillar_indices_cached')
-   delattr(grid, 'cols_for_split_pillars')
-   delattr(grid, 'cols_for_split_pillars_cl')
-   if hasattr(grid, 'pillars_for_column'):
-      delattr(grid, 'pillars_for_column')
+    grid.has_split_coordinate_lines = False
+    delattr(grid, 'split_pillar_indices_cached')
+    delattr(grid, 'cols_for_split_pillars')
+    delattr(grid, 'cols_for_split_pillars_cl')
+    if hasattr(grid, 'pillars_for_column'):
+        delattr(grid, 'pillars_for_column')
 
-   collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
-                                            inherit_all_realizations)
-   # todo: recompute depth properties (and volumes, cell lengths etc. if being strict)
+    collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
+                                             inherit_all_realizations)
+    # todo: recompute depth properties (and volumes, cell lengths etc. if being strict)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'unfaulted version of ' + str(rqet.citation_title_for_node(source_grid.root))
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'unfaulted version of ' + str(rqet.citation_title_for_node(source_grid.root))
 
-   # write model
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    # write model
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   return grid
+    return grid
 
 
 def add_faults(epc_file,
@@ -2675,7 +2682,7 @@ def add_faults(epc_file,
                inherit_all_realizations = False,
                new_grid_title = None,
                new_epc_file = None):
-   """Extends epc file with a new grid which is a version of the source grid with new curtain fault(s) added.
+    """Extends epc file with a new grid which is a version of the source grid with new curtain fault(s) added.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -2721,17 +2728,17 @@ def add_faults(epc_file,
       this function does not add a GridConnectionSet to the model – calling code may wish to do that
    """
 
-   def make_face_sets_for_new_lines(new_lines, face_set_id, grid, full_pillar_list_dict, composite_face_set_dict):
-      """Adds entries to full_pillar_list_dict & composite_face_set_dict for new lines."""
-      pillar_list_list = sl.nearest_pillars(new_lines, grid)
-      face_set_dict, full_pll_dict = grid.make_face_sets_from_pillar_lists(pillar_list_list, face_set_id)
-      for key, pll in full_pll_dict.items():
-         full_pillar_list_dict[key] = pll
-      for key, fs_info in face_set_dict.items():
-         composite_face_set_dict[key] = fs_info
+    def make_face_sets_for_new_lines(new_lines, face_set_id, grid, full_pillar_list_dict, composite_face_set_dict):
+        """Adds entries to full_pillar_list_dict & composite_face_set_dict for new lines."""
+        pillar_list_list = sl.nearest_pillars(new_lines, grid)
+        face_set_dict, full_pll_dict = grid.make_face_sets_from_pillar_lists(pillar_list_list, face_set_id)
+        for key, pll in full_pll_dict.items():
+            full_pillar_list_dict[key] = pll
+        for key, fs_info in face_set_dict.items():
+            composite_face_set_dict[key] = fs_info
 
-   def fault_from_pillar_list(grid, full_pillar_list, delta_throw_left, delta_throw_right):
-      """Creates and/or adjusts throw on a single fault defined by a full pillar list, in memory.
+    def fault_from_pillar_list(grid, full_pillar_list, delta_throw_left, delta_throw_right):
+        """Creates and/or adjusts throw on a single fault defined by a full pillar list, in memory.
 
       arguments:
          grid (grid.Grid): the grid object to be adjusted in memory (should have originally been copied
@@ -2745,245 +2752,248 @@ def add_faults(epc_file,
             line
       """
 
-      def pillar_vector(grid, p_index):
-         # return a unit vector for direction of pillar, in direction of increasing k
-         if np.all(np.isnan(grid.points_cached[:, p_index])):
-            return None
-         k_top = 0
-         while np.any(np.isnan(grid.points_cached[k_top, p_index])):
-            k_top += 1
-         k_bot = grid.nk_plus_k_gaps - 1
-         while np.any(np.isnan(grid.points_cached[k_bot, p_index])):
-            k_bot -= 1
-         if k_bot == k_top:  # following coded to treat None directions as downwards
-            if grid.k_direction_is_down is False:
-               if grid.z_inc_down() is False:
-                  return (0.0, 0.0, 1.0)
-               else:
-                  return (0.0, 0.0, -1.0)
+        def pillar_vector(grid, p_index):
+            # return a unit vector for direction of pillar, in direction of increasing k
+            if np.all(np.isnan(grid.points_cached[:, p_index])):
+                return None
+            k_top = 0
+            while np.any(np.isnan(grid.points_cached[k_top, p_index])):
+                k_top += 1
+            k_bot = grid.nk_plus_k_gaps - 1
+            while np.any(np.isnan(grid.points_cached[k_bot, p_index])):
+                k_bot -= 1
+            if k_bot == k_top:  # following coded to treat None directions as downwards
+                if grid.k_direction_is_down is False:
+                    if grid.z_inc_down() is False:
+                        return (0.0, 0.0, 1.0)
+                    else:
+                        return (0.0, 0.0, -1.0)
+                else:
+                    if grid.z_inc_down() is False:
+                        return (0.0, 0.0, -1.0)
+                    else:
+                        return (0.0, 0.0, 1.0)
             else:
-               if grid.z_inc_down() is False:
-                  return (0.0, 0.0, -1.0)
-               else:
-                  return (0.0, 0.0, 1.0)
-         else:
-            return vec.unit_vector(grid.points_cached[k_bot, p_index] - grid.points_cached[k_top, p_index])
+                return vec.unit_vector(grid.points_cached[k_bot, p_index] - grid.points_cached[k_top, p_index])
 
-      def extend_points_cached(grid, exist_p):
-         s = grid.points_cached.shape
-         e = np.empty((s[0], s[1] + 1, s[2]), dtype = float)
-         e[:, :-1, :] = grid.points_cached
-         e[:, -1, :] = grid.points_cached[:, exist_p, :]
-         grid.points_cached = e
+        def extend_points_cached(grid, exist_p):
+            s = grid.points_cached.shape
+            e = np.empty((s[0], s[1] + 1, s[2]), dtype = float)
+            e[:, :-1, :] = grid.points_cached
+            e[:, -1, :] = grid.points_cached[:, exist_p, :]
+            grid.points_cached = e
 
-      def np_int_extended(a, i):
-         e = np.empty(a.size + 1, dtype = int)
-         e[:-1] = a
-         e[-1] = i
-         return e
+        def np_int_extended(a, i):
+            e = np.empty(a.size + 1, dtype = int)
+            e[:-1] = a
+            e[-1] = i
+            return e
 
-      if full_pillar_list is None or len(full_pillar_list) < 3:
-         return
-      assert grid.z_units() == grid.xy_units()
-      grid.cache_all_geometry_arrays()
-      assert hasattr(grid, 'points_cached')
-      if not grid.has_split_coordinate_lines:
-         grid.points_cached = grid.points_cached.reshape((grid.nk_plus_k_gaps + 1, (grid.nj + 1) * (grid.ni + 1), 3))
-         grid.split_pillar_indices_cached = np.array([], dtype = int)
-         grid.cols_for_split_pillars = np.array([], dtype = int)
-         grid.cols_for_split_pillars_cl = np.array([], dtype = int)
-         grid.has_split_coordinate_lines = True
-      assert grid.points_cached.ndim == 3
-      if len(grid.cols_for_split_pillars_cl) == 0:
-         cl = 0
-      else:
-         cl = grid.cols_for_split_pillars_cl[-1]
-      original_p = np.zeros((grid.nk_plus_k_gaps + 1, 3), dtype = float)
-      n_primaries = (grid.nj + 1) * (grid.ni + 1)
-      for p_index in range(1, len(full_pillar_list) - 1):
-         primary_ji0 = full_pillar_list[p_index]
-         primary = primary_ji0[0] * (grid.ni + 1) + primary_ji0[1]
-         p_vector = np.array(pillar_vector(grid, primary), dtype = float)
-         if p_vector is None:
-            continue
-         throw_left_vector = np.expand_dims(delta_throw_left * p_vector, axis = 0)
-         throw_right_vector = np.expand_dims(delta_throw_right * p_vector, axis = 0)
-         #         log.debug(f'T: p ji0: {primary_ji0}; p vec: {p_vector}; left v: {throw_left_vector}; right v: {throw_right_vector}')
-         existing_foursome = grid.pillar_foursome(primary_ji0, none_if_unsplit = False)
-         lr_foursome = gf.left_right_foursome(full_pillar_list, p_index)
-         p_j, p_i = primary_ji0
-         #         log.debug(f'P: p ji0: {primary_ji0}; e foursome:\n{existing_foursome}; lr foursome:\n{lr_foursome}')
-         for exist_p in np.unique(existing_foursome):
-            exist_lr = None
-            new_p_made = False
-            for jp in range(2):
-               if (p_j == 0 and jp == 0) or (p_j == grid.nj and jp == 1):
-                  continue
-               for ip in range(2):
-                  if (p_i == 0 and ip == 0) or (p_i == grid.ni and ip == 1):
-                     continue
-                  if existing_foursome[jp, ip] != exist_p:
-                     continue
-                  if exist_lr is None:
-                     original_p[:] = grid.points_cached[:, exist_p, :]
-                     exist_lr = lr_foursome[jp, ip]
-                     #                     log.debug(f'A: p ji0: {primary_ji0}; exist_p: {exist_p}; jp,ip: {(jp,ip)}; exist_lr: {exist_lr}')
-                     grid.points_cached[:, exist_p, :] += throw_right_vector if exist_lr else throw_left_vector
-                     continue
-                  if lr_foursome[jp, ip] == exist_lr:
-                     continue
-                  natural_col = (p_j + jp - 1) * grid.ni + p_i + ip - 1
-                  if exist_p != primary:  # remove one of the columns currently assigned to exist_p
-                     extra_p = exist_p - n_primaries
-                     #                     log.debug(f're-split: primary: {primary}; exist: {exist_p}; col: {natural_col}; extra: {extra_p}')
-                     #                     log.debug(f'pre re-split: cols: {grid.cols_for_split_pillars}')
-                     #                     log.debug(f'pre re-split: ccl:  {grid.cols_for_split_pillars_cl}')
-                     assert grid.split_pillar_indices_cached[extra_p] == primary
-                     if extra_p == 0:
-                        start = 0
-                     else:
-                        start = grid.cols_for_split_pillars_cl[extra_p - 1]
-                     found = False
-                     for cols_index in range(start, start + grid.cols_for_split_pillars_cl[extra_p]):
-                        if grid.cols_for_split_pillars[cols_index] == natural_col:
-                           grid.cols_for_split_pillars = np.concatenate(
-                              (grid.cols_for_split_pillars[:cols_index], grid.cols_for_split_pillars[cols_index + 1:]))
-                           found = True
-                           break
-                     assert found
-                     grid.cols_for_split_pillars_cl[extra_p:] -= 1
-                     cl -= 1
-                     assert grid.cols_for_split_pillars_cl[extra_p] > 0
+        if full_pillar_list is None or len(full_pillar_list) < 3:
+            return
+        assert grid.z_units() == grid.xy_units()
+        grid.cache_all_geometry_arrays()
+        assert hasattr(grid, 'points_cached')
+        if not grid.has_split_coordinate_lines:
+            grid.points_cached = grid.points_cached.reshape((grid.nk_plus_k_gaps + 1, (grid.nj + 1) * (grid.ni + 1), 3))
+            grid.split_pillar_indices_cached = np.array([], dtype = int)
+            grid.cols_for_split_pillars = np.array([], dtype = int)
+            grid.cols_for_split_pillars_cl = np.array([], dtype = int)
+            grid.has_split_coordinate_lines = True
+        assert grid.points_cached.ndim == 3
+        if len(grid.cols_for_split_pillars_cl) == 0:
+            cl = 0
+        else:
+            cl = grid.cols_for_split_pillars_cl[-1]
+        original_p = np.zeros((grid.nk_plus_k_gaps + 1, 3), dtype = float)
+        n_primaries = (grid.nj + 1) * (grid.ni + 1)
+        for p_index in range(1, len(full_pillar_list) - 1):
+            primary_ji0 = full_pillar_list[p_index]
+            primary = primary_ji0[0] * (grid.ni + 1) + primary_ji0[1]
+            p_vector = np.array(pillar_vector(grid, primary), dtype = float)
+            if p_vector is None:
+                continue
+            throw_left_vector = np.expand_dims(delta_throw_left * p_vector, axis = 0)
+            throw_right_vector = np.expand_dims(delta_throw_right * p_vector, axis = 0)
+            #         log.debug(f'T: p ji0: {primary_ji0}; p vec: {p_vector}; left v: {throw_left_vector}; right v: {throw_right_vector}')
+            existing_foursome = grid.pillar_foursome(primary_ji0, none_if_unsplit = False)
+            lr_foursome = gf.left_right_foursome(full_pillar_list, p_index)
+            p_j, p_i = primary_ji0
+            #         log.debug(f'P: p ji0: {primary_ji0}; e foursome:\n{existing_foursome}; lr foursome:\n{lr_foursome}')
+            for exist_p in np.unique(existing_foursome):
+                exist_lr = None
+                new_p_made = False
+                for jp in range(2):
+                    if (p_j == 0 and jp == 0) or (p_j == grid.nj and jp == 1):
+                        continue
+                    for ip in range(2):
+                        if (p_i == 0 and ip == 0) or (p_i == grid.ni and ip == 1):
+                            continue
+                        if existing_foursome[jp, ip] != exist_p:
+                            continue
+                        if exist_lr is None:
+                            original_p[:] = grid.points_cached[:, exist_p, :]
+                            exist_lr = lr_foursome[jp, ip]
+                            #                     log.debug(f'A: p ji0: {primary_ji0}; exist_p: {exist_p}; jp,ip: {(jp,ip)}; exist_lr: {exist_lr}')
+                            grid.points_cached[:, exist_p, :] += throw_right_vector if exist_lr else throw_left_vector
+                            continue
+                        if lr_foursome[jp, ip] == exist_lr:
+                            continue
+                        natural_col = (p_j + jp - 1) * grid.ni + p_i + ip - 1
+                        if exist_p != primary:  # remove one of the columns currently assigned to exist_p
+                            extra_p = exist_p - n_primaries
+                            #                     log.debug(f're-split: primary: {primary}; exist: {exist_p}; col: {natural_col}; extra: {extra_p}')
+                            #                     log.debug(f'pre re-split: cols: {grid.cols_for_split_pillars}')
+                            #                     log.debug(f'pre re-split: ccl:  {grid.cols_for_split_pillars_cl}')
+                            assert grid.split_pillar_indices_cached[extra_p] == primary
+                            if extra_p == 0:
+                                start = 0
+                            else:
+                                start = grid.cols_for_split_pillars_cl[extra_p - 1]
+                            found = False
+                            for cols_index in range(start, start + grid.cols_for_split_pillars_cl[extra_p]):
+                                if grid.cols_for_split_pillars[cols_index] == natural_col:
+                                    grid.cols_for_split_pillars = np.concatenate(
+                                        (grid.cols_for_split_pillars[:cols_index],
+                                         grid.cols_for_split_pillars[cols_index + 1:]))
+                                    found = True
+                                    break
+                            assert found
+                            grid.cols_for_split_pillars_cl[extra_p:] -= 1
+                            cl -= 1
+                            assert grid.cols_for_split_pillars_cl[extra_p] > 0
 #                     log.debug(f'post re-split: cols: {grid.cols_for_split_pillars}')
 #                     log.debug(f'post re-split: ccl:  {grid.cols_for_split_pillars_cl}')
-                  if not new_p_made:  # create a new split of pillar
-                     extend_points_cached(grid, exist_p)
-                     #                     log.debug(f'B: p ji0: {primary_ji0}; exist_p: {exist_p}; jp,ip: {(jp,ip)}; lr: {lr_foursome[jp, ip]}; c ji0: {natural_col}')
-                     grid.points_cached[:, -1, :] = original_p + (throw_right_vector
-                                                                  if lr_foursome[jp, ip] else throw_left_vector)
-                     grid.split_pillar_indices_cached = np_int_extended(grid.split_pillar_indices_cached, primary)
-                     if grid.split_pillars_count is None:
-                        grid.split_pillars_count = 0
-                     grid.split_pillars_count += 1
-                     grid.cols_for_split_pillars = np_int_extended(grid.cols_for_split_pillars, natural_col)
-                     cl += 1
-                     grid.cols_for_split_pillars_cl = np_int_extended(grid.cols_for_split_pillars_cl, cl)
-                     new_p_made = True
-                  else:  # include this column in newly split version of pillar
-                     #                     log.debug(f'C: p ji0: {primary_ji0}; exist_p: {exist_p}; jp,ip: {(jp,ip)}; lr: {lr_foursome[jp, ip]}; c ji0: {natural_col}')
-                     grid.cols_for_split_pillars = np_int_extended(grid.cols_for_split_pillars, natural_col)
-                     cl += 1
-                     grid.cols_for_split_pillars_cl[-1] = cl
+                        if not new_p_made:  # create a new split of pillar
+                            extend_points_cached(grid, exist_p)
+                            #                     log.debug(f'B: p ji0: {primary_ji0}; exist_p: {exist_p}; jp,ip: {(jp,ip)}; lr: {lr_foursome[jp, ip]}; c ji0: {natural_col}')
+                            grid.points_cached[:, -1, :] = original_p + (throw_right_vector
+                                                                         if lr_foursome[jp, ip] else throw_left_vector)
+                            grid.split_pillar_indices_cached = np_int_extended(grid.split_pillar_indices_cached,
+                                                                               primary)
+                            if grid.split_pillars_count is None:
+                                grid.split_pillars_count = 0
+                            grid.split_pillars_count += 1
+                            grid.cols_for_split_pillars = np_int_extended(grid.cols_for_split_pillars, natural_col)
+                            cl += 1
+                            grid.cols_for_split_pillars_cl = np_int_extended(grid.cols_for_split_pillars_cl, cl)
+                            new_p_made = True
+                        else:  # include this column in newly split version of pillar
+                            #                     log.debug(f'C: p ji0: {primary_ji0}; exist_p: {exist_p}; jp,ip: {(jp,ip)}; lr: {lr_foursome[jp, ip]}; c ji0: {natural_col}')
+                            grid.cols_for_split_pillars = np_int_extended(grid.cols_for_split_pillars, natural_col)
+                            cl += 1
+                            grid.cols_for_split_pillars_cl[-1] = cl
 
-   log.info('adding faults')
+    log.info('adding faults')
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']  # unstructured grids not catered for
-   assert model is not None
-   assert len([arg for arg in (polylines, lines_file_list, full_pillar_list_dict) if arg is not None]) == 1
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']  # unstructured grids not catered for
+    assert model is not None
+    assert len([arg for arg in (polylines, lines_file_list, full_pillar_list_dict) if arg is not None]) == 1
 
-   # take a copy of the resqpy grid object, without writing to hdf5 or creating xml
-   # the copy will be a Grid, even if the source is a RegularGrid
-   grid = copy_grid(source_grid, model)
-   grid_crs = rqcrs.Crs(model, uuid = grid.crs_uuid)
-   assert grid_crs is not None
+    # take a copy of the resqpy grid object, without writing to hdf5 or creating xml
+    # the copy will be a Grid, even if the source is a RegularGrid
+    grid = copy_grid(source_grid, model)
+    grid_crs = rqcrs.Crs(model, uuid = grid.crs_uuid)
+    assert grid_crs is not None
 
-   if isinstance(polylines, rql.PolylineSet):
-      polylines = polylines.convert_to_polylines()
+    if isinstance(polylines, rql.PolylineSet):
+        polylines = polylines.convert_to_polylines()
 
-   if lines_crs_uuid is None:
-      lines_crs = None
-   else:
-      lines_crs = rqcrs.Crs(model, uuid = lines_crs_uuid)
+    if lines_crs_uuid is None:
+        lines_crs = None
+    else:
+        lines_crs = rqcrs.Crs(model, uuid = lines_crs_uuid)
 
-   if full_pillar_list_dict is None:
-      full_pillar_list_dict = {}
-      composite_face_set_dict = {}
-      if polylines:
-         for i, polyline in enumerate(polylines):
-            new_line = polyline.coordinates.copy()
-            if polyline.crs_uuid is not None and polyline.crs_uuid != lines_crs_uuid:
-               lines_crs_uuid = polyline.crs_uuid
-               lines_crs = rqcrs.Crs(model, uuid = lines_crs_uuid)
-            if lines_crs:
-               lines_crs.convert_array_to(grid_crs, new_line)
-            title = polyline.title if polyline.title else 'fault_' + str(i)
-            make_face_sets_for_new_lines([new_line], title, grid, full_pillar_list_dict, composite_face_set_dict)
-      else:
-         for filename in lines_file_list:
-            new_lines = sl.read_lines(filename)
-            if lines_crs is not None:
-               for a in new_lines:
-                  lines_crs.convert_array_to(grid_crs, a)
-            _, f_name = os.path.split(filename)
-            if f_name.lower().endswith('.dat'):
-               face_set_id = f_name[:-4]
-            else:
-               face_set_id = f_name
-            make_face_sets_for_new_lines(new_lines, face_set_id, grid, full_pillar_list_dict, composite_face_set_dict)
+    if full_pillar_list_dict is None:
+        full_pillar_list_dict = {}
+        composite_face_set_dict = {}
+        if polylines:
+            for i, polyline in enumerate(polylines):
+                new_line = polyline.coordinates.copy()
+                if polyline.crs_uuid is not None and polyline.crs_uuid != lines_crs_uuid:
+                    lines_crs_uuid = polyline.crs_uuid
+                    lines_crs = rqcrs.Crs(model, uuid = lines_crs_uuid)
+                if lines_crs:
+                    lines_crs.convert_array_to(grid_crs, new_line)
+                title = polyline.title if polyline.title else 'fault_' + str(i)
+                make_face_sets_for_new_lines([new_line], title, grid, full_pillar_list_dict, composite_face_set_dict)
+        else:
+            for filename in lines_file_list:
+                new_lines = sl.read_lines(filename)
+                if lines_crs is not None:
+                    for a in new_lines:
+                        lines_crs.convert_array_to(grid_crs, a)
+                _, f_name = os.path.split(filename)
+                if f_name.lower().endswith('.dat'):
+                    face_set_id = f_name[:-4]
+                else:
+                    face_set_id = f_name
+                make_face_sets_for_new_lines(new_lines, face_set_id, grid, full_pillar_list_dict,
+                                             composite_face_set_dict)
 
 
 #   log.debug(f'full_pillar_list_dict:\n{full_pillar_list_dict}')
 
-   for fault_key in full_pillar_list_dict:
+    for fault_key in full_pillar_list_dict:
 
-      full_pillar_list = full_pillar_list_dict[fault_key]
-      left_right_throw = None
-      if left_right_throw_dict is not None:
-         left_right_throw = left_right_throw_dict.get(fault_key)
-      if left_right_throw is None:
-         left_right_throw = (+0.5, -0.5)
+        full_pillar_list = full_pillar_list_dict[fault_key]
+        left_right_throw = None
+        if left_right_throw_dict is not None:
+            left_right_throw = left_right_throw_dict.get(fault_key)
+        if left_right_throw is None:
+            left_right_throw = (+0.5, -0.5)
 
-      log.debug(
-         f'generating fault {fault_key} pillar count {len(full_pillar_list)}; left, right throw {left_right_throw}')
+        log.debug(
+            f'generating fault {fault_key} pillar count {len(full_pillar_list)}; left, right throw {left_right_throw}')
 
-      fault_from_pillar_list(grid, full_pillar_list, left_right_throw[0], left_right_throw[1])
+        fault_from_pillar_list(grid, full_pillar_list, left_right_throw[0], left_right_throw[1])
 
-   collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
-                                            inherit_all_realizations)
-   # todo: recompute depth properties (and volumes, cell lengths etc. if being strict)
+    collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
+                                             inherit_all_realizations)
+    # todo: recompute depth properties (and volumes, cell lengths etc. if being strict)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'copy of ' + str(rqet.citation_title_for_node(source_grid.root)) + ' with added faults'
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'copy of ' + str(rqet.citation_title_for_node(source_grid.root)) + ' with added faults'
 
-   # write model
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid = model.h5_uuid()
+    # write model
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid = model.h5_uuid()
 
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   if create_gcs and (polylines is not None or lines_file_list is not None):
-      if new_epc_file is not None:
-         grid_uuid = grid.uuid
-         model = rq.Model(new_epc_file)
-         grid = grr.Grid(model, root = model.root(uuid = grid_uuid), find_properties = False)
-      grid.set_face_set_gcs_list_from_dict(composite_face_set_dict, create_organizing_objects_where_needed = True)
-      combined_gcs = grid.face_set_gcs_list[0]
-      for gcs in grid.face_set_gcs_list[1:]:
-         combined_gcs.append(gcs)
-      combined_gcs.write_hdf5()
-      combined_gcs.create_xml(title = 'faults added from lines')
-      grid.clear_face_sets()
-      grid.model.store_epc()
+    if create_gcs and (polylines is not None or lines_file_list is not None):
+        if new_epc_file is not None:
+            grid_uuid = grid.uuid
+            model = rq.Model(new_epc_file)
+            grid = grr.Grid(model, root = model.root(uuid = grid_uuid), find_properties = False)
+        grid.set_face_set_gcs_list_from_dict(composite_face_set_dict, create_organizing_objects_where_needed = True)
+        combined_gcs = grid.face_set_gcs_list[0]
+        for gcs in grid.face_set_gcs_list[1:]:
+            combined_gcs.append(gcs)
+        combined_gcs.write_hdf5()
+        combined_gcs.create_xml(title = 'faults added from lines')
+        grid.clear_face_sets()
+        grid.model.store_epc()
 
-   return grid
+    return grid
 
 
 def fault_throw_scaling(epc_file,
@@ -3002,7 +3012,7 @@ def fault_throw_scaling(epc_file,
                         inherit_gcs = True,
                         new_grid_title = None,
                         new_epc_file = None):
-   """Extends epc with a new grid with fault throws multiplied by scaling factors.
+    """Extends epc with a new grid with fault throws multiplied by scaling factors.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -3047,226 +3057,226 @@ def fault_throw_scaling(epc_file,
       scaling factor applied independently, leading to some unrealistic results
    """
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation == 'IjkGrid'
-   assert model is not None
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation == 'IjkGrid'
+    assert model is not None
 
-   assert source_grid.has_split_coordinate_lines, 'cannot scale fault throws in unfaulted grid'
-   assert scaling_factor is not None or (connection_set is not None and scaling_dict is not None)
+    assert source_grid.has_split_coordinate_lines, 'cannot scale fault throws in unfaulted grid'
+    assert scaling_factor is not None or (connection_set is not None and scaling_dict is not None)
 
-   if ref_k_faces == 'base':
-      ref_k0 += 1
-   assert ref_k0 >= 0 and ref_k0 <= source_grid.nk, 'reference layer out of range'
+    if ref_k_faces == 'base':
+        ref_k0 += 1
+    assert ref_k0 >= 0 and ref_k0 <= source_grid.nk, 'reference layer out of range'
 
-   # take a copy of the grid
-   log.debug('copying grid')
-   grid = copy_grid(source_grid, model)
-   grid.cache_all_geometry_arrays()  # probably already cached anyway
+    # take a copy of the grid
+    log.debug('copying grid')
+    grid = copy_grid(source_grid, model)
+    grid.cache_all_geometry_arrays()  # probably already cached anyway
 
-   # todo: handle pillars with no geometry defined, and cells without geometry defined
-   assert grid.geometry_defined_for_all_pillars(), 'not all pillars have defined geometry'
-   all_good = grid.geometry_defined_for_all_cells()
-   if not all_good:
-      log.warning('not all cells have defined geometry')
+    # todo: handle pillars with no geometry defined, and cells without geometry defined
+    assert grid.geometry_defined_for_all_pillars(), 'not all pillars have defined geometry'
+    all_good = grid.geometry_defined_for_all_cells()
+    if not all_good:
+        log.warning('not all cells have defined geometry')
 
-   primaries = (grid.nj + 1) * (grid.ni + 1)
-   offsets = np.zeros(grid.points_cached.shape[1:])
+    primaries = (grid.nj + 1) * (grid.ni + 1)
+    offsets = np.zeros(grid.points_cached.shape[1:])
 
-   if scaling_factor is not None:  # apply global scaling to throws
-      # fetch unsplit equivalent of grid points for reference layer interface
-      log.debug('fetching unsplit equivalent grid points')
-      unsplit_points = grid.unsplit_points_ref().reshape(grid.nk + 1, -1, 3)
-      # determine existing throws on split pillars
-      semi_throws = np.zeros(grid.points_cached.shape[1:])  # same throw applied to all layers
-      unique_spi = np.unique(grid.split_pillar_indices_cached)
-      semi_throws[unique_spi, :] = (grid.points_cached[ref_k0, unique_spi, :] - unsplit_points[ref_k0, unique_spi, :])
-      semi_throws[primaries:, :] = (grid.points_cached[ref_k0, primaries:, :] -
-                                    unsplit_points[ref_k0, grid.split_pillar_indices_cached, :]
-                                   )  # unsplit points are mid points
-      # ensure no adjustment in pillar where geometry is not defined in reference layer
-      if not all_good:
-         semi_throws[:, :] = np.where(np.isnan(semi_throws), 0.0, semi_throws)
-      # apply global scaling to throws
-      offsets[:] = semi_throws * (scaling_factor - 1.0)
+    if scaling_factor is not None:  # apply global scaling to throws
+        # fetch unsplit equivalent of grid points for reference layer interface
+        log.debug('fetching unsplit equivalent grid points')
+        unsplit_points = grid.unsplit_points_ref().reshape(grid.nk + 1, -1, 3)
+        # determine existing throws on split pillars
+        semi_throws = np.zeros(grid.points_cached.shape[1:])  # same throw applied to all layers
+        unique_spi = np.unique(grid.split_pillar_indices_cached)
+        semi_throws[unique_spi, :] = (grid.points_cached[ref_k0, unique_spi, :] - unsplit_points[ref_k0, unique_spi, :])
+        semi_throws[primaries:, :] = (grid.points_cached[ref_k0, primaries:, :] -
+                                      unsplit_points[ref_k0, grid.split_pillar_indices_cached, :]
+                                     )  # unsplit points are mid points
+        # ensure no adjustment in pillar where geometry is not defined in reference layer
+        if not all_good:
+            semi_throws[:, :] = np.where(np.isnan(semi_throws), 0.0, semi_throws)
+        # apply global scaling to throws
+        offsets[:] = semi_throws * (scaling_factor - 1.0)
 
-   if connection_set is not None and scaling_dict is not None:  # overwrite any global offsets with named fault throw adjustments
-      connection_set.cache_arrays()
-      for fault_index in range(len(connection_set.feature_list)):
-         fault_name = connection_set.fault_name_for_feature_index(fault_index)
-         if fault_name not in scaling_dict:
-            continue  # no scaling for this fault
-         fault_scaling = scaling_dict[fault_name]
-         if fault_scaling == 1.0:
-            continue
-         log.info('scaling throw on fault ' + fault_name + ' by factor of: {0:.4f}'.format(fault_scaling))
-         kelp_j, kelp_i = connection_set.simplified_sets_of_kelp_for_feature_index(fault_index)
-         p_list = []  # list of adjusted pillars
-         for kelp in kelp_j:
-            for ip in [0, 1]:
-               p_a = grid.pillars_for_column[kelp[0], kelp[1], 1, ip]
-               p_b = grid.pillars_for_column[kelp[0] + 1, kelp[1], 0, ip]  # other side of fault
-               mid_point = 0.5 * (grid.points_cached[ref_k0, p_a] + grid.points_cached[ref_k0, p_b])
-               if np.any(np.isnan(mid_point)):
-                  continue
-               if p_a not in p_list:
-                  offsets[p_a] = (grid.points_cached[ref_k0, p_a] - mid_point) * (fault_scaling - 1.0)
-                  p_list.append(p_a)
-               if p_b not in p_list:
-                  offsets[p_b] = (grid.points_cached[ref_k0, p_b] - mid_point) * (fault_scaling - 1.0)
-                  p_list.append(p_b)
-         for kelp in kelp_i:
-            for jp in [0, 1]:
-               p_a = grid.pillars_for_column[kelp[0], kelp[1], jp, 1]
-               p_b = grid.pillars_for_column[kelp[0], kelp[1] + 1, jp, 0]  # other side of fault
-               mid_point = 0.5 * (grid.points_cached[ref_k0, p_a] + grid.points_cached[ref_k0, p_b])
-               if np.any(np.isnan(mid_point)):
-                  continue
-               if p_a not in p_list:
-                  offsets[p_a] = (grid.points_cached[ref_k0, p_a] - mid_point) * (fault_scaling - 1.0)
-                  p_list.append(p_a)
-               if p_b not in p_list:
-                  offsets[p_b] = (grid.points_cached[ref_k0, p_b] - mid_point) * (fault_scaling - 1.0)
-                  p_list.append(p_b)
+    if connection_set is not None and scaling_dict is not None:  # overwrite any global offsets with named fault throw adjustments
+        connection_set.cache_arrays()
+        for fault_index in range(len(connection_set.feature_list)):
+            fault_name = connection_set.fault_name_for_feature_index(fault_index)
+            if fault_name not in scaling_dict:
+                continue  # no scaling for this fault
+            fault_scaling = scaling_dict[fault_name]
+            if fault_scaling == 1.0:
+                continue
+            log.info('scaling throw on fault ' + fault_name + ' by factor of: {0:.4f}'.format(fault_scaling))
+            kelp_j, kelp_i = connection_set.simplified_sets_of_kelp_for_feature_index(fault_index)
+            p_list = []  # list of adjusted pillars
+            for kelp in kelp_j:
+                for ip in [0, 1]:
+                    p_a = grid.pillars_for_column[kelp[0], kelp[1], 1, ip]
+                    p_b = grid.pillars_for_column[kelp[0] + 1, kelp[1], 0, ip]  # other side of fault
+                    mid_point = 0.5 * (grid.points_cached[ref_k0, p_a] + grid.points_cached[ref_k0, p_b])
+                    if np.any(np.isnan(mid_point)):
+                        continue
+                    if p_a not in p_list:
+                        offsets[p_a] = (grid.points_cached[ref_k0, p_a] - mid_point) * (fault_scaling - 1.0)
+                        p_list.append(p_a)
+                    if p_b not in p_list:
+                        offsets[p_b] = (grid.points_cached[ref_k0, p_b] - mid_point) * (fault_scaling - 1.0)
+                        p_list.append(p_b)
+            for kelp in kelp_i:
+                for jp in [0, 1]:
+                    p_a = grid.pillars_for_column[kelp[0], kelp[1], jp, 1]
+                    p_b = grid.pillars_for_column[kelp[0], kelp[1] + 1, jp, 0]  # other side of fault
+                    mid_point = 0.5 * (grid.points_cached[ref_k0, p_a] + grid.points_cached[ref_k0, p_b])
+                    if np.any(np.isnan(mid_point)):
+                        continue
+                    if p_a not in p_list:
+                        offsets[p_a] = (grid.points_cached[ref_k0, p_a] - mid_point) * (fault_scaling - 1.0)
+                        p_list.append(p_a)
+                    if p_b not in p_list:
+                        offsets[p_b] = (grid.points_cached[ref_k0, p_b] - mid_point) * (fault_scaling - 1.0)
+                        p_list.append(p_b)
 
-   # initialise flag array for adjustments
-   adjusted = np.zeros((primaries,), dtype = bool)
+    # initialise flag array for adjustments
+    adjusted = np.zeros((primaries,), dtype = bool)
 
-   # insert adjusted throws to all layers of split pillars
-   grid.points_cached[:, grid.split_pillar_indices_cached, :] += offsets[grid.split_pillar_indices_cached, :].reshape(
-      1, -1, 3)
-   adjusted[grid.split_pillar_indices_cached] = True
-   grid.points_cached[:, primaries:, :] += offsets[primaries:, :].reshape(1, -1, 3)
+    # insert adjusted throws to all layers of split pillars
+    grid.points_cached[:, grid.split_pillar_indices_cached, :] += offsets[grid.split_pillar_indices_cached, :].reshape(
+        1, -1, 3)
+    adjusted[grid.split_pillar_indices_cached] = True
+    grid.points_cached[:, primaries:, :] += offsets[primaries:, :].reshape(1, -1, 3)
 
-   # iteratively look for pillars neighbouring adjusted pillars, adjusting by a decayed amount
-   adjusted = adjusted.reshape((grid.nj + 1, grid.ni + 1))
-   while cell_range > 0:
-      offset_decay = (maths.pow(2.0, cell_range) - 1.0) / (maths.pow(2.0, cell_range + 1) - 1.0)
-      newly_adjusted = np.zeros((grid.nj + 1, grid.ni + 1), dtype = bool)
-      for j in range(grid.nj + 1):
-         for i in range(grid.ni + 1):
-            if adjusted[j, i]:
-               continue
-            p = j * (grid.ni + 1) + i
-            if p in grid.split_pillar_indices_cached:
-               continue
-            contributions = 0
-            accum = 0.0
-            if (i > 0) and adjusted[j, i - 1]:
-               if j > 0:
-                  accum += offsets[grid.pillars_for_column[j - 1, i - 1, 1, 0], 2]
-                  contributions += 1
-               if j < grid.nj:
-                  accum += offsets[grid.pillars_for_column[j, i - 1, 0, 0], 2]
-                  contributions += 1
-            if (j > 0) and adjusted[j - 1, i]:
-               if i > 0:
-                  accum += offsets[grid.pillars_for_column[j - 1, i - 1, 0, 1], 2]
-                  contributions += 1
-               if i < grid.ni:
-                  accum += offsets[grid.pillars_for_column[j - 1, i, 0, 0], 2]
-                  contributions += 1
-            if (i < grid.ni) and adjusted[j, i + 1]:
-               if j > 0:
-                  accum += offsets[grid.pillars_for_column[j - 1, i, 1, 1], 2]
-                  contributions += 1
-               if j < grid.nj:
-                  accum += offsets[grid.pillars_for_column[j, i, 0, 1], 2]
-                  contributions += 1
-            if (j < grid.nj) and adjusted[j + 1, i]:
-               if i > 0:
-                  accum += offsets[grid.pillars_for_column[j, i - 1, 1, 1], 2]
-                  contributions += 1
-               if i < grid.ni:
-                  accum += offsets[grid.pillars_for_column[j, i, 1, 0], 2]
-                  contributions += 1
-            if contributions == 0:
-               continue
-            dxy_dz = ((grid.points_cached[grid.nk, p, :2] - grid.points_cached[0, p, :2]) /
-                      (grid.points_cached[grid.nk, p, 2] - grid.points_cached[0, p, 2]))
-            offsets[p, 2] = offset_decay * accum / float(contributions)
-            offsets[p, :2] = offsets[p, 2] * dxy_dz
-            grid.points_cached[:, p, :] += offsets[p, :].reshape((1, 3))
-            newly_adjusted[j, i] = True
-      adjusted = np.logical_or(adjusted, newly_adjusted)
-      cell_range -= 1
+    # iteratively look for pillars neighbouring adjusted pillars, adjusting by a decayed amount
+    adjusted = adjusted.reshape((grid.nj + 1, grid.ni + 1))
+    while cell_range > 0:
+        offset_decay = (maths.pow(2.0, cell_range) - 1.0) / (maths.pow(2.0, cell_range + 1) - 1.0)
+        newly_adjusted = np.zeros((grid.nj + 1, grid.ni + 1), dtype = bool)
+        for j in range(grid.nj + 1):
+            for i in range(grid.ni + 1):
+                if adjusted[j, i]:
+                    continue
+                p = j * (grid.ni + 1) + i
+                if p in grid.split_pillar_indices_cached:
+                    continue
+                contributions = 0
+                accum = 0.0
+                if (i > 0) and adjusted[j, i - 1]:
+                    if j > 0:
+                        accum += offsets[grid.pillars_for_column[j - 1, i - 1, 1, 0], 2]
+                        contributions += 1
+                    if j < grid.nj:
+                        accum += offsets[grid.pillars_for_column[j, i - 1, 0, 0], 2]
+                        contributions += 1
+                if (j > 0) and adjusted[j - 1, i]:
+                    if i > 0:
+                        accum += offsets[grid.pillars_for_column[j - 1, i - 1, 0, 1], 2]
+                        contributions += 1
+                    if i < grid.ni:
+                        accum += offsets[grid.pillars_for_column[j - 1, i, 0, 0], 2]
+                        contributions += 1
+                if (i < grid.ni) and adjusted[j, i + 1]:
+                    if j > 0:
+                        accum += offsets[grid.pillars_for_column[j - 1, i, 1, 1], 2]
+                        contributions += 1
+                    if j < grid.nj:
+                        accum += offsets[grid.pillars_for_column[j, i, 0, 1], 2]
+                        contributions += 1
+                if (j < grid.nj) and adjusted[j + 1, i]:
+                    if i > 0:
+                        accum += offsets[grid.pillars_for_column[j, i - 1, 1, 1], 2]
+                        contributions += 1
+                    if i < grid.ni:
+                        accum += offsets[grid.pillars_for_column[j, i, 1, 0], 2]
+                        contributions += 1
+                if contributions == 0:
+                    continue
+                dxy_dz = ((grid.points_cached[grid.nk, p, :2] - grid.points_cached[0, p, :2]) /
+                          (grid.points_cached[grid.nk, p, 2] - grid.points_cached[0, p, 2]))
+                offsets[p, 2] = offset_decay * accum / float(contributions)
+                offsets[p, :2] = offsets[p, 2] * dxy_dz
+                grid.points_cached[:, p, :] += offsets[p, :].reshape((1, 3))
+                newly_adjusted[j, i] = True
+        adjusted = np.logical_or(adjusted, newly_adjusted)
+        cell_range -= 1
 
-   # check cell edge relative directions (in x,y) to ensure geometry is still coherent
-   log.debug('checking grid geometry coherence')
-   grid.check_top_and_base_cell_edge_directions()
+    # check cell edge relative directions (in x,y) to ensure geometry is still coherent
+    log.debug('checking grid geometry coherence')
+    grid.check_top_and_base_cell_edge_directions()
 
-   # build cell displacement property array(s)
-   if store_displacement:
-      log.debug('generating cell displacement property arrays')
-      displacement_collection = displacement_properties(grid, source_grid)
-   else:
-      displacement_collection = None
+    # build cell displacement property array(s)
+    if store_displacement:
+        log.debug('generating cell displacement property arrays')
+        displacement_collection = displacement_properties(grid, source_grid)
+    else:
+        displacement_collection = None
 
-   collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
-                                            inherit_all_realizations)
-   if collection is None:
-      collection = displacement_collection
-   elif displacement_collection is not None:
-      collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
+    collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
+                                             inherit_all_realizations)
+    if collection is None:
+        collection = displacement_collection
+    elif displacement_collection is not None:
+        collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'grid with fault throws scaled by ' + str(scaling_factor) + ' from ' +  \
-                       str(rqet.citation_title_for_node(source_grid.root))
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'grid with fault throws scaled by ' + str(scaling_factor) + ' from ' +  \
+                         str(rqet.citation_title_for_node(source_grid.root))
 
-   gcs_list = []
-   if inherit_gcs:
-      gcs_uuids = model.uuids(obj_type = 'GridConnectionSetRepresentation', related_uuid = source_grid.uuid)
-      for gcs_uuid in gcs_uuids:
-         gcs = rqf.GridConnectionSet(model, uuid = gcs_uuid)
-         gcs.cache_arrays()
-         gcs_list.append((gcs, gcs.title))
-      log.debug(f'{len(gcs_list)} grid connection sets to be inherited')
+    gcs_list = []
+    if inherit_gcs:
+        gcs_uuids = model.uuids(obj_type = 'GridConnectionSetRepresentation', related_uuid = source_grid.uuid)
+        for gcs_uuid in gcs_uuids:
+            gcs = rqf.GridConnectionSet(model, uuid = gcs_uuid)
+            gcs.cache_arrays()
+            gcs_list.append((gcs, gcs.title))
+        log.debug(f'{len(gcs_list)} grid connection sets to be inherited')
 
-   # write model
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-      epc_file = new_epc_file
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    # write model
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+        epc_file = new_epc_file
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   if len(gcs_list):
-      log.debug(f'inheriting grid connection sets related to source grid: {source_grid.uuid}')
-      gcs_inheritance_model = rq.Model(epc_file)
-      for gcs, gcs_title in gcs_list:
-         #         log.debug(f'inheriting gcs: {gcs_title}; old gcs uuid: {gcs.uuid}')
-         gcs.uuid = bu.new_uuid()
-         grid_list_modifications = []
-         for gi, g in enumerate(gcs.grid_list):
-            #            log.debug(f'gcs uses grid: {g.title}; grid uuid: {g.uuid}')
-            if bu.matching_uuids(g.uuid, source_grid.uuid):
-               grid_list_modifications.append(gi)
-         assert len(grid_list_modifications)
-         for gi in grid_list_modifications:
-            gcs.grid_list[gi] = grid
-         gcs.model = gcs_inheritance_model
-         gcs.write_hdf5()
-         gcs.create_xml(title = gcs_title)
-      gcs_inheritance_model.store_epc()
-      gcs_inheritance_model.h5_release()
+    if len(gcs_list):
+        log.debug(f'inheriting grid connection sets related to source grid: {source_grid.uuid}')
+        gcs_inheritance_model = rq.Model(epc_file)
+        for gcs, gcs_title in gcs_list:
+            #         log.debug(f'inheriting gcs: {gcs_title}; old gcs uuid: {gcs.uuid}')
+            gcs.uuid = bu.new_uuid()
+            grid_list_modifications = []
+            for gi, g in enumerate(gcs.grid_list):
+                #            log.debug(f'gcs uses grid: {g.title}; grid uuid: {g.uuid}')
+                if bu.matching_uuids(g.uuid, source_grid.uuid):
+                    grid_list_modifications.append(gi)
+            assert len(grid_list_modifications)
+            for gi in grid_list_modifications:
+                gcs.grid_list[gi] = grid
+            gcs.model = gcs_inheritance_model
+            gcs.write_hdf5()
+            gcs.create_xml(title = gcs_title)
+        gcs_inheritance_model.store_epc()
+        gcs_inheritance_model.h5_release()
 
-   return grid
+    return grid
 
 
 def global_fault_throw_scaling(epc_file,
@@ -3283,7 +3293,7 @@ def global_fault_throw_scaling(epc_file,
                                inherit_gcs = True,
                                new_grid_title = None,
                                new_epc_file = None):
-   """Rewrites epc with a new grid with all the fault throws multiplied by the same scaling factor.
+    """Rewrites epc with a new grid with all the fault throws multiplied by the same scaling factor.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -3318,21 +3328,21 @@ def global_fault_throw_scaling(epc_file,
       calls fault_throw_scaling(), see also documentation for that function
    """
 
-   return fault_throw_scaling(epc_file,
-                              source_grid = source_grid,
-                              scaling_factor = scaling_factor,
-                              connection_set = None,
-                              scaling_dict = None,
-                              ref_k0 = ref_k0,
-                              ref_k_faces = ref_k_faces,
-                              cell_range = cell_range,
-                              store_displacement = store_displacement,
-                              inherit_properties = inherit_properties,
-                              inherit_realization = inherit_realization,
-                              inherit_all_realizations = inherit_all_realizations,
-                              inherit_gcs = inherit_gcs,
-                              new_grid_title = new_grid_title,
-                              new_epc_file = new_epc_file)
+    return fault_throw_scaling(epc_file,
+                               source_grid = source_grid,
+                               scaling_factor = scaling_factor,
+                               connection_set = None,
+                               scaling_dict = None,
+                               ref_k0 = ref_k0,
+                               ref_k_faces = ref_k_faces,
+                               cell_range = cell_range,
+                               store_displacement = store_displacement,
+                               inherit_properties = inherit_properties,
+                               inherit_realization = inherit_realization,
+                               inherit_all_realizations = inherit_all_realizations,
+                               inherit_gcs = inherit_gcs,
+                               new_grid_title = new_grid_title,
+                               new_epc_file = new_epc_file)
 
 
 def drape_to_surface(epc_file,
@@ -3349,7 +3359,7 @@ def drape_to_surface(epc_file,
                      inherit_all_realizations = False,
                      new_grid_title = None,
                      new_epc_file = None):
-   """Extends a resqml model with a new grid where the reference layer boundary of the source grid has been re-draped to a surface.
+    """Extends a resqml model with a new grid where the reference layer boundary of the source grid has been re-draped to a surface.
 
    arguments:
       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
@@ -3395,178 +3405,178 @@ def drape_to_surface(epc_file,
       the epc file and associated hdf5 file are appended to (extended) with the new grid, as a side effect of this function
    """
 
-   log.info('draping grid to surface')
+    log.info('draping grid to surface')
 
-   assert epc_file or new_epc_file, 'epc file name not specified'
-   if new_epc_file and epc_file and (
-      (new_epc_file == epc_file) or
-      (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
-      new_epc_file = None
-   assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
-   if source_grid is None:
-      model = rq.Model(epc_file)
-      source_grid = model.grid()  # requires there to be exactly one grid in model
-   else:
-      model = source_grid.model
-   assert source_grid.grid_representation == 'IjkGrid'
-   assert model is not None
+    assert epc_file or new_epc_file, 'epc file name not specified'
+    if new_epc_file and epc_file and (
+        (new_epc_file == epc_file) or
+        (os.path.exists(new_epc_file) and os.path.exists(epc_file) and os.path.samefile(new_epc_file, epc_file))):
+        new_epc_file = None
+    assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
+    if source_grid is None:
+        model = rq.Model(epc_file)
+        source_grid = model.grid()  # requires there to be exactly one grid in model
+    else:
+        model = source_grid.model
+    assert source_grid.grid_representation == 'IjkGrid'
+    assert model is not None
 
-   assert ref_k0 >= 0 and ref_k0 < source_grid.nk
-   assert ref_k_faces in ['top', 'base']
-   assert surface is not None or (scaling_factor is not None and scaling_factor != 1.0)
+    assert ref_k0 >= 0 and ref_k0 < source_grid.nk
+    assert ref_k_faces in ['top', 'base']
+    assert surface is not None or (scaling_factor is not None and scaling_factor != 1.0)
 
-   if surface is None:
-      surface = rgs.generate_untorn_surface_for_layer_interface(source_grid,
-                                                                k0 = ref_k0,
-                                                                ref_k_faces = ref_k_faces,
-                                                                quad_triangles = quad_triangles,
-                                                                border = border)
+    if surface is None:
+        surface = rgs.generate_untorn_surface_for_layer_interface(source_grid,
+                                                                  k0 = ref_k0,
+                                                                  ref_k_faces = ref_k_faces,
+                                                                  quad_triangles = quad_triangles,
+                                                                  border = border)
 
-   if scaling_factor is not None and scaling_factor != 1.0:
-      scaled_surf = copy.deepcopy(surface)
-      scaled_surf.vertical_rescale_points(scaling_factor = scaling_factor)
-      surface = scaled_surf
+    if scaling_factor is not None and scaling_factor != 1.0:
+        scaled_surf = copy.deepcopy(surface)
+        scaled_surf.vertical_rescale_points(scaling_factor = scaling_factor)
+        surface = scaled_surf
 
-   # todo: check that surface and grid use same crs; if not, convert to same
+    # todo: check that surface and grid use same crs; if not, convert to same
 
-   # take a copy of the grid
-   log.debug('copying grid')
-   grid = copy_grid(source_grid, model)
-   grid.cache_all_geometry_arrays()  # probably already cached anyway
+    # take a copy of the grid
+    log.debug('copying grid')
+    grid = copy_grid(source_grid, model)
+    grid.cache_all_geometry_arrays()  # probably already cached anyway
 
-   # todo: handle pillars with no geometry defined, and cells without geometry defined
-   assert grid.geometry_defined_for_all_pillars(), 'not all pillars have defined geometry'
-   assert grid.geometry_defined_for_all_cells(), 'not all cells have defined geometry'
+    # todo: handle pillars with no geometry defined, and cells without geometry defined
+    assert grid.geometry_defined_for_all_pillars(), 'not all pillars have defined geometry'
+    assert grid.geometry_defined_for_all_cells(), 'not all cells have defined geometry'
 
-   # fetch unsplit equivalent of grid points
-   log.debug('fetching unsplit equivalent grid points')
-   unsplit_points = grid.unsplit_points_ref(cache_array = True)
+    # fetch unsplit equivalent of grid points
+    log.debug('fetching unsplit equivalent grid points')
+    unsplit_points = grid.unsplit_points_ref(cache_array = True)
 
-   # assume pillars to be straight lines based on top and base points
-   log.debug('setting up pillar sample points and directional vectors')
-   line_p = unsplit_points[0, :, :, :].reshape((-1, 3))
-   line_v = unsplit_points[-1, :, :, :].reshape((-1, 3)) - line_p
-   if ref_k_faces == 'base':
-      ref_k0 += 1
+    # assume pillars to be straight lines based on top and base points
+    log.debug('setting up pillar sample points and directional vectors')
+    line_p = unsplit_points[0, :, :, :].reshape((-1, 3))
+    line_v = unsplit_points[-1, :, :, :].reshape((-1, 3)) - line_p
+    if ref_k_faces == 'base':
+        ref_k0 += 1
 
-   # access triangulated surface as triangle node indices into array of points
-   log.debug('fetching surface points and triangle corner indices')
-   t, p = surface.triangles_and_points()
+    # access triangulated surface as triangle node indices into array of points
+    log.debug('fetching surface points and triangle corner indices')
+    t, p = surface.triangles_and_points()
 
-   # compute intersections of all pillars with all triangles (sparse array returned with NaN for no intersection)
-   log.debug('computing intersections of all pillars with all triangles')
-   intersects = meet.line_set_triangles_intersects(line_p, line_v, p[t])
+    # compute intersections of all pillars with all triangles (sparse array returned with NaN for no intersection)
+    log.debug('computing intersections of all pillars with all triangles')
+    intersects = meet.line_set_triangles_intersects(line_p, line_v, p[t])
 
-   # reduce to a single intersection point per pillar; todo: flag multiple intersections with a warning
-   log.debug('selecting last intersection for each pillar (there should be only one intersection anyway)')
-   picks = meet.last_intersects(intersects)
+    # reduce to a single intersection point per pillar; todo: flag multiple intersections with a warning
+    log.debug('selecting last intersection for each pillar (there should be only one intersection anyway)')
+    picks = meet.last_intersects(intersects)
 
-   # count the number of pillars with no intersection at surface (indicated by triple nan)
-   log.debug('counting number of pillars which fail to intersect with surface')
-   failures = np.count_nonzero(np.isnan(picks)) // 3
-   log.info('number of pillars which do not intersect with surface: ' + str(failures))
-   assert failures == 0, 'cannot proceed as some pillars do not intersect with surface'
+    # count the number of pillars with no intersection at surface (indicated by triple nan)
+    log.debug('counting number of pillars which fail to intersect with surface')
+    failures = np.count_nonzero(np.isnan(picks)) // 3
+    log.info('number of pillars which do not intersect with surface: ' + str(failures))
+    assert failures == 0, 'cannot proceed as some pillars do not intersect with surface'
 
-   # compute a translation vector per pillar
-   log.debug('computing translation vectors for pillars')
-   translate = picks - unsplit_points[ref_k0, :, :, :].reshape((-1, 3))
+    # compute a translation vector per pillar
+    log.debug('computing translation vectors for pillars')
+    translate = picks - unsplit_points[ref_k0, :, :, :].reshape((-1, 3))
 
-   # shift all points by translation vectors
-   log.debug('shifting entire grid along pillars')
-   if grid.has_split_coordinate_lines:
-      jip1 = (grid.nj + 1) * (grid.ni + 1)
-      # adjust primary pillars
-      grid.points_cached[:, :jip1, :] += translate.reshape((1, jip1, 3))  # will be broadcast over k axis
-      # adjust split pillars
-      for p in range(grid.split_pillars_count):
-         primary = grid.split_pillar_indices_cached[p]
-         grid.points_cached[:, jip1 + p, :] += translate.reshape(
-            (1, jip1, 3))[0, primary, :]  # will be broadcast over k axis
-   else:
-      grid.points_cached[:, :, :, :] +=  \
-         translate.reshape((1, grid.points_cached.shape[1], grid.points_cached.shape[2], 3))    # will be broadcast over k axis
+    # shift all points by translation vectors
+    log.debug('shifting entire grid along pillars')
+    if grid.has_split_coordinate_lines:
+        jip1 = (grid.nj + 1) * (grid.ni + 1)
+        # adjust primary pillars
+        grid.points_cached[:, :jip1, :] += translate.reshape((1, jip1, 3))  # will be broadcast over k axis
+        # adjust split pillars
+        for p in range(grid.split_pillars_count):
+            primary = grid.split_pillar_indices_cached[p]
+            grid.points_cached[:, jip1 + p, :] += translate.reshape(
+                (1, jip1, 3))[0, primary, :]  # will be broadcast over k axis
+    else:
+        grid.points_cached[:, :, :, :] +=  \
+           translate.reshape((1, grid.points_cached.shape[1], grid.points_cached.shape[2], 3))    # will be broadcast over k axis
 
-   # check cell edge relative directions (in x,y) to ensure geometry is still coherent
-   log.debug('checking grid geometry coherence')
-   grid.check_top_and_base_cell_edge_directions()
+    # check cell edge relative directions (in x,y) to ensure geometry is still coherent
+    log.debug('checking grid geometry coherence')
+    grid.check_top_and_base_cell_edge_directions()
 
-   # build cell displacement property array(s)
-   if store_displacement:
-      log.debug('generating cell displacement property arrays')
-      displacement_collection = displacement_properties(grid, source_grid)
-   else:
-      displacement_collection = None
+    # build cell displacement property array(s)
+    if store_displacement:
+        log.debug('generating cell displacement property arrays')
+        displacement_collection = displacement_properties(grid, source_grid)
+    else:
+        displacement_collection = None
 
-   collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
-                                            inherit_all_realizations)
-   if collection is None:
-      collection = displacement_collection
-   elif displacement_collection is not None:
-      collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
+    collection = _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
+                                             inherit_all_realizations)
+    if collection is None:
+        collection = displacement_collection
+    elif displacement_collection is not None:
+        collection.inherit_imported_list_from_other_collection(displacement_collection, copy_cached_arrays = False)
 
-   if new_grid_title is None or len(new_grid_title) == 0:
-      new_grid_title = 'grid flexed from ' + str(rqet.citation_title_for_node(source_grid.root))
+    if new_grid_title is None or len(new_grid_title) == 0:
+        new_grid_title = 'grid flexed from ' + str(rqet.citation_title_for_node(source_grid.root))
 
-   # write model
-   model.h5_release()
-   if new_epc_file:
-      write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
-   else:
-      ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
-                                                    'Coordinates')
-      write_grid(epc_file,
-                 grid,
-                 ext_uuid = ext_uuid,
-                 property_collection = collection,
-                 grid_title = new_grid_title,
-                 mode = 'a')
+    # write model
+    model.h5_release()
+    if new_epc_file:
+        write_grid(new_epc_file, grid, property_collection = collection, grid_title = new_grid_title, mode = 'w')
+    else:
+        ext_uuid, _ = model.h5_uuid_and_path_for_node(rqet.find_nested_tags(source_grid.root, ['Geometry', 'Points']),
+                                                      'Coordinates')
+        write_grid(epc_file,
+                   grid,
+                   ext_uuid = ext_uuid,
+                   property_collection = collection,
+                   grid_title = new_grid_title,
+                   mode = 'a')
 
-   return grid
+    return grid
 
 
 def add_single_cell_grid(points, new_grid_title = None, new_epc_file = None):
-   """Creates a model with a single cell IJK Grid, with a cuboid cell aligned with x,y,z axes, enclosing the range of points."""
+    """Creates a model with a single cell IJK Grid, with a cuboid cell aligned with x,y,z axes, enclosing the range of points."""
 
-   # determine range of points
-   min_xyz = np.nanmin(points.reshape((-1, 3)), axis = 0)
-   max_xyz = np.nanmax(points.reshape((-1, 3)), axis = 0)
-   assert not np.any(np.isnan(min_xyz)) and not np.any(np.isnan(max_xyz))
+    # determine range of points
+    min_xyz = np.nanmin(points.reshape((-1, 3)), axis = 0)
+    max_xyz = np.nanmax(points.reshape((-1, 3)), axis = 0)
+    assert not np.any(np.isnan(min_xyz)) and not np.any(np.isnan(max_xyz))
 
-   # create corner point array in pagoda protocol
-   cp = np.array([[min_xyz[0], min_xyz[1], min_xyz[2]], [max_xyz[0], min_xyz[1], min_xyz[2]],
-                  [min_xyz[0], max_xyz[1], min_xyz[2]], [max_xyz[0], max_xyz[1], min_xyz[2]],
-                  [min_xyz[0], min_xyz[1], max_xyz[2]], [max_xyz[0], min_xyz[1], max_xyz[2]],
-                  [min_xyz[0], max_xyz[1], max_xyz[2]], [max_xyz[0], max_xyz[1], max_xyz[2]]]).reshape(
-                     (1, 1, 1, 2, 2, 2, 3))
+    # create corner point array in pagoda protocol
+    cp = np.array([[min_xyz[0], min_xyz[1], min_xyz[2]], [max_xyz[0], min_xyz[1], min_xyz[2]],
+                   [min_xyz[0], max_xyz[1], min_xyz[2]], [max_xyz[0], max_xyz[1], min_xyz[2]],
+                   [min_xyz[0], min_xyz[1], max_xyz[2]], [max_xyz[0], min_xyz[1], max_xyz[2]],
+                   [min_xyz[0], max_xyz[1], max_xyz[2]], [max_xyz[0], max_xyz[1], max_xyz[2]]]).reshape(
+                       (1, 1, 1, 2, 2, 2, 3))
 
-   # switch to nexus ordering
-   gf.resequence_nexus_corp(cp)
+    # switch to nexus ordering
+    gf.resequence_nexus_corp(cp)
 
-   # write cp to temp pure binary file
-   temp_file = new_epc_file[:-4] + '.temp.db'
-   with open(temp_file, 'wb') as fp:
-      fp.write(cp.data)
+    # write cp to temp pure binary file
+    temp_file = new_epc_file[:-4] + '.temp.db'
+    with open(temp_file, 'wb') as fp:
+        fp.write(cp.data)
 
-   # use_rq_import to create a new model
-   one_cell_model = rqi.import_nexus(new_epc_file[:-4],
-                                     extent_ijk = (1, 1, 1),
-                                     corp_file = temp_file,
-                                     ijk_handedness = 'left',
-                                     use_binary = True,
-                                     split_pillars = False,
-                                     grid_title = new_grid_title)
-   grid = one_cell_model.grid()
+    # use_rq_import to create a new model
+    one_cell_model = rqi.import_nexus(new_epc_file[:-4],
+                                      extent_ijk = (1, 1, 1),
+                                      corp_file = temp_file,
+                                      ijk_handedness = 'left',
+                                      use_binary = True,
+                                      split_pillars = False,
+                                      grid_title = new_grid_title)
+    grid = one_cell_model.grid()
 
-   os.remove(temp_file)
+    os.remove(temp_file)
 
-   return grid
+    return grid
 
 
 # functions below primarily for 'private' use but can be exposed
 
 
 def copy_grid(source_grid, target_model = None, copy_crs = True):
-   """Creates a copy of the IJK grid object in the target model (usually prior to modifying points in situ).
+    """Creates a copy of the IJK grid object in the target model (usually prior to modifying points in situ).
 
    note:
       this function is not usually called directly by application code; it does not write to the hdf5
@@ -3574,105 +3584,105 @@ def copy_grid(source_grid, target_model = None, copy_crs = True):
       the copy will be a resqpy Grid even if the source grid is a RegularGrid
    """
 
-   assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
+    assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
 
-   model = source_grid.model
-   if target_model is None:
-      target_model = model
-   if target_model is model:
-      copy_crs = False
+    model = source_grid.model
+    if target_model is None:
+        target_model = model
+    if target_model is model:
+        copy_crs = False
 
-   # if the source grid is a RegularGrid, ensure that it has explicit points
-   if source_grid.grid_representation == 'IjkBlockGrid':
-      source_grid.make_regular_points_cached()
+    # if the source grid is a RegularGrid, ensure that it has explicit points
+    if source_grid.grid_representation == 'IjkBlockGrid':
+        source_grid.make_regular_points_cached()
 
-   # create empty grid object (with new uuid)
-   grid = grr.Grid(target_model)
+    # create empty grid object (with new uuid)
+    grid = grr.Grid(target_model)
 
-   # inherit attributes from source grid
-   grid.grid_representation = 'IjkGrid'
-   grid.extent_kji = np.array(source_grid.extent_kji, dtype = 'int')
-   grid.nk, grid.nj, grid.ni = source_grid.nk, source_grid.nj, source_grid.ni
-   grid.k_direction_is_down = source_grid.k_direction_is_down
-   grid.grid_is_right_handed = source_grid.grid_is_right_handed
-   grid.pillar_shape = source_grid.pillar_shape
-   grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
-   grid.k_gaps = source_grid.k_gaps
-   if grid.k_gaps:
-      grid.k_gap_after_array = source_grid.k_gap_after_array.copy()
-      grid.k_raw_index_array = source_grid.k_raw_index_array.copy()
+    # inherit attributes from source grid
+    grid.grid_representation = 'IjkGrid'
+    grid.extent_kji = np.array(source_grid.extent_kji, dtype = 'int')
+    grid.nk, grid.nj, grid.ni = source_grid.nk, source_grid.nj, source_grid.ni
+    grid.k_direction_is_down = source_grid.k_direction_is_down
+    grid.grid_is_right_handed = source_grid.grid_is_right_handed
+    grid.pillar_shape = source_grid.pillar_shape
+    grid.has_split_coordinate_lines = source_grid.has_split_coordinate_lines
+    grid.k_gaps = source_grid.k_gaps
+    if grid.k_gaps:
+        grid.k_gap_after_array = source_grid.k_gap_after_array.copy()
+        grid.k_raw_index_array = source_grid.k_raw_index_array.copy()
 
-   # inherit a copy of the coordinate reference system used by the grid geometry
-   if copy_crs:
-      grid.crs_root = model.duplicate_node(source_grid.crs_root)
-   else:
-      grid.crs_root = source_grid.crs_root  # pointer to a source model xml tree
-   grid.crs_uuid = rqet.uuid_for_part_root(grid.crs_root)
+    # inherit a copy of the coordinate reference system used by the grid geometry
+    if copy_crs:
+        grid.crs_root = model.duplicate_node(source_grid.crs_root)
+    else:
+        grid.crs_root = source_grid.crs_root  # pointer to a source model xml tree
+    grid.crs_uuid = rqet.uuid_for_part_root(grid.crs_root)
 
-   # inherit a copy of the inactive cell mask
-   if source_grid.inactive is None:
-      grid.inactive = None
-   else:
-      grid.inactive = source_grid.inactive.copy()
-   grid.active_property_uuid = source_grid.active_property_uuid
+    # inherit a copy of the inactive cell mask
+    if source_grid.inactive is None:
+        grid.inactive = None
+    else:
+        grid.inactive = source_grid.inactive.copy()
+    grid.active_property_uuid = source_grid.active_property_uuid
 
-   # take a copy of the grid geometry
-   source_grid.cache_all_geometry_arrays()
-   grid.geometry_defined_for_all_pillars_cached = source_grid.geometry_defined_for_all_pillars_cached
-   if hasattr(source_grid, 'array_pillar_geometry_is_defined'):
-      grid.array_pillar_geometry_is_defined = source_grid.array_pillar_geometry_is_defined.copy()
-   if hasattr(source_grid, 'array_cell_geometry_is_defined'):
-      grid.array_cell_geometry_is_defined = source_grid.array_cell_geometry_is_defined.copy()
-   grid.geometry_defined_for_all_cells_cached = source_grid.geometry_defined_for_all_cells_cached
-   grid.points_cached = source_grid.points_cached.copy()
-   if grid.has_split_coordinate_lines:
-      source_grid.create_column_pillar_mapping()
-      grid.split_pillar_indices_cached = source_grid.split_pillar_indices_cached.copy()
-      grid.cols_for_split_pillars = source_grid.cols_for_split_pillars.copy()
-      grid.cols_for_split_pillars_cl = source_grid.cols_for_split_pillars_cl.copy()
-      grid.split_pillars_count = source_grid.split_pillars_count
-      grid.pillars_for_column = source_grid.pillars_for_column.copy()
+    # take a copy of the grid geometry
+    source_grid.cache_all_geometry_arrays()
+    grid.geometry_defined_for_all_pillars_cached = source_grid.geometry_defined_for_all_pillars_cached
+    if hasattr(source_grid, 'array_pillar_geometry_is_defined'):
+        grid.array_pillar_geometry_is_defined = source_grid.array_pillar_geometry_is_defined.copy()
+    if hasattr(source_grid, 'array_cell_geometry_is_defined'):
+        grid.array_cell_geometry_is_defined = source_grid.array_cell_geometry_is_defined.copy()
+    grid.geometry_defined_for_all_cells_cached = source_grid.geometry_defined_for_all_cells_cached
+    grid.points_cached = source_grid.points_cached.copy()
+    if grid.has_split_coordinate_lines:
+        source_grid.create_column_pillar_mapping()
+        grid.split_pillar_indices_cached = source_grid.split_pillar_indices_cached.copy()
+        grid.cols_for_split_pillars = source_grid.cols_for_split_pillars.copy()
+        grid.cols_for_split_pillars_cl = source_grid.cols_for_split_pillars_cl.copy()
+        grid.split_pillars_count = source_grid.split_pillars_count
+        grid.pillars_for_column = source_grid.pillars_for_column.copy()
 
-   return grid
+    return grid
 
 
 def displacement_properties(new_grid, old_grid):
-   """Computes cell centre differences in x, y, & z, between old & new grids, and returns a collection of 3 properties.
+    """Computes cell centre differences in x, y, & z, between old & new grids, and returns a collection of 3 properties.
 
    note:
       this function is not usually called directly by application code
    """
 
-   displacement_collection = rqp.GridPropertyCollection()
-   displacement_collection.set_grid(new_grid)
-   old_grid.centre_point(cache_centre_array = True)
-   new_grid.centre_point(cache_centre_array = True)
-   displacement = new_grid.array_centre_point - old_grid.array_centre_point
-   log.debug('displacement array shape: ' + str(displacement.shape))
-   displacement_collection.x_array = displacement[..., 0].copy()
-   displacement_collection.y_array = displacement[..., 1].copy()
-   displacement_collection.z_array = displacement[..., 2].copy()
-   # horizontal_displacement = np.sqrt(x_displacement * x_displacement  +  y_displacement * y_displacement)
-   # todo: create prop collection to hold z_displacement and horizontal_displacement; add them to imported list
-   xy_units = rqet.find_tag(new_grid.crs_root, 'ProjectedUom').text.lower()
-   z_units = rqet.find_tag(new_grid.crs_root, 'VerticalUom').text.lower()
-   # todo: could replace 3 displacement properties with a single points property
-   displacement_collection.add_cached_array_to_imported_list(displacement_collection.x_array,
-                                                             'easterly displacement from tilt',
-                                                             'DX_DISPLACEMENT',
-                                                             discrete = False,
-                                                             uom = xy_units)
-   displacement_collection.add_cached_array_to_imported_list(displacement_collection.y_array,
-                                                             'northerly displacement from tilt',
-                                                             'DY_DISPLACEMENT',
-                                                             discrete = False,
-                                                             uom = xy_units)
-   displacement_collection.add_cached_array_to_imported_list(displacement_collection.z_array,
-                                                             'vertical displacement from tilt',
-                                                             'DZ_DISPLACEMENT',
-                                                             discrete = False,
-                                                             uom = z_units)
-   return displacement_collection
+    displacement_collection = rqp.GridPropertyCollection()
+    displacement_collection.set_grid(new_grid)
+    old_grid.centre_point(cache_centre_array = True)
+    new_grid.centre_point(cache_centre_array = True)
+    displacement = new_grid.array_centre_point - old_grid.array_centre_point
+    log.debug('displacement array shape: ' + str(displacement.shape))
+    displacement_collection.x_array = displacement[..., 0].copy()
+    displacement_collection.y_array = displacement[..., 1].copy()
+    displacement_collection.z_array = displacement[..., 2].copy()
+    # horizontal_displacement = np.sqrt(x_displacement * x_displacement  +  y_displacement * y_displacement)
+    # todo: create prop collection to hold z_displacement and horizontal_displacement; add them to imported list
+    xy_units = rqet.find_tag(new_grid.crs_root, 'ProjectedUom').text.lower()
+    z_units = rqet.find_tag(new_grid.crs_root, 'VerticalUom').text.lower()
+    # todo: could replace 3 displacement properties with a single points property
+    displacement_collection.add_cached_array_to_imported_list(displacement_collection.x_array,
+                                                              'easterly displacement from tilt',
+                                                              'DX_DISPLACEMENT',
+                                                              discrete = False,
+                                                              uom = xy_units)
+    displacement_collection.add_cached_array_to_imported_list(displacement_collection.y_array,
+                                                              'northerly displacement from tilt',
+                                                              'DY_DISPLACEMENT',
+                                                              discrete = False,
+                                                              uom = xy_units)
+    displacement_collection.add_cached_array_to_imported_list(displacement_collection.z_array,
+                                                              'vertical displacement from tilt',
+                                                              'DZ_DISPLACEMENT',
+                                                              discrete = False,
+                                                              uom = z_units)
+    return displacement_collection
 
 
 def write_grid(epc_file,
@@ -3685,7 +3695,7 @@ def write_grid(epc_file,
                time_series_uuid = None,
                string_lookup_uuid = None,
                extra_metadata = {}):
-   """Append to or create epc and h5 files, with grid and optionally property collection.
+    """Append to or create epc and h5 files, with grid and optionally property collection.
 
    arguments:
       epc_file (string): name of existing epc file (if appending) or new epc file to be created (if writing)
@@ -3715,86 +3725,86 @@ def write_grid(epc_file,
       this function is not usually called directly by application code
    """
 
-   log.debug('write_grid(): epc_file: ' + str(epc_file) + '; mode: ' + str(mode) + '; grid extent: ' +
-             str(grid.extent_kji))
+    log.debug('write_grid(): epc_file: ' + str(epc_file) + '; mode: ' + str(mode) + '; grid extent: ' +
+              str(grid.extent_kji))
 
-   assert mode in ['a', 'w']
-   assert geometry or mode == 'a', 'for now, a copy of the grid must be included with property collection'
-   assert geometry or property_collection is not None, 'write_grid called without anything to write'
+    assert mode in ['a', 'w']
+    assert geometry or mode == 'a', 'for now, a copy of the grid must be included with property collection'
+    assert geometry or property_collection is not None, 'write_grid called without anything to write'
 
-   if not epc_file.endswith('.epc'):
-      epc_file += '.epc'
+    if not epc_file.endswith('.epc'):
+        epc_file += '.epc'
 
-   is_regular = grr.is_regular_grid(grid.root)
+    is_regular = grr.is_regular_grid(grid.root)
 
-   if not is_regular:
-      grid.cache_all_geometry_arrays()
-   working_model = grid.model
+    if not is_regular:
+        grid.cache_all_geometry_arrays()
+    working_model = grid.model
 
-   if mode == 'a':  # append to existing model
-      log.debug('write_grid(): re-using existing model object')
-      model = working_model
-      if ext_uuid is None:
-         ext_uuid = model.h5_uuid()
-   else:  # create new model with crs, grid and properties
-      log.debug('write_grid(): creating new model object')
-      model = rq.new_model(epc_file)
-      ext_uuid = model.h5_uuid()
-      crs_root = model.duplicate_node(grid.crs_root)
-      grid.model = model
-      grid.crs_root = crs_root
-   log.debug('write_grid(): number of starting parts: ' + str(model.number_of_parts()))
+    if mode == 'a':  # append to existing model
+        log.debug('write_grid(): re-using existing model object')
+        model = working_model
+        if ext_uuid is None:
+            ext_uuid = model.h5_uuid()
+    else:  # create new model with crs, grid and properties
+        log.debug('write_grid(): creating new model object')
+        model = rq.new_model(epc_file)
+        ext_uuid = model.h5_uuid()
+        crs_root = model.duplicate_node(grid.crs_root)
+        grid.model = model
+        grid.crs_root = crs_root
+    log.debug('write_grid(): number of starting parts: ' + str(model.number_of_parts()))
 
-   if grid.inactive is not None and geometry:
-      inactive_count = np.count_nonzero(grid.inactive)
-      if inactive_count == grid.inactive.size:
-         log.warning('writing grid with all cells inactive')
-      else:
-         log.info(f'grid has {grid.inactive.size - inactive_count} active cells out of {grid.inactive.size}')
-   collection = property_collection
-   if collection is not None:
-      log.debug('write_grid(): number of properties in collection: ' + str(collection.number_of_parts()))
+    if grid.inactive is not None and geometry:
+        inactive_count = np.count_nonzero(grid.inactive)
+        if inactive_count == grid.inactive.size:
+            log.warning('writing grid with all cells inactive')
+        else:
+            log.info(f'grid has {grid.inactive.size - inactive_count} active cells out of {grid.inactive.size}')
+    collection = property_collection
+    if collection is not None:
+        log.debug('write_grid(): number of properties in collection: ' + str(collection.number_of_parts()))
 
-   # append to hdf5 file using arrays cached in grid above
-   hdf5_file = model.h5_file_name(uuid = ext_uuid, file_must_exist = (mode == 'a'))
-   if geometry or collection is not None:
-      log.debug('writing grid arrays to hdf5 file')
-      grid.write_hdf5_from_caches(hdf5_file, mode = mode, geometry = geometry, imported_properties = collection)
-      model.h5_release()
-   if ext_uuid is None:
-      ext_uuid = model.h5_uuid()
+    # append to hdf5 file using arrays cached in grid above
+    hdf5_file = model.h5_file_name(uuid = ext_uuid, file_must_exist = (mode == 'a'))
+    if geometry or collection is not None:
+        log.debug('writing grid arrays to hdf5 file')
+        grid.write_hdf5_from_caches(hdf5_file, mode = mode, geometry = geometry, imported_properties = collection)
+        model.h5_release()
+    if ext_uuid is None:
+        ext_uuid = model.h5_uuid()
 
-   # build xml for grid geometry
-   if geometry:
-      log.debug('building xml for grid object')
-      ijk_node = grid.create_xml(ext_uuid, add_as_part = True, add_relationships = True, title = grid_title)
-      assert ijk_node is not None, 'failed to create IjkGrid node in xml tree'
-      if collection is not None:
-         collection.set_grid(grid, grid_root = grid.root)
-      grid.geometry_root = rqet.find_tag(ijk_node, 'Geometry')
+    # build xml for grid geometry
+    if geometry:
+        log.debug('building xml for grid object')
+        ijk_node = grid.create_xml(ext_uuid, add_as_part = True, add_relationships = True, title = grid_title)
+        assert ijk_node is not None, 'failed to create IjkGrid node in xml tree'
+        if collection is not None:
+            collection.set_grid(grid, grid_root = grid.root)
+        grid.geometry_root = rqet.find_tag(ijk_node, 'Geometry')
 
-   # add derived inactive array as part
-   if collection is not None:
-      prop_uuid_list = collection.create_xml_for_imported_list_and_add_parts_to_model(
-         ext_uuid,
-         support_uuid = grid.uuid,
-         time_series_uuid = time_series_uuid,
-         string_lookup_uuid = string_lookup_uuid,
-         extra_metadata = extra_metadata)
-   else:
-      prop_uuid_list = []
+    # add derived inactive array as part
+    if collection is not None:
+        prop_uuid_list = collection.create_xml_for_imported_list_and_add_parts_to_model(
+            ext_uuid,
+            support_uuid = grid.uuid,
+            time_series_uuid = time_series_uuid,
+            string_lookup_uuid = string_lookup_uuid,
+            extra_metadata = extra_metadata)
+    else:
+        prop_uuid_list = []
 
-   # set grid related short cuts in Model object
-   if geometry:
-      model.grid_list.append(grid)
+    # set grid related short cuts in Model object
+    if geometry:
+        model.grid_list.append(grid)
 
-   log.debug('write_grid(): number of finishing parts: ' + str(model.number_of_parts()))
+    log.debug('write_grid(): number of finishing parts: ' + str(model.number_of_parts()))
 
-   # store new version of model
-   log.info('writing model xml data in epc file: ' + epc_file)
-   model.store_epc(epc_file)
+    # store new version of model
+    log.info('writing model xml data in epc file: ' + epc_file)
+    model.store_epc(epc_file)
 
-   return prop_uuid_list
+    return prop_uuid_list
 
 
 def add_edges_per_column_property_array(epc_file,
@@ -3815,7 +3825,7 @@ def add_edges_per_column_property_array(epc_file,
                                         local_property_kind_uuid = None,
                                         extra_metadata = {},
                                         new_epc_file = None):
-   """Adds an edges per column grid property from a numpy array to an existing resqml dataset.
+    """Adds an edges per column grid property from a numpy array to an existing resqml dataset.
 
    arguments:
       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
@@ -3856,35 +3866,35 @@ def add_edges_per_column_property_array(epc_file,
       reformat_column_edges_to_resqml_format() to convert between the protocols if needed
    """
 
-   assert a.ndim in [3, 4]
-   if a.ndim == 4:  # resqpy protocol
-      assert a.shape[2] == 2 and a.shape[3] == 2, 'Wrong shape! Expected shape (nj, ni, 2, 2)'
-      array_rq = rqp.reformat_column_edges_to_resqml_format(a)
-   else:  # RESQML protocol
-      assert a.shape[2] == 4, 'Wrong shape! Expected shape (nj, ni, 4)'
-      array_rq = a
+    assert a.ndim in [3, 4]
+    if a.ndim == 4:  # resqpy protocol
+        assert a.shape[2] == 2 and a.shape[3] == 2, 'Wrong shape! Expected shape (nj, ni, 2, 2)'
+        array_rq = rqp.reformat_column_edges_to_resqml_format(a)
+    else:  # RESQML protocol
+        assert a.shape[2] == 4, 'Wrong shape! Expected shape (nj, ni, 4)'
+        array_rq = a
 
-   property_uuid = add_one_grid_property_array(epc_file,
-                                               array_rq,
-                                               property_kind,
-                                               grid_uuid = grid_uuid,
-                                               source_info = source_info,
-                                               title = title,
-                                               discrete = discrete,
-                                               uom = uom,
-                                               time_index = time_index,
-                                               time_series_uuid = time_series_uuid,
-                                               string_lookup_uuid = string_lookup_uuid,
-                                               null_value = null_value,
-                                               indexable_element = 'edges per column',
-                                               facet_type = facet_type,
-                                               facet = facet,
-                                               realization = realization,
-                                               local_property_kind_uuid = local_property_kind_uuid,
-                                               count_per_element = 1,
-                                               extra_metadata = extra_metadata,
-                                               new_epc_file = new_epc_file)
-   return property_uuid
+    property_uuid = add_one_grid_property_array(epc_file,
+                                                array_rq,
+                                                property_kind,
+                                                grid_uuid = grid_uuid,
+                                                source_info = source_info,
+                                                title = title,
+                                                discrete = discrete,
+                                                uom = uom,
+                                                time_index = time_index,
+                                                time_series_uuid = time_series_uuid,
+                                                string_lookup_uuid = string_lookup_uuid,
+                                                null_value = null_value,
+                                                indexable_element = 'edges per column',
+                                                facet_type = facet_type,
+                                                facet = facet,
+                                                realization = realization,
+                                                local_property_kind_uuid = local_property_kind_uuid,
+                                                count_per_element = 1,
+                                                extra_metadata = extra_metadata,
+                                                new_epc_file = new_epc_file)
+    return property_uuid
 
 
 def gather_ensemble(case_epc_list,
@@ -3893,7 +3903,7 @@ def gather_ensemble(case_epc_list,
                     shared_grids = True,
                     shared_time_series = True,
                     create_epc_lookup = True):
-   """Creates a composite resqml dataset by merging all parts from all models in list, assigning realization numbers.
+    """Creates a composite resqml dataset by merging all parts from all models in list, assigning realization numbers.
 
    arguments:
       case_epc_list (list of strings): paths of individual realization epc files
@@ -3915,93 +3925,94 @@ def gather_ensemble(case_epc_list,
       an exception will be raised if the grids are not matched between realisations
    """
 
-   if not consolidate:
-      shared_grids = False
+    if not consolidate:
+        shared_grids = False
 
-   composite_model = rq.Model(new_epc_file, new_epc = True, create_basics = True, create_hdf5_ext = True)
+    composite_model = rq.Model(new_epc_file, new_epc = True, create_basics = True, create_hdf5_ext = True)
 
-   epc_lookup_dict = {}
+    epc_lookup_dict = {}
 
-   for r, case_epc in enumerate(case_epc_list):
-      t_r_start = time()  # debug
-      log.info(f'gathering realszation {r}: {case_epc}')
-      epc_lookup_dict[r] = case_epc
-      case_model = rq.Model(case_epc)
-      if r == 0:  # first case
-         log.info('first case')  # debug
-         composite_model.copy_all_parts_from_other_model(case_model, realization = 0, consolidate = consolidate)
-         if shared_time_series:
-            host_ts_uuids = case_model.uuids(obj_type = 'TimeSeries')
-            host_ts_titles = []
-            for ts_uuid in host_ts_uuids:
-               host_ts_titles.append(case_model.title(uuid = ts_uuid))
-         if shared_grids:
-            host_grid_uuids = case_model.uuids(obj_type = 'IjkGridRepresentation')
-            host_grid_shapes = []
-            host_grid_titles = []
-            title_match_required = False
-            for grid_uuid in host_grid_uuids:
-               grid_root = case_model.root(uuid = grid_uuid)
-               host_grid_shapes.append(grr.extent_kji_from_root(grid_root))
-               host_grid_titles.append(rqet.citation_title_for_node(grid_root))
-            if len(set(host_grid_shapes)) < len(host_grid_shapes):
-               log.warning(
-                  'shapes of representative grids are not distinct, grid titles must match during ensemble gathering')
-               title_match_required = True
-      else:  # subsequent cases
-         log.info('subsequent case')  # debug
-         composite_model.consolidation = None  # discard any previous mappings to limit dictionary growth
-         if shared_time_series:
-            for ts_uuid in case_model.uuids(obj_type = 'TimeSeries'):
-               ts_title = case_model.title(uuid = ts_uuid)
-               ts_index = host_ts_titles.index(ts_title)
-               host_ts_uuid = host_ts_uuids[ts_index]
-               composite_model.force_consolidation_uuid_equivalence(ts_uuid, host_ts_uuid)
-         if shared_grids:
-            log.info('shared grids')  # debug
-            for grid_uuid in case_model.uuids(obj_type = 'IjkGridRepresentation'):
-               grid_root = case_model.root(uuid = grid_uuid)
-               grid_extent = grr.extent_kji_from_root(grid_root)
-               host_index = None
-               if grid_extent in host_grid_shapes:
-                  if title_match_required:
-                     case_grid_title = rqet.citation_title_for_node(grid_root)
-                     for host_grid_index in len(host_grid_uuids):
-                        if grid_extent == host_grid_shapes[host_grid_index] and case_grid_title == host_grid_titles[
-                              host_grid_index]:
-                           host_index = host_grid_index
-                           break
-                  else:
-                     host_index = host_grid_shapes.index(grid_extent)
-               assert host_index is not None, 'failed to match grids when gathering ensemble'
-               composite_model.force_consolidation_uuid_equivalence(grid_uuid, host_grid_uuids[host_index])
-               grid_relatives = case_model.parts(related_uuid = grid_uuid)
-               t_props = 0.0
-               composite_h5_file_name = composite_model.h5_file_name()
-               composite_h5_uuid = composite_model.h5_uuid()
-               case_h5_file_name = case_model.h5_file_name()
-               for part in grid_relatives:
-                  if 'Property' in part:
-                     t_p_start = time()
-                     composite_model.copy_part_from_other_model(case_model,
-                                                                part,
-                                                                realization = r,
-                                                                consolidate = True,
-                                                                force = shared_time_series,
-                                                                self_h5_file_name = composite_h5_file_name,
-                                                                h5_uuid = composite_h5_uuid,
-                                                                other_h5_file_name = case_h5_file_name)
-                     t_props += time() - t_p_start
-               log.info(f'time props: {t_props:.3f} sec')  # debug
-         else:
-            log.info('non shared grids')  # debug
-            composite_model.copy_all_parts_from_other_model(case_model, realization = r, consolidate = consolidate)
-      log.info(f'case time: {time() - t_r_start:.2f} secs')  # debug
+    for r, case_epc in enumerate(case_epc_list):
+        t_r_start = time()  # debug
+        log.info(f'gathering realszation {r}: {case_epc}')
+        epc_lookup_dict[r] = case_epc
+        case_model = rq.Model(case_epc)
+        if r == 0:  # first case
+            log.info('first case')  # debug
+            composite_model.copy_all_parts_from_other_model(case_model, realization = 0, consolidate = consolidate)
+            if shared_time_series:
+                host_ts_uuids = case_model.uuids(obj_type = 'TimeSeries')
+                host_ts_titles = []
+                for ts_uuid in host_ts_uuids:
+                    host_ts_titles.append(case_model.title(uuid = ts_uuid))
+            if shared_grids:
+                host_grid_uuids = case_model.uuids(obj_type = 'IjkGridRepresentation')
+                host_grid_shapes = []
+                host_grid_titles = []
+                title_match_required = False
+                for grid_uuid in host_grid_uuids:
+                    grid_root = case_model.root(uuid = grid_uuid)
+                    host_grid_shapes.append(grr.extent_kji_from_root(grid_root))
+                    host_grid_titles.append(rqet.citation_title_for_node(grid_root))
+                if len(set(host_grid_shapes)) < len(host_grid_shapes):
+                    log.warning(
+                        'shapes of representative grids are not distinct, grid titles must match during ensemble gathering'
+                    )
+                    title_match_required = True
+        else:  # subsequent cases
+            log.info('subsequent case')  # debug
+            composite_model.consolidation = None  # discard any previous mappings to limit dictionary growth
+            if shared_time_series:
+                for ts_uuid in case_model.uuids(obj_type = 'TimeSeries'):
+                    ts_title = case_model.title(uuid = ts_uuid)
+                    ts_index = host_ts_titles.index(ts_title)
+                    host_ts_uuid = host_ts_uuids[ts_index]
+                    composite_model.force_consolidation_uuid_equivalence(ts_uuid, host_ts_uuid)
+            if shared_grids:
+                log.info('shared grids')  # debug
+                for grid_uuid in case_model.uuids(obj_type = 'IjkGridRepresentation'):
+                    grid_root = case_model.root(uuid = grid_uuid)
+                    grid_extent = grr.extent_kji_from_root(grid_root)
+                    host_index = None
+                    if grid_extent in host_grid_shapes:
+                        if title_match_required:
+                            case_grid_title = rqet.citation_title_for_node(grid_root)
+                            for host_grid_index in len(host_grid_uuids):
+                                if grid_extent == host_grid_shapes[
+                                        host_grid_index] and case_grid_title == host_grid_titles[host_grid_index]:
+                                    host_index = host_grid_index
+                                    break
+                        else:
+                            host_index = host_grid_shapes.index(grid_extent)
+                    assert host_index is not None, 'failed to match grids when gathering ensemble'
+                    composite_model.force_consolidation_uuid_equivalence(grid_uuid, host_grid_uuids[host_index])
+                    grid_relatives = case_model.parts(related_uuid = grid_uuid)
+                    t_props = 0.0
+                    composite_h5_file_name = composite_model.h5_file_name()
+                    composite_h5_uuid = composite_model.h5_uuid()
+                    case_h5_file_name = case_model.h5_file_name()
+                    for part in grid_relatives:
+                        if 'Property' in part:
+                            t_p_start = time()
+                            composite_model.copy_part_from_other_model(case_model,
+                                                                       part,
+                                                                       realization = r,
+                                                                       consolidate = True,
+                                                                       force = shared_time_series,
+                                                                       self_h5_file_name = composite_h5_file_name,
+                                                                       h5_uuid = composite_h5_uuid,
+                                                                       other_h5_file_name = case_h5_file_name)
+                            t_props += time() - t_p_start
+                    log.info(f'time props: {t_props:.3f} sec')  # debug
+            else:
+                log.info('non shared grids')  # debug
+                composite_model.copy_all_parts_from_other_model(case_model, realization = r, consolidate = consolidate)
+        log.info(f'case time: {time() - t_r_start:.2f} secs')  # debug
 
-   if create_epc_lookup and len(epc_lookup_dict):
-      epc_lookup = rqp.StringLookup(composite_model, int_to_str_dict = epc_lookup_dict, title = 'ensemble epc table')
-      epc_lookup.create_xml()
+    if create_epc_lookup and len(epc_lookup_dict):
+        epc_lookup = rqp.StringLookup(composite_model, int_to_str_dict = epc_lookup_dict, title = 'ensemble epc table')
+        epc_lookup.create_xml()
 
-   composite_model.store_epc()
+    composite_model.store_epc()
 
-   log.info(f'{len(epc_lookup_dict)} realizations merged into ensemble {new_epc_file}')
+    log.info(f'{len(epc_lookup_dict)} realizations merged into ensemble {new_epc_file}')

--- a/resqpy/fault.py
+++ b/resqpy/fault.py
@@ -29,29 +29,29 @@ import resqpy.property as rqp
 
 
 class GridConnectionSet(BaseResqpy):
-   """Class for obj_GridConnectionSetRepresentation holding pairs of connected faces, usually for faults."""
+    """Class for obj_GridConnectionSetRepresentation holding pairs of connected faces, usually for faults."""
 
-   resqml_type = 'GridConnectionSetRepresentation'
+    resqml_type = 'GridConnectionSetRepresentation'
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                connection_set_root = None,
-                find_properties = True,
-                grid = None,
-                ascii_load_format = None,
-                ascii_file = None,
-                k_faces = None,
-                j_faces = None,
-                i_faces = None,
-                feature_name = None,
-                create_organizing_objects_where_needed = False,
-                create_transmissibility_multiplier_property = True,
-                fault_tmult_dict = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Initializes a new GridConnectionSet and optionally loads it from xml or a list of simulator format ascii files.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 connection_set_root = None,
+                 find_properties = True,
+                 grid = None,
+                 ascii_load_format = None,
+                 ascii_file = None,
+                 k_faces = None,
+                 j_faces = None,
+                 i_faces = None,
+                 feature_name = None,
+                 create_organizing_objects_where_needed = False,
+                 create_transmissibility_multiplier_property = True,
+                 fault_tmult_dict = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Initializes a new GridConnectionSet and optionally loads it from xml or a list of simulator format ascii files.
 
       arguments:
          parent_model (model.Model object): the resqml model that this grid connection set will be part of
@@ -105,293 +105,295 @@ class GridConnectionSet(BaseResqpy):
       :meta common:
       """
 
-      log.debug('initialising grid connection set')
-      self.count = None  #: number of face-juxtaposition pairs in this connection set
-      self.cell_index_pairs = None  #: shape (count, 2); dtype int; index normalized for flattened array
-      self.cell_index_pairs_null_value = -1  #: integer null value for array above
-      self.grid_index_pairs = None  #: shape (count, 2); dtype int; optional; used if more than one grid referenced
-      self.face_index_pairs = None  #: shape (count, 2); dtype int32; local to cell, ie. range 0 to 5
-      self.face_index_pairs_null_value = -1  #: integer null value for array above
-      # NB face index values 0..5 usually mean [K-, K+, J+, I+, J-, I-] respectively but there is some ambiguity
-      #    over I & J in the Energistics RESQML Usage Guide; see comments in DevOps backlog item 269001 for more info
-      self.grid_list = []  #: ordered list of grid objects, indexed by grid_index_pairs
-      self.feature_indices = None  #: shape (count,); dtype int; optional; which fault interpretation each pair is part of
-      # note: resqml data structures allow a face pair to be part of more than one fault but this code restricts to one
-      self.feature_list = None  #: ordered list, actually of interpretations, indexed by feature_indices
-      # feature list contains tuples: (content_type, uuid, title) for fault features (or other interpretations)
-      self.property_collection = None  #: optional property.PropertyCollection
+        log.debug('initialising grid connection set')
+        self.count = None  #: number of face-juxtaposition pairs in this connection set
+        self.cell_index_pairs = None  #: shape (count, 2); dtype int; index normalized for flattened array
+        self.cell_index_pairs_null_value = -1  #: integer null value for array above
+        self.grid_index_pairs = None  #: shape (count, 2); dtype int; optional; used if more than one grid referenced
+        self.face_index_pairs = None  #: shape (count, 2); dtype int32; local to cell, ie. range 0 to 5
+        self.face_index_pairs_null_value = -1  #: integer null value for array above
+        # NB face index values 0..5 usually mean [K-, K+, J+, I+, J-, I-] respectively but there is some ambiguity
+        #    over I & J in the Energistics RESQML Usage Guide; see comments in DevOps backlog item 269001 for more info
+        self.grid_list = []  #: ordered list of grid objects, indexed by grid_index_pairs
+        self.feature_indices = None  #: shape (count,); dtype int; optional; which fault interpretation each pair is part of
+        # note: resqml data structures allow a face pair to be part of more than one fault but this code restricts to one
+        self.feature_list = None  #: ordered list, actually of interpretations, indexed by feature_indices
+        # feature list contains tuples: (content_type, uuid, title) for fault features (or other interpretations)
+        self.property_collection = None  #: optional property.PropertyCollection
 
-      # NB: RESQML documentation is not clear which order is correct; should be kept consistent with same data in property.py
-      # face_index_map maps from (axis, p01) to face index value in range 0..5
-      # this is the default as indicated on page 139 (but not p. 180) of the RESQML Usage Gude v2.0.1
-      # also assumes K is generally increasing downwards
-      # see DevOps backlog item 269001 discussion for more information
-      #     self.face_index_map = np.array([[0, 1], [4, 2], [5, 3]], dtype = int)
-      self.face_index_map = np.array([[0, 1], [2, 4], [5, 3]], dtype = int)  # order: top, base, J-, I+, J+, I-
-      # and the inverse, maps from 0..5 to (axis, p01)
-      #     self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 1], [2, 1], [1, 0], [2, 0]], dtype = int)
-      self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 0], [2, 1], [1, 1], [2, 0]], dtype = int)
-      # note: the rework_face_pairs() method, below, overwrites the face indices based on I, J cell indices
-      if not title:
-         title = feature_name
+        # NB: RESQML documentation is not clear which order is correct; should be kept consistent with same data in property.py
+        # face_index_map maps from (axis, p01) to face index value in range 0..5
+        # this is the default as indicated on page 139 (but not p. 180) of the RESQML Usage Gude v2.0.1
+        # also assumes K is generally increasing downwards
+        # see DevOps backlog item 269001 discussion for more information
+        #     self.face_index_map = np.array([[0, 1], [4, 2], [5, 3]], dtype = int)
+        self.face_index_map = np.array([[0, 1], [2, 4], [5, 3]], dtype = int)  # order: top, base, J-, I+, J+, I-
+        # and the inverse, maps from 0..5 to (axis, p01)
+        #     self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 1], [2, 1], [1, 0], [2, 0]], dtype = int)
+        self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 0], [2, 1], [1, 1], [2, 0]], dtype = int)
+        # note: the rework_face_pairs() method, below, overwrites the face indices based on I, J cell indices
+        if not title:
+            title = feature_name
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = connection_set_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = connection_set_root)
 
-      if self.root is None:
-         log.debug('setting grid for new connection set to default (ROOT)')
-         if grid is None:
+        if self.root is None:
+            log.debug('setting grid for new connection set to default (ROOT)')
+            if grid is None:
+                grid = self.model.grid(find_properties = False)  # should find only or ROOT grid
+                assert grid is not None, 'No ROOT grid found in model'
+            self.grid_list = [grid]
+            if ascii_load_format and ascii_file:
+                faces = None
+                if ascii_load_format == 'nexus':
+                    log.debug('loading connection set (fault) faces from Nexus format ascii file: ' + ascii_file)
+                    tm.log_nexus_tm('debug')
+                    faces = rnf.load_nexus_fault_mult_table(ascii_file)
+                else:
+                    log.warning('ascii format for connection set faces not handled by base resqpy code: ' +
+                                ascii_load_format)
+                assert faces is not None, 'failed to load fault face information from file: ' + ascii_file
+                self.set_pairs_from_faces_df(
+                    faces,
+                    create_organizing_objects_where_needed = create_organizing_objects_where_needed,
+                    create_mult_prop = create_transmissibility_multiplier_property,
+                    fault_tmult_dict = fault_tmult_dict,
+                    one_based_indexing = True)
+                # note: hdf5 write and xml generation elsewhere
+                # todo: optionally set face sets in grid object? or add to existing set?
+                # grid.make_face_set_from_dataframe(faces) to set from dataframe
+                # to access pair of lists for j & i plus faces, from grid attibutes, eg:
+                # for fs in grid.face_set_dict.keys():
+                #    list_pair = grid.face_set_dict[fs][0:2]
+                #    face_sets.append(str(fs) + ': ' + str(len(list_pair[1])) + ' i face cols; ' +
+                #                                      str(len(list_pair[0])) + ' j face cols; from ' + origin)
+                # note: grid structures assume curtain like set of kelp
+            elif k_faces is not None or j_faces is not None or i_faces is not None:
+                self.set_pairs_from_face_masks(k_faces, j_faces, i_faces, feature_name,
+                                               create_organizing_objects_where_needed)
+        elif find_properties:
+            self.extract_property_collection()
+
+    def _load_from_xml(self):
+        root = self.root
+        assert root is not None
+        self.count = rqet.find_tag_int(root, 'Count')
+        assert self.count > 0, 'empty grid connection set'
+        self.cell_index_pairs_null_value = rqet.find_nested_tags_int(root, ['CellIndexPairs', 'NullValue'])
+        self.face_index_pairs_null_value = rqet.find_nested_tags_int(root, ['LocalFacePerCellIndexPairs', 'NullValue'])
+        # postpone loading of hdf5 array data till on-demand load (cell, grid & face index pairs)
+        interp_root = rqet.find_tag(root, 'ConnectionInterpretations')
+        if interp_root is None:
+            return
+        # load ordered feature list
+        self.feature_list = []  # ordered list of (content_type, uuid, title) for faults
+        for child in interp_root:
+            if rqet.stripped_of_prefix(child.tag) != 'FeatureInterpretation':
+                continue
+            feature_type = rqet.content_type(rqet.find_tag_text(child, 'ContentType'))
+            feature_uuid = bu.uuid_from_string(rqet.find_tag_text(child, 'UUID'))
+            feature_title = rqet.find_tag_text(child, 'Title')
+            # for now, only accept faults
+            assert feature_type in ['obj_FaultInterpretation', 'obj_HorizonInterpretation']
+            self.feature_list.append((feature_type, feature_uuid, feature_title))
+            log.debug('connection set references fault interpretation: ' + feature_title)
+        log.debug('number of faults referred to in connection set: ' + str(len(self.feature_list)))
+        assert len(self.feature_list) > 0, 'list of fault interpretation references is empty for connection set'
+        # leave feature indices till on-demand load
+        self.grid_list = []
+        for child in root:
+            if rqet.stripped_of_prefix(child.tag) != 'Grid':
+                continue
+            grid_type = rqet.content_type(rqet.find_tag_text(child, 'ContentType'))
+            grid_uuid = bu.uuid_from_string(rqet.find_tag_text(child, 'UUID'))
+            assert grid_type == 'obj_IjkGridRepresentation', 'only IJK grids supported for grid connection sets'
+            grid = self.model.grid(uuid = grid_uuid,
+                                   find_properties = False)  # centralised list of grid objects for shared use
+            self.grid_list.append(grid)
+        if len(self.grid_list
+              ) == 0:  # this code only needed to handle defective datasets generated by earlier versions!
+            log.warning('no grid nodes found in xml for connection set')
             grid = self.model.grid(find_properties = False)  # should find only or ROOT grid
             assert grid is not None, 'No ROOT grid found in model'
-         self.grid_list = [grid]
-         if ascii_load_format and ascii_file:
-            faces = None
-            if ascii_load_format == 'nexus':
-               log.debug('loading connection set (fault) faces from Nexus format ascii file: ' + ascii_file)
-               tm.log_nexus_tm('debug')
-               faces = rnf.load_nexus_fault_mult_table(ascii_file)
+            self.grid_list = [grid]
+
+    def extract_property_collection(self):
+        """Prepares the property collection for this grid connection set."""
+
+        if self.property_collection is None:
+            self.property_collection = rqp.PropertyCollection(support = self)
+        return self.property_collection
+
+    def set_pairs_from_kelp(self, kelp_0, kelp_1, feature_name, create_organizing_objects_where_needed, axis = 'K'):
+        """Sets cell_index_pairs and face_index_pairs based on j and i face kelp strands, using simple no throw pairing."""
+
+        # note: this method has been reworked to allow 'kelp' to be 'horizontal' strands when working in cross section
+
+        if axis == 'K':
+            kelp_k = None
+            kelp_j = kelp_0
+            kelp_i = kelp_1
+        elif axis == 'J':
+            kelp_k = kelp_0
+            kelp_j = None
+            kelp_i = kelp_1
+        else:
+            assert axis == 'I'
+            kelp_k = kelp_0
+            kelp_j = kelp_1
+            kelp_i = None
+
+        if feature_name is None:
+            feature_name = 'feature from kelp lists'
+        if len(self.grid_list) > 1:
+            log.warning('setting grid connection set pairs from kelp for first grid in list only')
+        grid = self.grid_list[0]
+        if grid.nk > 1 and kelp_k is not None and len(kelp_k) > 0:
+            if axis == 'J':
+                k_layer = np.zeros((grid.nk - 1, grid.ni), dtype = bool)
             else:
-               log.warning('ascii format for connection set faces not handled by base resqpy code: ' +
-                           ascii_load_format)
-            assert faces is not None, 'failed to load fault face information from file: ' + ascii_file
-            self.set_pairs_from_faces_df(
-               faces,
-               create_organizing_objects_where_needed = create_organizing_objects_where_needed,
-               create_mult_prop = create_transmissibility_multiplier_property,
-               fault_tmult_dict = fault_tmult_dict,
-               one_based_indexing = True)
-            # note: hdf5 write and xml generation elsewhere
-            # todo: optionally set face sets in grid object? or add to existing set?
-            # grid.make_face_set_from_dataframe(faces) to set from dataframe
-            # to access pair of lists for j & i plus faces, from grid attibutes, eg:
-            # for fs in grid.face_set_dict.keys():
-            #    list_pair = grid.face_set_dict[fs][0:2]
-            #    face_sets.append(str(fs) + ': ' + str(len(list_pair[1])) + ' i face cols; ' +
-            #                                      str(len(list_pair[0])) + ' j face cols; from ' + origin)
-            # note: grid structures assume curtain like set of kelp
-         elif k_faces is not None or j_faces is not None or i_faces is not None:
-            self.set_pairs_from_face_masks(k_faces, j_faces, i_faces, feature_name,
-                                           create_organizing_objects_where_needed)
-      elif find_properties:
-         self.extract_property_collection()
+                k_layer = np.zeros((grid.nk - 1, grid.nj), dtype = bool)
+            kelp_a = np.array(kelp_k, dtype = int).T
+            k_layer[kelp_a[0], kelp_a[1]] = True
+            k_faces = np.zeros((grid.nk - 1, grid.nj, grid.ni), dtype = bool)
+            if axis == 'J':
+                k_faces[:] = k_layer.reshape((grid.nk - 1, 1, grid.ni))
+            else:
+                k_faces[:] = k_layer.reshape((grid.nk - 1, grid.nj, 1))
+        else:
+            k_faces = None
+        if grid.nj > 1 and kelp_j is not None and len(kelp_j) > 0:
+            if axis == 'K':
+                j_layer = np.zeros((grid.nj - 1, grid.ni), dtype = bool)
+            else:
+                j_layer = np.zeros((grid.nk, grid.nj - 1), dtype = bool)
+            kelp_a = np.array(kelp_j, dtype = int).T
+            j_layer[kelp_a[0], kelp_a[1]] = True
+            j_faces = np.zeros((grid.nk, grid.nj - 1, grid.ni), dtype = bool)
+            if axis == 'K':
+                j_faces[:] = j_layer.reshape((1, grid.nj - 1, grid.ni))
+            else:
+                j_faces[:] = j_layer.reshape((grid.nk, grid.nj - 1, 1))
+        else:
+            j_faces = None
+        if grid.ni > 1 and kelp_i is not None and len(kelp_i) > 0:
+            if axis == 'K':
+                i_layer = np.zeros((grid.nj, grid.ni - 1), dtype = bool)
+            else:
+                i_layer = np.zeros((grid.nk, grid.ni - 1), dtype = bool)
+            kelp_a = np.array(kelp_i, dtype = int).T
+            i_layer[kelp_a[0], kelp_a[1]] = True
+            i_faces = np.zeros((grid.nk, grid.nj, grid.ni - 1), dtype = bool)
+            if axis == 'K':
+                i_faces[:] = i_layer.reshape((1, grid.nj, grid.ni - 1))
+            else:
+                i_faces[:] = i_layer.reshape((grid.nk, 1, grid.ni - 1))
+        else:
+            i_faces = None
+        self.set_pairs_from_face_masks(k_faces, j_faces, i_faces, feature_name, create_organizing_objects_where_needed)
 
-   def _load_from_xml(self):
-      root = self.root
-      assert root is not None
-      self.count = rqet.find_tag_int(root, 'Count')
-      assert self.count > 0, 'empty grid connection set'
-      self.cell_index_pairs_null_value = rqet.find_nested_tags_int(root, ['CellIndexPairs', 'NullValue'])
-      self.face_index_pairs_null_value = rqet.find_nested_tags_int(root, ['LocalFacePerCellIndexPairs', 'NullValue'])
-      # postpone loading of hdf5 array data till on-demand load (cell, grid & face index pairs)
-      interp_root = rqet.find_tag(root, 'ConnectionInterpretations')
-      if interp_root is None:
-         return
-      # load ordered feature list
-      self.feature_list = []  # ordered list of (content_type, uuid, title) for faults
-      for child in interp_root:
-         if rqet.stripped_of_prefix(child.tag) != 'FeatureInterpretation':
-            continue
-         feature_type = rqet.content_type(rqet.find_tag_text(child, 'ContentType'))
-         feature_uuid = bu.uuid_from_string(rqet.find_tag_text(child, 'UUID'))
-         feature_title = rqet.find_tag_text(child, 'Title')
-         # for now, only accept faults
-         assert feature_type in ['obj_FaultInterpretation', 'obj_HorizonInterpretation']
-         self.feature_list.append((feature_type, feature_uuid, feature_title))
-         log.debug('connection set references fault interpretation: ' + feature_title)
-      log.debug('number of faults referred to in connection set: ' + str(len(self.feature_list)))
-      assert len(self.feature_list) > 0, 'list of fault interpretation references is empty for connection set'
-      # leave feature indices till on-demand load
-      self.grid_list = []
-      for child in root:
-         if rqet.stripped_of_prefix(child.tag) != 'Grid':
-            continue
-         grid_type = rqet.content_type(rqet.find_tag_text(child, 'ContentType'))
-         grid_uuid = bu.uuid_from_string(rqet.find_tag_text(child, 'UUID'))
-         assert grid_type == 'obj_IjkGridRepresentation', 'only IJK grids supported for grid connection sets'
-         grid = self.model.grid(uuid = grid_uuid,
-                                find_properties = False)  # centralised list of grid objects for shared use
-         self.grid_list.append(grid)
-      if len(self.grid_list) == 0:  # this code only needed to handle defective datasets generated by earlier versions!
-         log.warning('no grid nodes found in xml for connection set')
-         grid = self.model.grid(find_properties = False)  # should find only or ROOT grid
-         assert grid is not None, 'No ROOT grid found in model'
-         self.grid_list = [grid]
+    def set_pairs_from_face_masks(self,
+                                  k_faces,
+                                  j_faces,
+                                  i_faces,
+                                  feature_name,
+                                  create_organizing_objects_where_needed,
+                                  feature_type = 'fault'):  # other feature_type values: 'horizon', 'geobody boundary'
+        """Sets cell_index_pairs and face_index_pairs based on triple face masks, using simple no throw pairing."""
 
-   def extract_property_collection(self):
-      """Prepares the property collection for this grid connection set."""
+        assert feature_type in ['fault', 'horizon', 'geobody boundary']
+        if feature_name is None:
+            feature_name = 'feature from face masks'  # not sure this default is wise
+        if len(self.grid_list) > 1:
+            log.warning('setting grid connection set pairs from face masks for first grid in list only')
+        grid = self.grid_list[0]
+        if feature_type == 'fault':
+            feature_flavour = 'TectonicBoundaryFeature'
+            interpretation_flavour = 'FaultInterpretation'
+        else:
+            feature_flavour = 'GeneticBoundaryFeature'
+            if feature_type == 'horizon':
+                interpretation_flavour = 'HorizonInterpretation'
+            else:
+                interpretation_flavour = 'GeobodyBoundaryInterpretation'
+            # kind differentiates between horizon and geobody boundary
+        fi_parts_list = self.model.parts_list_of_type(interpretation_flavour)
+        if fi_parts_list is None or len(fi_parts_list) == 0:
+            log.warning('no interpretation parts found in model for ' + feature_type)
+        fi_uuid = None
+        for fi_part in fi_parts_list:
+            if self.model.title_for_part(fi_part).split()[0].lower() == feature_name.lower():
+                fi_uuid = self.model.uuid_for_part(fi_part)
+                break
+        if fi_uuid is None:
+            if create_organizing_objects_where_needed:
+                tbf_parts_list = self.model.parts_list_of_type(feature_flavour)
+                tbf = None
+                for tbf_part in tbf_parts_list:
+                    if feature_name.lower() == self.model.title_for_part(tbf_part).split()[0].lower():
+                        tbf_root = self.model.root_for_part(tbf_part)
+                        if feature_type == 'fault':
+                            tbf = rqo.TectonicBoundaryFeature(self.model, root_node = tbf_root)
+                        else:
+                            tbf = rqo.GeneticBoundaryFeature(self.model, kind = feature_type, root_node = tbf_root)
+                        break
+                if tbf is None:
+                    if feature_type == 'fault':
+                        tbf = rqo.TectonicBoundaryFeature(self.model, kind = 'fault', feature_name = feature_name)
+                    else:
+                        tbf = rqo.GeneticBoundaryFeature(self.model, kind = feature_type, feature_name = feature_name)
+                    tbf_root = tbf.create_xml()
+                if feature_type == 'fault':
+                    fi = rqo.FaultInterpretation(
+                        self.model, tectonic_boundary_feature = tbf,
+                        is_normal = True)  # todo: set is_normal based on fault geometry in grid?
+                elif feature_type == 'horizon':
+                    fi = rqo.HorizonInterpretation(self.model, genetic_boundary_feature = tbf)
+                    # todo: support boundary relation list and sequence stratigraphy surface
+                else:  # geobody boundary
+                    fi = rqo.GeobodyBoundaryInterpretation(self.model, genetic_boundary_feature = tbf)
+                fi_root = fi.create_xml(tbf_root)
+                fi_uuid = rqet.uuid_for_part_root(fi_root)
+            else:
+                log.error('no interpretation found for feature: ' + feature_name)
+                return
+        self.feature_list = [('obj_FaultInterpretation', fi_uuid, str(feature_name))]
+        cell_pair_list = []
+        face_pair_list = []
+        nj_ni = grid.nj * grid.ni
+        if k_faces is not None:
+            for cell_kji0 in np.stack(np.where(k_faces)).T:
+                cell = grid.natural_cell_index(cell_kji0)
+                cell_pair_list.append((cell, cell + nj_ni))
+                face_pair_list.append((self.face_index_map[0, 1], self.face_index_map[0, 0]))
+        if j_faces is not None:
+            for cell_kji0 in np.stack(np.where(j_faces)).T:
+                cell = grid.natural_cell_index(cell_kji0)
+                cell_pair_list.append((cell, cell + grid.ni))
+                face_pair_list.append((self.face_index_map[1, 1], self.face_index_map[1, 0]))
+        if i_faces is not None:
+            for cell_kji0 in np.stack(np.where(i_faces)).T:
+                cell = grid.natural_cell_index(cell_kji0)
+                cell_pair_list.append((cell, cell + 1))
+                face_pair_list.append((self.face_index_map[2, 1], self.face_index_map[2, 0]))
+        self.cell_index_pairs = np.array(cell_pair_list, dtype = int)
+        self.face_index_pairs = np.array(face_pair_list, dtype = int)
+        self.count = len(self.cell_index_pairs)
+        self.feature_indices = np.zeros(self.count, dtype = int)
+        assert len(self.face_index_pairs) == self.count
 
-      if self.property_collection is None:
-         self.property_collection = rqp.PropertyCollection(support = self)
-      return self.property_collection
-
-   def set_pairs_from_kelp(self, kelp_0, kelp_1, feature_name, create_organizing_objects_where_needed, axis = 'K'):
-      """Sets cell_index_pairs and face_index_pairs based on j and i face kelp strands, using simple no throw pairing."""
-
-      # note: this method has been reworked to allow 'kelp' to be 'horizontal' strands when working in cross section
-
-      if axis == 'K':
-         kelp_k = None
-         kelp_j = kelp_0
-         kelp_i = kelp_1
-      elif axis == 'J':
-         kelp_k = kelp_0
-         kelp_j = None
-         kelp_i = kelp_1
-      else:
-         assert axis == 'I'
-         kelp_k = kelp_0
-         kelp_j = kelp_1
-         kelp_i = None
-
-      if feature_name is None:
-         feature_name = 'feature from kelp lists'
-      if len(self.grid_list) > 1:
-         log.warning('setting grid connection set pairs from kelp for first grid in list only')
-      grid = self.grid_list[0]
-      if grid.nk > 1 and kelp_k is not None and len(kelp_k) > 0:
-         if axis == 'J':
-            k_layer = np.zeros((grid.nk - 1, grid.ni), dtype = bool)
-         else:
-            k_layer = np.zeros((grid.nk - 1, grid.nj), dtype = bool)
-         kelp_a = np.array(kelp_k, dtype = int).T
-         k_layer[kelp_a[0], kelp_a[1]] = True
-         k_faces = np.zeros((grid.nk - 1, grid.nj, grid.ni), dtype = bool)
-         if axis == 'J':
-            k_faces[:] = k_layer.reshape((grid.nk - 1, 1, grid.ni))
-         else:
-            k_faces[:] = k_layer.reshape((grid.nk - 1, grid.nj, 1))
-      else:
-         k_faces = None
-      if grid.nj > 1 and kelp_j is not None and len(kelp_j) > 0:
-         if axis == 'K':
-            j_layer = np.zeros((grid.nj - 1, grid.ni), dtype = bool)
-         else:
-            j_layer = np.zeros((grid.nk, grid.nj - 1), dtype = bool)
-         kelp_a = np.array(kelp_j, dtype = int).T
-         j_layer[kelp_a[0], kelp_a[1]] = True
-         j_faces = np.zeros((grid.nk, grid.nj - 1, grid.ni), dtype = bool)
-         if axis == 'K':
-            j_faces[:] = j_layer.reshape((1, grid.nj - 1, grid.ni))
-         else:
-            j_faces[:] = j_layer.reshape((grid.nk, grid.nj - 1, 1))
-      else:
-         j_faces = None
-      if grid.ni > 1 and kelp_i is not None and len(kelp_i) > 0:
-         if axis == 'K':
-            i_layer = np.zeros((grid.nj, grid.ni - 1), dtype = bool)
-         else:
-            i_layer = np.zeros((grid.nk, grid.ni - 1), dtype = bool)
-         kelp_a = np.array(kelp_i, dtype = int).T
-         i_layer[kelp_a[0], kelp_a[1]] = True
-         i_faces = np.zeros((grid.nk, grid.nj, grid.ni - 1), dtype = bool)
-         if axis == 'K':
-            i_faces[:] = i_layer.reshape((1, grid.nj, grid.ni - 1))
-         else:
-            i_faces[:] = i_layer.reshape((grid.nk, 1, grid.ni - 1))
-      else:
-         i_faces = None
-      self.set_pairs_from_face_masks(k_faces, j_faces, i_faces, feature_name, create_organizing_objects_where_needed)
-
-   def set_pairs_from_face_masks(self,
-                                 k_faces,
-                                 j_faces,
-                                 i_faces,
-                                 feature_name,
-                                 create_organizing_objects_where_needed,
-                                 feature_type = 'fault'):  # other feature_type values: 'horizon', 'geobody boundary'
-      """Sets cell_index_pairs and face_index_pairs based on triple face masks, using simple no throw pairing."""
-
-      assert feature_type in ['fault', 'horizon', 'geobody boundary']
-      if feature_name is None:
-         feature_name = 'feature from face masks'  # not sure this default is wise
-      if len(self.grid_list) > 1:
-         log.warning('setting grid connection set pairs from face masks for first grid in list only')
-      grid = self.grid_list[0]
-      if feature_type == 'fault':
-         feature_flavour = 'TectonicBoundaryFeature'
-         interpretation_flavour = 'FaultInterpretation'
-      else:
-         feature_flavour = 'GeneticBoundaryFeature'
-         if feature_type == 'horizon':
-            interpretation_flavour = 'HorizonInterpretation'
-         else:
-            interpretation_flavour = 'GeobodyBoundaryInterpretation'
-         # kind differentiates between horizon and geobody boundary
-      fi_parts_list = self.model.parts_list_of_type(interpretation_flavour)
-      if fi_parts_list is None or len(fi_parts_list) == 0:
-         log.warning('no interpretation parts found in model for ' + feature_type)
-      fi_uuid = None
-      for fi_part in fi_parts_list:
-         if self.model.title_for_part(fi_part).split()[0].lower() == feature_name.lower():
-            fi_uuid = self.model.uuid_for_part(fi_part)
-            break
-      if fi_uuid is None:
-         if create_organizing_objects_where_needed:
-            tbf_parts_list = self.model.parts_list_of_type(feature_flavour)
-            tbf = None
-            for tbf_part in tbf_parts_list:
-               if feature_name.lower() == self.model.title_for_part(tbf_part).split()[0].lower():
-                  tbf_root = self.model.root_for_part(tbf_part)
-                  if feature_type == 'fault':
-                     tbf = rqo.TectonicBoundaryFeature(self.model, root_node = tbf_root)
-                  else:
-                     tbf = rqo.GeneticBoundaryFeature(self.model, kind = feature_type, root_node = tbf_root)
-                  break
-            if tbf is None:
-               if feature_type == 'fault':
-                  tbf = rqo.TectonicBoundaryFeature(self.model, kind = 'fault', feature_name = feature_name)
-               else:
-                  tbf = rqo.GeneticBoundaryFeature(self.model, kind = feature_type, feature_name = feature_name)
-               tbf_root = tbf.create_xml()
-            if feature_type == 'fault':
-               fi = rqo.FaultInterpretation(self.model, tectonic_boundary_feature = tbf,
-                                            is_normal = True)  # todo: set is_normal based on fault geometry in grid?
-            elif feature_type == 'horizon':
-               fi = rqo.HorizonInterpretation(self.model, genetic_boundary_feature = tbf)
-               # todo: support boundary relation list and sequence stratigraphy surface
-            else:  # geobody boundary
-               fi = rqo.GeobodyBoundaryInterpretation(self.model, genetic_boundary_feature = tbf)
-            fi_root = fi.create_xml(tbf_root)
-            fi_uuid = rqet.uuid_for_part_root(fi_root)
-         else:
-            log.error('no interpretation found for feature: ' + feature_name)
-            return
-      self.feature_list = [('obj_FaultInterpretation', fi_uuid, str(feature_name))]
-      cell_pair_list = []
-      face_pair_list = []
-      nj_ni = grid.nj * grid.ni
-      if k_faces is not None:
-         for cell_kji0 in np.stack(np.where(k_faces)).T:
-            cell = grid.natural_cell_index(cell_kji0)
-            cell_pair_list.append((cell, cell + nj_ni))
-            face_pair_list.append((self.face_index_map[0, 1], self.face_index_map[0, 0]))
-      if j_faces is not None:
-         for cell_kji0 in np.stack(np.where(j_faces)).T:
-            cell = grid.natural_cell_index(cell_kji0)
-            cell_pair_list.append((cell, cell + grid.ni))
-            face_pair_list.append((self.face_index_map[1, 1], self.face_index_map[1, 0]))
-      if i_faces is not None:
-         for cell_kji0 in np.stack(np.where(i_faces)).T:
-            cell = grid.natural_cell_index(cell_kji0)
-            cell_pair_list.append((cell, cell + 1))
-            face_pair_list.append((self.face_index_map[2, 1], self.face_index_map[2, 0]))
-      self.cell_index_pairs = np.array(cell_pair_list, dtype = int)
-      self.face_index_pairs = np.array(face_pair_list, dtype = int)
-      self.count = len(self.cell_index_pairs)
-      self.feature_indices = np.zeros(self.count, dtype = int)
-      assert len(self.face_index_pairs) == self.count
-
-   def set_pairs_from_faces_df(self,
-                               faces,
-                               create_organizing_objects_where_needed = False,
-                               create_mult_prop = True,
-                               fault_tmult_dict = None,
-                               one_based_indexing = True):
-      """Sets cell_index_pairs and face_index_pairs based on pandas dataframe, using simple no throw pairing.
+    def set_pairs_from_faces_df(self,
+                                faces,
+                                create_organizing_objects_where_needed = False,
+                                create_mult_prop = True,
+                                fault_tmult_dict = None,
+                                one_based_indexing = True):
+        """Sets cell_index_pairs and face_index_pairs based on pandas dataframe, using simple no throw pairing.
 
       arguments:
          faces (pandas.DataFrame): dataframe with columns 'name', 'face', 'i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult'
@@ -408,154 +410,157 @@ class GridConnectionSet(BaseResqpy):
          as a side effect, this method will set the cell indices in faces to be zero based
       """
 
-      if len(self.grid_list) > 1:
-         log.warning('setting grid connection set pairs from dataframe for first grid in list only')
-      grid = self.grid_list[0]
-      standardize_face_indicator_in_faces_df(faces)
-      if one_based_indexing:
-         zero_base_cell_indices_in_faces_df(faces)
-      faces = remove_external_faces_from_faces_df(faces, self.grid_list[0].extent_kji)
-      self.feature_list = []
-      cell_pair_list = []
-      face_pair_list = []
-      fi_list = []
-      feature_index = 0
-      name_list = faces['name'].unique()
-      fi_parts_list = self.model.parts_list_of_type('FaultInterpretation')
-      if not create_organizing_objects_where_needed and (fi_parts_list is None or len(fi_parts_list) == 0):
-         log.warning('no fault interpretation parts found in model')
-      fi_dict = {}  # maps fault name to interpretation uuid
-      mult_list = []
-      const_mult = True
-      for fi_part in fi_parts_list:
-         fi_dict[self.model.title_for_part(fi_part).split()[0].lower()] = self.model.uuid_for_part(fi_part)
-      if create_organizing_objects_where_needed:
-         tbf_parts_list = self.model.parts_list_of_type('TectonicBoundaryFeature')
-      for name in name_list:
-         fault_dict_multiplier = 1.0
-         if fault_tmult_dict is not None:
-            if name in fault_tmult_dict:
-               fault_dict_multiplier = float(fault_tmult_dict[name])
-            if name.lower() in fault_tmult_dict:
-               fault_dict_multiplier = float(fault_tmult_dict[name.lower()])
-         # fetch uuid for fault interpretation object
-         if name.lower() in fi_dict:
-            fi_uuid = fi_dict[name.lower()]
-         elif create_organizing_objects_where_needed:
-            tbf = None
-            fi_root = None
-            for tbf_part in tbf_parts_list:
-               if name.lower() == self.model.title_for_part(tbf_part).split()[0].lower():
-                  tbf = rqo.TectonicBoundaryFeature(self.model, uuid = self.model.uuid_for_part(tbf_part))
-                  break
-            if tbf is None:
-               tbf = rqo.TectonicBoundaryFeature(self.model, feature_name = name, kind = 'fault')
-               tbf.create_xml()
-            fi = rqo.FaultInterpretation(self.model, title = name, tectonic_boundary_feature = tbf,
-                                         is_normal = True)  # todo: set is_normal based on fault geometry in grid?
-            fi_root = fi.create_xml(tectonic_boundary_feature_root = tbf.root)
-            fi_uuid = rqet.uuid_for_part_root(fi_root)
-            fi_dict[name.lower()] = fi_uuid
-         else:
-            log.error('no interpretation found for fault: ' + name)
-            continue
-         self.feature_list.append(('obj_FaultInterpretation', fi_uuid, str(name)))
-         feature_faces = faces[faces['name'] == name]
-         fault_const_mult = True
-         fault_mult_value = None
-         for i in range(len(feature_faces)):
-            entry = feature_faces.iloc[i]
-            f = entry['face']
-            axis = 'KJI'.index(f[0])
-            fp = '-+'.index(f[1])
-            multiplier = float(entry['mult']) * fault_dict_multiplier
-            if const_mult and len(mult_list):
-               const_mult = maths.isclose(multiplier, mult_list[0])
-            if fault_const_mult:
-               if fault_mult_value is None:
-                  fault_mult_value = multiplier
-               else:
-                  fault_const_mult = maths.isclose(multiplier, fault_mult_value)
-            for k0 in range(entry['k1'], entry['k2'] + 1):
-               for j0 in range(entry['j1'], entry['j2'] + 1):
-                  for i0 in range(entry['i1'], entry['i2'] + 1):
-                     neighbour = np.array([k0, j0, i0], dtype = int)
-                     if fp:
-                        neighbour[axis] += 1
-                     else:
-                        neighbour[axis] -= 1
-                     fi_list.append(feature_index)
-                     cell_pair_list.append((grid.natural_cell_index((k0, j0, i0)), grid.natural_cell_index(neighbour)))
-                     face_pair_list.append((self.face_index_map[axis, fp], self.face_index_map[axis, 1 - fp]))
-                     if create_mult_prop:
-                        mult_list.append(multiplier)
-         if fi_root is not None and fault_const_mult and fault_mult_value is not None:
-            #patch extra_metadata into xml for new fault interpretation object
-            rqet.create_metadata_xml(fi_root, {"Transmissibility multiplier": str(fault_mult_value)})
-         feature_index += 1
-      self.feature_indices = np.array(fi_list, dtype = int)
-      self.cell_index_pairs = np.array(cell_pair_list, dtype = int)
-      self.face_index_pairs = np.array(face_pair_list, dtype = int)
-      self.count = len(self.cell_index_pairs)
-      assert len(self.face_index_pairs) == self.count
-      if create_mult_prop and self.count > 0:
-         pc = self.extract_property_collection()
-         if const_mult:
-            mult_array = None
-            const_value = mult_list[0]
-         else:
-            mult_array = np.array(mult_list, dtype = float)
-            const_value = None
-         pc.add_cached_array_to_imported_list(
-            mult_array,
-            'dataframe from ascii simulator input file',
-            'TMULT',
-            uom = 'Euc',  # actually a ratio of transmissibilities
-            property_kind = 'transmissibility multiplier',
-            local_property_kind_uuid = None,
-            realization = None,
-            indexable_element = 'faces',
-            const_value = const_value)
+        if len(self.grid_list) > 1:
+            log.warning('setting grid connection set pairs from dataframe for first grid in list only')
+        grid = self.grid_list[0]
+        standardize_face_indicator_in_faces_df(faces)
+        if one_based_indexing:
+            zero_base_cell_indices_in_faces_df(faces)
+        faces = remove_external_faces_from_faces_df(faces, self.grid_list[0].extent_kji)
+        self.feature_list = []
+        cell_pair_list = []
+        face_pair_list = []
+        fi_list = []
+        feature_index = 0
+        name_list = faces['name'].unique()
+        fi_parts_list = self.model.parts_list_of_type('FaultInterpretation')
+        if not create_organizing_objects_where_needed and (fi_parts_list is None or len(fi_parts_list) == 0):
+            log.warning('no fault interpretation parts found in model')
+        fi_dict = {}  # maps fault name to interpretation uuid
+        mult_list = []
+        const_mult = True
+        for fi_part in fi_parts_list:
+            fi_dict[self.model.title_for_part(fi_part).split()[0].lower()] = self.model.uuid_for_part(fi_part)
+        if create_organizing_objects_where_needed:
+            tbf_parts_list = self.model.parts_list_of_type('TectonicBoundaryFeature')
+        for name in name_list:
+            fault_dict_multiplier = 1.0
+            if fault_tmult_dict is not None:
+                if name in fault_tmult_dict:
+                    fault_dict_multiplier = float(fault_tmult_dict[name])
+                if name.lower() in fault_tmult_dict:
+                    fault_dict_multiplier = float(fault_tmult_dict[name.lower()])
+            # fetch uuid for fault interpretation object
+            if name.lower() in fi_dict:
+                fi_uuid = fi_dict[name.lower()]
+            elif create_organizing_objects_where_needed:
+                tbf = None
+                fi_root = None
+                for tbf_part in tbf_parts_list:
+                    if name.lower() == self.model.title_for_part(tbf_part).split()[0].lower():
+                        tbf = rqo.TectonicBoundaryFeature(self.model, uuid = self.model.uuid_for_part(tbf_part))
+                        break
+                if tbf is None:
+                    tbf = rqo.TectonicBoundaryFeature(self.model, feature_name = name, kind = 'fault')
+                    tbf.create_xml()
+                fi = rqo.FaultInterpretation(self.model,
+                                             title = name,
+                                             tectonic_boundary_feature = tbf,
+                                             is_normal = True)  # todo: set is_normal based on fault geometry in grid?
+                fi_root = fi.create_xml(tectonic_boundary_feature_root = tbf.root)
+                fi_uuid = rqet.uuid_for_part_root(fi_root)
+                fi_dict[name.lower()] = fi_uuid
+            else:
+                log.error('no interpretation found for fault: ' + name)
+                continue
+            self.feature_list.append(('obj_FaultInterpretation', fi_uuid, str(name)))
+            feature_faces = faces[faces['name'] == name]
+            fault_const_mult = True
+            fault_mult_value = None
+            for i in range(len(feature_faces)):
+                entry = feature_faces.iloc[i]
+                f = entry['face']
+                axis = 'KJI'.index(f[0])
+                fp = '-+'.index(f[1])
+                multiplier = float(entry['mult']) * fault_dict_multiplier
+                if const_mult and len(mult_list):
+                    const_mult = maths.isclose(multiplier, mult_list[0])
+                if fault_const_mult:
+                    if fault_mult_value is None:
+                        fault_mult_value = multiplier
+                    else:
+                        fault_const_mult = maths.isclose(multiplier, fault_mult_value)
+                for k0 in range(entry['k1'], entry['k2'] + 1):
+                    for j0 in range(entry['j1'], entry['j2'] + 1):
+                        for i0 in range(entry['i1'], entry['i2'] + 1):
+                            neighbour = np.array([k0, j0, i0], dtype = int)
+                            if fp:
+                                neighbour[axis] += 1
+                            else:
+                                neighbour[axis] -= 1
+                            fi_list.append(feature_index)
+                            cell_pair_list.append((grid.natural_cell_index(
+                                (k0, j0, i0)), grid.natural_cell_index(neighbour)))
+                            face_pair_list.append((self.face_index_map[axis, fp], self.face_index_map[axis, 1 - fp]))
+                            if create_mult_prop:
+                                mult_list.append(multiplier)
+            if fi_root is not None and fault_const_mult and fault_mult_value is not None:
+                #patch extra_metadata into xml for new fault interpretation object
+                rqet.create_metadata_xml(fi_root, {"Transmissibility multiplier": str(fault_mult_value)})
+            feature_index += 1
+        self.feature_indices = np.array(fi_list, dtype = int)
+        self.cell_index_pairs = np.array(cell_pair_list, dtype = int)
+        self.face_index_pairs = np.array(face_pair_list, dtype = int)
+        self.count = len(self.cell_index_pairs)
+        assert len(self.face_index_pairs) == self.count
+        if create_mult_prop and self.count > 0:
+            pc = self.extract_property_collection()
+            if const_mult:
+                mult_array = None
+                const_value = mult_list[0]
+            else:
+                mult_array = np.array(mult_list, dtype = float)
+                const_value = None
+            pc.add_cached_array_to_imported_list(
+                mult_array,
+                'dataframe from ascii simulator input file',
+                'TMULT',
+                uom = 'Euc',  # actually a ratio of transmissibilities
+                property_kind = 'transmissibility multiplier',
+                local_property_kind_uuid = None,
+                realization = None,
+                indexable_element = 'faces',
+                const_value = const_value)
 
-   def write_hdf5_and_create_xml_for_new_properties(self):
-      """Wites any new property arrays to hdf5, creates xml for the properties and adds them to model.
+    def write_hdf5_and_create_xml_for_new_properties(self):
+        """Wites any new property arrays to hdf5, creates xml for the properties and adds them to model.
 
       note:
          this method is usually called by the create_xml() method for the grid connection set
       """
 
-      if self.property_collection is not None:
-         self.property_collection.write_hdf5_for_imported_list()
-         self.property_collection.create_xml_for_imported_list_and_add_parts_to_model()
+        if self.property_collection is not None:
+            self.property_collection.write_hdf5_for_imported_list()
+            self.property_collection.create_xml_for_imported_list_and_add_parts_to_model()
 
-   def append(self, other):
-      """Adds the features in other grid connection set to this one."""
+    def append(self, other):
+        """Adds the features in other grid connection set to this one."""
 
-      # todo: check that grid is common to both connection sets
-      assert len(self.grid_list) == 1 and len(other.grid_list) == 1, 'attempt to merge multi-grid connection sets'
-      assert bu.matching_uuids(self.grid_list[0].uuid, other.grid_list[0].uuid),  \
-            'attempt to merge grid connection sets from different grids'
-      if self.count is None or self.count == 0:
-         self.feature_list = other.feature_list.copy()
-         self.count = other.count
-         self.feature_indices = other.feature_indices.copy()
-         self.cell_index_pairs = other.cell_index_pairs.copy()
-         self.face_index_pairs = other.face_index_pairs.copy()
-      else:
-         feature_offset = len(self.feature_list)
-         self.feature_list += other.feature_list
-         combined_feature_indices = np.concatenate((self.feature_indices, other.feature_indices))
-         combined_feature_indices[self.count:] += feature_offset
-         combined_cell_index_pairs = np.concatenate((self.cell_index_pairs, other.cell_index_pairs))
-         combined_face_index_pairs = np.concatenate((self.face_index_pairs, other.face_index_pairs))
-         self.count += other.count
-         self.cell_index_pairs = combined_cell_index_pairs
-         self.face_index_pairs = combined_face_index_pairs
-         self.feature_indices = combined_feature_indices
-      self.uuid = bu.new_uuid()
+        # todo: check that grid is common to both connection sets
+        assert len(self.grid_list) == 1 and len(other.grid_list) == 1, 'attempt to merge multi-grid connection sets'
+        assert bu.matching_uuids(self.grid_list[0].uuid, other.grid_list[0].uuid),  \
+              'attempt to merge grid connection sets from different grids'
+        if self.count is None or self.count == 0:
+            self.feature_list = other.feature_list.copy()
+            self.count = other.count
+            self.feature_indices = other.feature_indices.copy()
+            self.cell_index_pairs = other.cell_index_pairs.copy()
+            self.face_index_pairs = other.face_index_pairs.copy()
+        else:
+            feature_offset = len(self.feature_list)
+            self.feature_list += other.feature_list
+            combined_feature_indices = np.concatenate((self.feature_indices, other.feature_indices))
+            combined_feature_indices[self.count:] += feature_offset
+            combined_cell_index_pairs = np.concatenate((self.cell_index_pairs, other.cell_index_pairs))
+            combined_face_index_pairs = np.concatenate((self.face_index_pairs, other.face_index_pairs))
+            self.count += other.count
+            self.cell_index_pairs = combined_cell_index_pairs
+            self.face_index_pairs = combined_face_index_pairs
+            self.feature_indices = combined_feature_indices
+        self.uuid = bu.new_uuid()
 
-   def single_feature(self, feature_index = None, feature_name = None):
-      """Returns a new GridConnectionSet object containing the single feature copied from this set.
+    def single_feature(self, feature_index = None, feature_name = None):
+        """Returns a new GridConnectionSet object containing the single feature copied from this set.
 
       note:
          the single feature connection set is established in memory but this method does not write
@@ -564,24 +569,24 @@ class GridConnectionSet(BaseResqpy):
       :meta common:
       """
 
-      assert feature_index is not None or feature_name is not None
+        assert feature_index is not None or feature_name is not None
 
-      if feature_index is None:
-         feature_index, _ = self.feature_index_and_uuid_for_fault_name(feature_name)
-      if feature_index is None:
-         return None
-      if feature_index < 0 or feature_index >= len(self.feature_list):
-         return None
-      singleton = GridConnectionSet(self.model, grid = self.grid_list[0])
-      singleton.cell_index_pairs, singleton.face_index_pairs =  \
-         self.raw_list_of_cell_face_pairs_for_feature_index(feature_index)
-      singleton.count = singleton.cell_index_pairs.shape[0]
-      singleton.feature_indices = np.zeros((singleton.count,), dtype = int)
-      singleton.feature_list = [self.feature_list[feature_index]]
-      return singleton
+        if feature_index is None:
+            feature_index, _ = self.feature_index_and_uuid_for_fault_name(feature_name)
+        if feature_index is None:
+            return None
+        if feature_index < 0 or feature_index >= len(self.feature_list):
+            return None
+        singleton = GridConnectionSet(self.model, grid = self.grid_list[0])
+        singleton.cell_index_pairs, singleton.face_index_pairs =  \
+           self.raw_list_of_cell_face_pairs_for_feature_index(feature_index)
+        singleton.count = singleton.cell_index_pairs.shape[0]
+        singleton.feature_indices = np.zeros((singleton.count,), dtype = int)
+        singleton.feature_list = [self.feature_list[feature_index]]
+        return singleton
 
-   def filtered_by_layer_range(self, min_k0 = None, max_k0 = None, pare_down = True, return_indices = False):
-      """Returns a new GridConnectionSet, being a copy with cell faces whittled down to a layer range.
+    def filtered_by_layer_range(self, min_k0 = None, max_k0 = None, pare_down = True, return_indices = False):
+        """Returns a new GridConnectionSet, being a copy with cell faces whittled down to a layer range.
 
       arguments:
          min_k0 (int, optional): if present, the minimum layer number to be included (zero based)
@@ -603,28 +608,28 @@ class GridConnectionSet(BaseResqpy):
          select equivalent entries from associated properties
       """
 
-      self.cache_arrays()
-      assert len(self.grid_list) == 1, 'attempt to filter multi-grid connection set by layer range'
-      grid = self.grid_list[0]
-      if min_k0 <= 0:
-         min_k0 = None
-      if max_k0 >= grid.extent_kji[0] - 1:
-         max_k0 = None
-      if min_k0 is None and max_k0 is None:
-         dupe = GridConnectionSet(self.model, grid = grid)
-         dupe.append(self)
-         return (dupe, np.arange(self.count)) if return_indices else dupe
-      mask = np.zeros(grid.extent_kji, dtype = bool)
-      if min_k0 is not None and max_k0 is not None:
-         mask[min_k0:max_k0 + 1, :, :] = True
-      elif min_k0 is not None:
-         mask[min_k0:, :, :] = True
-      else:
-         mask[:max_k0 + 1, :, :] = True
-      return self.filtered_by_cell_mask(mask, pare_down = pare_down, return_indices = return_indices)
+        self.cache_arrays()
+        assert len(self.grid_list) == 1, 'attempt to filter multi-grid connection set by layer range'
+        grid = self.grid_list[0]
+        if min_k0 <= 0:
+            min_k0 = None
+        if max_k0 >= grid.extent_kji[0] - 1:
+            max_k0 = None
+        if min_k0 is None and max_k0 is None:
+            dupe = GridConnectionSet(self.model, grid = grid)
+            dupe.append(self)
+            return (dupe, np.arange(self.count)) if return_indices else dupe
+        mask = np.zeros(grid.extent_kji, dtype = bool)
+        if min_k0 is not None and max_k0 is not None:
+            mask[min_k0:max_k0 + 1, :, :] = True
+        elif min_k0 is not None:
+            mask[min_k0:, :, :] = True
+        else:
+            mask[:max_k0 + 1, :, :] = True
+        return self.filtered_by_cell_mask(mask, pare_down = pare_down, return_indices = return_indices)
 
-   def filtered_by_cell_mask(self, mask, both_cells_required = True, pare_down = True, return_indices = False):
-      """Returns a new GridConnectionSet, being a copy with cell faces whittled down by a boolean mask array.
+    def filtered_by_cell_mask(self, mask, both_cells_required = True, pare_down = True, return_indices = False):
+        """Returns a new GridConnectionSet, being a copy with cell faces whittled down by a boolean mask array.
 
       arguments:
          mask (numpy bool array of shape grid.extent_kji): connections will be kept for cells where this mask is True
@@ -646,166 +651,166 @@ class GridConnectionSet(BaseResqpy):
          select equivalent entries from associated properties
       """
 
-      assert len(self.grid_list) == 1, 'attempt to filter multi-grid connection set by cell mask'
-      grid = self.grid_list[0]
-      flat_extent = grid.cell_count()
-      flat_mask = mask.reshape((flat_extent,))
-      where_0 = flat_mask[self.cell_index_pairs[:, 0]]
-      where_1 = flat_mask[self.cell_index_pairs[:, 1]]
-      if both_cells_required:
-         where_both = np.logical_and(where_0, where_1)
-      else:
-         where_both = np.logical_or(where_0, where_1)
-      indices = np.where(where_both)[0]  # indices into primary axis of original arrays
-      if len(indices) == 0:
-         log.warning('no connections have passed filtering')
-         return (None, None) if return_indices else None
-      masked_gcs = GridConnectionSet(self.model, grid = grid)
-      masked_gcs.count = len(indices)
-      masked_gcs.cell_index_pairs = self.cell_index_pairs[indices, :]
-      masked_gcs.face_index_pairs = self.face_index_pairs[indices, :]
-      masked_gcs.feature_indices = self.feature_indices[indices]
-      masked_gcs.feature_list = self.feature_list.copy()
-      if pare_down:
-         masked_gcs.clean_feature_list()
-      return (masked_gcs, indices) if return_indices else masked_gcs
+        assert len(self.grid_list) == 1, 'attempt to filter multi-grid connection set by cell mask'
+        grid = self.grid_list[0]
+        flat_extent = grid.cell_count()
+        flat_mask = mask.reshape((flat_extent,))
+        where_0 = flat_mask[self.cell_index_pairs[:, 0]]
+        where_1 = flat_mask[self.cell_index_pairs[:, 1]]
+        if both_cells_required:
+            where_both = np.logical_and(where_0, where_1)
+        else:
+            where_both = np.logical_or(where_0, where_1)
+        indices = np.where(where_both)[0]  # indices into primary axis of original arrays
+        if len(indices) == 0:
+            log.warning('no connections have passed filtering')
+            return (None, None) if return_indices else None
+        masked_gcs = GridConnectionSet(self.model, grid = grid)
+        masked_gcs.count = len(indices)
+        masked_gcs.cell_index_pairs = self.cell_index_pairs[indices, :]
+        masked_gcs.face_index_pairs = self.face_index_pairs[indices, :]
+        masked_gcs.feature_indices = self.feature_indices[indices]
+        masked_gcs.feature_list = self.feature_list.copy()
+        if pare_down:
+            masked_gcs.clean_feature_list()
+        return (masked_gcs, indices) if return_indices else masked_gcs
 
-   def clean_feature_list(self):
-      """Removes any features that have no associated connections."""
+    def clean_feature_list(self):
+        """Removes any features that have no associated connections."""
 
-      keep_list = np.unique(self.feature_indices)
-      if len(keep_list) == len(self.feature_list):
-         return
-      cleaned_list = []
-      for i in range(len(keep_list)):
-         assert i <= keep_list[i]
-         if i != keep_list[i]:
-            self.feature_indices[np.where(self.feature_indices == keep_list[i])[0]] = i
-         cleaned_list.append(self.feature_list[keep_list[i]])
-      self.feature_list = cleaned_list
+        keep_list = np.unique(self.feature_indices)
+        if len(keep_list) == len(self.feature_list):
+            return
+        cleaned_list = []
+        for i in range(len(keep_list)):
+            assert i <= keep_list[i]
+            if i != keep_list[i]:
+                self.feature_indices[np.where(self.feature_indices == keep_list[i])[0]] = i
+            cleaned_list.append(self.feature_list[keep_list[i]])
+        self.feature_list = cleaned_list
 
-   def cache_arrays(self):
-      """Checks that the connection set array data is loaded and loads from hdf5 if not.
+    def cache_arrays(self):
+        """Checks that the connection set array data is loaded and loads from hdf5 if not.
 
       :meta common:
       """
 
-      if self.cell_index_pairs is None or self.face_index_pairs is None or (self.feature_list is not None and
-                                                                            self.feature_indices is None):
-         assert self.root is not None
+        if self.cell_index_pairs is None or self.face_index_pairs is None or (self.feature_list is not None and
+                                                                              self.feature_indices is None):
+            assert self.root is not None
 
-      if self.cell_index_pairs is None:
-         log.debug('caching cell index pairs from hdf5')
-         cell_index_pairs_node = rqet.find_tag(self.root, 'CellIndexPairs')
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(cell_index_pairs_node, tag = 'Values')
-         assert h5_key_pair is not None
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'cell_index_pairs',
-                                     dtype = 'int')
+        if self.cell_index_pairs is None:
+            log.debug('caching cell index pairs from hdf5')
+            cell_index_pairs_node = rqet.find_tag(self.root, 'CellIndexPairs')
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(cell_index_pairs_node, tag = 'Values')
+            assert h5_key_pair is not None
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'cell_index_pairs',
+                                        dtype = 'int')
 
-      if self.face_index_pairs is None:
-         log.debug('caching face index pairs from hdf5')
-         face_index_pairs_node = rqet.find_tag(self.root, 'LocalFacePerCellIndexPairs')
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(face_index_pairs_node, tag = 'Values')
-         assert h5_key_pair is not None
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'face_index_pairs',
-                                     dtype = 'int32')
+        if self.face_index_pairs is None:
+            log.debug('caching face index pairs from hdf5')
+            face_index_pairs_node = rqet.find_tag(self.root, 'LocalFacePerCellIndexPairs')
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(face_index_pairs_node, tag = 'Values')
+            assert h5_key_pair is not None
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'face_index_pairs',
+                                        dtype = 'int32')
 
-      if len(self.grid_list) > 1 and self.grid_index_pairs is None:
-         grid_index_node = rqet.find_tag(self.root, 'GridIndexPairs')
-         assert grid_index_node is not None, 'grid index pair data missing in grid connection set'
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(grid_index_node, tag = 'Values')
-         assert h5_key_pair is not None
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'grid_index_pairs',
-                                     dtype = 'int')
+        if len(self.grid_list) > 1 and self.grid_index_pairs is None:
+            grid_index_node = rqet.find_tag(self.root, 'GridIndexPairs')
+            assert grid_index_node is not None, 'grid index pair data missing in grid connection set'
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(grid_index_node, tag = 'Values')
+            assert h5_key_pair is not None
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'grid_index_pairs',
+                                        dtype = 'int')
 
-      if self.feature_list is None:
-         return
-      interp_root = rqet.find_tag(self.root, 'ConnectionInterpretations')
+        if self.feature_list is None:
+            return
+        interp_root = rqet.find_tag(self.root, 'ConnectionInterpretations')
 
-      if self.feature_indices is None:
-         log.debug('caching feature indices')
-         elements_node = rqet.find_nested_tags(interp_root, ['InterpretationIndices', 'Elements'])
-         #         elements_node = rqet.find_nested_tags(interp_root, ['FaultIndices', 'Elements'])
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(elements_node, tag = 'Values')
-         assert h5_key_pair is not None
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'feature_indices',
-                                     dtype = 'uint32')
-         assert self.feature_indices.shape == (self.count,)
+        if self.feature_indices is None:
+            log.debug('caching feature indices')
+            elements_node = rqet.find_nested_tags(interp_root, ['InterpretationIndices', 'Elements'])
+            #         elements_node = rqet.find_nested_tags(interp_root, ['FaultIndices', 'Elements'])
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(elements_node, tag = 'Values')
+            assert h5_key_pair is not None
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'feature_indices',
+                                        dtype = 'uint32')
+            assert self.feature_indices.shape == (self.count,)
 
-         cl_node = rqet.find_nested_tags(interp_root, ['InterpretationIndices', 'CumulativeLength'])
-         #         cl_node = rqet.find_nested_tags(interp_root, ['FaultIndices', 'CumulativeLength'])
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(cl_node, tag = 'Values')
-         assert h5_key_pair is not None
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'fi_cl',
-                                     dtype = 'uint32')
-         assert self.fi_cl.shape == (
-            self.count,), 'connection set face pair(s) not assigned to exactly one fault'  # rough check
+            cl_node = rqet.find_nested_tags(interp_root, ['InterpretationIndices', 'CumulativeLength'])
+            #         cl_node = rqet.find_nested_tags(interp_root, ['FaultIndices', 'CumulativeLength'])
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(cl_node, tag = 'Values')
+            assert h5_key_pair is not None
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'fi_cl',
+                                        dtype = 'uint32')
+            assert self.fi_cl.shape == (
+                self.count,), 'connection set face pair(s) not assigned to exactly one fault'  # rough check
 
 
 #        delattr(self, 'fi_cl')  # assumed to be one-to-one mapping, so cumulative length is discarded
 
-   def number_of_grids(self):
-      """Returns the number of grids involved in the connection set.
+    def number_of_grids(self):
+        """Returns the number of grids involved in the connection set.
 
       :meta common:
       """
 
-      return len(self.grid_list)
+        return len(self.grid_list)
 
-   def grid_for_index(self, grid_index):
-      """Returns the grid object for the given grid_index."""
+    def grid_for_index(self, grid_index):
+        """Returns the grid object for the given grid_index."""
 
-      assert 0 <= grid_index < len(self.grid_list)
-      return self.grid_list[grid_index]
+        assert 0 <= grid_index < len(self.grid_list)
+        return self.grid_list[grid_index]
 
-   def number_of_features(self):
-      """Returns the number of features (faults) in the connection set.
-
-      :meta common:
-      """
-
-      if self.feature_list is None:
-         return 0
-      return len(self.feature_list)
-
-   def list_of_feature_names(self, strip = True):
-      """Returns a list of the feature (fault) names for which the connection set has cell face data.
+    def number_of_features(self):
+        """Returns the number of features (faults) in the connection set.
 
       :meta common:
       """
 
-      if self.feature_list is None:
-         return None
-      name_list = []
-      for (_, _, title) in self.feature_list:
-         if strip:
-            name_list.append(title.split()[0])
-         else:
-            name_list.append(title)
-      return name_list
+        if self.feature_list is None:
+            return 0
+        return len(self.feature_list)
 
-   def list_of_fault_names(self, strip = True):
-      """Returns a list of the fault names for which the connection set has cell face data."""
+    def list_of_feature_names(self, strip = True):
+        """Returns a list of the feature (fault) names for which the connection set has cell face data.
 
-      return self.list_of_feature_names(strip = strip)
+      :meta common:
+      """
 
-   def feature_index_and_uuid_for_fault_name(self, fault_name):
-      """Returns the index into the feature (fault) list for the named fault.
+        if self.feature_list is None:
+            return None
+        name_list = []
+        for (_, _, title) in self.feature_list:
+            if strip:
+                name_list.append(title.split()[0])
+            else:
+                name_list.append(title)
+        return name_list
+
+    def list_of_fault_names(self, strip = True):
+        """Returns a list of the fault names for which the connection set has cell face data."""
+
+        return self.list_of_feature_names(strip = strip)
+
+    def feature_index_and_uuid_for_fault_name(self, fault_name):
+        """Returns the index into the feature (fault) list for the named fault.
 
       arguments:
          fault_name (string): the name of the fault of interest
@@ -817,18 +822,18 @@ class GridConnectionSet(BaseResqpy):
             (None, None) is returned if the named fault is not found in the feature list
       """
 
-      if self.feature_list is None:
-         return (None, None)
-      # the protocol adopted here is that the citation title must start with the fault name
-      index = 0
-      for (_, uuid, title) in self.feature_list:
-         if title.startswith(fault_name):
-            return (index, uuid)
-         index += 1
-      return (None, None)
+        if self.feature_list is None:
+            return (None, None)
+        # the protocol adopted here is that the citation title must start with the fault name
+        index = 0
+        for (_, uuid, title) in self.feature_list:
+            if title.startswith(fault_name):
+                return (index, uuid)
+            index += 1
+        return (None, None)
 
-   def feature_name_for_feature_index(self, feature_index, strip = True):
-      """Returns the fault name corresponding to the given index into the feature (fault) list.
+    def feature_name_for_feature_index(self, feature_index, strip = True):
+        """Returns the fault name corresponding to the given index into the feature (fault) list.
 
       arguments:
          feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
@@ -841,47 +846,47 @@ class GridConnectionSet(BaseResqpy):
          down to the first word; by convention this is the name of the fault
       """
 
-      if self.feature_list is None:
-         return None
-      if strip:
-         return self.feature_list[feature_index][2].split()[0]
-      return self.feature_list[feature_index][2]
+        if self.feature_list is None:
+            return None
+        if strip:
+            return self.feature_list[feature_index][2].split()[0]
+        return self.feature_list[feature_index][2]
 
-   def fault_name_for_feature_index(self, feature_index, strip = True):
-      """Returns the fault name corresponding to the given index into the feature (fault) list."""
+    def fault_name_for_feature_index(self, feature_index, strip = True):
+        """Returns the fault name corresponding to the given index into the feature (fault) list."""
 
-      return self.feature_name_for_feature_index(feature_index = feature_index, strip = strip)
+        return self.feature_name_for_feature_index(feature_index = feature_index, strip = strip)
 
-   def feature_index_for_cell_face(self, cell_kji0, axis, p01):
-      """Returns the index into the feature (fault) list for the given face of the given cell, or None.
+    def feature_index_for_cell_face(self, cell_kji0, axis, p01):
+        """Returns the index into the feature (fault) list for the given face of the given cell, or None.
 
       note:
          where the cell face appears in more than one feature, the result will arbitrarily be the first
          occurrence in the cell_index_pair ordering of the grid connection set
       """
 
-      self.cache_arrays()
-      if self.feature_indices is None:
-         return None
-      cell = self.grid_list[0].natural_cell_index(cell_kji0)
-      face = self.face_index_map[axis, p01]
-      cell_matches = np.stack(np.where(self.cell_index_pairs == cell)).T
-      for match in cell_matches[:]:
-         if self.face_index_pairs[match[0], match[1]] == face:
-            return self.feature_indices[match[0]]
-      return None
+        self.cache_arrays()
+        if self.feature_indices is None:
+            return None
+        cell = self.grid_list[0].natural_cell_index(cell_kji0)
+        face = self.face_index_map[axis, p01]
+        cell_matches = np.stack(np.where(self.cell_index_pairs == cell)).T
+        for match in cell_matches[:]:
+            if self.face_index_pairs[match[0], match[1]] == face:
+                return self.feature_indices[match[0]]
+        return None
 
-   def indices_for_feature_index(self, feature_index):
-      """Returns numpy list of indices into main arrays for elements for the specified feature."""
+    def indices_for_feature_index(self, feature_index):
+        """Returns numpy list of indices into main arrays for elements for the specified feature."""
 
-      self.cache_arrays()
-      if self.feature_indices is None:
-         return None
-      matches = np.where(self.feature_indices == feature_index)[0]
-      return matches
+        self.cache_arrays()
+        if self.feature_indices is None:
+            return None
+        matches = np.where(self.feature_indices == feature_index)[0]
+        return matches
 
-   def raw_list_of_cell_face_pairs_for_feature_index(self, feature_index):
-      """Returns list of cell face pairs contributing to feature (fault) with given index, in raw form.
+    def raw_list_of_cell_face_pairs_for_feature_index(self, feature_index):
+        """Returns list of cell face pairs contributing to feature (fault) with given index, in raw form.
 
       arguments:
          feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
@@ -894,16 +899,16 @@ class GridConnectionSet(BaseResqpy):
          in range 0..5; grid indices can be used to index the grid_list attribute for relevant Grid object
       """
 
-      matches = self.indices_for_feature_index(feature_index)
-      if matches is None:
-         return None
-      if len(self.grid_list) == 1:
-         return self.cell_index_pairs[matches], self.face_index_pairs[matches]
-      assert self.grid_index_pairs is not None
-      return self.cell_index_pairs[matches], self.face_index_pairs[matches], self.grid_index_pairs[matches]
+        matches = self.indices_for_feature_index(feature_index)
+        if matches is None:
+            return None
+        if len(self.grid_list) == 1:
+            return self.cell_index_pairs[matches], self.face_index_pairs[matches]
+        assert self.grid_index_pairs is not None
+        return self.cell_index_pairs[matches], self.face_index_pairs[matches], self.grid_index_pairs[matches]
 
-   def inherit_properties_for_selected_indices(self, other, selected_indices):
-      """Adds to imported property list by sampling the properties for another grid connection set.
+    def inherit_properties_for_selected_indices(self, other, selected_indices):
+        """Adds to imported property list by sampling the properties for another grid connection set.
 
       arguments:
          other (GridConnectionSet): the source grid connection set whose properties will be sampled
@@ -926,16 +931,16 @@ class GridConnectionSet(BaseResqpy):
          other
       """
 
-      if other.property_collection is None or other.property_collection.number_of_parts() == 0:
-         return
-      if self.property_collection is None:
-         self.property_collection = rqp.PropertyCollection()
-         self.property_collection.set_support(support = self)
-      self.property_collection.add_to_imported_list_sampling_other_collection(other.property_collection,
-                                                                              selected_indices)
+        if other.property_collection is None or other.property_collection.number_of_parts() == 0:
+            return
+        if self.property_collection is None:
+            self.property_collection = rqp.PropertyCollection()
+            self.property_collection.set_support(support = self)
+        self.property_collection.add_to_imported_list_sampling_other_collection(other.property_collection,
+                                                                                selected_indices)
 
-   def list_of_cell_face_pairs_for_feature_index(self, feature_index):
-      """Returns list of cell face pairs contributing to feature (fault) with given index.
+    def list_of_cell_face_pairs_for_feature_index(self, feature_index):
+        """Returns list of cell face pairs contributing to feature (fault) with given index.
 
       arguments:
          feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
@@ -951,25 +956,25 @@ class GridConnectionSet(BaseResqpy):
          if the connection set is for a single grid, the return value is a pair; otherwise a triplet
       """
 
-      self.cache_arrays()
-      if self.feature_indices is None:
-         return None
-      pairs_tuple = self.raw_list_of_cell_face_pairs_for_feature_index(feature_index)
-      if len(self.grid_list) == 1:
-         raw_cell_pairs, raw_face_pairs = pairs_tuple
-         grid_pairs = None
-      else:
-         raw_cell_pairs, raw_face_pairs, grid_pairs = pairs_tuple
+        self.cache_arrays()
+        if self.feature_indices is None:
+            return None
+        pairs_tuple = self.raw_list_of_cell_face_pairs_for_feature_index(feature_index)
+        if len(self.grid_list) == 1:
+            raw_cell_pairs, raw_face_pairs = pairs_tuple
+            grid_pairs = None
+        else:
+            raw_cell_pairs, raw_face_pairs, grid_pairs = pairs_tuple
 
-      cell_pairs = self.grid_list[0].denaturalized_cell_indices(raw_cell_pairs)
-      face_pairs = self.face_index_inverse_map[raw_face_pairs]
+        cell_pairs = self.grid_list[0].denaturalized_cell_indices(raw_cell_pairs)
+        face_pairs = self.face_index_inverse_map[raw_face_pairs]
 
-      if grid_pairs is None:
-         return cell_pairs, face_pairs
-      return cell_pairs, face_pairs, grid_pairs
+        if grid_pairs is None:
+            return cell_pairs, face_pairs
+        return cell_pairs, face_pairs, grid_pairs
 
-   def simplified_sets_of_kelp_for_feature_index(self, feature_index):
-      """Returns a pair of sets of column indices, one for J+ faces, one for I+ faces, contributing to feature.
+    def simplified_sets_of_kelp_for_feature_index(self, feature_index):
+        """Returns a pair of sets of column indices, one for J+ faces, one for I+ faces, contributing to feature.
 
       arguments:
          feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
@@ -984,30 +989,30 @@ class GridConnectionSet(BaseResqpy):
          this is compatible with the resqml baffle functionality elsewhere
       """
 
-      cell_pairs, face_pairs = self.list_of_cell_face_pairs_for_feature_index(feature_index)
-      simple_j_set = set(
-      )  # set of (j0, i0) pairs of column indices where J+ faces contribute, as 2 element numpy arrays
-      simple_i_set = set(
-      )  # set of (j0, i0) pairs of column indices where I+ faces contribute, as 2 element numpy arrays
-      for i in range(cell_pairs.shape[0]):
-         for ip in range(2):
-            cell_kji0 = cell_pairs[i, ip].copy()
-            axis = face_pairs[i, ip, 0]
-            if axis == 0:
-               continue  # skip k faces
-            polarity = face_pairs[i, ip, 1]
-            if polarity == 0:
-               cell_kji0[axis] -= 1
-               if cell_kji0[axis] < 0:
-                  continue
-            if axis == 1:  # J axis
-               simple_j_set.add(tuple(cell_kji0[1:]))
-            else:  # axis == 2; ie. I axis
-               simple_i_set.add(tuple(cell_kji0[1:]))
-      return (simple_j_set, simple_i_set)
+        cell_pairs, face_pairs = self.list_of_cell_face_pairs_for_feature_index(feature_index)
+        simple_j_set = set(
+        )  # set of (j0, i0) pairs of column indices where J+ faces contribute, as 2 element numpy arrays
+        simple_i_set = set(
+        )  # set of (j0, i0) pairs of column indices where I+ faces contribute, as 2 element numpy arrays
+        for i in range(cell_pairs.shape[0]):
+            for ip in range(2):
+                cell_kji0 = cell_pairs[i, ip].copy()
+                axis = face_pairs[i, ip, 0]
+                if axis == 0:
+                    continue  # skip k faces
+                polarity = face_pairs[i, ip, 1]
+                if polarity == 0:
+                    cell_kji0[axis] -= 1
+                    if cell_kji0[axis] < 0:
+                        continue
+                if axis == 1:  # J axis
+                    simple_j_set.add(tuple(cell_kji0[1:]))
+                else:  # axis == 2; ie. I axis
+                    simple_i_set.add(tuple(cell_kji0[1:]))
+        return (simple_j_set, simple_i_set)
 
-   def rework_face_pairs(self):
-      """Overwrites the in-memory array of face pairs to reflect neighbouring I or J columns.
+    def rework_face_pairs(self):
+        """Overwrites the in-memory array of face pairs to reflect neighbouring I or J columns.
 
       note:
          the indexing of faces within a cell is not clearly documented in the RESQML guides;
@@ -1017,311 +1022,312 @@ class GridConnectionSet(BaseResqpy):
          for some implausibly extreme gridding, this might not give the correct result
       """
 
-      self.cache_arrays()
-      if self.feature_indices is None:
-         return None
+        self.cache_arrays()
+        if self.feature_indices is None:
+            return None
 
-      assert len(self.grid_list) == 1
+        assert len(self.grid_list) == 1
 
-      cell_pairs = self.grid_list[0].denaturalized_cell_indices(self.cell_index_pairs)
+        cell_pairs = self.grid_list[0].denaturalized_cell_indices(self.cell_index_pairs)
 
-      modifications = 0
-      for i in range(self.count):
-         kji0_pair = cell_pairs[i]
-         new_faces = None
-         if kji0_pair[0][1] == kji0_pair[1][1]:  # same J index
-            if kji0_pair[0][2] == kji0_pair[1][2] + 1:
-               new_faces = (self.face_index_map[2, 0], self.face_index_map[2, 1])
-            elif kji0_pair[0][2] == kji0_pair[1][2] - 1:
-               new_faces = (self.face_index_map[2, 1], self.face_index_map[2, 0])
-         elif kji0_pair[0][2] == kji0_pair[1][2]:  # same I index
-            if kji0_pair[0][1] == kji0_pair[1][1] + 1:
-               new_faces = (self.face_index_map[1, 0], self.face_index_map[1, 1])
-            elif kji0_pair[0][1] == kji0_pair[1][1] - 1:
-               new_faces = (self.face_index_map[1, 1], self.face_index_map[1, 0])
-         if new_faces is not None and np.any(self.face_index_pairs[i] != new_faces):
-            self.face_index_pairs[i] = new_faces
-            modifications += 1
-      log.debug('number of face pairs modified during neighbour based reworking: ' + str(modifications))
+        modifications = 0
+        for i in range(self.count):
+            kji0_pair = cell_pairs[i]
+            new_faces = None
+            if kji0_pair[0][1] == kji0_pair[1][1]:  # same J index
+                if kji0_pair[0][2] == kji0_pair[1][2] + 1:
+                    new_faces = (self.face_index_map[2, 0], self.face_index_map[2, 1])
+                elif kji0_pair[0][2] == kji0_pair[1][2] - 1:
+                    new_faces = (self.face_index_map[2, 1], self.face_index_map[2, 0])
+            elif kji0_pair[0][2] == kji0_pair[1][2]:  # same I index
+                if kji0_pair[0][1] == kji0_pair[1][1] + 1:
+                    new_faces = (self.face_index_map[1, 0], self.face_index_map[1, 1])
+                elif kji0_pair[0][1] == kji0_pair[1][1] - 1:
+                    new_faces = (self.face_index_map[1, 1], self.face_index_map[1, 0])
+            if new_faces is not None and np.any(self.face_index_pairs[i] != new_faces):
+                self.face_index_pairs[i] = new_faces
+                modifications += 1
+        log.debug('number of face pairs modified during neighbour based reworking: ' + str(modifications))
 
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Create or append to an hdf5 file, writing datasets for the connection set after caching arrays.
-
-      :meta common:
-      """
-
-      # NB: cell pairs, face pairs, and feature indices arrays must be ready, in memory
-      # note: grid pairs not yet supported
-      # prepare one-to-one mapping of cell face pairs with feaature indices
-      if not file_name:
-         file_name = self.model.h5_file_name()
-      log.debug('gcs write to hdf5 file: ' + file_name + ' mode: ' + mode)
-
-      one_to_one = np.empty(self.feature_indices.shape, dtype = int)
-      for i in range(one_to_one.size):
-         one_to_one[i] = i + 1
-
-      h5_reg = rwh5.H5Register(self.model)
-
-      # register arrays
-      # note: this implementation requires each cell face pair to be assigned to exactly one interpretation
-      # uuid/CellIndexPairs  (N, 2)  int64
-      h5_reg.register_dataset(self.uuid, 'CellIndexPairs', self.cell_index_pairs)
-      if len(self.grid_list) > 1 and self.grid_index_pairs is not None:
-         # uuid/GridIndexPairs  (N, 2)  int64
-         h5_reg.register_dataset(self.uuid, 'GridIndexPairs', self.grid_index_pairs)
-      # uuid/LocalFacePerCellIndexPairs  (N, 2)  int32
-      h5_reg.register_dataset(self.uuid, 'LocalFacePerCellIndexPairs', self.face_index_pairs)
-      # uuid/FaultIndices/elements  (N,)  uint32
-      h5_reg.register_dataset(self.uuid, 'InterpretationIndices/elements', self.feature_indices)
-      #      h5_reg.register_dataset(self.uuid, 'FaultIndices/elements', self.feature_indices)
-      # uuid/FaultIndices/cumulativeLength  (N,)  uint32
-      h5_reg.register_dataset(self.uuid, 'InterpretationIndices/cumulativeLength', one_to_one)
-      #      h5_reg.register_dataset(self.uuid, 'FaultIndices/cumulativeLength', one_to_one)
-
-      h5_reg.write(file_name, mode = mode)
-
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  write_new_properties = True,
-                  title = None,
-                  originator = None):
-      """Creates a Grid Connection Set (fault faces) xml node and optionally adds as child of root and/or to parts forest.
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Create or append to an hdf5 file, writing datasets for the connection set after caching arrays.
 
       :meta common:
       """
 
-      # NB: only one grid handled for now
-      # xml for grid(s) must be created before calling this method
+        # NB: cell pairs, face pairs, and feature indices arrays must be ready, in memory
+        # note: grid pairs not yet supported
+        # prepare one-to-one mapping of cell face pairs with feaature indices
+        if not file_name:
+            file_name = self.model.h5_file_name()
+        log.debug('gcs write to hdf5 file: ' + file_name + ' mode: ' + mode)
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
-      if not self.title and not title:
-         title = 'ROOT'
+        one_to_one = np.empty(self.feature_indices.shape, dtype = int)
+        for i in range(one_to_one.size):
+            one_to_one[i] = i + 1
 
-      gcs = super().create_xml(add_as_part = False, title = title, originator = originator)
+        h5_reg = rwh5.H5Register(self.model)
 
-      c_node = rqet.SubElement(gcs, ns['resqml2'] + 'Count')
-      c_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      c_node.text = str(self.count)
+        # register arrays
+        # note: this implementation requires each cell face pair to be assigned to exactly one interpretation
+        # uuid/CellIndexPairs  (N, 2)  int64
+        h5_reg.register_dataset(self.uuid, 'CellIndexPairs', self.cell_index_pairs)
+        if len(self.grid_list) > 1 and self.grid_index_pairs is not None:
+            # uuid/GridIndexPairs  (N, 2)  int64
+            h5_reg.register_dataset(self.uuid, 'GridIndexPairs', self.grid_index_pairs)
+        # uuid/LocalFacePerCellIndexPairs  (N, 2)  int32
+        h5_reg.register_dataset(self.uuid, 'LocalFacePerCellIndexPairs', self.face_index_pairs)
+        # uuid/FaultIndices/elements  (N,)  uint32
+        h5_reg.register_dataset(self.uuid, 'InterpretationIndices/elements', self.feature_indices)
+        #      h5_reg.register_dataset(self.uuid, 'FaultIndices/elements', self.feature_indices)
+        # uuid/FaultIndices/cumulativeLength  (N,)  uint32
+        h5_reg.register_dataset(self.uuid, 'InterpretationIndices/cumulativeLength', one_to_one)
+        #      h5_reg.register_dataset(self.uuid, 'FaultIndices/cumulativeLength', one_to_one)
 
-      cip_node = rqet.SubElement(gcs, ns['resqml2'] + 'CellIndexPairs')
-      cip_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      cip_node.text = '\n'
+        h5_reg.write(file_name, mode = mode)
 
-      cip_null = rqet.SubElement(cip_node, ns['resqml2'] + 'NullValue')
-      cip_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      cip_null.text = str(self.cell_index_pairs_null_value)
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   write_new_properties = True,
+                   title = None,
+                   originator = None):
+        """Creates a Grid Connection Set (fault faces) xml node and optionally adds as child of root and/or to parts forest.
 
-      cip_values = rqet.SubElement(cip_node, ns['resqml2'] + 'Values')
-      cip_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      cip_values.text = '\n'
+      :meta common:
+      """
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellIndexPairs', root = cip_values)
+        # NB: only one grid handled for now
+        # xml for grid(s) must be created before calling this method
 
-      if len(self.grid_list) > 1 and self.grid_index_pairs is not None:
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
+        if not self.title and not title:
+            title = 'ROOT'
 
-         gip_node = rqet.SubElement(gcs, ns['resqml2'] + 'GridIndexPairs')
-         gip_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-         gip_node.text = '\n'
+        gcs = super().create_xml(add_as_part = False, title = title, originator = originator)
 
-         gip_null = rqet.SubElement(gip_node, ns['resqml2'] + 'NullValue')
-         gip_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         gip_null.text = str(self.grid_index_pairs_null_value)
+        c_node = rqet.SubElement(gcs, ns['resqml2'] + 'Count')
+        c_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        c_node.text = str(self.count)
 
-         gip_values = rqet.SubElement(gip_node, ns['resqml2'] + 'Values')
-         gip_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         gip_values.text = '\n'
+        cip_node = rqet.SubElement(gcs, ns['resqml2'] + 'CellIndexPairs')
+        cip_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        cip_node.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'GridIndexPairs', root = gip_values)
+        cip_null = rqet.SubElement(cip_node, ns['resqml2'] + 'NullValue')
+        cip_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        cip_null.text = str(self.cell_index_pairs_null_value)
 
-      fip_node = rqet.SubElement(gcs, ns['resqml2'] + 'LocalFacePerCellIndexPairs')
-      fip_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      fip_node.text = '\n'
+        cip_values = rqet.SubElement(cip_node, ns['resqml2'] + 'Values')
+        cip_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        cip_values.text = '\n'
 
-      fip_null = rqet.SubElement(fip_node, ns['resqml2'] + 'NullValue')
-      fip_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      fip_null.text = str(self.face_index_pairs_null_value)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellIndexPairs', root = cip_values)
 
-      fip_values = rqet.SubElement(fip_node, ns['resqml2'] + 'Values')
-      fip_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      fip_values.text = '\n'
+        if len(self.grid_list) > 1 and self.grid_index_pairs is not None:
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'LocalFacePerCellIndexPairs', root = fip_values)
+            gip_node = rqet.SubElement(gcs, ns['resqml2'] + 'GridIndexPairs')
+            gip_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+            gip_node.text = '\n'
 
-      if self.feature_indices is not None and self.feature_list is not None:
+            gip_null = rqet.SubElement(gip_node, ns['resqml2'] + 'NullValue')
+            gip_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            gip_null.text = str(self.grid_index_pairs_null_value)
 
-         ci_node = rqet.SubElement(gcs, ns['resqml2'] + 'ConnectionInterpretations')
-         ci_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ConnectionInterpretations')
-         ci_node.text = '\n'
+            gip_values = rqet.SubElement(gip_node, ns['resqml2'] + 'Values')
+            gip_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            gip_values.text = '\n'
 
-         ii = rqet.SubElement(ci_node, ns['resqml2'] + 'InterpretationIndices')
-         #         ii = rqet.SubElement(ci_node, ns['resqml2'] + 'FaultIndices')
-         ii.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlJaggedArray')
-         ii.text = '\n'
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'GridIndexPairs', root = gip_values)
 
-         elements = rqet.SubElement(ii, ns['resqml2'] + 'Elements')
-         elements.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-         elements.text = '\n'
+        fip_node = rqet.SubElement(gcs, ns['resqml2'] + 'LocalFacePerCellIndexPairs')
+        fip_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        fip_node.text = '\n'
 
-         el_null = rqet.SubElement(elements, ns['resqml2'] + 'NullValue')
-         el_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         el_null.text = '-1'
+        fip_null = rqet.SubElement(fip_node, ns['resqml2'] + 'NullValue')
+        fip_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        fip_null.text = str(self.face_index_pairs_null_value)
 
-         el_values = rqet.SubElement(elements, ns['resqml2'] + 'Values')
-         el_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         el_values.text = '\n'
+        fip_values = rqet.SubElement(fip_node, ns['resqml2'] + 'Values')
+        fip_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        fip_values.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'InterpretationIndices/elements', root = el_values)
-         #         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'FaultIndices/elements', root = el_values)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'LocalFacePerCellIndexPairs', root = fip_values)
 
-         c_length = rqet.SubElement(ii, ns['resqml2'] + 'CumulativeLength')
-         c_length.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-         c_length.text = '\n'
+        if self.feature_indices is not None and self.feature_list is not None:
 
-         cl_null = rqet.SubElement(c_length, ns['resqml2'] + 'NullValue')
-         cl_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         cl_null.text = '-1'
+            ci_node = rqet.SubElement(gcs, ns['resqml2'] + 'ConnectionInterpretations')
+            ci_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ConnectionInterpretations')
+            ci_node.text = '\n'
 
-         cl_values = rqet.SubElement(c_length, ns['resqml2'] + 'Values')
-         cl_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         cl_values.text = '\n'
+            ii = rqet.SubElement(ci_node, ns['resqml2'] + 'InterpretationIndices')
+            #         ii = rqet.SubElement(ci_node, ns['resqml2'] + 'FaultIndices')
+            ii.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlJaggedArray')
+            ii.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid,
-                                            self.uuid,
-                                            'InterpretationIndices/cumulativeLength',
-                                            root = cl_values)
-         #         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'FaultIndices/cumulativeLength', root = cl_values)
+            elements = rqet.SubElement(ii, ns['resqml2'] + 'Elements')
+            elements.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+            elements.text = '\n'
 
-         # add feature interpretation reference node for each fault in list, NB: ordered list
-         for (f_content_type, f_uuid, f_title) in self.feature_list:
+            el_null = rqet.SubElement(elements, ns['resqml2'] + 'NullValue')
+            el_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            el_null.text = '-1'
 
-            # for now, only support connection sets for faults
-            if f_content_type == 'obj_FaultInterpretation':
-               fi_part = rqet.part_name_for_object('obj_FaultInterpretation', f_uuid)
-               fi_root = self.model.root_for_part(fi_part)
-               self.model.create_ref_node('FeatureInterpretation',
-                                          self.model.title_for_root(fi_root),
-                                          f_uuid,
-                                          content_type = 'obj_FaultInterpretation',
-                                          root = ci_node)
-            elif f_content_type == 'obj_HorizonInterpretation':
-               fi_part = rqet.part_name_for_object('obj_HorizonInterpretation', f_uuid)
-               fi_root = self.model.root_for_part(fi_part)
-               self.model.create_ref_node('FeatureInterpretation',
-                                          self.model.title_for_root(fi_root),
-                                          f_uuid,
-                                          content_type = 'obj_HorizonInterpretation',
-                                          root = ci_node)
-            else:
-               raise Exception('unsupported content type in grid connection set')
+            el_values = rqet.SubElement(elements, ns['resqml2'] + 'Values')
+            el_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            el_values.text = '\n'
 
-      for grid in self.grid_list:
-         self.model.create_ref_node('Grid',
-                                    self.model.title_for_root(grid.root),
-                                    grid.uuid,
-                                    content_type = 'obj_IjkGridRepresentation',
-                                    root = gcs)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'InterpretationIndices/elements', root = el_values)
+            #         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'FaultIndices/elements', root = el_values)
 
-      if add_as_part:
-         self.model.add_part('obj_GridConnectionSetRepresentation', self.uuid, gcs)
+            c_length = rqet.SubElement(ii, ns['resqml2'] + 'CumulativeLength')
+            c_length.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+            c_length.text = '\n'
 
-         if add_relationships:
-            for (obj_type, f_uuid, _) in self.feature_list:
-               fi_part = rqet.part_name_for_object(obj_type, f_uuid)
-               fi_root = self.model.root_for_part(fi_part)
-               self.model.create_reciprocal_relationship(gcs, 'destinationObject', fi_root, 'sourceObject')
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(gcs, 'mlToExternalPartProxy', ext_node, 'externalPartProxyToMl')
-            for grid in self.grid_list:
-               self.model.create_reciprocal_relationship(gcs, 'destinationObject', grid.root, 'sourceObject')
+            cl_null = rqet.SubElement(c_length, ns['resqml2'] + 'NullValue')
+            cl_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            cl_null.text = '-1'
 
-      if write_new_properties:
-         self.write_hdf5_and_create_xml_for_new_properties()
+            cl_values = rqet.SubElement(c_length, ns['resqml2'] + 'Values')
+            cl_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            cl_values.text = '\n'
 
-      return gcs
+            self.model.create_hdf5_dataset_ref(ext_uuid,
+                                               self.uuid,
+                                               'InterpretationIndices/cumulativeLength',
+                                               root = cl_values)
+            #         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'FaultIndices/cumulativeLength', root = cl_values)
 
-   def write_simulator(self, filename, mode = 'w', simulator = 'nexus', include_both_sides = False, use_minus = False):
-      """Creates a Nexus include file holding FAULTS (or MULT) keyword and data."""
+            # add feature interpretation reference node for each fault in list, NB: ordered list
+            for (f_content_type, f_uuid, f_title) in self.feature_list:
 
-      assert simulator == 'nexus'
+                # for now, only support connection sets for faults
+                if f_content_type == 'obj_FaultInterpretation':
+                    fi_part = rqet.part_name_for_object('obj_FaultInterpretation', f_uuid)
+                    fi_root = self.model.root_for_part(fi_part)
+                    self.model.create_ref_node('FeatureInterpretation',
+                                               self.model.title_for_root(fi_root),
+                                               f_uuid,
+                                               content_type = 'obj_FaultInterpretation',
+                                               root = ci_node)
+                elif f_content_type == 'obj_HorizonInterpretation':
+                    fi_part = rqet.part_name_for_object('obj_HorizonInterpretation', f_uuid)
+                    fi_root = self.model.root_for_part(fi_part)
+                    self.model.create_ref_node('FeatureInterpretation',
+                                               self.model.title_for_root(fi_root),
+                                               f_uuid,
+                                               content_type = 'obj_HorizonInterpretation',
+                                               root = ci_node)
+                else:
+                    raise Exception('unsupported content type in grid connection set')
 
-      active_nexus_head = None
-      row_count = 0
+        for grid in self.grid_list:
+            self.model.create_ref_node('Grid',
+                                       self.model.title_for_root(grid.root),
+                                       grid.uuid,
+                                       content_type = 'obj_IjkGridRepresentation',
+                                       root = gcs)
 
-      def write_nexus_header_lines(fp, axis, polarity, fault_name, grid_name = 'ROOT'):
-         nonlocal active_nexus_head
-         if (axis, polarity, fault_name, grid_name) == active_nexus_head:
-            return
-         T = 'T' + 'ZYX'[axis]
-         plus_minus = ['MINUS', 'PLUS'][polarity]
-         fp.write('\nMULT\t' + T + '\tALL\t' + plus_minus + '\tMULT\n')
-         fp.write('\tGRID\t' + grid_name + '\n')
-         fp.write('\tFNAME\t' + fault_name + '\n')
-         if len(fault_name) > 256:
-            log.warning('exported fault name longer than Nexus limit of 256 characters: ' + fault_name)
-            tm.log_nexus_tm('warning')
-         active_nexus_head = (axis, polarity, fault_name, grid_name)
+        if add_as_part:
+            self.model.add_part('obj_GridConnectionSetRepresentation', self.uuid, gcs)
 
-      def write_row(gcs, fp, name, i, j, k1, k2, axis, polarity):
-         nonlocal row_count
-         write_nexus_header_lines(fp, axis, polarity, name)
-         fp.write('\t{0:1d}\t{1:1d}\t{2:1d}\t{3:1d}\t{4:1d}\t{5:1d}\t1.0\n'.format(i + 1, i + 1, j + 1, j + 1, k1 + 1,
-                                                                                   k2 + 1))
-         row_count += 1
+            if add_relationships:
+                for (obj_type, f_uuid, _) in self.feature_list:
+                    fi_part = rqet.part_name_for_object(obj_type, f_uuid)
+                    fi_root = self.model.root_for_part(fi_part)
+                    self.model.create_reciprocal_relationship(gcs, 'destinationObject', fi_root, 'sourceObject')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(gcs, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
+                for grid in self.grid_list:
+                    self.model.create_reciprocal_relationship(gcs, 'destinationObject', grid.root, 'sourceObject')
 
-      log.info('writing fault data in simulator format to file: ' + filename)
+        if write_new_properties:
+            self.write_hdf5_and_create_xml_for_new_properties()
 
-      if include_both_sides:
-         sides = [0, 1]
-      elif use_minus:
-         sides = [1]
-      else:
-         sides = [0]
+        return gcs
 
-      with open(filename, mode, newline = '') as fp:
-         for feature_index in range(len(self.feature_list)):
-            feature_name = self.feature_list[feature_index][2].split()[0].upper()
-            cell_index_pairs, face_index_pairs = self.list_of_cell_face_pairs_for_feature_index(feature_index)
-            for side in sides:
-               both = np.empty((cell_index_pairs.shape[0], 5), dtype = int)
-               both[:, :2] = face_index_pairs[:, side, :]  # axis, polarity
-               both[:, 2:] = cell_index_pairs[:, side, :]  # k, j, i
-               df = pd.DataFrame(both, columns = ['axis', 'polarity', 'k', 'j', 'i'])
-               df = df.sort_values(by = ['axis', 'polarity', 'j', 'i', 'k'])
-               both_sorted = np.empty(both.shape, dtype = int)
-               both_sorted[:] = df
-               cell_indices = both_sorted[:, 2:]
-               face_indices = np.empty((both_sorted.shape[0], 2), dtype = int)
-               face_indices[:, :] = both_sorted[:, :2]
-               del both_sorted
-               del both
-               del df
-               k = None
-               i = j = k2 = axis = polarity = None  # only needed to placate flake8 which whinges incorrectly otherwise
-               for row in range(cell_indices.shape[0]):
-                  kp, jp, ip = cell_indices[row]
-                  axis_p, polarity_p = face_indices[row]
-                  if k is not None:
-                     if axis_p != axis or polarity_p != polarity or ip != i or jp != j or kp != k2 + 1:
+    def write_simulator(self, filename, mode = 'w', simulator = 'nexus', include_both_sides = False, use_minus = False):
+        """Creates a Nexus include file holding FAULTS (or MULT) keyword and data."""
+
+        assert simulator == 'nexus'
+
+        active_nexus_head = None
+        row_count = 0
+
+        def write_nexus_header_lines(fp, axis, polarity, fault_name, grid_name = 'ROOT'):
+            nonlocal active_nexus_head
+            if (axis, polarity, fault_name, grid_name) == active_nexus_head:
+                return
+            T = 'T' + 'ZYX'[axis]
+            plus_minus = ['MINUS', 'PLUS'][polarity]
+            fp.write('\nMULT\t' + T + '\tALL\t' + plus_minus + '\tMULT\n')
+            fp.write('\tGRID\t' + grid_name + '\n')
+            fp.write('\tFNAME\t' + fault_name + '\n')
+            if len(fault_name) > 256:
+                log.warning('exported fault name longer than Nexus limit of 256 characters: ' + fault_name)
+                tm.log_nexus_tm('warning')
+            active_nexus_head = (axis, polarity, fault_name, grid_name)
+
+        def write_row(gcs, fp, name, i, j, k1, k2, axis, polarity):
+            nonlocal row_count
+            write_nexus_header_lines(fp, axis, polarity, name)
+            fp.write('\t{0:1d}\t{1:1d}\t{2:1d}\t{3:1d}\t{4:1d}\t{5:1d}\t1.0\n'.format(
+                i + 1, i + 1, j + 1, j + 1, k1 + 1, k2 + 1))
+            row_count += 1
+
+        log.info('writing fault data in simulator format to file: ' + filename)
+
+        if include_both_sides:
+            sides = [0, 1]
+        elif use_minus:
+            sides = [1]
+        else:
+            sides = [0]
+
+        with open(filename, mode, newline = '') as fp:
+            for feature_index in range(len(self.feature_list)):
+                feature_name = self.feature_list[feature_index][2].split()[0].upper()
+                cell_index_pairs, face_index_pairs = self.list_of_cell_face_pairs_for_feature_index(feature_index)
+                for side in sides:
+                    both = np.empty((cell_index_pairs.shape[0], 5), dtype = int)
+                    both[:, :2] = face_index_pairs[:, side, :]  # axis, polarity
+                    both[:, 2:] = cell_index_pairs[:, side, :]  # k, j, i
+                    df = pd.DataFrame(both, columns = ['axis', 'polarity', 'k', 'j', 'i'])
+                    df = df.sort_values(by = ['axis', 'polarity', 'j', 'i', 'k'])
+                    both_sorted = np.empty(both.shape, dtype = int)
+                    both_sorted[:] = df
+                    cell_indices = both_sorted[:, 2:]
+                    face_indices = np.empty((both_sorted.shape[0], 2), dtype = int)
+                    face_indices[:, :] = both_sorted[:, :2]
+                    del both_sorted
+                    del both
+                    del df
+                    k = None
+                    i = j = k2 = axis = polarity = None  # only needed to placate flake8 which whinges incorrectly otherwise
+                    for row in range(cell_indices.shape[0]):
+                        kp, jp, ip = cell_indices[row]
+                        axis_p, polarity_p = face_indices[row]
+                        if k is not None:
+                            if axis_p != axis or polarity_p != polarity or ip != i or jp != j or kp != k2 + 1:
+                                write_row(self, fp, feature_name, i, j, k, k2, axis, polarity)
+                                k = None
+                            else:
+                                k2 = kp
+                        if k is None:
+                            i = ip
+                            j = jp
+                            k = k2 = kp
+                            axis = axis_p
+                            polarity = polarity_p
+                    if k is not None:
                         write_row(self, fp, feature_name, i, j, k, k2, axis, polarity)
-                        k = None
-                     else:
-                        k2 = kp
-                  if k is None:
-                     i = ip
-                     j = jp
-                     k = k2 = kp
-                     axis = axis_p
-                     polarity = polarity_p
-               if k is not None:
-                  write_row(self, fp, feature_name, i, j, k, k2, axis, polarity)
 
-   def get_column_edge_list_for_feature(self, feature, gridindex = 0, min_k = 0, max_k = 0):
-      """Extracts a list of cell faces for a given feature index, over a given range of layers in the grid
+    def get_column_edge_list_for_feature(self, feature, gridindex = 0, min_k = 0, max_k = 0):
+        """Extracts a list of cell faces for a given feature index, over a given range of layers in the grid
 
       Args:
          feature - feature index
@@ -1331,36 +1337,36 @@ class GridConnectionSet(BaseResqpy):
       Returns:
          list of cell faces for the feature (j_col, i_col, face_axis, face_polarity)
       """
-      subgcs = self.filtered_by_layer_range(min_k0 = min_k, max_k0 = max_k, pare_down = False)
-      if subgcs is None:
-         return None
+        subgcs = self.filtered_by_layer_range(min_k0 = min_k, max_k0 = max_k, pare_down = False)
+        if subgcs is None:
+            return None
 
-      cell_face_details = subgcs.list_of_cell_face_pairs_for_feature_index(feature)
+        cell_face_details = subgcs.list_of_cell_face_pairs_for_feature_index(feature)
 
-      if len(cell_face_details) == 2:
-         assert gridindex == 0, 'Only one grid present'
-         cell_ind_pairs, face_ind_pairs = cell_face_details
-         grid_ind_pairs = None
-      else:
-         cell_ind_pairs, face_ind_pairs, grid_ind_pairs = cell_face_details
-      ij_faces = []
-      for i in range(len(cell_ind_pairs)):
-         for a_or_b in [0, 1]:
-            if grid_ind_pairs is None or grid_ind_pairs[i, a_or_b] == gridindex:
-               if face_ind_pairs[i, a_or_b, 0] != 0:
-                  entry = ((
-                     int(cell_ind_pairs[i, a_or_b, 1]),
-                     int(cell_ind_pairs[i, a_or_b, 2]),
-                     int(face_ind_pairs[i, a_or_b, 0]) - 1,  # in the outputs j=0, i=1
-                     int(face_ind_pairs[i, a_or_b, 1])))  # in the outputs negativeface=0, positiveface=1
-                  if entry in ij_faces:
-                     continue
-                  ij_faces.append(entry)
-      ij_faces_np = np.array((ij_faces))
-      return ij_faces_np
+        if len(cell_face_details) == 2:
+            assert gridindex == 0, 'Only one grid present'
+            cell_ind_pairs, face_ind_pairs = cell_face_details
+            grid_ind_pairs = None
+        else:
+            cell_ind_pairs, face_ind_pairs, grid_ind_pairs = cell_face_details
+        ij_faces = []
+        for i in range(len(cell_ind_pairs)):
+            for a_or_b in [0, 1]:
+                if grid_ind_pairs is None or grid_ind_pairs[i, a_or_b] == gridindex:
+                    if face_ind_pairs[i, a_or_b, 0] != 0:
+                        entry = ((
+                            int(cell_ind_pairs[i, a_or_b, 1]),
+                            int(cell_ind_pairs[i, a_or_b, 2]),
+                            int(face_ind_pairs[i, a_or_b, 0]) - 1,  # in the outputs j=0, i=1
+                            int(face_ind_pairs[i, a_or_b, 1])))  # in the outputs negativeface=0, positiveface=1
+                        if entry in ij_faces:
+                            continue
+                        ij_faces.append(entry)
+        ij_faces_np = np.array((ij_faces))
+        return ij_faces_np
 
-   def get_column_edge_bool_array_for_feature(self, feature, gridindex = 0, min_k = 0, max_k = 0):
-      """Generate a boolean aray defining which column edges are present for a given feature and k-layer range
+    def get_column_edge_bool_array_for_feature(self, feature, gridindex = 0, min_k = 0, max_k = 0):
+        """Generate a boolean aray defining which column edges are present for a given feature and k-layer range
 
       Args:
          feature - feature index
@@ -1376,20 +1382,20 @@ class GridConnectionSet(BaseResqpy):
 
          so [[True,False],[False,True]] indicates the -j and +i edges of the column are present
       """
-      cell_face_list = self.get_column_edge_list_for_feature(feature, gridindex, min_k, max_k)
+        cell_face_list = self.get_column_edge_list_for_feature(feature, gridindex, min_k, max_k)
 
-      fault_by_column_edge_mask = np.zeros((self.grid_list[gridindex].nj, self.grid_list[gridindex].ni, 2, 2),
-                                           dtype = bool)
-      if cell_face_list is not None:
-         for i in cell_face_list:
-            fault_by_column_edge_mask[tuple(i)] = True
+        fault_by_column_edge_mask = np.zeros((self.grid_list[gridindex].nj, self.grid_list[gridindex].ni, 2, 2),
+                                             dtype = bool)
+        if cell_face_list is not None:
+            for i in cell_face_list:
+                fault_by_column_edge_mask[tuple(i)] = True
 
-      return fault_by_column_edge_mask
+        return fault_by_column_edge_mask
 
-   def get_property_by_feature_index_list(self,
-                                          feature_index_list = None,
-                                          property_name = 'Transmissibility multiplier'):
-      """Returns a list of property values by feature based on extra metadata items.
+    def get_property_by_feature_index_list(self,
+                                           feature_index_list = None,
+                                           property_name = 'Transmissibility multiplier'):
+        """Returns a list of property values by feature based on extra metadata items.
 
       arguments:
          feature_index_list (list of int, optional): if present, the feature indices for which property values will be included
@@ -1405,28 +1411,28 @@ class GridConnectionSet(BaseResqpy):
          for each feature; where no such item is found, a NaN is added to the return list
       """
 
-      if feature_index_list is None:
-         feature_index_list = range(len(self.feature_list))
-      value_list = []
-      for feature_index in feature_index_list:
-         _, feature_uuid, _ = self.feature_list[feature_index]
-         feat = rqo.FaultInterpretation(parent_model = self.model, uuid = feature_uuid)
-         if property_name not in feat.extra_metadata.keys():
-            log.info(
-               f'Property name {property_name} not found in extra_metadata for {self.model.citation_title_for_part(self.model.part_for_uuid(feature_uuid))}'
-            )
-            value_list.append(np.NaN)
-         else:
-            value_list.append(float(feat.extra_metadata[property_name]))
-      return value_list
+        if feature_index_list is None:
+            feature_index_list = range(len(self.feature_list))
+        value_list = []
+        for feature_index in feature_index_list:
+            _, feature_uuid, _ = self.feature_list[feature_index]
+            feat = rqo.FaultInterpretation(parent_model = self.model, uuid = feature_uuid)
+            if property_name not in feat.extra_metadata.keys():
+                log.info(
+                    f'Property name {property_name} not found in extra_metadata for {self.model.citation_title_for_part(self.model.part_for_uuid(feature_uuid))}'
+                )
+                value_list.append(np.NaN)
+            else:
+                value_list.append(float(feat.extra_metadata[property_name]))
+        return value_list
 
-   def get_column_edge_float_array_for_feature(self,
-                                               feature,
-                                               fault_by_column_edge_mask,
-                                               property_name = 'Transmissibility multiplier',
-                                               gridindex = 0,
-                                               ref_k = None):
-      """Generate a float value aray defining the property values for different column edges present for a given feature
+    def get_column_edge_float_array_for_feature(self,
+                                                feature,
+                                                fault_by_column_edge_mask,
+                                                property_name = 'Transmissibility multiplier',
+                                                gridindex = 0,
+                                                ref_k = None):
+        """Generate a float value aray defining the property values for different column edges present for a given feature
 
       Args:
          feature - feature index
@@ -1450,65 +1456,65 @@ class GridConnectionSet(BaseResqpy):
          collection being used when the extra metadata is absent
       """
 
-      single_grid = (self.number_of_grids() == 1)
-      if single_grid:
-         assert gridindex == 0
-      else:
-         assert self.grid_index_pairs is not None
+        single_grid = (self.number_of_grids() == 1)
+        if single_grid:
+            assert gridindex == 0
+        else:
+            assert self.grid_index_pairs is not None
 
-      prop_values = self.get_property_by_feature_index_list(feature_index_list = [feature],
-                                                            property_name = property_name)
-      if prop_values == [] or np.isnan(prop_values[0]):
-         pc = self.extract_property_collection()
-         if ref_k is None or pc is None:
-            return None
-         # use property name as (local) property kind
-         pk = property_name.lower()
-         prop_array = pc.single_array_ref(property_kind = pk)
-         if prop_array is None:
-            return None
-         # filter down to a single layer and single feature
-         feature_gcs = self.single_feature(feature)
-         feature_indices = self.indices_for_feature_index(feature)
-         feature_prop_array = prop_array[feature_indices]
-         layer_gcs, layer_indices = feature_gcs.filtered_by_layer_range(min_k0 = ref_k,
-                                                                        max_k0 = ref_k,
-                                                                        pare_down = False,
-                                                                        return_indices = True)
-         assert layer_gcs.count == len(layer_indices)
-         if layer_gcs.count == 0:  # feature does not have any faces in reference layer
-            return None
-         layer_prop_array = feature_prop_array[layer_indices]
-         # fill in individual values rather laboriously
-         property_value_by_column_edge = np.full(fault_by_column_edge_mask.shape, np.nan)
-         for i in range(layer_gcs.count):
-            for side in range(2):
-               gi = 0 if single_grid else layer_gcs.grid_index_pairs[i, side]
-               if gi != gridindex:
-                  continue
-               cell = layer_gcs.cell_index_pairs[i, side]
-               if cell == layer_gcs.cell_index_pairs_null_value:
-                  continue
-               cell_kji = self.grid_list[gi].denaturalized_cell_index(cell)
-               face_index = layer_gcs.face_index_pairs[i, side]
-               if face_index == layer_gcs.face_index_pairs_null_value:
-                  continue
-               axis, polarity = self.face_index_inverse_map[face_index]
-               if axis == 0:  # k face
-                  continue
-               property_value_by_column_edge[cell_kji[1], cell_kji[2], axis - 1, polarity] = layer_prop_array[i]
-      else:
-         property_value_by_column_edge = np.where(fault_by_column_edge_mask, prop_values[0], np.nan)
-      return property_value_by_column_edge
+        prop_values = self.get_property_by_feature_index_list(feature_index_list = [feature],
+                                                              property_name = property_name)
+        if prop_values == [] or np.isnan(prop_values[0]):
+            pc = self.extract_property_collection()
+            if ref_k is None or pc is None:
+                return None
+            # use property name as (local) property kind
+            pk = property_name.lower()
+            prop_array = pc.single_array_ref(property_kind = pk)
+            if prop_array is None:
+                return None
+            # filter down to a single layer and single feature
+            feature_gcs = self.single_feature(feature)
+            feature_indices = self.indices_for_feature_index(feature)
+            feature_prop_array = prop_array[feature_indices]
+            layer_gcs, layer_indices = feature_gcs.filtered_by_layer_range(min_k0 = ref_k,
+                                                                           max_k0 = ref_k,
+                                                                           pare_down = False,
+                                                                           return_indices = True)
+            assert layer_gcs.count == len(layer_indices)
+            if layer_gcs.count == 0:  # feature does not have any faces in reference layer
+                return None
+            layer_prop_array = feature_prop_array[layer_indices]
+            # fill in individual values rather laboriously
+            property_value_by_column_edge = np.full(fault_by_column_edge_mask.shape, np.nan)
+            for i in range(layer_gcs.count):
+                for side in range(2):
+                    gi = 0 if single_grid else layer_gcs.grid_index_pairs[i, side]
+                    if gi != gridindex:
+                        continue
+                    cell = layer_gcs.cell_index_pairs[i, side]
+                    if cell == layer_gcs.cell_index_pairs_null_value:
+                        continue
+                    cell_kji = self.grid_list[gi].denaturalized_cell_index(cell)
+                    face_index = layer_gcs.face_index_pairs[i, side]
+                    if face_index == layer_gcs.face_index_pairs_null_value:
+                        continue
+                    axis, polarity = self.face_index_inverse_map[face_index]
+                    if axis == 0:  # k face
+                        continue
+                    property_value_by_column_edge[cell_kji[1], cell_kji[2], axis - 1, polarity] = layer_prop_array[i]
+        else:
+            property_value_by_column_edge = np.where(fault_by_column_edge_mask, prop_values[0], np.nan)
+        return property_value_by_column_edge
 
-   def get_combined_fault_mask_index_value_arrays(self,
-                                                  gridindex = 0,
-                                                  min_k = 0,
-                                                  max_k = 0,
-                                                  property_name = 'Transmissibility multiplier',
-                                                  feature_list = None,
-                                                  ref_k = None):
-      """Generate a combined mask, index and value arrays for all column edges across a k-layer range, for a defined feature_list
+    def get_combined_fault_mask_index_value_arrays(self,
+                                                   gridindex = 0,
+                                                   min_k = 0,
+                                                   max_k = 0,
+                                                   property_name = 'Transmissibility multiplier',
+                                                   feature_list = None,
+                                                   ref_k = None):
+        """Generate a combined mask, index and value arrays for all column edges across a k-layer range, for a defined feature_list
 
       Args:
          gridindex - index of grid to be used in grid connection set gridlist, default 0
@@ -1524,50 +1530,51 @@ class GridConnectionSet(BaseResqpy):
          int array showing the feature index for all column edges within features (shape nj,ni,2,2)
          float array showing the property value for all column edges within features (shape nj,ni,2,2)
       """
-      self.cache_arrays()
-      #     if feature_list is None: feature_list = np.unique(self.feature_indices)
-      if feature_list is None:
-         feature_list = np.arange(len(self.feature_list))
-      if ref_k is None:
-         ref_k = min_k
+        self.cache_arrays()
+        #     if feature_list is None: feature_list = np.unique(self.feature_indices)
+        if feature_list is None:
+            feature_list = np.arange(len(self.feature_list))
+        if ref_k is None:
+            ref_k = min_k
 
-      sum_unmasked = None
+        sum_unmasked = None
 
-      for i, feature in enumerate(feature_list):
-         fault_by_column_edge_mask = self.get_column_edge_bool_array_for_feature(feature,
-                                                                                 gridindex,
-                                                                                 min_k = min_k,
-                                                                                 max_k = max_k)
-         property_value_by_column_edge = self.get_column_edge_float_array_for_feature(feature,
-                                                                                      fault_by_column_edge_mask,
-                                                                                      property_name = property_name,
-                                                                                      gridindex = gridindex,
-                                                                                      ref_k = ref_k)
-         if i == 0:
-            combined_mask = fault_by_column_edge_mask.copy()
-            if property_value_by_column_edge is not None:
-               combined_values = property_value_by_column_edge.copy()
+        for i, feature in enumerate(feature_list):
+            fault_by_column_edge_mask = self.get_column_edge_bool_array_for_feature(feature,
+                                                                                    gridindex,
+                                                                                    min_k = min_k,
+                                                                                    max_k = max_k)
+            property_value_by_column_edge = self.get_column_edge_float_array_for_feature(feature,
+                                                                                         fault_by_column_edge_mask,
+                                                                                         property_name = property_name,
+                                                                                         gridindex = gridindex,
+                                                                                         ref_k = ref_k)
+            if i == 0:
+                combined_mask = fault_by_column_edge_mask.copy()
+                if property_value_by_column_edge is not None:
+                    combined_values = property_value_by_column_edge.copy()
+                else:
+                    combined_values = None
+                combined_index = np.full((fault_by_column_edge_mask.shape), -1, dtype = int)
+                combined_index = np.where(fault_by_column_edge_mask, feature, combined_index)
+                sum_unmasked = np.sum(fault_by_column_edge_mask)
             else:
-               combined_values = None
-            combined_index = np.full((fault_by_column_edge_mask.shape), -1, dtype = int)
-            combined_index = np.where(fault_by_column_edge_mask, feature, combined_index)
-            sum_unmasked = np.sum(fault_by_column_edge_mask)
-         else:
-            combined_mask = np.logical_or(combined_mask, fault_by_column_edge_mask)
-            if property_value_by_column_edge is not None:
-               if combined_values is not None:
-                  combined_values = np.where(fault_by_column_edge_mask, property_value_by_column_edge, combined_values)
-               else:
-                  combined_values = property_value_by_column_edge.copy()
-            combined_index = np.where(fault_by_column_edge_mask, feature, combined_index)
-            sum_unmasked += np.sum(fault_by_column_edge_mask)
+                combined_mask = np.logical_or(combined_mask, fault_by_column_edge_mask)
+                if property_value_by_column_edge is not None:
+                    if combined_values is not None:
+                        combined_values = np.where(fault_by_column_edge_mask, property_value_by_column_edge,
+                                                   combined_values)
+                    else:
+                        combined_values = property_value_by_column_edge.copy()
+                combined_index = np.where(fault_by_column_edge_mask, feature, combined_index)
+                sum_unmasked += np.sum(fault_by_column_edge_mask)
 
-      if not np.sum(combined_mask) == sum_unmasked:
-         log.warning("One or more features exist across the same column edge!")
-      return combined_mask, combined_index, combined_values
+        if not np.sum(combined_mask) == sum_unmasked:
+            log.warning("One or more features exist across the same column edge!")
+        return combined_mask, combined_index, combined_values
 
-   def tr_property_array(self, fa = None, tol_fa = 0.0001, tol_half_t = 1.0e-5, apply_multipliers = False):
-      """Return a transmissibility array with one value per pair in the connection set.
+    def tr_property_array(self, fa = None, tol_fa = 0.0001, tol_half_t = 1.0e-5, apply_multipliers = False):
+        """Return a transmissibility array with one value per pair in the connection set.
 
       argument:
          fa (numpy float array of shape (count, 2), optional): if present, the fractional area for each pair connection,
@@ -1592,56 +1599,56 @@ class GridConnectionSet(BaseResqpy):
          does not add the transmissibility array as a property
       """
 
-      feature_mult_list = None
-      mult_array = None
-      if apply_multipliers:
-         pc = self.extract_property_collection()
-         mult_array = pc.single_array_ref(property_kind = 'transmissibility multiplier')
-         if mult_array is None:
-            feature_mult_list = self.get_property_by_feature_index_list()
+        feature_mult_list = None
+        mult_array = None
+        if apply_multipliers:
+            pc = self.extract_property_collection()
+            mult_array = pc.single_array_ref(property_kind = 'transmissibility multiplier')
+            if mult_array is None:
+                feature_mult_list = self.get_property_by_feature_index_list()
 
-      count = self.count
-      if fa is not None:
-         assert fa.shape == (count, 2)
-      f_tr = np.zeros(count)
-      half_t_list = []
-      for grid in self.grid_list:
-         half_t_list.append(grid.half_cell_transmissibility())  # todo: pass realization argument
-      single_grid = (self.number_of_grids() == 1)
-      kji0 = self.grid_list[0].denaturalized_cell_indices(self.cell_index_pairs) if single_grid else None
-      # kji0 shape (count, 2, 3); 2 being m,p; 3 being k,j,i; multi-grid cell indices denaturalised within for loop below
-      fa_m = fa_p = 1.0
-      gi_m = gi_p = 0  # used below in single grid case
-      for e in range(count):
-         axis_m, polarity_m = self.face_index_inverse_map[self.face_index_pairs[e, 0]]
-         axis_p, polarity_p = self.face_index_inverse_map[self.face_index_pairs[e, 0]]
-         if single_grid:
-            kji0_m = kji0[e, 0]
-            kji0_p = kji0[e, 1]
-         else:
-            gi_m = self.grid_index_pairs[e, 0]
-            gi_p = self.grid_index_pairs[e, 1]
-            kji0_m = self.grid_list[gi_m].denaturalized_cell_index(self.cell_index_pairs[e, 0])
-            kji0_p = self.grid_list[gi_p].denaturalized_cell_index(self.cell_index_pairs[e, 1])
-         half_t_m = half_t_list[gi_m][kji0_m[0], kji0_m[1], kji0_m[2], axis_m, polarity_m]
-         half_t_p = half_t_list[gi_p][kji0_p[0], kji0_p[1], kji0_p[2], axis_p, polarity_p]
-         if half_t_m < tol_half_t or half_t_p < tol_half_t:
-            continue
-         if fa is not None:
-            fa_m, fa_p = fa[e]
-            if fa_m < tol_fa or fa_p < tol_fa:
-               continue
-         mult_tr = 1.0
-         if apply_multipliers:
-            if mult_array is not None:
-               mult_tr = mult_array[e]
-            elif feature_mult_list is not None:
-               mult_tr = feature_mult_list[self.feature_indices[e]]
-         f_tr[e] = mult_tr / (1.0 / (half_t_m * fa_m) + 1.0 / (half_t_p * fa_p))
-      return f_tr
+        count = self.count
+        if fa is not None:
+            assert fa.shape == (count, 2)
+        f_tr = np.zeros(count)
+        half_t_list = []
+        for grid in self.grid_list:
+            half_t_list.append(grid.half_cell_transmissibility())  # todo: pass realization argument
+        single_grid = (self.number_of_grids() == 1)
+        kji0 = self.grid_list[0].denaturalized_cell_indices(self.cell_index_pairs) if single_grid else None
+        # kji0 shape (count, 2, 3); 2 being m,p; 3 being k,j,i; multi-grid cell indices denaturalised within for loop below
+        fa_m = fa_p = 1.0
+        gi_m = gi_p = 0  # used below in single grid case
+        for e in range(count):
+            axis_m, polarity_m = self.face_index_inverse_map[self.face_index_pairs[e, 0]]
+            axis_p, polarity_p = self.face_index_inverse_map[self.face_index_pairs[e, 0]]
+            if single_grid:
+                kji0_m = kji0[e, 0]
+                kji0_p = kji0[e, 1]
+            else:
+                gi_m = self.grid_index_pairs[e, 0]
+                gi_p = self.grid_index_pairs[e, 1]
+                kji0_m = self.grid_list[gi_m].denaturalized_cell_index(self.cell_index_pairs[e, 0])
+                kji0_p = self.grid_list[gi_p].denaturalized_cell_index(self.cell_index_pairs[e, 1])
+            half_t_m = half_t_list[gi_m][kji0_m[0], kji0_m[1], kji0_m[2], axis_m, polarity_m]
+            half_t_p = half_t_list[gi_p][kji0_p[0], kji0_p[1], kji0_p[2], axis_p, polarity_p]
+            if half_t_m < tol_half_t or half_t_p < tol_half_t:
+                continue
+            if fa is not None:
+                fa_m, fa_p = fa[e]
+                if fa_m < tol_fa or fa_p < tol_fa:
+                    continue
+            mult_tr = 1.0
+            if apply_multipliers:
+                if mult_array is not None:
+                    mult_tr = mult_array[e]
+                elif feature_mult_list is not None:
+                    mult_tr = feature_mult_list[self.feature_indices[e]]
+            f_tr[e] = mult_tr / (1.0 / (half_t_m * fa_m) + 1.0 / (half_t_p * fa_p))
+        return f_tr
 
-   def inherit_features(self, featured):
-      """Inherit features from another connection set, reassigning feature indices for matching faces.
+    def inherit_features(self, featured):
+        """Inherit features from another connection set, reassigning feature indices for matching faces.
 
       arguments:
          featured (GridConnectionSet): the other connection set which holds features to be inherited
@@ -1655,105 +1662,105 @@ class GridConnectionSet(BaseResqpy):
          with named features; currently restricted to single grid connection sets
       """
 
-      def sorted_paired_cell_face_index_position(cell_face_index, a_or_b):
-         # pair one side (a_or_b) of cell_face_index with its position, then sort
-         count = len(cell_face_index)
-         sp = np.empty((count, 2), dtype = int)
-         sp[:, 0] = cell_face_index[:, a_or_b]
-         sp[:, 1] = np.arange(count)
-         t = [tuple(r) for r in sp]  # could use numpy fields based sort instead of tuple list?
-         t.sort()
-         return np.array(t)
+        def sorted_paired_cell_face_index_position(cell_face_index, a_or_b):
+            # pair one side (a_or_b) of cell_face_index with its position, then sort
+            count = len(cell_face_index)
+            sp = np.empty((count, 2), dtype = int)
+            sp[:, 0] = cell_face_index[:, a_or_b]
+            sp[:, 1] = np.arange(count)
+            t = [tuple(r) for r in sp]  # could use numpy fields based sort instead of tuple list?
+            t.sort()
+            return np.array(t)
 
-      def find_in_sorted(paired, v):
+        def find_in_sorted(paired, v):
 
-         def fis(p, v, a, b):  # recursive binary search
-            if a >= b:
-               return None
-            m = (a + b) // 2
-            s = p[m, 0]
-            if s == v:
-               return p[m, 1]
-            if s > v:
-               return fis(p, v, a, m)
-            return fis(p, v, m + 1, b)
+            def fis(p, v, a, b):  # recursive binary search
+                if a >= b:
+                    return None
+                m = (a + b) // 2
+                s = p[m, 0]
+                if s == v:
+                    return p[m, 1]
+                if s > v:
+                    return fis(p, v, a, m)
+                return fis(p, v, m + 1, b)
 
-         return fis(paired, v, 0, len(paired))
+            return fis(paired, v, 0, len(paired))
 
-      assert len(self.grid_list) == 1 and len(featured.grid_list) == 1
-      assert bu.matching_uuids(self.grid_list[0].uuid, featured.grid_list[0].uuid)
+        assert len(self.grid_list) == 1 and len(featured.grid_list) == 1
+        assert bu.matching_uuids(self.grid_list[0].uuid, featured.grid_list[0].uuid)
 
-      # build combined feature list and mapping of feature indices
-      featured.cache_arrays()
-      original_feature_count = len(self.feature_list)
-      featured_index_map = []  # maps from feature index in featured to extended feature list in this set
-      feature_uuid_list = [bu.uuid_from_string(u) for _, u, _ in self.feature_list]  # bu call probably not needed
-      for featured_triplet in featured.feature_list:
-         featured_uuid = bu.uuid_from_string(featured_triplet[1])  # bu call probably not needed
-         if featured_uuid in feature_uuid_list:
-            featured_index_map.append(feature_uuid_list.index[featured_uuid])
-         else:
-            featured_index_map.append(len(self.feature_list))
-            self.feature_list.append(featured_triplet)
-            feature_uuid_list.append(featured_uuid)
-            self.model.copy_part_from_other_model(featured, featured.model.part(uuid = featured_uuid))
-
-      # convert cell index, face index to a single integer to facilitate sorting and comparison
-      cell_face_index_self = self.compact_indices()
-      cell_face_index_featured = featured.compact_indices()
-
-      # sort all 4 (2 sides in each of 2 sets) cell_face index data, keeping track of positions in original lists
-      cfp_a_self = sorted_paired_cell_face_index_position(cell_face_index_self, 0)
-      cfp_b_self = sorted_paired_cell_face_index_position(cell_face_index_self, 1)
-      cfp_a_featured = sorted_paired_cell_face_index_position(cell_face_index_featured, 0)
-      cfp_b_featured = sorted_paired_cell_face_index_position(cell_face_index_featured, 1)
-
-      # for each cell face in self, look for same in featured and inherit feature index if found
-      previous_cell_face_index = previous_feature_index = None
-      for (a_or_b, cfp_self) in [(0, cfp_a_self), (1, cfp_b_self)]:  # could risk being lazy and only using one side?
-         for (cell_face_index, place) in cfp_self:
-            if self.feature_indices[place] >= original_feature_count:
-               continue  # already been updated
-            if cell_face_index == previous_cell_face_index:
-               if previous_feature_index is not None:
-                  self.feature_indices[place] = previous_feature_index
-            elif cell_face_index == self.face_index_pairs_null_value:
-               continue
+        # build combined feature list and mapping of feature indices
+        featured.cache_arrays()
+        original_feature_count = len(self.feature_list)
+        featured_index_map = []  # maps from feature index in featured to extended feature list in this set
+        feature_uuid_list = [bu.uuid_from_string(u) for _, u, _ in self.feature_list]  # bu call probably not needed
+        for featured_triplet in featured.feature_list:
+            featured_uuid = bu.uuid_from_string(featured_triplet[1])  # bu call probably not needed
+            if featured_uuid in feature_uuid_list:
+                featured_index_map.append(feature_uuid_list.index[featured_uuid])
             else:
-               featured_place = find_in_sorted(cfp_a_featured, cell_face_index)
-               if featured_place is None:
-                  featured_place = find_in_sorted(cfp_b_featured, cell_face_index)
-               if featured_place is None:
-                  previous_feature_index = None
-               else:
-                  featured_index = featured.feature_indices[featured_place]
-                  self.feature_indices[place] = previous_feature_index = featured_index_map[featured_index]
-               previous_cell_face_index = cell_face_index
+                featured_index_map.append(len(self.feature_list))
+                self.feature_list.append(featured_triplet)
+                feature_uuid_list.append(featured_uuid)
+                self.model.copy_part_from_other_model(featured, featured.model.part(uuid = featured_uuid))
 
-      # clean up by removing any original features no longer in use
-      removals = []
-      for fi in range(original_feature_count):
-         if fi not in self.feature_indices:
-            removals.append(fi)
-      reduction = len(removals)
-      if reduction > 0:
-         while len(removals) > 0:
-            self.feature_list.pop(removals[-1])
-            removals.pop()
-         self.feature_indices[:] -= reduction
+        # convert cell index, face index to a single integer to facilitate sorting and comparison
+        cell_face_index_self = self.compact_indices()
+        cell_face_index_featured = featured.compact_indices()
 
-   def compact_indices(self):
-      """Returns numpy int array of shape (count, 2) combining each cell index, face index into a single integer."""
-      if self.cell_index_pairs is None or self.face_index_pairs is None:
-         return None
-      null_mask = np.logical_or(self.cell_index_pairs == self.cell_index_pairs_null_value,
-                                self.face_index_pairs == self.face_index_pairs_null_value)
-      combined = 6 * self.cell_index_pairs + self.face_index_pairs
-      return np.where(null_mask, self.face_index_pairs_null_value, combined)
+        # sort all 4 (2 sides in each of 2 sets) cell_face index data, keeping track of positions in original lists
+        cfp_a_self = sorted_paired_cell_face_index_position(cell_face_index_self, 0)
+        cfp_b_self = sorted_paired_cell_face_index_position(cell_face_index_self, 1)
+        cfp_a_featured = sorted_paired_cell_face_index_position(cell_face_index_featured, 0)
+        cfp_b_featured = sorted_paired_cell_face_index_position(cell_face_index_featured, 1)
+
+        # for each cell face in self, look for same in featured and inherit feature index if found
+        previous_cell_face_index = previous_feature_index = None
+        for (a_or_b, cfp_self) in [(0, cfp_a_self), (1, cfp_b_self)]:  # could risk being lazy and only using one side?
+            for (cell_face_index, place) in cfp_self:
+                if self.feature_indices[place] >= original_feature_count:
+                    continue  # already been updated
+                if cell_face_index == previous_cell_face_index:
+                    if previous_feature_index is not None:
+                        self.feature_indices[place] = previous_feature_index
+                elif cell_face_index == self.face_index_pairs_null_value:
+                    continue
+                else:
+                    featured_place = find_in_sorted(cfp_a_featured, cell_face_index)
+                    if featured_place is None:
+                        featured_place = find_in_sorted(cfp_b_featured, cell_face_index)
+                    if featured_place is None:
+                        previous_feature_index = None
+                    else:
+                        featured_index = featured.feature_indices[featured_place]
+                        self.feature_indices[place] = previous_feature_index = featured_index_map[featured_index]
+                    previous_cell_face_index = cell_face_index
+
+        # clean up by removing any original features no longer in use
+        removals = []
+        for fi in range(original_feature_count):
+            if fi not in self.feature_indices:
+                removals.append(fi)
+        reduction = len(removals)
+        if reduction > 0:
+            while len(removals) > 0:
+                self.feature_list.pop(removals[-1])
+                removals.pop()
+            self.feature_indices[:] -= reduction
+
+    def compact_indices(self):
+        """Returns numpy int array of shape (count, 2) combining each cell index, face index into a single integer."""
+        if self.cell_index_pairs is None or self.face_index_pairs is None:
+            return None
+        null_mask = np.logical_or(self.cell_index_pairs == self.cell_index_pairs_null_value,
+                                  self.face_index_pairs == self.face_index_pairs_null_value)
+        combined = 6 * self.cell_index_pairs + self.face_index_pairs
+        return np.where(null_mask, self.face_index_pairs_null_value, combined)
 
 
 def pinchout_connection_set(grid, skip_inactive = True, feature_name = 'pinchout'):
-   """Returns a new GridConnectionSet representing non-standard K face connections across pinchouts.
+    """Returns a new GridConnectionSet representing non-standard K face connections across pinchouts.
 
    arguments:
       grid (grid.Grid): the grid for which a pinchout connection set is required
@@ -1766,48 +1773,48 @@ def pinchout_connection_set(grid, skip_inactive = True, feature_name = 'pinchout
       however, it does create one feature and a corresponding interpretation and creates xml for those
    """
 
-   assert grid is not None
+    assert grid is not None
 
-   po = grid.pinched_out()
-   dead = grid.extract_inactive_mask() if skip_inactive else None
+    po = grid.pinched_out()
+    dead = grid.extract_inactive_mask() if skip_inactive else None
 
-   cip_list = []  # cell index pair list
+    cip_list = []  # cell index pair list
 
-   for j in range(grid.nj):
-      for i in range(grid.ni):
-         ka = 0
-         while True:
-            while ka < grid.nk - 1 and po[ka, j, i]:
-               ka += 1
-            while ka < grid.nk - 1 and not po[ka + 1, j, i]:
-               ka += 1
-            if ka >= grid.nk - 1:
-               break
-            # ka now in non-pinched out cell above pinchout
-            if (skip_inactive and dead[ka, j, i]) or (grid.k_gaps and grid.k_gap_after[ka]):
-               ka += 1
-               continue
-            kb = ka + 1
-            while kb < grid.nk and po[kb, j, i]:
-               kb += 1
-            if kb >= grid.nk:
-               break
-            if skip_inactive and dead[kb, j, i]:
-               ka = kb + 1
-               continue
-            # kb now beneath pinchout
-            cip_list.append((grid.natural_cell_index((ka, j, i)), grid.natural_cell_index((kb, j, i))))
-            ka = kb + 1
+    for j in range(grid.nj):
+        for i in range(grid.ni):
+            ka = 0
+            while True:
+                while ka < grid.nk - 1 and po[ka, j, i]:
+                    ka += 1
+                while ka < grid.nk - 1 and not po[ka + 1, j, i]:
+                    ka += 1
+                if ka >= grid.nk - 1:
+                    break
+                # ka now in non-pinched out cell above pinchout
+                if (skip_inactive and dead[ka, j, i]) or (grid.k_gaps and grid.k_gap_after[ka]):
+                    ka += 1
+                    continue
+                kb = ka + 1
+                while kb < grid.nk and po[kb, j, i]:
+                    kb += 1
+                if kb >= grid.nk:
+                    break
+                if skip_inactive and dead[kb, j, i]:
+                    ka = kb + 1
+                    continue
+                # kb now beneath pinchout
+                cip_list.append((grid.natural_cell_index((ka, j, i)), grid.natural_cell_index((kb, j, i))))
+                ka = kb + 1
 
-   log.debug(f'{len(cip_list)} pinchout connections found')
+    log.debug(f'{len(cip_list)} pinchout connections found')
 
-   pcs = _make_k_gcs_from_cip_list(grid, cip_list, feature_name)
+    pcs = _make_k_gcs_from_cip_list(grid, cip_list, feature_name)
 
-   return pcs
+    return pcs
 
 
 def k_gap_connection_set(grid, skip_inactive = True, feature_name = 'k gap connection', tolerance = 0.001):
-   """Returns a new GridConnectionSet representing K face connections where a K gap is zero thickness.
+    """Returns a new GridConnectionSet representing K face connections where a K gap is zero thickness.
 
    arguments:
       grid (grid.Grid): the grid for which a K gap connection set is required
@@ -1824,44 +1831,44 @@ def k_gap_connection_set(grid, skip_inactive = True, feature_name = 'k gap conne
       are omitted from the standard transmissibilities due to the presence of the K gap layer
    """
 
-   assert grid is not None
-   if not grid.k_gaps:
-      return None
+    assert grid is not None
+    if not grid.k_gaps:
+        return None
 
-   p = grid.points_ref(masked = False)
-   dead = grid.extract_inactive_mask() if skip_inactive else None
-   flip_z = (grid.k_direction_is_down != rqet.find_tag_bool(grid.crs_root, 'ZIncreasingDownward'))
+    p = grid.points_ref(masked = False)
+    dead = grid.extract_inactive_mask() if skip_inactive else None
+    flip_z = (grid.k_direction_is_down != rqet.find_tag_bool(grid.crs_root, 'ZIncreasingDownward'))
 
-   cip_list = []  # cell index pair list
+    cip_list = []  # cell index pair list
 
-   for k in range(grid.nk - 1):
-      if grid.k_gap_after_array[k]:
-         k_gap_pillar_z = p[grid.k_raw_index_array[k + 1]][..., 2] - p[grid.k_raw_index_array[k] + 1][..., 2]
-         if grid.has_split_coordinate_lines:
-            pfc = grid.create_column_pillar_mapping()  # pillars for column
-            k_gap_z = 0.25 * np.sum(k_gap_pillar_z[pfc], axis = (2, 3))  # resulting shape (nj, ni)
-         else:
-            k_gap_z = 0.25 * (k_gap_pillar_z[:-1, :-1] + k_gap_pillar_z[:-1, 1:] + k_gap_pillar_z[1:, :-1] +
-                              k_gap_pillar_z[1:, 1:])  # shape (nj, ni)
-      if flip_z:
-         k_gap_z = -k_gap_z
-      layer_mask = np.logical_and(np.logical_not(np.isnan(k_gap_z)), k_gap_z < tolerance)
-      if skip_inactive:
-         layer_mask = np.logical_and(layer_mask, np.logical_not(np.logical_or(dead[k], dead[k + 1])))
-      # layer mask now boolean array of shape (nj, ni) set True where connection needed
-      ji_list = np.stack(np.where(layer_mask)).T  # numpy array being list of [j, i] pairs
-      for (j, i) in ji_list:
-         cip_list.append((grid.natural_cell_index((k, j, i)), grid.natural_cell_index((k + 1, j, i))))
+    for k in range(grid.nk - 1):
+        if grid.k_gap_after_array[k]:
+            k_gap_pillar_z = p[grid.k_raw_index_array[k + 1]][..., 2] - p[grid.k_raw_index_array[k] + 1][..., 2]
+            if grid.has_split_coordinate_lines:
+                pfc = grid.create_column_pillar_mapping()  # pillars for column
+                k_gap_z = 0.25 * np.sum(k_gap_pillar_z[pfc], axis = (2, 3))  # resulting shape (nj, ni)
+            else:
+                k_gap_z = 0.25 * (k_gap_pillar_z[:-1, :-1] + k_gap_pillar_z[:-1, 1:] + k_gap_pillar_z[1:, :-1] +
+                                  k_gap_pillar_z[1:, 1:])  # shape (nj, ni)
+        if flip_z:
+            k_gap_z = -k_gap_z
+        layer_mask = np.logical_and(np.logical_not(np.isnan(k_gap_z)), k_gap_z < tolerance)
+        if skip_inactive:
+            layer_mask = np.logical_and(layer_mask, np.logical_not(np.logical_or(dead[k], dead[k + 1])))
+        # layer mask now boolean array of shape (nj, ni) set True where connection needed
+        ji_list = np.stack(np.where(layer_mask)).T  # numpy array being list of [j, i] pairs
+        for (j, i) in ji_list:
+            cip_list.append((grid.natural_cell_index((k, j, i)), grid.natural_cell_index((k + 1, j, i))))
 
-   log.debug(f'{len(cip_list)} k gap connections found')
+    log.debug(f'{len(cip_list)} k gap connections found')
 
-   kgcs = _make_k_gcs_from_cip_list(grid, cip_list, feature_name)
+    kgcs = _make_k_gcs_from_cip_list(grid, cip_list, feature_name)
 
-   return kgcs
+    return kgcs
 
 
 def add_connection_set_and_tmults(model, fault_incl, tmult_dict = None):
-   """Add a grid connection set to a resqml model, based on a fault include file and a dictionary of fault:tmult pairs.
+    """Add a grid connection set to a resqml model, based on a fault include file and a dictionary of fault:tmult pairs.
 
    Grid connection set added to resqml model, with extra_metadata on the fault interpretation containing the MULTFL values
 
@@ -1874,42 +1881,42 @@ def add_connection_set_and_tmults(model, fault_incl, tmult_dict = None):
       grid connection set uuid
    """
 
-   if isinstance(fault_incl, list):
-      if len(fault_incl) > 1:
-         # Making a concatenated version of the faultincl files
-         # TODO: perhaps a better/more unique name and location could be used in future?
-         temp_faults = os.path.join(os.path.dirname(model.epc_file), 'faults_combined_temp.txt')
-         with open(temp_faults, 'w') as outfile:
-            log.debug("combining multiple include files into one")
-            for fname in fault_incl:
-               with open(fname) as infile:
-                  for line in infile:
-                     outfile.write(line)
-      else:
-         temp_faults = fault_incl[0]
-   else:
-      temp_faults = fault_incl
+    if isinstance(fault_incl, list):
+        if len(fault_incl) > 1:
+            # Making a concatenated version of the faultincl files
+            # TODO: perhaps a better/more unique name and location could be used in future?
+            temp_faults = os.path.join(os.path.dirname(model.epc_file), 'faults_combined_temp.txt')
+            with open(temp_faults, 'w') as outfile:
+                log.debug("combining multiple include files into one")
+                for fname in fault_incl:
+                    with open(fname) as infile:
+                        for line in infile:
+                            outfile.write(line)
+        else:
+            temp_faults = fault_incl[0]
+    else:
+        temp_faults = fault_incl
 
-   log.info("Creating grid connection set")
-   gcs = GridConnectionSet(parent_model = model,
-                           ascii_load_format = 'nexus',
-                           ascii_file = temp_faults,
-                           create_organizing_objects_where_needed = True,
-                           create_transmissibility_multiplier_property = True,
-                           fault_tmult_dict = tmult_dict)
-   gcs.write_hdf5(model.h5_file_name())
-   gcs.create_xml(model.h5_uuid())
+    log.info("Creating grid connection set")
+    gcs = GridConnectionSet(parent_model = model,
+                            ascii_load_format = 'nexus',
+                            ascii_file = temp_faults,
+                            create_organizing_objects_where_needed = True,
+                            create_transmissibility_multiplier_property = True,
+                            fault_tmult_dict = tmult_dict)
+    gcs.write_hdf5(model.h5_file_name())
+    gcs.create_xml(model.h5_uuid())
 
-   model.store_epc()
+    model.store_epc()
 
-   # clean up
-   temp_combined_file = os.path.join(os.path.dirname(model.epc_file), 'faults_combined_temp.txt')
-   if os.path.exists(temp_combined_file):
-      os.remove(temp_combined_file)
+    # clean up
+    temp_combined_file = os.path.join(os.path.dirname(model.epc_file), 'faults_combined_temp.txt')
+    if os.path.exists(temp_combined_file):
+        os.remove(temp_combined_file)
 
-   log.info("Grid connection set added")
+    log.info("Grid connection set added")
 
-   return gcs.uuid
+    return gcs.uuid
 
 
 # fault face table pandas dataframe functions
@@ -1917,79 +1924,79 @@ def add_connection_set_and_tmults(model, fault_incl, tmult_dict = None):
 
 
 def zero_base_cell_indices_in_faces_df(faces, reverse = False):
-   """Decrements all the cell indices in the fault face dataframe, in situ (or increments if reverse is True)."""
+    """Decrements all the cell indices in the fault face dataframe, in situ (or increments if reverse is True)."""
 
-   if reverse:
-      offset = 1
-   else:
-      offset = -1
-   for col in ['i1', 'i2', 'j1', 'j2', 'k1', 'k2']:
-      temp = faces[col] + offset
-      faces[col] = temp
+    if reverse:
+        offset = 1
+    else:
+        offset = -1
+    for col in ['i1', 'i2', 'j1', 'j2', 'k1', 'k2']:
+        temp = faces[col] + offset
+        faces[col] = temp
 
 
 def standardize_face_indicator_in_faces_df(faces):
-   """Sets face indicators to uppercase I, J or K, always with + or - following direction, in situ."""
+    """Sets face indicators to uppercase I, J or K, always with + or - following direction, in situ."""
 
-   # todo: convert XYZ into IJK respectively?
-   temp = faces['face'].copy().str.upper()
-   temp[faces['face'].str.len() == 1] = faces['face'][faces['face'].str.len() == 1] + '+'
-   for u in temp.unique():
-      s = str(u)
-      assert len(s) == 2, 'incorrect length to face string in fault dataframe: ' + s
-      assert s[0] in 'IJK', 'unknown direction (axis) character in fault dataframe: ' + s
-      assert s[1] in '+-', 'unknown face polarity character in fault dataframe: ' + s
-   faces['face'] = temp
+    # todo: convert XYZ into IJK respectively?
+    temp = faces['face'].copy().str.upper()
+    temp[faces['face'].str.len() == 1] = faces['face'][faces['face'].str.len() == 1] + '+'
+    for u in temp.unique():
+        s = str(u)
+        assert len(s) == 2, 'incorrect length to face string in fault dataframe: ' + s
+        assert s[0] in 'IJK', 'unknown direction (axis) character in fault dataframe: ' + s
+        assert s[1] in '+-', 'unknown face polarity character in fault dataframe: ' + s
+    faces['face'] = temp
 
 
 def remove_external_faces_from_faces_df(faces, extent_kji, remove_all_k_faces = False):
-   """Returns a subset of the rows of faces dataframe, excluding rows on external faces."""
+    """Returns a subset of the rows of faces dataframe, excluding rows on external faces."""
 
-   # NB: assumes cell indices have been converted to zero based
-   # NB: ignores grid column, ie. assumes extent_kji is applicable to all rows
-   # NB: assumes single layer of cells is specified in the direction of the face
-   filtered = []
-   max_k0 = extent_kji[0] - 1
-   max_j0 = extent_kji[1] - 1
-   max_i0 = extent_kji[2] - 1
-   for i in range(len(faces)):
-      entry = faces.iloc[i]
-      f = entry['face']
-      if ((entry['i1'] <= 0 and f == 'I-') or (entry['j1'] <= 0 and f == 'J-') or (entry['k1'] <= 0 and f == 'K-') or
-          (entry['i2'] >= max_i0 and f == 'I+') or (entry['j2'] >= max_j0 and f == 'J+') or
-          (entry['k2'] >= max_k0 and f == 'K+')):
-         continue
-      if remove_all_k_faces and f[0] == 'K':
-         continue
-      filtered.append(i)
-   return faces.loc[filtered]
+    # NB: assumes cell indices have been converted to zero based
+    # NB: ignores grid column, ie. assumes extent_kji is applicable to all rows
+    # NB: assumes single layer of cells is specified in the direction of the face
+    filtered = []
+    max_k0 = extent_kji[0] - 1
+    max_j0 = extent_kji[1] - 1
+    max_i0 = extent_kji[2] - 1
+    for i in range(len(faces)):
+        entry = faces.iloc[i]
+        f = entry['face']
+        if ((entry['i1'] <= 0 and f == 'I-') or (entry['j1'] <= 0 and f == 'J-') or (entry['k1'] <= 0 and f == 'K-') or
+            (entry['i2'] >= max_i0 and f == 'I+') or (entry['j2'] >= max_j0 and f == 'J+') or
+            (entry['k2'] >= max_k0 and f == 'K+')):
+            continue
+        if remove_all_k_faces and f[0] == 'K':
+            continue
+        filtered.append(i)
+    return faces.loc[filtered]
 
 
 def _make_k_gcs_from_cip_list(grid, cip_list, feature_name):
-   # cip (cell index pair) list contains pairs of natural cell indices for which k connection is required
-   # first of pair is layer above (lower k to be precise), second is below (higher k)
-   # called by pinchout_connection_set() and k_gap_connection_set() functions
+    # cip (cell index pair) list contains pairs of natural cell indices for which k connection is required
+    # first of pair is layer above (lower k to be precise), second is below (higher k)
+    # called by pinchout_connection_set() and k_gap_connection_set() functions
 
-   count = len(cip_list)
+    count = len(cip_list)
 
-   if count == 0:
-      return None
+    if count == 0:
+        return None
 
-   pcs = GridConnectionSet(grid.model)
-   pcs.grid_list = [grid]
-   pcs.count = count
-   pcs.grid_index_pairs = np.zeros((count, 2), dtype = int)
-   pcs.cell_index_pairs = np.array(cip_list, dtype = int)
-   pcs.face_index_pairs = np.zeros((count, 2), dtype = int)  # initialize to top faces
-   pcs.face_index_pairs[:, 0] = 1  # bottom face of cells above pinchout
+    pcs = GridConnectionSet(grid.model)
+    pcs.grid_list = [grid]
+    pcs.count = count
+    pcs.grid_index_pairs = np.zeros((count, 2), dtype = int)
+    pcs.cell_index_pairs = np.array(cip_list, dtype = int)
+    pcs.face_index_pairs = np.zeros((count, 2), dtype = int)  # initialize to top faces
+    pcs.face_index_pairs[:, 0] = 1  # bottom face of cells above pinchout
 
-   pcs.feature_indices = np.zeros(count, dtype = int)  # could create seperate features by layer above or below?
-   gbf = rqo.GeneticBoundaryFeature(grid.model, kind = 'horizon', feature_name = feature_name)
-   gbf_root = gbf.create_xml()
-   fi = rqo.HorizonInterpretation(grid.model, genetic_boundary_feature = gbf)
-   fi_root = fi.create_xml(gbf_root, title_suffix = None)
-   fi_uuid = rqet.uuid_for_part_root(fi_root)
+    pcs.feature_indices = np.zeros(count, dtype = int)  # could create seperate features by layer above or below?
+    gbf = rqo.GeneticBoundaryFeature(grid.model, kind = 'horizon', feature_name = feature_name)
+    gbf_root = gbf.create_xml()
+    fi = rqo.HorizonInterpretation(grid.model, genetic_boundary_feature = gbf)
+    fi_root = fi.create_xml(gbf_root, title_suffix = None)
+    fi_uuid = rqet.uuid_for_part_root(fi_root)
 
-   pcs.feature_list = [('obj_HorizonInterpretation', fi_uuid, str(feature_name))]
+    pcs.feature_list = [('obj_HorizonInterpretation', fi_uuid, str(feature_name))]
 
-   return pcs
+    return pcs

--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -44,51 +44,51 @@ always_write_cell_geometry_is_defined_array = False
 
 
 def _add_to_kelp_list(extent_kji, kelp_list, face_axis, ji):
-   """
+    """
       :meta private:
    """
-   if isinstance(face_axis, bool):
-      face_axis = 'J' if face_axis else 'I'
-   # ignore external faces
-   if face_axis == 'J':
-      if ji[0] < 0 or ji[0] >= extent_kji[1] - 1:
-         return
-   elif face_axis == 'I':
-      if ji[1] < 0 or ji[1] >= extent_kji[2] - 1:
-         return
-   else:  # ji is actually kj or ki
-      assert face_axis == 'K'
-      if ji[0] < 0 or ji[0] >= extent_kji[0] - 1:
-         return
-   pair = ji
-   if pair in kelp_list:
-      return  # avoid duplication
-   kelp_list.append(pair)
+    if isinstance(face_axis, bool):
+        face_axis = 'J' if face_axis else 'I'
+    # ignore external faces
+    if face_axis == 'J':
+        if ji[0] < 0 or ji[0] >= extent_kji[1] - 1:
+            return
+    elif face_axis == 'I':
+        if ji[1] < 0 or ji[1] >= extent_kji[2] - 1:
+            return
+    else:  # ji is actually kj or ki
+        assert face_axis == 'K'
+        if ji[0] < 0 or ji[0] >= extent_kji[0] - 1:
+            return
+    pair = ji
+    if pair in kelp_list:
+        return  # avoid duplication
+    kelp_list.append(pair)
 
 
 class Grid(BaseResqpy):
-   """Class for RESQML Grid (extent and geometry) within RESQML model object."""
+    """Class for RESQML Grid (extent and geometry) within RESQML model object."""
 
-   resqml_type = 'IjkGridRepresentation'
+    resqml_type = 'IjkGridRepresentation'
 
-   @property
-   def nk_plus_k_gaps(self):
-      if self.nk is None:
-         return None
-      if self.k_gaps is None:
-         return self.nk
-      return self.nk + self.k_gaps
+    @property
+    def nk_plus_k_gaps(self):
+        if self.nk is None:
+            return None
+        if self.k_gaps is None:
+            return self.nk
+        return self.nk + self.k_gaps
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                grid_root = None,
-                find_properties = True,
-                geometry_required = True,
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Create a Grid object and optionally populate from xml tree.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 grid_root = None,
+                 find_properties = True,
+                 geometry_required = True,
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Create a Grid object and optionally populate from xml tree.
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -114,100 +114,100 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      # note: currently only handles IJK grids
-      # todo: check grid_root, if passed, is for an IJK grid
-      self.parent_grid_uuid = None  #: parent grid when this is a local grid
-      self.parent_window = None  #: FineCoarse cell index mapping info between self and parent grid
-      self.is_refinement = None  #: True indicates self is a refinement wrt. parent; False means coarsening
-      self.local_grid_uuid_list = None  #: LGR & LGC children list
-      self.grid_representation = None  #: flavour of grid, currently 'IjkGrid' or 'IjkBlockGrid'; not much used
-      self.geometry_root = None  #: xml node at root of geometry sub-tree
-      self.extent_kji = None  #: size of grid: (nk, nj, ni)
-      self.ni = self.nj = self.nk = None  #: duplicated extent information as individual integers
-      self.crs_uuid = None  #: uuid of the coordinate reference system used by the grid's geometry
-      self.crs_root = None  #: xml root node for the crs used by the grid's geometry
-      self.points_cached = None  #: numpy array of raw points data; loaded on demand
-      # Following are only relevant to structured grid varieties
-      self.grid_is_right_handed = None  #: boolean indicating ijk handedness
-      self.k_direction_is_down = None  #: boolean indicating dominant direction of k increase
-      self.pillar_shape = None  #: string: often 'curved' is used, even for straight pillars
-      self.has_split_coordinate_lines = None  #: boolean; affects dimensionality of points array
-      self.split_pillars_count = None  #: int
-      self.k_gaps = None  #: int; number of k gaps, or None
-      self.k_gap_after_array = None  #: 1D numpy bool array of extent nk-1, or None
-      self.k_raw_index_array = None  #: 1D numpy int array of extent nk, or None
-      self.geometry_defined_for_all_pillars_cached = None
-      self.geometry_defined_for_all_cells_cached = None
-      self.xyz_box_cached = None  #: numpy array of shape (2, 3) being (min max, x y z)
-      self.property_collection = None  #: GridPropertyCollection object
-      self.inactive = None  #: numpy bool array: inactive cell mask (not native resqml - derived from active property)
-      self.all_inactive = None  #: numpy bool indicating whether all cells are inactive
-      self.active_property_uuid = None  #: uuid of property holding active cell boolean array (used to populate inactive)
-      self.pinchout = None  #: numpy bool array: pinchout mask, only set on demand (not native resqml)
-      self.grid_skin = None  #: outer skin of grid as a GridSkin object, computed and cached on demand
-      self.stratigraphic_column_rank_uuid = None  #: optional reference for interpreting stratigraphic units
-      self.stratigraphic_units = None  #: optional array of unit indices (one per layer or K gap)
-      self.time_index = None  #: optional time index for dynamic geometry
-      self.time_series_uuid = None  #: optional time series for dynamic geometry
+        # note: currently only handles IJK grids
+        # todo: check grid_root, if passed, is for an IJK grid
+        self.parent_grid_uuid = None  #: parent grid when this is a local grid
+        self.parent_window = None  #: FineCoarse cell index mapping info between self and parent grid
+        self.is_refinement = None  #: True indicates self is a refinement wrt. parent; False means coarsening
+        self.local_grid_uuid_list = None  #: LGR & LGC children list
+        self.grid_representation = None  #: flavour of grid, currently 'IjkGrid' or 'IjkBlockGrid'; not much used
+        self.geometry_root = None  #: xml node at root of geometry sub-tree
+        self.extent_kji = None  #: size of grid: (nk, nj, ni)
+        self.ni = self.nj = self.nk = None  #: duplicated extent information as individual integers
+        self.crs_uuid = None  #: uuid of the coordinate reference system used by the grid's geometry
+        self.crs_root = None  #: xml root node for the crs used by the grid's geometry
+        self.points_cached = None  #: numpy array of raw points data; loaded on demand
+        # Following are only relevant to structured grid varieties
+        self.grid_is_right_handed = None  #: boolean indicating ijk handedness
+        self.k_direction_is_down = None  #: boolean indicating dominant direction of k increase
+        self.pillar_shape = None  #: string: often 'curved' is used, even for straight pillars
+        self.has_split_coordinate_lines = None  #: boolean; affects dimensionality of points array
+        self.split_pillars_count = None  #: int
+        self.k_gaps = None  #: int; number of k gaps, or None
+        self.k_gap_after_array = None  #: 1D numpy bool array of extent nk-1, or None
+        self.k_raw_index_array = None  #: 1D numpy int array of extent nk, or None
+        self.geometry_defined_for_all_pillars_cached = None
+        self.geometry_defined_for_all_cells_cached = None
+        self.xyz_box_cached = None  #: numpy array of shape (2, 3) being (min max, x y z)
+        self.property_collection = None  #: GridPropertyCollection object
+        self.inactive = None  #: numpy bool array: inactive cell mask (not native resqml - derived from active property)
+        self.all_inactive = None  #: numpy bool indicating whether all cells are inactive
+        self.active_property_uuid = None  #: uuid of property holding active cell boolean array (used to populate inactive)
+        self.pinchout = None  #: numpy bool array: pinchout mask, only set on demand (not native resqml)
+        self.grid_skin = None  #: outer skin of grid as a GridSkin object, computed and cached on demand
+        self.stratigraphic_column_rank_uuid = None  #: optional reference for interpreting stratigraphic units
+        self.stratigraphic_units = None  #: optional array of unit indices (one per layer or K gap)
+        self.time_index = None  #: optional time index for dynamic geometry
+        self.time_series_uuid = None  #: optional time series for dynamic geometry
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = grid_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = grid_root)
 
-      if not self.title:
-         self.title = 'ROOT'
+        if not self.title:
+            self.title = 'ROOT'
 
-      if (uuid is not None or grid_root is not None):
-         if geometry_required:
-            assert self.geometry_root is not None, 'grid geometry not present in xml'
-         if find_properties:
-            self.extract_property_collection()
+        if (uuid is not None or grid_root is not None):
+            if geometry_required:
+                assert self.geometry_root is not None, 'grid geometry not present in xml'
+            if find_properties:
+                self.extract_property_collection()
 
-   def _load_from_xml(self):
-      # Extract simple attributes from xml and set as attributes in this resqpy object
-      grid_root = self.root
-      assert grid_root is not None
-      self.grid_representation = 'IjkGrid'  # this attribute not much used
-      self.extract_extent_kji()
-      self.nk = self.extent_kji[0]  # for convenience available as individual attribs as well as np triplet
-      self.nj = self.extent_kji[1]
-      self.ni = self.extent_kji[2]
-      self.geometry_root = rqet.find_tag(grid_root, 'Geometry')
-      if self.geometry_root is None:
-         self.geometry_defined_for_all_pillars_cached = True
-         self.geometry_defined_for_all_cells_cached = True
-         self.pillar_shape = 'straight'
-         self.has_split_coordinate_lines = False
-         self.k_direction_is_down = True  # arbitrary, as 'down' is rather meaningless without a crs
-      else:
-         self.extract_crs_root()
-         self.extract_crs_uuid()
-         self.extract_has_split_coordinate_lines()
-         self.extract_grid_is_right_handed()
-         self.pillar_geometry_is_defined()  # note: if there is no geometry at all, resqpy sets this True
-         self.cell_geometry_is_defined()  # note: if there is no geometry at all, resqpy sets this True
-         self.extract_pillar_shape()
-         self.extract_k_direction_is_down()
-         self.extract_geometry_time_index()
-      self.extract_k_gaps()
-      if self.geometry_root is None:
-         assert not self.k_gaps, 'K gaps present in grid without geometry'
-      self.extract_parent()
-      self.extract_children()
-      #        self.create_column_pillar_mapping()  # mapping now created on demand in other methods
-      self.extract_inactive_mask()
-      self.extract_stratigraphy()
+    def _load_from_xml(self):
+        # Extract simple attributes from xml and set as attributes in this resqpy object
+        grid_root = self.root
+        assert grid_root is not None
+        self.grid_representation = 'IjkGrid'  # this attribute not much used
+        self.extract_extent_kji()
+        self.nk = self.extent_kji[0]  # for convenience available as individual attribs as well as np triplet
+        self.nj = self.extent_kji[1]
+        self.ni = self.extent_kji[2]
+        self.geometry_root = rqet.find_tag(grid_root, 'Geometry')
+        if self.geometry_root is None:
+            self.geometry_defined_for_all_pillars_cached = True
+            self.geometry_defined_for_all_cells_cached = True
+            self.pillar_shape = 'straight'
+            self.has_split_coordinate_lines = False
+            self.k_direction_is_down = True  # arbitrary, as 'down' is rather meaningless without a crs
+        else:
+            self.extract_crs_root()
+            self.extract_crs_uuid()
+            self.extract_has_split_coordinate_lines()
+            self.extract_grid_is_right_handed()
+            self.pillar_geometry_is_defined()  # note: if there is no geometry at all, resqpy sets this True
+            self.cell_geometry_is_defined()  # note: if there is no geometry at all, resqpy sets this True
+            self.extract_pillar_shape()
+            self.extract_k_direction_is_down()
+            self.extract_geometry_time_index()
+        self.extract_k_gaps()
+        if self.geometry_root is None:
+            assert not self.k_gaps, 'K gaps present in grid without geometry'
+        self.extract_parent()
+        self.extract_children()
+        #        self.create_column_pillar_mapping()  # mapping now created on demand in other methods
+        self.extract_inactive_mask()
+        self.extract_stratigraphy()
 
-   @property
-   def grid_root(self):
-      """Alias for root"""
-      return self.root
+    @property
+    def grid_root(self):
+        """Alias for root"""
+        return self.root
 
-   def set_modified(self, update_xml = False, update_hdf5 = False):
-      """Assigns a new uuid to this grid; also calls set_modified() for parent model.
+    def set_modified(self, update_xml = False, update_hdf5 = False):
+        """Assigns a new uuid to this grid; also calls set_modified() for parent model.
 
       arguments:
          update_xml (boolean, default False): if True, the uuid is modified in the xml tree
@@ -229,28 +229,28 @@ class Grid(BaseResqpy):
          hdf5 external part
       """
 
-      old_uuid = self.uuid
-      self.uuid = bu.new_uuid()
-      if old_uuid is not None:
-         log.info('changing uuid for grid from: ' + str(old_uuid) + ' to: ' + str(self.uuid))
-      else:
-         log.info('setting new uuid for grid: ' + str(self.uuid))
-      if update_xml:
-         rqet.patch_uuid_in_part_root(self.root, self.uuid)
-         self.model.add_part('obj_IjkGridRepresentation', self.uuid, self.root)
-         self.model.remove_part(rqet.part_name_for_object('obj_IjkGridRepresentation', old_uuid))
-      if update_hdf5:
-         hdf5_uuid_list = self.model.h5_uuid_list(self.root)
-         for ext_uuid in hdf5_uuid_list:
-            hdf5_file = self.model.h5_access(ext_uuid, mode = 'r+')
-            rwh5.change_uuid(hdf5_file, old_uuid, self.uuid)
-      if update_xml and update_hdf5:
-         self.model.change_uuid_in_hdf5_references(self.root, old_uuid, self.uuid)
-      self.model.set_modified()
-      return self.uuid
+        old_uuid = self.uuid
+        self.uuid = bu.new_uuid()
+        if old_uuid is not None:
+            log.info('changing uuid for grid from: ' + str(old_uuid) + ' to: ' + str(self.uuid))
+        else:
+            log.info('setting new uuid for grid: ' + str(self.uuid))
+        if update_xml:
+            rqet.patch_uuid_in_part_root(self.root, self.uuid)
+            self.model.add_part('obj_IjkGridRepresentation', self.uuid, self.root)
+            self.model.remove_part(rqet.part_name_for_object('obj_IjkGridRepresentation', old_uuid))
+        if update_hdf5:
+            hdf5_uuid_list = self.model.h5_uuid_list(self.root)
+            for ext_uuid in hdf5_uuid_list:
+                hdf5_file = self.model.h5_access(ext_uuid, mode = 'r+')
+                rwh5.change_uuid(hdf5_file, old_uuid, self.uuid)
+        if update_xml and update_hdf5:
+            self.model.change_uuid_in_hdf5_references(self.root, old_uuid, self.uuid)
+        self.model.set_modified()
+        return self.uuid
 
-   def extract_extent_kji(self):
-      """Returns the grid extent; for IJK grids this is a 3 integer numpy array, order is Nk, Nj, Ni.
+    def extract_extent_kji(self):
+        """Returns the grid extent; for IJK grids this is a 3 integer numpy array, order is Nk, Nj, Ni.
 
       returns:
          numpy int array of shape (3,) being number of cells in k, j & i axes respectively;
@@ -258,16 +258,16 @@ class Grid(BaseResqpy):
          directly by calling code as the value is set from xml on initialisation
       """
 
-      if self.extent_kji is not None:
-         return self.extent_kji
-      self.extent_kji = np.ones(3, dtype = 'int')  # todo: handle other varieties of grid
-      self.extent_kji[0] = int(rqet.find_tag(self.root, 'Nk').text)
-      self.extent_kji[1] = int(rqet.find_tag(self.root, 'Nj').text)
-      self.extent_kji[2] = int(rqet.find_tag(self.root, 'Ni').text)
-      return self.extent_kji
+        if self.extent_kji is not None:
+            return self.extent_kji
+        self.extent_kji = np.ones(3, dtype = 'int')  # todo: handle other varieties of grid
+        self.extent_kji[0] = int(rqet.find_tag(self.root, 'Nk').text)
+        self.extent_kji[1] = int(rqet.find_tag(self.root, 'Nj').text)
+        self.extent_kji[2] = int(rqet.find_tag(self.root, 'Ni').text)
+        return self.extent_kji
 
-   def cell_count(self, active_only = False, non_pinched_out_only = False, geometry_defined_only = False):
-      """Returns number of cells in grid; optionally limited by active, non-pinched-out, or having geometry.
+    def cell_count(self, active_only = False, non_pinched_out_only = False, geometry_defined_only = False):
+        """Returns number of cells in grid; optionally limited by active, non-pinched-out, or having geometry.
 
       arguments:
          active_only (boolean, default False): if True, the count of active cells is returned
@@ -280,32 +280,32 @@ class Grid(BaseResqpy):
          integer being the number of cells in the grid
       """
 
-      # todo: elsewhere: setting of active array from boolean array or zero pore volume
-      if not (active_only or non_pinched_out_only or geometry_defined_only):
-         return np.prod(self.extent_kji)
-      if non_pinched_out_only:
-         self.pinched_out(cache_pinchout_array = True)
-         return self.pinchout.size - np.count_nonzero(self.pinchout)
-      if active_only:
-         if self.all_inactive:
-            return 0
-         if self.inactive is not None:
-            return self.inactive.size - np.count_nonzero(self.inactive)
-         else:
-            geometry_defined_only = True
-      if geometry_defined_only:
-         if self.geometry_defined_for_all_cells(cache_array = True):
+        # todo: elsewhere: setting of active array from boolean array or zero pore volume
+        if not (active_only or non_pinched_out_only or geometry_defined_only):
             return np.prod(self.extent_kji)
-         return np.count_nonzero(self.array_cell_geometry_is_defined)
-      return None
+        if non_pinched_out_only:
+            self.pinched_out(cache_pinchout_array = True)
+            return self.pinchout.size - np.count_nonzero(self.pinchout)
+        if active_only:
+            if self.all_inactive:
+                return 0
+            if self.inactive is not None:
+                return self.inactive.size - np.count_nonzero(self.inactive)
+            else:
+                geometry_defined_only = True
+        if geometry_defined_only:
+            if self.geometry_defined_for_all_cells(cache_array = True):
+                return np.prod(self.extent_kji)
+            return np.count_nonzero(self.array_cell_geometry_is_defined)
+        return None
 
-   def natural_cell_index(self, cell_kji0):
-      """Returns a single integer for the cell, being the index into a flattened array."""
+    def natural_cell_index(self, cell_kji0):
+        """Returns a single integer for the cell, being the index into a flattened array."""
 
-      return (cell_kji0[0] * self.nj + cell_kji0[1]) * self.ni + cell_kji0[2]
+        return (cell_kji0[0] * self.nj + cell_kji0[1]) * self.ni + cell_kji0[2]
 
-   def natural_cell_indices(self, cell_kji0s):
-      """Returns a numpy integer array with a value for each of the cells, being the index into a flattened array.
+    def natural_cell_indices(self, cell_kji0s):
+        """Returns a numpy integer array with a value for each of the cells, being the index into a flattened array.
 
       argument:
          cell_kji0s: numpy integer array of shape (..., 3) being a list of cell indices in kji0 protocol
@@ -314,17 +314,17 @@ class Grid(BaseResqpy):
          numpy integer array of shape (...,) being the equivalent natural cell indices (for a flattened array of cells)
       """
 
-      return (cell_kji0s[..., 0] * self.nj + cell_kji0s[..., 1]) * self.ni + cell_kji0s[..., 2]
+        return (cell_kji0s[..., 0] * self.nj + cell_kji0s[..., 1]) * self.ni + cell_kji0s[..., 2]
 
-   def denaturalized_cell_index(self, c0):
-      """Returns a 3 element cell_kji0 index (as a tuple) for the cell with given natural index."""
+    def denaturalized_cell_index(self, c0):
+        """Returns a 3 element cell_kji0 index (as a tuple) for the cell with given natural index."""
 
-      k0, ji0 = divmod(c0, self.nj * self.ni)
-      j0, i0 = divmod(ji0, self.ni)
-      return (k0, j0, i0)
+        k0, ji0 = divmod(c0, self.nj * self.ni)
+        j0, i0 = divmod(ji0, self.ni)
+        return (k0, j0, i0)
 
-   def denaturalized_cell_indices(self, c0s):
-      """Returns an integer numpy array of shape (..., 3) holding kji0 indices for the cells with given natural indices.
+    def denaturalized_cell_indices(self, c0s):
+        """Returns an integer numpy array of shape (..., 3) holding kji0 indices for the cells with given natural indices.
 
       argument:
          c0s: numpy integer array of shape (...,) being natural cell indices (for a flattened array)
@@ -333,12 +333,12 @@ class Grid(BaseResqpy):
          numpy integer array of shape (..., 3) being the equivalent kji0 protocol cell indices
       """
 
-      k0s, ji0s = divmod(c0s, self.nj * self.ni)
-      j0s, i0s = divmod(ji0s, self.ni)
-      return np.stack((k0s, j0s, i0s), axis = -1)
+        k0s, ji0s = divmod(c0s, self.nj * self.ni)
+        j0s, i0s = divmod(ji0s, self.ni)
+        return np.stack((k0s, j0s, i0s), axis = -1)
 
-   def resolve_geometry_child(self, tag, child_node = None):
-      """If xml child node is None, looks for tag amongst children of geometry root.
+    def resolve_geometry_child(self, tag, child_node = None):
+        """If xml child node is None, looks for tag amongst children of geometry root.
 
       arguments:
          tag (string): the tag of the geometry child node of interest
@@ -352,27 +352,27 @@ class Grid(BaseResqpy):
          if child_node is None, the geometry node for this grid is scanned for a child with matching tag
       """
 
-      if child_node is not None:
-         return child_node
-      return rqet.find_tag(self.geometry_root, tag)
+        if child_node is not None:
+            return child_node
+        return rqet.find_tag(self.geometry_root, tag)
 
-   def extract_crs_uuid(self):
-      """Returns uuid for coordinate reference system, as stored in geometry xml tree.
+    def extract_crs_uuid(self):
+        """Returns uuid for coordinate reference system, as stored in geometry xml tree.
 
       returns:
          uuid.UUID object
       """
 
-      if self.crs_uuid is not None:
-         return self.crs_uuid
-      crs_root = self.resolve_geometry_child('LocalCrs')
-      uuid_str = rqet.find_tag_text(crs_root, 'UUID')
-      if uuid_str:
-         self.crs_uuid = bu.uuid_from_string(uuid_str)
-      return self.crs_uuid
+        if self.crs_uuid is not None:
+            return self.crs_uuid
+        crs_root = self.resolve_geometry_child('LocalCrs')
+        uuid_str = rqet.find_tag_text(crs_root, 'UUID')
+        if uuid_str:
+            self.crs_uuid = bu.uuid_from_string(uuid_str)
+        return self.crs_uuid
 
-   def extract_crs_root(self):
-      """Returns root in parent model xml parts forest of coordinate reference system used by this grid geomwtry.
+    def extract_crs_root(self):
+        """Returns root in parent model xml parts forest of coordinate reference system used by this grid geomwtry.
 
       returns:
          root node in xml tree for coordinate reference system
@@ -383,16 +383,16 @@ class Grid(BaseResqpy):
          if the crs is not present, this method will return None (I think)
       """
 
-      if self.crs_root is not None:
-         return self.crs_root
-      crs_uuid = self.extract_crs_uuid()
-      if crs_uuid is None:
-         return None
-      self.crs_root = self.model.root(uuid = crs_uuid)
-      return self.crs_root
+        if self.crs_root is not None:
+            return self.crs_root
+        crs_uuid = self.extract_crs_uuid()
+        if crs_uuid is None:
+            return None
+        self.crs_root = self.model.root(uuid = crs_uuid)
+        return self.crs_root
 
-   def extract_grid_is_right_handed(self):
-      """Returns boolean indicating whether grid IJK axes are right handed, as stored in xml.
+    def extract_grid_is_right_handed(self):
+        """Returns boolean indicating whether grid IJK axes are right handed, as stored in xml.
 
       returns:
          boolean: True if grid is right handed; False if left handed
@@ -405,16 +405,16 @@ class Grid(BaseResqpy):
          handedness of the IJK space with respect to the xyz space that matters)
       """
 
-      if self.grid_is_right_handed is not None:
-         return self.grid_is_right_handed
-      rh_node = self.resolve_geometry_child('GridIsRighthanded')
-      if rh_node is None:
-         return None
-      self.grid_is_right_handed = (rh_node.text.lower() == 'true')
-      return self.grid_is_right_handed
+        if self.grid_is_right_handed is not None:
+            return self.grid_is_right_handed
+        rh_node = self.resolve_geometry_child('GridIsRighthanded')
+        if rh_node is None:
+            return None
+        self.grid_is_right_handed = (rh_node.text.lower() == 'true')
+        return self.grid_is_right_handed
 
-   def extract_k_direction_is_down(self):
-      """Returns boolean indicating whether increasing K indices are generally for deeper cells, as stored in xml.
+    def extract_k_direction_is_down(self):
+        """Returns boolean indicating whether increasing K indices are generally for deeper cells, as stored in xml.
 
       returns:
          boolean: True if increasing K generally indicates increasing depth
@@ -427,49 +427,49 @@ class Grid(BaseResqpy):
          this method does not modify the grid_is_righthanded indicator
       """
 
-      if self.k_direction_is_down is not None:
-         return self.k_direction_is_down
-      k_dir_node = self.resolve_geometry_child('KDirection')
-      if k_dir_node is None:
-         return None
-      self.k_direction_is_down = (k_dir_node.text.lower() == 'down')
-      return self.k_direction_is_down
+        if self.k_direction_is_down is not None:
+            return self.k_direction_is_down
+        k_dir_node = self.resolve_geometry_child('KDirection')
+        if k_dir_node is None:
+            return None
+        self.k_direction_is_down = (k_dir_node.text.lower() == 'down')
+        return self.k_direction_is_down
 
-   def extract_geometry_time_index(self):
-      """Returns integer time index, or None, for the grid geometry, as stored in xml for dynamic geometries.
+    def extract_geometry_time_index(self):
+        """Returns integer time index, or None, for the grid geometry, as stored in xml for dynamic geometries.
 
       notes:
          if the value is not None, it represents the time index as stored in the xml, or the time index as
          updated when setting the node points from a points property
       """
-      if self.time_index is not None and self.time_series_uuid is not None:
-         return self.time_index
-      self.time_index = None
-      self.time_series_uuid = None
-      ti_node = self.resolve_geometry_child('TimeIndex')
-      if ti_node is None:
-         return None
-      self.time_index = rqet.find_tag_int(ti_node, 'Index')
-      self.time_series_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(ti_node, ['TimeSeries', 'UUID']))
-      return self.time_index
+        if self.time_index is not None and self.time_series_uuid is not None:
+            return self.time_index
+        self.time_index = None
+        self.time_series_uuid = None
+        ti_node = self.resolve_geometry_child('TimeIndex')
+        if ti_node is None:
+            return None
+        self.time_index = rqet.find_tag_int(ti_node, 'Index')
+        self.time_series_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(ti_node, ['TimeSeries', 'UUID']))
+        return self.time_index
 
-   def set_k_direction_from_points(self):
-      """Sets the K direction indicator based on z direction and mean z values for top and base.
+    def set_k_direction_from_points(self):
+        """Sets the K direction indicator based on z direction and mean z values for top and base.
 
       note:
          this method does not modify the grid_is_righthanded indicator
       """
 
-      p = self.points_ref(masked = False)
-      self.k_direction_is_down = True  # arbitrary default
-      if p is not None:
-         diff = np.nanmean(p[-1] - p[0])
-         if not np.isnan(diff):
-            self.k_direction_is_down = ((diff >= 0.0) == self.z_inc_down())
-      return self.k_direction_is_down
+        p = self.points_ref(masked = False)
+        self.k_direction_is_down = True  # arbitrary default
+        if p is not None:
+            diff = np.nanmean(p[-1] - p[0])
+            if not np.isnan(diff):
+                self.k_direction_is_down = ((diff >= 0.0) == self.z_inc_down())
+        return self.k_direction_is_down
 
-   def extract_pillar_shape(self):
-      """Returns string indicating whether whether pillars are curved, straight, or vertical as stored in xml.
+    def extract_pillar_shape(self):
+        """Returns string indicating whether whether pillars are curved, straight, or vertical as stored in xml.
 
       returns:
          string: either 'curved', 'straight' or 'vertical'
@@ -479,16 +479,16 @@ class Grid(BaseResqpy):
          use actual_pillar_shape() method to determine the shape from the actual xyz points data
       """
 
-      if self.pillar_shape is not None:
-         return self.pillar_shape
-      ps_node = self.resolve_geometry_child('PillarShape')
-      if ps_node is None:
-         return None
-      self.pillar_shape = ps_node.text
-      return self.pillar_shape
+        if self.pillar_shape is not None:
+            return self.pillar_shape
+        ps_node = self.resolve_geometry_child('PillarShape')
+        if ps_node is None:
+            return None
+        self.pillar_shape = ps_node.text
+        return self.pillar_shape
 
-   def extract_has_split_coordinate_lines(self):
-      """Returns boolean indicating whether grid geometry has any split coordinate lines (split pillars, ie. faults).
+    def extract_has_split_coordinate_lines(self):
+        """Returns boolean indicating whether grid geometry has any split coordinate lines (split pillars, ie. faults).
 
       returns:
          boolean: True if the grid has one or more split pillars; False if all pillars are unsplit
@@ -501,16 +501,16 @@ class Grid(BaseResqpy):
          range of nk+k_gaps+1, nj+1, ni+1 respectively)
       """
 
-      if self.has_split_coordinate_lines is not None:
-         return self.has_split_coordinate_lines
-      split_node = self.resolve_geometry_child('SplitCoordinateLines')
-      self.has_split_coordinate_lines = (split_node is not None)
-      if split_node is not None:
-         self.split_pillars_count = int(rqet.find_tag(split_node, 'Count').text.strip())
-      return self.has_split_coordinate_lines
+        if self.has_split_coordinate_lines is not None:
+            return self.has_split_coordinate_lines
+        split_node = self.resolve_geometry_child('SplitCoordinateLines')
+        self.has_split_coordinate_lines = (split_node is not None)
+        if split_node is not None:
+            self.split_pillars_count = int(rqet.find_tag(split_node, 'Count').text.strip())
+        return self.has_split_coordinate_lines
 
-   def extract_k_gaps(self):
-      """Returns information about gaps (voids) between layers in the grid.
+    def extract_k_gaps(self):
+        """Returns information about gaps (voids) between layers in the grid.
 
       returns:
          (int, numpy bool array, numpy int array) being the number of gaps between layers;
@@ -525,255 +525,258 @@ class Grid(BaseResqpy):
          layer and the successor in k will always index the basal face of the same layer
       """
 
-      if self.k_gaps is not None:
-         return self.k_gaps, self.k_gap_after_array, self.k_raw_index_array
-      self.k_gaps = rqet.find_nested_tags_int(self.root, ['KGaps', 'Count'])
-      if self.k_gaps:
-         k_gap_after_root = rqet.find_nested_tags(self.root, ['KGaps', 'GapAfterLayer'])
-         assert k_gap_after_root is not None
-         bool_array_type = rqet.node_type(k_gap_after_root)
-         assert bool_array_type == 'BooleanHdf5Array'  # could be a constant array but not handled by this code
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(k_gap_after_root)
-         assert h5_key_pair is not None
-         self.model.h5_array_element(h5_key_pair,
-                                     index = None,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'k_gap_after_array',
-                                     dtype = 'bool')
-         assert hasattr(self, 'k_gap_after_array')
-         assert self.k_gap_after_array.ndim == 1 and self.k_gap_after_array.size == self.nk - 1
-         self._set_k_raw_index_array()
-      else:
-         self.k_gap_after_array = None
-         self.k_raw_index_array = np.arange(self.nk, dtype = int)
-      return self.k_gaps, self.k_gap_after_array, self.k_raw_index_array
-
-   def _set_k_raw_index_array(self):
-      """Sets the layering raw index array based on the k gap after boolean array."""
-      if self.k_gap_after_array is None:
-         self.k_raw_index_array = None
-         return
-      self.k_raw_index_array = np.empty((self.nk,), dtype = int)
-      gap_count = 0
-      for k in range(self.nk):
-         self.k_raw_index_array[k] = k + gap_count
-         if k < self.nk - 1 and self.k_gap_after_array[k]:
-            gap_count += 1
-      assert gap_count == self.k_gaps, 'inconsistency in k gap data'
-
-   def extract_stratigraphy(self):
-      """Loads stratigraphic information from xml."""
-
-      self.stratigraphic_column_rank_uuid = None
-      self.stratigraphic_units = None
-      strata_node = rqet.find_tag(self.root, 'IntervalStratigraphicUnits')
-      if strata_node is None:
-         return
-      self.stratigraphic_column_rank_uuid =  \
-         bu.uuid_from_string(rqet.find_nested_tags_text(strata_node, ['StratigraphicOrganization', 'UUID']))
-      assert self.stratigraphic_column_rank_uuid is not None
-      unit_indices_node = rqet.find_tag(strata_node, 'UnitIndices')
-      h5_key_pair = self.model.h5_uuid_and_path_for_node(unit_indices_node)
-      self.model.h5_array_element(h5_key_pair,
-                                  index = None,
-                                  cache_array = True,
-                                  object = self,
-                                  array_attribute = 'stratigraphic_units',
-                                  dtype = 'int')
-      assert len(self.stratigraphic_units) == self.nk_plus_k_gaps
-
-   def extract_parent(self):
-      """Loads fine:coarse mapping information between this grid and parent, if any, returning parent grid uuid."""
-
-      class IntervalsInfo:
-
-         def __init__(self):
-            pass
-
-      if self.extent_kji is None:
-         self.extract_extent_kji()
-      if self.parent_grid_uuid is not None:
-         return self.parent_grid_uuid
-      self.parent_window = None  # FineCoarse cell index mapping info with respect to parent
-      self.is_refinement = None
-      pw_node = rqet.find_tag(self.root, 'ParentWindow')
-      if pw_node is None:
-         return None
-      # load a FineCoarse object as parent_window attirbute and set parent_grid_uuid attribute
-      self.parent_grid_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(pw_node, ['ParentGrid', 'UUID']))
-      assert self.parent_grid_uuid is not None
-      parent_grid_root = self.model.root(uuid = self.parent_grid_uuid)
-      if parent_grid_root is None:
-         log.warning('parent grid not present in model, unable to treat as local grid')
-         return None
-      # etxract parent grid extent directly from xml to avoid risk of circular references
-      parent_grid_extent_kji = np.array((rqet.find_tag_int(
-         parent_grid_root, 'Nk'), rqet.find_tag_int(parent_grid_root, 'Nj'), rqet.find_tag_int(parent_grid_root, 'Ni')),
-                                        dtype = int)
-      parent_initials = []
-      intervals_count_list = []
-      parent_count_list_list = []
-      child_count_list_list = []
-      child_weight_list_list = []
-      refining_flag = None  # gets set True if local grid is a refinement, False if a coarsening
-      parent_box = np.zeros((2, 3), dtype = int)
-      for axis in range(3):
-         regrid_node = rqet.find_tag(pw_node, 'KJI'[axis] + 'Regrid')
-         assert regrid_node is not None
-         pii = rqet.find_tag_int(regrid_node, 'InitialIndexOnParentGrid')
-         assert pii is not None and 0 <= pii < parent_grid_extent_kji[axis]
-         parent_initials.append(pii)
-         parent_box[0, axis] = pii
-         intervals_node = rqet.find_tag(regrid_node, 'Intervals')
-         if intervals_node is None:  # implicit one-to-one mapping
-            intervals_count_list.append(1)
-            parent_count_list_list.append(np.array(self.extent_kji[axis], dtype = int))
-            parent_box[1, axis] = parent_box[0, axis] + self.extent_kji[axis] - 1
-            assert parent_box[1, axis] < parent_grid_extent_kji[axis]
-            child_count_list_list.append(np.array(self.extent_kji[axis], dtype = int))
-            child_weight_list_list.append(None)
-         else:
-            intervals_info = IntervalsInfo()
-            intervals_count = rqet.find_tag_int(intervals_node, 'IntervalCount')
-            assert intervals_count is not None and intervals_count > 0
-            pcpi_node = rqet.find_tag(intervals_node, 'ParentCountPerInterval')
-            assert pcpi_node is not None
-            h5_key_pair = self.model.h5_uuid_and_path_for_node(pcpi_node)
+        if self.k_gaps is not None:
+            return self.k_gaps, self.k_gap_after_array, self.k_raw_index_array
+        self.k_gaps = rqet.find_nested_tags_int(self.root, ['KGaps', 'Count'])
+        if self.k_gaps:
+            k_gap_after_root = rqet.find_nested_tags(self.root, ['KGaps', 'GapAfterLayer'])
+            assert k_gap_after_root is not None
+            bool_array_type = rqet.node_type(k_gap_after_root)
+            assert bool_array_type == 'BooleanHdf5Array'  # could be a constant array but not handled by this code
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(k_gap_after_root)
             assert h5_key_pair is not None
             self.model.h5_array_element(h5_key_pair,
                                         index = None,
                                         cache_array = True,
-                                        object = intervals_info,
-                                        array_attribute = 'parent_count_per_interval',
-                                        dtype = 'int')
-            assert hasattr(intervals_info, 'parent_count_per_interval')
-            assert intervals_info.parent_count_per_interval.ndim == 1 and intervals_info.parent_count_per_interval.size == intervals_count
-            parent_box[1, axis] = parent_box[0, axis] + np.sum(intervals_info.parent_count_per_interval) - 1
-            assert parent_box[1, axis] < parent_grid_extent_kji[axis]
-            ccpi_node = rqet.find_tag(intervals_node, 'ChildCountPerInterval')
-            assert ccpi_node is not None
-            h5_key_pair = self.model.h5_uuid_and_path_for_node(ccpi_node)
-            assert h5_key_pair is not None
-            self.model.h5_array_element(h5_key_pair,
-                                        index = None,
-                                        cache_array = True,
-                                        object = intervals_info,
-                                        array_attribute = 'child_count_per_interval',
-                                        dtype = 'int')
-            assert hasattr(intervals_info, 'child_count_per_interval')
-            assert intervals_info.child_count_per_interval.ndim == 1 and intervals_info.child_count_per_interval.size == intervals_count
-            assert np.sum(intervals_info.child_count_per_interval) == self.extent_kji[
-               axis]  # assumes both local and parent grids are IjkGrids
-            for interval in range(intervals_count):
-               if intervals_info.child_count_per_interval[interval] == intervals_info.parent_count_per_interval[
-                     interval]:
-                  continue  # one-to-one
-               if refining_flag is None:
-                  refining_flag = (intervals_info.child_count_per_interval[interval] >
-                                   intervals_info.parent_count_per_interval[interval])
-               assert refining_flag == (intervals_info.child_count_per_interval[interval] > intervals_info.parent_count_per_interval[interval]),  \
-                  'mixture of refining and coarsening in one local grid – allowed by RESQML but not handled by this code'
-               if refining_flag:
-                  assert intervals_info.child_count_per_interval[interval] % intervals_info.parent_count_per_interval[interval] == 0,  \
-                     'within a single refinement interval, fine and coarse cell boundaries are not obviously aligned'
-               else:
-                  assert intervals_info.parent_count_per_interval[interval] % intervals_info.child_count_per_interval[interval] == 0,  \
-                     'within a single coarsening interval, fine and coarse cell boundaries are not obviously aligned'
-            ccw_node = rqet.find_tag(intervals_node, 'ChildCellWeights')
-            if ccw_node is None:
-               intervals_info.child_cell_weights = None
+                                        object = self,
+                                        array_attribute = 'k_gap_after_array',
+                                        dtype = 'bool')
+            assert hasattr(self, 'k_gap_after_array')
+            assert self.k_gap_after_array.ndim == 1 and self.k_gap_after_array.size == self.nk - 1
+            self._set_k_raw_index_array()
+        else:
+            self.k_gap_after_array = None
+            self.k_raw_index_array = np.arange(self.nk, dtype = int)
+        return self.k_gaps, self.k_gap_after_array, self.k_raw_index_array
+
+    def _set_k_raw_index_array(self):
+        """Sets the layering raw index array based on the k gap after boolean array."""
+        if self.k_gap_after_array is None:
+            self.k_raw_index_array = None
+            return
+        self.k_raw_index_array = np.empty((self.nk,), dtype = int)
+        gap_count = 0
+        for k in range(self.nk):
+            self.k_raw_index_array[k] = k + gap_count
+            if k < self.nk - 1 and self.k_gap_after_array[k]:
+                gap_count += 1
+        assert gap_count == self.k_gaps, 'inconsistency in k gap data'
+
+    def extract_stratigraphy(self):
+        """Loads stratigraphic information from xml."""
+
+        self.stratigraphic_column_rank_uuid = None
+        self.stratigraphic_units = None
+        strata_node = rqet.find_tag(self.root, 'IntervalStratigraphicUnits')
+        if strata_node is None:
+            return
+        self.stratigraphic_column_rank_uuid =  \
+           bu.uuid_from_string(rqet.find_nested_tags_text(strata_node, ['StratigraphicOrganization', 'UUID']))
+        assert self.stratigraphic_column_rank_uuid is not None
+        unit_indices_node = rqet.find_tag(strata_node, 'UnitIndices')
+        h5_key_pair = self.model.h5_uuid_and_path_for_node(unit_indices_node)
+        self.model.h5_array_element(h5_key_pair,
+                                    index = None,
+                                    cache_array = True,
+                                    object = self,
+                                    array_attribute = 'stratigraphic_units',
+                                    dtype = 'int')
+        assert len(self.stratigraphic_units) == self.nk_plus_k_gaps
+
+    def extract_parent(self):
+        """Loads fine:coarse mapping information between this grid and parent, if any, returning parent grid uuid."""
+
+        class IntervalsInfo:
+
+            def __init__(self):
+                pass
+
+        if self.extent_kji is None:
+            self.extract_extent_kji()
+        if self.parent_grid_uuid is not None:
+            return self.parent_grid_uuid
+        self.parent_window = None  # FineCoarse cell index mapping info with respect to parent
+        self.is_refinement = None
+        pw_node = rqet.find_tag(self.root, 'ParentWindow')
+        if pw_node is None:
+            return None
+        # load a FineCoarse object as parent_window attirbute and set parent_grid_uuid attribute
+        self.parent_grid_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(pw_node, ['ParentGrid', 'UUID']))
+        assert self.parent_grid_uuid is not None
+        parent_grid_root = self.model.root(uuid = self.parent_grid_uuid)
+        if parent_grid_root is None:
+            log.warning('parent grid not present in model, unable to treat as local grid')
+            return None
+        # etxract parent grid extent directly from xml to avoid risk of circular references
+        parent_grid_extent_kji = np.array(
+            (rqet.find_tag_int(parent_grid_root, 'Nk'), rqet.find_tag_int(
+                parent_grid_root, 'Nj'), rqet.find_tag_int(parent_grid_root, 'Ni')),
+            dtype = int)
+        parent_initials = []
+        intervals_count_list = []
+        parent_count_list_list = []
+        child_count_list_list = []
+        child_weight_list_list = []
+        refining_flag = None  # gets set True if local grid is a refinement, False if a coarsening
+        parent_box = np.zeros((2, 3), dtype = int)
+        for axis in range(3):
+            regrid_node = rqet.find_tag(pw_node, 'KJI'[axis] + 'Regrid')
+            assert regrid_node is not None
+            pii = rqet.find_tag_int(regrid_node, 'InitialIndexOnParentGrid')
+            assert pii is not None and 0 <= pii < parent_grid_extent_kji[axis]
+            parent_initials.append(pii)
+            parent_box[0, axis] = pii
+            intervals_node = rqet.find_tag(regrid_node, 'Intervals')
+            if intervals_node is None:  # implicit one-to-one mapping
+                intervals_count_list.append(1)
+                parent_count_list_list.append(np.array(self.extent_kji[axis], dtype = int))
+                parent_box[1, axis] = parent_box[0, axis] + self.extent_kji[axis] - 1
+                assert parent_box[1, axis] < parent_grid_extent_kji[axis]
+                child_count_list_list.append(np.array(self.extent_kji[axis], dtype = int))
+                child_weight_list_list.append(None)
             else:
-               h5_key_pair = self.model.h5_uuid_and_path_for_node(ccw_node)
-               assert h5_key_pair is not None
-               self.model.h5_array_element(h5_key_pair,
-                                           index = None,
-                                           cache_array = True,
-                                           object = intervals_info,
-                                           array_attribute = 'child_cell_weights',
-                                           dtype = 'float')
-               assert hasattr(intervals_info, 'child_cell_weights')
-               assert intervals_info.child_cell_weights.ndim == 1 and intervals_info.child_cell_weights.size == self.extent_kji[
-                  axis]
-            intervals_count_list.append(intervals_count)
-            parent_count_list_list.append(intervals_info.parent_count_per_interval)
-            child_count_list_list.append(intervals_info.child_count_per_interval)
-            child_weight_list_list.append(intervals_info.child_cell_weights)
-      cell_overlap_node = rqet.find_tag(pw_node, 'CellOverlap')
-      if cell_overlap_node is not None:
-         log.warning('ignoring cell overlap information in grid relationship')
-      omit_node = rqet.find_tag(pw_node, 'OmitParentCells')
-      if omit_node is not None:
-         log.warning('unable to handle parent cell omissions in local grid definition – ignoring')
-      # todo: handle omissions
+                intervals_info = IntervalsInfo()
+                intervals_count = rqet.find_tag_int(intervals_node, 'IntervalCount')
+                assert intervals_count is not None and intervals_count > 0
+                pcpi_node = rqet.find_tag(intervals_node, 'ParentCountPerInterval')
+                assert pcpi_node is not None
+                h5_key_pair = self.model.h5_uuid_and_path_for_node(pcpi_node)
+                assert h5_key_pair is not None
+                self.model.h5_array_element(h5_key_pair,
+                                            index = None,
+                                            cache_array = True,
+                                            object = intervals_info,
+                                            array_attribute = 'parent_count_per_interval',
+                                            dtype = 'int')
+                assert hasattr(intervals_info, 'parent_count_per_interval')
+                assert intervals_info.parent_count_per_interval.ndim == 1 and intervals_info.parent_count_per_interval.size == intervals_count
+                parent_box[1, axis] = parent_box[0, axis] + np.sum(intervals_info.parent_count_per_interval) - 1
+                assert parent_box[1, axis] < parent_grid_extent_kji[axis]
+                ccpi_node = rqet.find_tag(intervals_node, 'ChildCountPerInterval')
+                assert ccpi_node is not None
+                h5_key_pair = self.model.h5_uuid_and_path_for_node(ccpi_node)
+                assert h5_key_pair is not None
+                self.model.h5_array_element(h5_key_pair,
+                                            index = None,
+                                            cache_array = True,
+                                            object = intervals_info,
+                                            array_attribute = 'child_count_per_interval',
+                                            dtype = 'int')
+                assert hasattr(intervals_info, 'child_count_per_interval')
+                assert intervals_info.child_count_per_interval.ndim == 1 and intervals_info.child_count_per_interval.size == intervals_count
+                assert np.sum(intervals_info.child_count_per_interval) == self.extent_kji[
+                    axis]  # assumes both local and parent grids are IjkGrids
+                for interval in range(intervals_count):
+                    if intervals_info.child_count_per_interval[interval] == intervals_info.parent_count_per_interval[
+                            interval]:
+                        continue  # one-to-one
+                    if refining_flag is None:
+                        refining_flag = (intervals_info.child_count_per_interval[interval] >
+                                         intervals_info.parent_count_per_interval[interval])
+                    assert refining_flag == (intervals_info.child_count_per_interval[interval] > intervals_info.parent_count_per_interval[interval]),  \
+                       'mixture of refining and coarsening in one local grid – allowed by RESQML but not handled by this code'
+                    if refining_flag:
+                        assert intervals_info.child_count_per_interval[interval] % intervals_info.parent_count_per_interval[interval] == 0,  \
+                           'within a single refinement interval, fine and coarse cell boundaries are not obviously aligned'
+                    else:
+                        assert intervals_info.parent_count_per_interval[interval] % intervals_info.child_count_per_interval[interval] == 0,  \
+                           'within a single coarsening interval, fine and coarse cell boundaries are not obviously aligned'
+                ccw_node = rqet.find_tag(intervals_node, 'ChildCellWeights')
+                if ccw_node is None:
+                    intervals_info.child_cell_weights = None
+                else:
+                    h5_key_pair = self.model.h5_uuid_and_path_for_node(ccw_node)
+                    assert h5_key_pair is not None
+                    self.model.h5_array_element(h5_key_pair,
+                                                index = None,
+                                                cache_array = True,
+                                                object = intervals_info,
+                                                array_attribute = 'child_cell_weights',
+                                                dtype = 'float')
+                    assert hasattr(intervals_info, 'child_cell_weights')
+                    assert intervals_info.child_cell_weights.ndim == 1 and intervals_info.child_cell_weights.size == self.extent_kji[
+                        axis]
+                intervals_count_list.append(intervals_count)
+                parent_count_list_list.append(intervals_info.parent_count_per_interval)
+                child_count_list_list.append(intervals_info.child_count_per_interval)
+                child_weight_list_list.append(intervals_info.child_cell_weights)
+        cell_overlap_node = rqet.find_tag(pw_node, 'CellOverlap')
+        if cell_overlap_node is not None:
+            log.warning('ignoring cell overlap information in grid relationship')
+        omit_node = rqet.find_tag(pw_node, 'OmitParentCells')
+        if omit_node is not None:
+            log.warning('unable to handle parent cell omissions in local grid definition – ignoring')
+        # todo: handle omissions
 
-      if refining_flag is None:
-         log.warning('local grid has no refinement nor coarsening – treating as a refined grid')
-         refining_flag = True
-      self.is_refinement = refining_flag
+        if refining_flag is None:
+            log.warning('local grid has no refinement nor coarsening – treating as a refined grid')
+            refining_flag = True
+        self.is_refinement = refining_flag
 
-      if refining_flag:  # local grid is a refinement
-         self.parent_window = fc.FineCoarse(self.extent_kji,
-                                            parent_box[1] - parent_box[0] + 1,
-                                            within_coarse_box = parent_box)
-         for axis in range(3):
-            if intervals_count_list[axis] == 1:
-               self.parent_window.set_constant_ratio(axis)
-               constant_ratio = self.extent_kji[axis] // (parent_box[1, axis] - parent_box[0, axis] + 1)
-               ratio_vector = None
-            else:
-               constant_ratio = None
-               ratio_vector = child_count_list_list[axis] // parent_count_list_list[axis]
-               self.parent_window.set_ratio_vector(axis, ratio_vector)
-            if child_weight_list_list[axis] is None:
-               self.parent_window.set_equal_proportions(axis)
-            else:
-               proportions_list = []
-               place = 0
-               for coarse_slice in range(parent_box[1, axis] - parent_box[0, axis] + 1):
-                  if ratio_vector is None:
-                     proportions_list.append(np.array(child_weight_list_list[axis][place:place + constant_ratio]))
-                     place += constant_ratio
-                  else:
-                     proportions_list.append(
-                        np.array(child_weight_list_list[axis][place:place + ratio_vector[coarse_slice]]))
-                     place += ratio_vector[coarse_slice]
-               self.parent_window.set_proportions_list_of_vectors(axis, proportions_list)
+        if refining_flag:  # local grid is a refinement
+            self.parent_window = fc.FineCoarse(self.extent_kji,
+                                               parent_box[1] - parent_box[0] + 1,
+                                               within_coarse_box = parent_box)
+            for axis in range(3):
+                if intervals_count_list[axis] == 1:
+                    self.parent_window.set_constant_ratio(axis)
+                    constant_ratio = self.extent_kji[axis] // (parent_box[1, axis] - parent_box[0, axis] + 1)
+                    ratio_vector = None
+                else:
+                    constant_ratio = None
+                    ratio_vector = child_count_list_list[axis] // parent_count_list_list[axis]
+                    self.parent_window.set_ratio_vector(axis, ratio_vector)
+                if child_weight_list_list[axis] is None:
+                    self.parent_window.set_equal_proportions(axis)
+                else:
+                    proportions_list = []
+                    place = 0
+                    for coarse_slice in range(parent_box[1, axis] - parent_box[0, axis] + 1):
+                        if ratio_vector is None:
+                            proportions_list.append(np.array(child_weight_list_list[axis][place:place +
+                                                                                          constant_ratio]))
+                            place += constant_ratio
+                        else:
+                            proportions_list.append(
+                                np.array(child_weight_list_list[axis][place:place + ratio_vector[coarse_slice]]))
+                            place += ratio_vector[coarse_slice]
+                    self.parent_window.set_proportions_list_of_vectors(axis, proportions_list)
 
-      else:  # local grid is a coarsening
-         self.parent_window = fc.FineCoarse(parent_box[1] - parent_box[0] + 1,
-                                            self.extent_kji,
-                                            within_fine_box = parent_box)
-         for axis in range(3):
-            if intervals_count_list[axis] == 1:
-               self.parent_window.set_constant_ratio(axis)
-               constant_ratio = (parent_box[1, axis] - parent_box[0, axis] + 1) // self.extent_kji[axis]
-               ratio_vector = None
-            else:
-               constant_ratio = None
-               ratio_vector = parent_count_list_list[axis] // child_count_list_list[axis]
-               self.parent_window.set_ratio_vector(axis, ratio_vector)
-            if child_weight_list_list[axis] is None:
-               self.parent_window.set_equal_proportions(axis)
-            else:
-               proportions_list = []
-               place = 0
-               for coarse_slice in range(self.extent_kji[axis]):
-                  if ratio_vector is None:
-                     proportions_list.append(np.array(child_weight_list_list[axis][place:place + constant_ratio]))
-                     place += constant_ratio
-                  else:
-                     proportions_list.append(
-                        np.array(child_weight_list_list[axis][place:place + ratio_vector[coarse_slice]]))
-                     place += ratio_vector[coarse_slice]
-               self.parent_window.set_proportions_list_of_vectors(axis, proportions_list)
+        else:  # local grid is a coarsening
+            self.parent_window = fc.FineCoarse(parent_box[1] - parent_box[0] + 1,
+                                               self.extent_kji,
+                                               within_fine_box = parent_box)
+            for axis in range(3):
+                if intervals_count_list[axis] == 1:
+                    self.parent_window.set_constant_ratio(axis)
+                    constant_ratio = (parent_box[1, axis] - parent_box[0, axis] + 1) // self.extent_kji[axis]
+                    ratio_vector = None
+                else:
+                    constant_ratio = None
+                    ratio_vector = parent_count_list_list[axis] // child_count_list_list[axis]
+                    self.parent_window.set_ratio_vector(axis, ratio_vector)
+                if child_weight_list_list[axis] is None:
+                    self.parent_window.set_equal_proportions(axis)
+                else:
+                    proportions_list = []
+                    place = 0
+                    for coarse_slice in range(self.extent_kji[axis]):
+                        if ratio_vector is None:
+                            proportions_list.append(np.array(child_weight_list_list[axis][place:place +
+                                                                                          constant_ratio]))
+                            place += constant_ratio
+                        else:
+                            proportions_list.append(
+                                np.array(child_weight_list_list[axis][place:place + ratio_vector[coarse_slice]]))
+                            place += ratio_vector[coarse_slice]
+                    self.parent_window.set_proportions_list_of_vectors(axis, proportions_list)
 
-      self.parent_window.assert_valid()
+        self.parent_window.assert_valid()
 
-      return self.parent_grid_uuid
+        return self.parent_grid_uuid
 
-   def set_parent(self, parent_grid_uuid, self_is_refinement, parent_window):
-      """Set relationship with respect to a parent grid.
+    def set_parent(self, parent_grid_uuid, self_is_refinement, parent_window):
+        """Set relationship with respect to a parent grid.
 
       arguments:
          parent_grid_uuid (uuid.UUID): the uuid of the parent grid
@@ -783,35 +786,35 @@ class Grid(BaseResqpy):
             that self_is_refinement determines which of the 2 grids is fine and which is coarse
       """
 
-      if self.parent_grid_uuid is not None:
-         log.warning('overwriting parent grid information')
-      self.parent_grid_uuid = parent_grid_uuid
-      if parent_grid_uuid is None:
-         self.parent_window = None
-         self.is_refinement = None
-      else:
-         parent_window.assert_valid()
-         self.parent_window = parent_window
-         self.is_refinement = self_is_refinement
+        if self.parent_grid_uuid is not None:
+            log.warning('overwriting parent grid information')
+        self.parent_grid_uuid = parent_grid_uuid
+        if parent_grid_uuid is None:
+            self.parent_window = None
+            self.is_refinement = None
+        else:
+            parent_window.assert_valid()
+            self.parent_window = parent_window
+            self.is_refinement = self_is_refinement
 
-   def extract_children(self):
-      assert self.uuid is not None
-      if self.local_grid_uuid_list is not None:
-         return self.local_grid_uuid_list
-      self.local_grid_uuid_list = []
-      related_grid_roots = self.model.roots(obj_type = 'IjkGridRepresentation', related_uuid = self.uuid)
-      if related_grid_roots is not None:
-         for related_root in related_grid_roots:
-            parent_uuid = rqet.find_nested_tags_text(related_root, ['ParentWindow', 'ParentGrid', 'UUID'])
-            if parent_uuid is None:
-               continue
-            parent_uuid = bu.uuid_from_string(parent_uuid)
-            if bu.matching_uuids(self.uuid, parent_uuid):
-               self.local_grid_uuid_list.append(parent_uuid)
-      return self.local_grid_uuid_list
+    def extract_children(self):
+        assert self.uuid is not None
+        if self.local_grid_uuid_list is not None:
+            return self.local_grid_uuid_list
+        self.local_grid_uuid_list = []
+        related_grid_roots = self.model.roots(obj_type = 'IjkGridRepresentation', related_uuid = self.uuid)
+        if related_grid_roots is not None:
+            for related_root in related_grid_roots:
+                parent_uuid = rqet.find_nested_tags_text(related_root, ['ParentWindow', 'ParentGrid', 'UUID'])
+                if parent_uuid is None:
+                    continue
+                parent_uuid = bu.uuid_from_string(parent_uuid)
+                if bu.matching_uuids(self.uuid, parent_uuid):
+                    self.local_grid_uuid_list.append(parent_uuid)
+        return self.local_grid_uuid_list
 
-   def extract_property_collection(self):
-      """Load grid property collection object holding lists of all properties in model that relate to this grid.
+    def extract_property_collection(self):
+        """Load grid property collection object holding lists of all properties in model that relate to this grid.
 
       returns:
          resqml_property.GridPropertyCollection object
@@ -822,13 +825,13 @@ class Grid(BaseResqpy):
          would need to be reset to None elsewhere before calling this method again
       """
 
-      if self.property_collection is not None:
-         return self.property_collection
-      self.property_collection = rprop.GridPropertyCollection(grid = self)
-      return self.property_collection
+        if self.property_collection is not None:
+            return self.property_collection
+        self.property_collection = rprop.GridPropertyCollection(grid = self)
+        return self.property_collection
 
-   def extract_inactive_mask(self, check_pinchout = False):
-      """Returns boolean numpy array indicating which cells are inactive, if (in)active property found in this grid.
+    def extract_inactive_mask(self, check_pinchout = False):
+        """Returns boolean numpy array indicating which cells are inactive, if (in)active property found in this grid.
 
       returns:
          numpy array of booleans, of shape (nk, nj, ni) being True for cells which are inactive; False for active
@@ -839,63 +842,64 @@ class Grid(BaseResqpy):
          attribute for the grid object, which is a boolean numpy array indicating which cells are inactive
       """
 
-      if self.inactive is not None and not check_pinchout:
-         return self.inactive
-      geom_defined = self.cell_geometry_is_defined_ref()
-      if self.inactive is None:
-         if geom_defined is None or geom_defined is True:
-            self.inactive = np.zeros(tuple(self.extent_kji))  # ie. all active
-         else:
-            self.inactive = np.logical_not(self.cell_geometry_is_defined_ref())
-      if check_pinchout:
-         self.inactive = np.logical_or(self.inactive, self.pinched_out())
-      gpc = self.extract_property_collection()
-      if gpc is None:
-         self.all_inactive = np.all(self.inactive)
-         return self.inactive
-      active_gpc = rprop.GridPropertyCollection()
-      # note: use of bespoke (local) property kind 'active' as suggested in resqml usage guide
-      active_gpc.inherit_parts_selectively_from_other_collection(other = gpc,
-                                                                 property_kind = 'active',
-                                                                 continuous = False)
-      active_parts = active_gpc.parts()
-      if len(active_parts) > 1:
-         # try further filtering based on grid's time index data (or filtering out time based arrays)
-         self.extract_geometry_time_index()
-         if self.time_index is not None and self.time_series_uuid is not None:
-            active_gpc = rprop.selective_version_of_collection(active_gpc,
-                                                               time_index = self.time_index,
-                                                               time_series_uuid = self.time_series_uuid)
-         else:
-            active_parts = []
-            for part in active_gpc.parts():
-               if active_gpc.time_series_uuid_for_part(part) is None and active_gpc.time_index_for_part(part) is None:
-                  active_parts.append(part)
-      if len(active_parts) > 0:
-         if len(active_parts) > 1:
-            log.warning('more than one property found with bespoke kind "active", using last encountered')
-         active_part = active_parts[-1]
-         active_array = active_gpc.cached_part_array_ref(active_part, dtype = 'bool')
-         self.inactive = np.logical_or(self.inactive, np.logical_not(active_array))
-         self.active_property_uuid = active_gpc.uuid_for_part(active_part)
-         active_gpc.uncache_part_array(active_part)
-      else:  # for backward compatibility with earlier versions of resqpy
-         inactive_gpc = rprop.GridPropertyCollection()
-         inactive_gpc.inherit_parts_selectively_from_other_collection(other = gpc,
-                                                                      property_kind = 'code',
-                                                                      facet_type = 'what',
-                                                                      facet = 'inactive')
-         if inactive_gpc.number_of_parts() == 1:
-            inactive_part = inactive_gpc.parts()[0]
-            inactive_array = inactive_gpc.cached_part_array_ref(inactive_part, dtype = 'bool')
-            self.inactive = np.logical_or(self.inactive, inactive_array)
-            inactive_gpc.uncache_part_array(inactive_part)
+        if self.inactive is not None and not check_pinchout:
+            return self.inactive
+        geom_defined = self.cell_geometry_is_defined_ref()
+        if self.inactive is None:
+            if geom_defined is None or geom_defined is True:
+                self.inactive = np.zeros(tuple(self.extent_kji))  # ie. all active
+            else:
+                self.inactive = np.logical_not(self.cell_geometry_is_defined_ref())
+        if check_pinchout:
+            self.inactive = np.logical_or(self.inactive, self.pinched_out())
+        gpc = self.extract_property_collection()
+        if gpc is None:
+            self.all_inactive = np.all(self.inactive)
+            return self.inactive
+        active_gpc = rprop.GridPropertyCollection()
+        # note: use of bespoke (local) property kind 'active' as suggested in resqml usage guide
+        active_gpc.inherit_parts_selectively_from_other_collection(other = gpc,
+                                                                   property_kind = 'active',
+                                                                   continuous = False)
+        active_parts = active_gpc.parts()
+        if len(active_parts) > 1:
+            # try further filtering based on grid's time index data (or filtering out time based arrays)
+            self.extract_geometry_time_index()
+            if self.time_index is not None and self.time_series_uuid is not None:
+                active_gpc = rprop.selective_version_of_collection(active_gpc,
+                                                                   time_index = self.time_index,
+                                                                   time_series_uuid = self.time_series_uuid)
+            else:
+                active_parts = []
+                for part in active_gpc.parts():
+                    if active_gpc.time_series_uuid_for_part(part) is None and active_gpc.time_index_for_part(
+                            part) is None:
+                        active_parts.append(part)
+        if len(active_parts) > 0:
+            if len(active_parts) > 1:
+                log.warning('more than one property found with bespoke kind "active", using last encountered')
+            active_part = active_parts[-1]
+            active_array = active_gpc.cached_part_array_ref(active_part, dtype = 'bool')
+            self.inactive = np.logical_or(self.inactive, np.logical_not(active_array))
+            self.active_property_uuid = active_gpc.uuid_for_part(active_part)
+            active_gpc.uncache_part_array(active_part)
+        else:  # for backward compatibility with earlier versions of resqpy
+            inactive_gpc = rprop.GridPropertyCollection()
+            inactive_gpc.inherit_parts_selectively_from_other_collection(other = gpc,
+                                                                         property_kind = 'code',
+                                                                         facet_type = 'what',
+                                                                         facet = 'inactive')
+            if inactive_gpc.number_of_parts() == 1:
+                inactive_part = inactive_gpc.parts()[0]
+                inactive_array = inactive_gpc.cached_part_array_ref(inactive_part, dtype = 'bool')
+                self.inactive = np.logical_or(self.inactive, inactive_array)
+                inactive_gpc.uncache_part_array(inactive_part)
 
-      self.all_inactive = np.all(self.inactive)
-      return self.inactive
+        self.all_inactive = np.all(self.inactive)
+        return self.inactive
 
-   def cell_geometry_is_defined(self, cell_kji0 = None, cell_geometry_is_defined_root = None, cache_array = True):
-      """Returns True if the geometry of the specified cell is defined; can also be used to cache (load) the boolean array.
+    def cell_geometry_is_defined(self, cell_kji0 = None, cell_geometry_is_defined_root = None, cache_array = True):
+        """Returns True if the geometry of the specified cell is defined; can also be used to cache (load) the boolean array.
 
       arguments:
          cell_kji0 (triplet of integer, optional): if present, the index of the cell of interest, in kji0 protocol;
@@ -910,49 +914,49 @@ class Grid(BaseResqpy):
          if cell_kji0 is None, None is returned (but the array caching logic will have been applied)
       """
 
-      if self.geometry_defined_for_all_cells_cached:
-         return True
-      if hasattr(self, 'array_cell_geometry_is_defined') and self.array_cell_geometry_is_defined is None:
-         delattr(self, 'array_cell_geometry_is_defined')
-      if hasattr(self, 'array_cell_geometry_is_defined'):
-         self.geometry_defined_for_all_cells_cached = np.all(self.array_cell_geometry_is_defined)
-         if self.geometry_defined_for_all_cells_cached:
+        if self.geometry_defined_for_all_cells_cached:
             return True
-         if cell_kji0 is None:
-            return False
-         return self.array_cell_geometry_is_defined[tuple(cell_kji0)]
-      is_def_root = self.resolve_geometry_child('CellGeometryIsDefined', child_node = cell_geometry_is_defined_root)
-      if is_def_root is None:
-         points = self.points_ref(masked = False)
-         assert points is not None
-         self.geometry_defined_for_all_cells_cached = not np.any(np.isnan(points))
-         if self.geometry_defined_for_all_cells_cached or cell_kji0 is None:
-            return self.geometry_defined_for_all_cells_cached
-      is_def_type = rqet.node_type(is_def_root)
-      if is_def_type == 'BooleanConstantArray':
-         self.geometry_defined_for_all_cells_cached = (rqet.find_tag_text(is_def_root, 'Value').lower() == 'true')
-         return self.geometry_defined_for_all_cells_cached
-      else:
-         assert (is_def_type == 'BooleanHdf5Array')
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(is_def_root)
-         if h5_key_pair is None:
-            return None
-         result = self.model.h5_array_element(h5_key_pair,
-                                              index = cell_kji0,
-                                              cache_array = cache_array,
-                                              object = self,
-                                              array_attribute = 'array_cell_geometry_is_defined',
-                                              dtype = 'bool')
-         if self.geometry_defined_for_all_cells_cached is None and cache_array and hasattr(
-               self, 'array_cell_geometry_is_defined'):
-            self.geometry_defined_for_all_cells_cached = (np.count_nonzero(
-               self.array_cell_geometry_is_defined) == self.array_cell_geometry_is_defined.size)
+        if hasattr(self, 'array_cell_geometry_is_defined') and self.array_cell_geometry_is_defined is None:
+            delattr(self, 'array_cell_geometry_is_defined')
+        if hasattr(self, 'array_cell_geometry_is_defined'):
+            self.geometry_defined_for_all_cells_cached = np.all(self.array_cell_geometry_is_defined)
             if self.geometry_defined_for_all_cells_cached:
-               delattr(self, 'array_cell_geometry_is_defined')
-         return result
+                return True
+            if cell_kji0 is None:
+                return False
+            return self.array_cell_geometry_is_defined[tuple(cell_kji0)]
+        is_def_root = self.resolve_geometry_child('CellGeometryIsDefined', child_node = cell_geometry_is_defined_root)
+        if is_def_root is None:
+            points = self.points_ref(masked = False)
+            assert points is not None
+            self.geometry_defined_for_all_cells_cached = not np.any(np.isnan(points))
+            if self.geometry_defined_for_all_cells_cached or cell_kji0 is None:
+                return self.geometry_defined_for_all_cells_cached
+        is_def_type = rqet.node_type(is_def_root)
+        if is_def_type == 'BooleanConstantArray':
+            self.geometry_defined_for_all_cells_cached = (rqet.find_tag_text(is_def_root, 'Value').lower() == 'true')
+            return self.geometry_defined_for_all_cells_cached
+        else:
+            assert (is_def_type == 'BooleanHdf5Array')
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(is_def_root)
+            if h5_key_pair is None:
+                return None
+            result = self.model.h5_array_element(h5_key_pair,
+                                                 index = cell_kji0,
+                                                 cache_array = cache_array,
+                                                 object = self,
+                                                 array_attribute = 'array_cell_geometry_is_defined',
+                                                 dtype = 'bool')
+            if self.geometry_defined_for_all_cells_cached is None and cache_array and hasattr(
+                    self, 'array_cell_geometry_is_defined'):
+                self.geometry_defined_for_all_cells_cached = (np.count_nonzero(
+                    self.array_cell_geometry_is_defined) == self.array_cell_geometry_is_defined.size)
+                if self.geometry_defined_for_all_cells_cached:
+                    delattr(self, 'array_cell_geometry_is_defined')
+            return result
 
-   def pillar_geometry_is_defined(self, pillar_ji0 = None, pillar_geometry_is_defined_root = None, cache_array = True):
-      """Returns True if the geometry of the specified pillar is defined; False otherwise; can also be used to cache (load) the boolean array.
+    def pillar_geometry_is_defined(self, pillar_ji0 = None, pillar_geometry_is_defined_root = None, cache_array = True):
+        """Returns True if the geometry of the specified pillar is defined; False otherwise; can also be used to cache (load) the boolean array.
 
       arguments:
          pillar_ji0 (pair of integers, optional): if present, the index of the pillar of interest, in ji0 protocol;
@@ -967,41 +971,42 @@ class Grid(BaseResqpy):
          if pillar_ji0 is None, None is returned unless geometry is defined for all pillars in which case True is returned
       """
 
-      if self.geometry_defined_for_all_pillars_cached:
-         return True
-      if hasattr(self, 'array_pillar_geometry_is_defined'):
-         if pillar_ji0 is None:
-            return None  # this option allows caching of array without actually referring to any pillar
-         return self.array_pillar_geometry_is_defined[tuple(pillar_ji0)]
-      is_def_root = self.resolve_geometry_child('PillarGeometryIsDefined', child_node = pillar_geometry_is_defined_root)
-      if is_def_root is None:
-         return True  # maybe default should be False?
-      is_def_type = rqet.node_type(is_def_root)
-      if is_def_type == 'BooleanConstantArray':
-         assert rqet.find_tag(is_def_root, 'Value').text.lower() == 'true'
-         self.geometry_defined_for_all_pillars_cached = True
-         return True
-      else:
-         assert is_def_type == 'BooleanHdf5Array'
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(is_def_root)
-         if h5_key_pair is None:
-            return None
-         result = self.model.h5_array_element(h5_key_pair,
-                                              index = pillar_ji0,
-                                              cache_array = cache_array,
-                                              object = self,
-                                              array_attribute = 'array_pillar_geometry_is_defined',
-                                              dtype = 'bool')
-         if self.geometry_defined_for_all_pillars_cached is None and cache_array and hasattr(
-               self, 'array_pillar_geometry_is_defined'):
-            self.geometry_defined_for_all_pillars_cached = (np.count_nonzero(
-               self.array_pillar_geometry_is_defined) == self.array_pillar_geometry_is_defined.size)
-            if self.geometry_defined_for_all_pillars_cached:
-               del self.array_pillar_geometry_is_defined  # memory optimisation
-         return result
+        if self.geometry_defined_for_all_pillars_cached:
+            return True
+        if hasattr(self, 'array_pillar_geometry_is_defined'):
+            if pillar_ji0 is None:
+                return None  # this option allows caching of array without actually referring to any pillar
+            return self.array_pillar_geometry_is_defined[tuple(pillar_ji0)]
+        is_def_root = self.resolve_geometry_child('PillarGeometryIsDefined',
+                                                  child_node = pillar_geometry_is_defined_root)
+        if is_def_root is None:
+            return True  # maybe default should be False?
+        is_def_type = rqet.node_type(is_def_root)
+        if is_def_type == 'BooleanConstantArray':
+            assert rqet.find_tag(is_def_root, 'Value').text.lower() == 'true'
+            self.geometry_defined_for_all_pillars_cached = True
+            return True
+        else:
+            assert is_def_type == 'BooleanHdf5Array'
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(is_def_root)
+            if h5_key_pair is None:
+                return None
+            result = self.model.h5_array_element(h5_key_pair,
+                                                 index = pillar_ji0,
+                                                 cache_array = cache_array,
+                                                 object = self,
+                                                 array_attribute = 'array_pillar_geometry_is_defined',
+                                                 dtype = 'bool')
+            if self.geometry_defined_for_all_pillars_cached is None and cache_array and hasattr(
+                    self, 'array_pillar_geometry_is_defined'):
+                self.geometry_defined_for_all_pillars_cached = (np.count_nonzero(
+                    self.array_pillar_geometry_is_defined) == self.array_pillar_geometry_is_defined.size)
+                if self.geometry_defined_for_all_pillars_cached:
+                    del self.array_pillar_geometry_is_defined  # memory optimisation
+            return result
 
-   def geometry_defined_for_all_cells(self, cache_array = True):
-      """Returns True if geometry is defined for all cells; False otherwise.
+    def geometry_defined_for_all_cells(self, cache_array = True):
+        """Returns True if geometry is defined for all cells; False otherwise.
 
       argument:
          cache_array (boolean, default True): if True, the 'cell geometry is defined' array is cached in memory,
@@ -1011,27 +1016,27 @@ class Grid(BaseResqpy):
          boolean: True if geometry is defined for all cells; False otherwise
       """
 
-      if self.geometry_defined_for_all_cells_cached is not None:
-         return self.geometry_defined_for_all_cells_cached
-      if cache_array:
-         self.cell_geometry_is_defined(cache_array = True)
-         return self.geometry_defined_for_all_cells_cached
-      # loop over all cells (until a False is encountered) – only executes if cache_array is False
-      cell_geom_defined_root = self.resolve_geometry_child('CellGeometryIsDefined')
-      if cell_geom_defined_root is not None:
-         for k0 in range(self.nk):
-            for j0 in range(self.nj):
-               for i0 in range(self.ni):
-                  if not self.cell_geometry_is_defined(cell_kji0 = (k0, j0, i0),
-                                                       cell_geometry_is_defined_root = cell_geom_defined_root,
-                                                       cache_array = False):
-                     self.geometry_defined_for_all_cells_cached = False
-                     return False
-      self.geometry_defined_for_all_cells_cached = True
-      return True
+        if self.geometry_defined_for_all_cells_cached is not None:
+            return self.geometry_defined_for_all_cells_cached
+        if cache_array:
+            self.cell_geometry_is_defined(cache_array = True)
+            return self.geometry_defined_for_all_cells_cached
+        # loop over all cells (until a False is encountered) – only executes if cache_array is False
+        cell_geom_defined_root = self.resolve_geometry_child('CellGeometryIsDefined')
+        if cell_geom_defined_root is not None:
+            for k0 in range(self.nk):
+                for j0 in range(self.nj):
+                    for i0 in range(self.ni):
+                        if not self.cell_geometry_is_defined(cell_kji0 = (k0, j0, i0),
+                                                             cell_geometry_is_defined_root = cell_geom_defined_root,
+                                                             cache_array = False):
+                            self.geometry_defined_for_all_cells_cached = False
+                            return False
+        self.geometry_defined_for_all_cells_cached = True
+        return True
 
-   def geometry_defined_for_all_pillars(self, cache_array = True, pillar_geometry_is_defined_root = None):
-      """Returns True if geometry is defined for all pillars; False otherwise.
+    def geometry_defined_for_all_pillars(self, cache_array = True, pillar_geometry_is_defined_root = None):
+        """Returns True if geometry is defined for all pillars; False otherwise.
 
       arguments:
          cache_array (boolean, default True): if True, the 'pillar geometry is defined' array is cached in memory,
@@ -1043,26 +1048,27 @@ class Grid(BaseResqpy):
          boolean: True if the geometry is defined for all pillars; False otherwise
       """
 
-      if self.geometry_defined_for_all_pillars_cached is not None:
-         return self.geometry_defined_for_all_pillars_cached
-      if cache_array:
-         self.pillar_geometry_is_defined(cache_array = cache_array)
-         return self.geometry_defined_for_all_pillars_cached
-      is_def_root = self.resolve_geometry_child('PillarGeometryIsDefined', child_node = pillar_geometry_is_defined_root)
-      self.geometry_defined_for_all_pillars_cached = True
-      if is_def_root is not None:
-         for pillar_j in range(self.nj):
-            for pillar_i in range(self.ni):
-               if not self.pillar_geometry_is_defined(
-                  [pillar_j, pillar_i], pillar_geometry_is_defined_root = is_def_root, cache_array = False):
-                  self.geometry_defined_for_all_pillars_cached = False
-                  break
-            if not self.geometry_defined_for_all_pillars_cached:
-               break
-      return self.geometry_defined_for_all_pillars_cached
+        if self.geometry_defined_for_all_pillars_cached is not None:
+            return self.geometry_defined_for_all_pillars_cached
+        if cache_array:
+            self.pillar_geometry_is_defined(cache_array = cache_array)
+            return self.geometry_defined_for_all_pillars_cached
+        is_def_root = self.resolve_geometry_child('PillarGeometryIsDefined',
+                                                  child_node = pillar_geometry_is_defined_root)
+        self.geometry_defined_for_all_pillars_cached = True
+        if is_def_root is not None:
+            for pillar_j in range(self.nj):
+                for pillar_i in range(self.ni):
+                    if not self.pillar_geometry_is_defined(
+                        [pillar_j, pillar_i], pillar_geometry_is_defined_root = is_def_root, cache_array = False):
+                        self.geometry_defined_for_all_pillars_cached = False
+                        break
+                if not self.geometry_defined_for_all_pillars_cached:
+                    break
+        return self.geometry_defined_for_all_pillars_cached
 
-   def cell_geometry_is_defined_ref(self):
-      """Returns an in-memory numpy array containing the boolean data indicating which cells have geometry defined.
+    def cell_geometry_is_defined_ref(self):
+        """Returns an in-memory numpy array containing the boolean data indicating which cells have geometry defined.
 
       returns:
          numpy array of booleans of shape (nk, nj, ni); True value indicates cell has geometry defined; False
@@ -1073,14 +1079,14 @@ class Grid(BaseResqpy):
          geometry_defined_for_all_cells() can be used to test for that situation
       """
 
-      # todo: treat this array like any other property?; handle constant array seamlessly?
-      self.cell_geometry_is_defined(cache_array = True)
-      if hasattr(self, 'array_cell_geometry_is_defined'):
-         return self.array_cell_geometry_is_defined
-      return None  # can happen, if geometry is defined for all cells
+        # todo: treat this array like any other property?; handle constant array seamlessly?
+        self.cell_geometry_is_defined(cache_array = True)
+        if hasattr(self, 'array_cell_geometry_is_defined'):
+            return self.array_cell_geometry_is_defined
+        return None  # can happen, if geometry is defined for all cells
 
-   def pillar_geometry_is_defined_ref(self):
-      """Returns an in-memory numpy array containing the boolean data indicating which pillars have geometry defined.
+    def pillar_geometry_is_defined_ref(self):
+        """Returns an in-memory numpy array containing the boolean data indicating which pillars have geometry defined.
 
       returns:
          numpy array of booleans of shape (nj + 1, ni + 1); True value indicates pillar has geometry defined (at
@@ -1092,20 +1098,20 @@ class Grid(BaseResqpy):
          if geometry is flagged in the xml as being defined for all pillars, then this function returns None
       """
 
-      # todo: double-check behaviour in presence of split pillars
-      # todo: treat this array like any other property?; handle constant array seamlessly?
-      self.pillar_geometry_is_defined(cache_array = True)
-      if hasattr(self, 'array_pillar_geometry_is_defined'):
-         return self.array_pillar_geometry_is_defined
-      return None  # can happen, if geometry is defined for all pillars
+        # todo: double-check behaviour in presence of split pillars
+        # todo: treat this array like any other property?; handle constant array seamlessly?
+        self.pillar_geometry_is_defined(cache_array = True)
+        if hasattr(self, 'array_pillar_geometry_is_defined'):
+            return self.array_pillar_geometry_is_defined
+        return None  # can happen, if geometry is defined for all pillars
 
-   def set_geometry_is_defined(self,
-                               treat_as_nan = None,
-                               treat_dots_as_nan = False,
-                               complete_partial_pillars = False,
-                               nullify_partial_pillars = False,
-                               complete_all = False):
-      """Sets cached flags and/or arrays indicating which primary pillars have any points defined and which cells all points.
+    def set_geometry_is_defined(self,
+                                treat_as_nan = None,
+                                treat_dots_as_nan = False,
+                                complete_partial_pillars = False,
+                                nullify_partial_pillars = False,
+                                complete_all = False):
+        """Sets cached flags and/or arrays indicating which primary pillars have any points defined and which cells all points.
 
       arguments:
          treat_as_nan (float, optional): if present, any point with this value as x, y or z is changed
@@ -1131,360 +1137,362 @@ class Grid(BaseResqpy):
          although the method modifies the cached (attribute) copies of various arrays, they are not written to hdf5 here
       """
 
-      def infill_partial_pillar(grid, pillar_index):
-         points = grid.points_ref(masked = False).reshape((grid.nk_plus_k_gaps + 1, -1, 3))
-         nan_mask = np.isnan(points[:, pillar_index, 0])
-         first_k = 0
-         while first_k < grid.nk_plus_k_gaps + 1 and nan_mask[first_k]:
-            first_k += 1
-         assert first_k < grid.nk_plus_k_gaps + 1
-         if first_k > 0:
-            points[:first_k, pillar_index] = points[first_k, pillar_index]
-         last_k = grid.nk_plus_k_gaps
-         while nan_mask[last_k]:
-            last_k -= 1
-         if last_k < grid.nk_plus_k_gaps:
-            points[last_k + 1:, pillar_index] = points[last_k, pillar_index]
-         while True:
-            while first_k < last_k and not nan_mask[first_k]:
-               first_k += 1
-            if first_k >= last_k:
-               break
-            scan_k = first_k + 1
-            while nan_mask[scan_k]:
-               scan_k += 1
-            points[first_k - 1 : scan_k, pillar_index] =  \
-               np.linspace(points[first_k - 1, pillar_index], points[scan_k, pillar_index],
-                           num = scan_k - first_k + 1, endpoint = False)
-            first_k = scan_k
+        def infill_partial_pillar(grid, pillar_index):
+            points = grid.points_ref(masked = False).reshape((grid.nk_plus_k_gaps + 1, -1, 3))
+            nan_mask = np.isnan(points[:, pillar_index, 0])
+            first_k = 0
+            while first_k < grid.nk_plus_k_gaps + 1 and nan_mask[first_k]:
+                first_k += 1
+            assert first_k < grid.nk_plus_k_gaps + 1
+            if first_k > 0:
+                points[:first_k, pillar_index] = points[first_k, pillar_index]
+            last_k = grid.nk_plus_k_gaps
+            while nan_mask[last_k]:
+                last_k -= 1
+            if last_k < grid.nk_plus_k_gaps:
+                points[last_k + 1:, pillar_index] = points[last_k, pillar_index]
+            while True:
+                while first_k < last_k and not nan_mask[first_k]:
+                    first_k += 1
+                if first_k >= last_k:
+                    break
+                scan_k = first_k + 1
+                while nan_mask[scan_k]:
+                    scan_k += 1
+                points[first_k - 1 : scan_k, pillar_index] =  \
+                   np.linspace(points[first_k - 1, pillar_index], points[scan_k, pillar_index],
+                               num = scan_k - first_k + 1, endpoint = False)
+                first_k = scan_k
 
-      def create_surround_masks(top_nan_mask):
-         assert top_nan_mask.ndim == 2
-         nj1, ni1 = top_nan_mask.shape  # nj + 1, ni + 1
-         surround_mask = np.zeros(top_nan_mask.shape, dtype = bool)
-         coastal_mask = np.zeros(top_nan_mask.shape, dtype = bool)
-         for j in range(nj1):
-            i = 0
-            while i < ni1 and top_nan_mask[j, i]:
-               coastal_mask[j, i] = True
-               i += 1
-            if i < ni1:
-               i = ni1 - 1
-               while top_nan_mask[j, i]:
-                  coastal_mask[j, i] = True
-                  i -= 1
-            else:
-               surround_mask[j] = True
-               coastal_mask[j] = False
-         for i in range(ni1):
-            j = 0
-            while j < nj1 and top_nan_mask[j, i]:
-               coastal_mask[j, i] = True
-               j += 1
-            if j < nj1:
-               j = nj1 - 1
-               while top_nan_mask[j, i]:
-                  coastal_mask[j, i] = True
-                  j -= 1
-            else:
-               surround_mask[:, i] = True
-               coastal_mask[:, i] = False
-         return surround_mask, coastal_mask
+        def create_surround_masks(top_nan_mask):
+            assert top_nan_mask.ndim == 2
+            nj1, ni1 = top_nan_mask.shape  # nj + 1, ni + 1
+            surround_mask = np.zeros(top_nan_mask.shape, dtype = bool)
+            coastal_mask = np.zeros(top_nan_mask.shape, dtype = bool)
+            for j in range(nj1):
+                i = 0
+                while i < ni1 and top_nan_mask[j, i]:
+                    coastal_mask[j, i] = True
+                    i += 1
+                if i < ni1:
+                    i = ni1 - 1
+                    while top_nan_mask[j, i]:
+                        coastal_mask[j, i] = True
+                        i -= 1
+                else:
+                    surround_mask[j] = True
+                    coastal_mask[j] = False
+            for i in range(ni1):
+                j = 0
+                while j < nj1 and top_nan_mask[j, i]:
+                    coastal_mask[j, i] = True
+                    j += 1
+                if j < nj1:
+                    j = nj1 - 1
+                    while top_nan_mask[j, i]:
+                        coastal_mask[j, i] = True
+                        j -= 1
+                else:
+                    surround_mask[:, i] = True
+                    coastal_mask[:, i] = False
+            return surround_mask, coastal_mask
 
-      def fill_holes(grid, holes_mask):
-         log.debug(f'filling {np.count_nonzero(holes_mask)} pillars for holes')
-         points = grid.points_ref(masked = False).reshape(grid.nk_plus_k_gaps + 1, -1, 3)
-         ni_plus_1 = grid.ni + 1
-         mask_01 = np.empty(holes_mask.shape, dtype = int)
-         while np.any(holes_mask):
-            flat_holes_mask = holes_mask.flatten()
-            mask_01[:] = np.where(holes_mask, 0, 1)
+        def fill_holes(grid, holes_mask):
+            log.debug(f'filling {np.count_nonzero(holes_mask)} pillars for holes')
+            points = grid.points_ref(masked = False).reshape(grid.nk_plus_k_gaps + 1, -1, 3)
+            ni_plus_1 = grid.ni + 1
+            mask_01 = np.empty(holes_mask.shape, dtype = int)
+            while np.any(holes_mask):
+                flat_holes_mask = holes_mask.flatten()
+                mask_01[:] = np.where(holes_mask, 0, 1)
+                modified = False
+                # fix isolated NaN pillars with 4 neighbours
+                neighbours = np.zeros(holes_mask.shape, dtype = int)
+                neighbours[:-1, :] += mask_01[1:, :]
+                neighbours[1:, :] += mask_01[:-1, :]
+                neighbours[:, :-1] += mask_01[:, 1:]
+                neighbours[:, 1:] += mask_01[:, :-1]
+                foursomes = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 4))[0]
+                if len(foursomes) > 0:
+                    interpolated = 0.25 * (points[:, foursomes - 1, :] + points[:, foursomes + 1, :] +
+                                           points[:, foursomes - ni_plus_1, :] + points[:, foursomes + ni_plus_1, :])
+                    points[:, foursomes, :] = interpolated
+                    flat_holes_mask[foursomes] = False
+                    modified = True
+                # fix NaN pillars with defined opposing neighbours in -J and +J
+                neighbours[:] = 0
+                neighbours[:-1, :] += mask_01[1:, :]
+                neighbours[1:, :] += mask_01[:-1, :]
+                twosomes = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
+                if len(twosomes) > 0:
+                    interpolated = 0.5 * (points[:, twosomes - ni_plus_1, :] + points[:, twosomes + ni_plus_1, :])
+                    points[:, twosomes, :] = interpolated
+                    flat_holes_mask[twosomes] = False
+                    modified = True
+                # fix NaN pillars with defined opposing neighbours in -I and +I
+                neighbours[:] = 0
+                neighbours[:, :-1] += mask_01[:, 1:]
+                neighbours[:, 1:] += mask_01[:, :-1]
+                twosomes = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
+                if len(twosomes) > 0:
+                    interpolated = 0.5 * (points[:, twosomes - 1, :] + points[:, twosomes + 1, :])
+                    points[:, twosomes, :] = interpolated
+                    flat_holes_mask[twosomes] = False
+                    modified = True
+                # fix NaN pillars with defined cornering neighbours in J- and I-
+                neighbours[:] = 0
+                neighbours[1:, :] += mask_01[:-1, :]
+                neighbours[:, 1:] += mask_01[:, :-1]
+                corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
+                neighbours[1:, 1:] += mask_01[:-1, :-1]
+                pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
+                if len(corners) > 0:
+                    interpolated = 0.5 * (points[:, corners - ni_plus_1, :] + points[:, corners - 1, :])
+                    points[:, corners, :] = interpolated
+                    pushed = 2.0 * points[:, pushable, :] - points[:, pushable - ni_plus_1 - 1, :]
+                    points[:, pushable, :] = pushed
+                    flat_holes_mask[corners] = False
+                    modified = True
+                # fix NaN pillars with defined cornering neighbours in J- and I+
+                neighbours[:] = 0
+                neighbours[1:, :] += mask_01[:-1, :]
+                neighbours[:, :-1] += mask_01[:, 1:]
+                corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
+                neighbours[1:, :-1] += mask_01[:-1, 1:]
+                pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
+                if len(corners) > 0:
+                    interpolated = 0.5 * (points[:, corners - ni_plus_1, :] + points[:, corners + 1, :])
+                    points[:, corners, :] = interpolated
+                    pushed = 2.0 * points[:, pushable, :] - points[:, pushable - ni_plus_1 + 1, :]
+                    points[:, pushable, :] = pushed
+                    flat_holes_mask[corners] = False
+                    modified = True
+                # fix NaN pillars with defined cornering neighbours in J+ and I-
+                neighbours[:] = 0
+                neighbours[:-1, :] += mask_01[1:, :]
+                neighbours[:, 1:] += mask_01[:, :-1]
+                corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
+                neighbours[:-1, 1:] += mask_01[1:, :-1]
+                pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
+                if len(corners) > 0:
+                    interpolated = 0.5 * (points[:, corners + ni_plus_1, :] + points[:, corners - 1, :])
+                    points[:, corners, :] = interpolated
+                    pushed = 2.0 * points[:, pushable, :] - points[:, pushable + ni_plus_1 - 1, :]
+                    points[:, pushable, :] = pushed
+                    flat_holes_mask[corners] = False
+                    modified = True
+                # fix NaN pillars with defined cornering neighbours in J+ and I+
+                neighbours[:] = 0
+                neighbours[:-1, :] += mask_01[1:, :]
+                neighbours[:, :-1] += mask_01[:, 1:]
+                corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
+                neighbours[:-1, :-1] += mask_01[1:, 1:]
+                pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
+                if len(corners) > 0:
+                    interpolated = 0.5 * (points[:, corners + ni_plus_1, :] + points[:, corners + 1, :])
+                    points[:, corners, :] = interpolated
+                    pushed = 2.0 * points[:, pushable, :] - points[:, pushable + ni_plus_1 + 1, :]
+                    points[:, pushable, :] = pushed
+                    flat_holes_mask[corners] = False
+                    modified = True
+                holes_mask = flat_holes_mask.reshape((grid.nj + 1, ni_plus_1))
+                if not modified:
+                    log.warning('failed to fill all holes in grid geometry')
+                    break
+
+        def fill_surround(grid, surround_mask):
+            # note: only fills x,y; based on bottom layer of points; assumes surround mask is a regularly shaped frame of columns
+            log.debug(f'filling {np.count_nonzero(surround_mask)} pillars for surround')
+            points = grid.points_ref(masked = False)
+            points_view = points[-1, :, :2].reshape((-1, 2))[:(grid.nj + 1) * (grid.ni + 1), :].reshape(
+                (grid.nj + 1, grid.ni + 1, 2))
             modified = False
-            # fix isolated NaN pillars with 4 neighbours
-            neighbours = np.zeros(holes_mask.shape, dtype = int)
-            neighbours[:-1, :] += mask_01[1:, :]
-            neighbours[1:, :] += mask_01[:-1, :]
-            neighbours[:, :-1] += mask_01[:, 1:]
-            neighbours[:, 1:] += mask_01[:, :-1]
-            foursomes = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 4))[0]
-            if len(foursomes) > 0:
-               interpolated = 0.25 * (points[:, foursomes - 1, :] + points[:, foursomes + 1, :] +
-                                      points[:, foursomes - ni_plus_1, :] + points[:, foursomes + ni_plus_1, :])
-               points[:, foursomes, :] = interpolated
-               flat_holes_mask[foursomes] = False
-               modified = True
-            # fix NaN pillars with defined opposing neighbours in -J and +J
-            neighbours[:] = 0
-            neighbours[:-1, :] += mask_01[1:, :]
-            neighbours[1:, :] += mask_01[:-1, :]
-            twosomes = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
-            if len(twosomes) > 0:
-               interpolated = 0.5 * (points[:, twosomes - ni_plus_1, :] + points[:, twosomes + ni_plus_1, :])
-               points[:, twosomes, :] = interpolated
-               flat_holes_mask[twosomes] = False
-               modified = True
-            # fix NaN pillars with defined opposing neighbours in -I and +I
-            neighbours[:] = 0
-            neighbours[:, :-1] += mask_01[:, 1:]
-            neighbours[:, 1:] += mask_01[:, :-1]
-            twosomes = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
-            if len(twosomes) > 0:
-               interpolated = 0.5 * (points[:, twosomes - 1, :] + points[:, twosomes + 1, :])
-               points[:, twosomes, :] = interpolated
-               flat_holes_mask[twosomes] = False
-               modified = True
-            # fix NaN pillars with defined cornering neighbours in J- and I-
-            neighbours[:] = 0
-            neighbours[1:, :] += mask_01[:-1, :]
-            neighbours[:, 1:] += mask_01[:, :-1]
-            corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
-            neighbours[1:, 1:] += mask_01[:-1, :-1]
-            pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
-            if len(corners) > 0:
-               interpolated = 0.5 * (points[:, corners - ni_plus_1, :] + points[:, corners - 1, :])
-               points[:, corners, :] = interpolated
-               pushed = 2.0 * points[:, pushable, :] - points[:, pushable - ni_plus_1 - 1, :]
-               points[:, pushable, :] = pushed
-               flat_holes_mask[corners] = False
-               modified = True
-            # fix NaN pillars with defined cornering neighbours in J- and I+
-            neighbours[:] = 0
-            neighbours[1:, :] += mask_01[:-1, :]
-            neighbours[:, :-1] += mask_01[:, 1:]
-            corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
-            neighbours[1:, :-1] += mask_01[:-1, 1:]
-            pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
-            if len(corners) > 0:
-               interpolated = 0.5 * (points[:, corners - ni_plus_1, :] + points[:, corners + 1, :])
-               points[:, corners, :] = interpolated
-               pushed = 2.0 * points[:, pushable, :] - points[:, pushable - ni_plus_1 + 1, :]
-               points[:, pushable, :] = pushed
-               flat_holes_mask[corners] = False
-               modified = True
-            # fix NaN pillars with defined cornering neighbours in J+ and I-
-            neighbours[:] = 0
-            neighbours[:-1, :] += mask_01[1:, :]
-            neighbours[:, 1:] += mask_01[:, :-1]
-            corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
-            neighbours[:-1, 1:] += mask_01[1:, :-1]
-            pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
-            if len(corners) > 0:
-               interpolated = 0.5 * (points[:, corners + ni_plus_1, :] + points[:, corners - 1, :])
-               points[:, corners, :] = interpolated
-               pushed = 2.0 * points[:, pushable, :] - points[:, pushable + ni_plus_1 - 1, :]
-               points[:, pushable, :] = pushed
-               flat_holes_mask[corners] = False
-               modified = True
-            # fix NaN pillars with defined cornering neighbours in J+ and I+
-            neighbours[:] = 0
-            neighbours[:-1, :] += mask_01[1:, :]
-            neighbours[:, :-1] += mask_01[:, 1:]
-            corners = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 2))[0]
-            neighbours[:-1, :-1] += mask_01[1:, 1:]
-            pushable = np.where(np.logical_and(flat_holes_mask, neighbours.flatten() == 3))[0]
-            if len(corners) > 0:
-               interpolated = 0.5 * (points[:, corners + ni_plus_1, :] + points[:, corners + 1, :])
-               points[:, corners, :] = interpolated
-               pushed = 2.0 * points[:, pushable, :] - points[:, pushable + ni_plus_1 + 1, :]
-               points[:, pushable, :] = pushed
-               flat_holes_mask[corners] = False
-               modified = True
-            holes_mask = flat_holes_mask.reshape((grid.nj + 1, ni_plus_1))
-            if not modified:
-               log.warning('failed to fill all holes in grid geometry')
-               break
+            if grid.nj > 1:
+                j_xy_vector = np.nanmean(points_view[1:, :] - points_view[:-1, :])
+                j = 0
+                while j < grid.nj and np.all(surround_mask[j, :]):
+                    j += 1
+                assert j < grid.nj
+                while j > 0:
+                    points_view[j - 1, :] = points_view[j, :] - j_xy_vector
+                    modified = True
+                    j -= 1
+                j = grid.nj - 1
+                while j >= 0 and np.all(surround_mask[j, :]):
+                    j -= 1
+                assert j >= 0
+                while j < grid.nj - 1:
+                    points_view[j + 1, :] = points_view[j, :] + j_xy_vector
+                    modified = True
+                    j += 1
+            if grid.ni > 1:
+                i_xy_vector = np.nanmean(points_view[:, 1:] - points_view[:, :-1])
+                i = 0
+                while i < grid.ni and np.all(surround_mask[:, i]):
+                    i += 1
+                assert i < grid.ni
+                while i > 0:
+                    points_view[:, i - 1] = points_view[:, i] - i_xy_vector
+                    modified = True
+                    i -= 1
+                i = grid.ni - 1
+                while i >= 0 and np.all(surround_mask[:, i]):
+                    i -= 1
+                assert i >= 0
+                while i < grid.ni - 1:
+                    points_view[:, i + 1] = points_view[:, i] + i_xy_vector
+                    modified = True
+                    i += 1
+            if modified:
+                points.reshape((grid.nk_plus_k_gaps + 1, -1, 3))[:-1, :(grid.nj + 1) * (grid.ni + 1), :2][:, surround_mask.flatten(), :] =  \
+                   points_view[surround_mask, :].reshape((1, -1, 2))
 
-      def fill_surround(grid, surround_mask):
-         # note: only fills x,y; based on bottom layer of points; assumes surround mask is a regularly shaped frame of columns
-         log.debug(f'filling {np.count_nonzero(surround_mask)} pillars for surround')
-         points = grid.points_ref(masked = False)
-         points_view = points[-1, :, :2].reshape((-1, 2))[:(grid.nj + 1) * (grid.ni + 1), :].reshape(
-            (grid.nj + 1, grid.ni + 1, 2))
-         modified = False
-         if grid.nj > 1:
-            j_xy_vector = np.nanmean(points_view[1:, :] - points_view[:-1, :])
-            j = 0
-            while j < grid.nj and np.all(surround_mask[j, :]):
-               j += 1
-            assert j < grid.nj
-            while j > 0:
-               points_view[j - 1, :] = points_view[j, :] - j_xy_vector
-               modified = True
-               j -= 1
-            j = grid.nj - 1
-            while j >= 0 and np.all(surround_mask[j, :]):
-               j -= 1
-            assert j >= 0
-            while j < grid.nj - 1:
-               points_view[j + 1, :] = points_view[j, :] + j_xy_vector
-               modified = True
-               j += 1
-         if grid.ni > 1:
-            i_xy_vector = np.nanmean(points_view[:, 1:] - points_view[:, :-1])
-            i = 0
-            while i < grid.ni and np.all(surround_mask[:, i]):
-               i += 1
-            assert i < grid.ni
-            while i > 0:
-               points_view[:, i - 1] = points_view[:, i] - i_xy_vector
-               modified = True
-               i -= 1
-            i = grid.ni - 1
-            while i >= 0 and np.all(surround_mask[:, i]):
-               i -= 1
-            assert i >= 0
-            while i < grid.ni - 1:
-               points_view[:, i + 1] = points_view[:, i] + i_xy_vector
-               modified = True
-               i += 1
-         if modified:
-            points.reshape((grid.nk_plus_k_gaps + 1, -1, 3))[:-1, :(grid.nj + 1) * (grid.ni + 1), :2][:, surround_mask.flatten(), :] =  \
-               points_view[surround_mask, :].reshape((1, -1, 2))
+        assert not (complete_partial_pillars and nullify_partial_pillars)
+        if complete_all and not nullify_partial_pillars:
+            complete_partial_pillars = True
 
-      assert not (complete_partial_pillars and nullify_partial_pillars)
-      if complete_all and not nullify_partial_pillars:
-         complete_partial_pillars = True
+        points = self.points_ref(masked = False)
 
-      points = self.points_ref(masked = False)
+        if treat_as_nan is not None:
+            nan_mask = np.any(np.logical_or(np.isnan(points), points == treat_as_nan), axis = -1)
+        else:
+            nan_mask = np.any(np.isnan(points), axis = -1)
 
-      if treat_as_nan is not None:
-         nan_mask = np.any(np.logical_or(np.isnan(points), points == treat_as_nan), axis = -1)
-      else:
-         nan_mask = np.any(np.isnan(points), axis = -1)
+        if treat_dots_as_nan:
+            areal_dots = self.point_areally()
+            some_areal_dots = np.any(areal_dots)
+        else:
+            areal_dots = None
+            some_areal_dots = False
 
-      if treat_dots_as_nan:
-         areal_dots = self.point_areally()
-         some_areal_dots = np.any(areal_dots)
-      else:
-         areal_dots = None
-         some_areal_dots = False
-
-      self.geometry_defined_for_all_pillars_cached = None
-      if hasattr(self, 'array_pillar_geometry_is_defined'):
-         del self.array_pillar_geometry_is_defined
-      self.geometry_defined_for_all_cells_cached = None
-      if hasattr(self, 'array_cell_geometry_is_defined'):
-         del self.array_cell_geometry_is_defined
-
-      if not np.any(nan_mask) and not some_areal_dots:
-         self.geometry_defined_for_all_pillars_cached = True
-         self.geometry_defined_for_all_cells_cached = True
-         return
-
-      if some_areal_dots:
-         # inject NaNs into the pillars around any cell that has zero length in I and J
-         if self.k_gaps:
-            dot_mask = np.zeros((self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1), dtype = bool)
-            dot_mask[self.k_raw_index_array, :-1, :-1] = areal_dots
-            dot_mask[self.k_raw_index_array + 1, :-1, :-1] = np.logical_or(
-               dot_mask[self.k_raw_index_array + 1, :-1, :-1], areal_dots)
-         else:
-            dot_mask = np.zeros((self.nk + 1, self.nj + 1, self.ni + 1), dtype = bool)
-            dot_mask[:-1, :-1, :-1] = areal_dots
-            dot_mask[1:, :-1, :-1] = np.logical_or(dot_mask[:-1, :-1, :-1], areal_dots)
-         dot_mask[:, 1:, :-1] = np.logical_or(dot_mask[:, :-1, :-1], dot_mask[:, 1:, :-1])
-         dot_mask[:, :, 1:] = np.logical_or(dot_mask[:, :, :-1], dot_mask[:, :, 1:])
-         if self.has_split_coordinate_lines:
-            # only set points in primary pillars to NaN; todo: more thorough to consider split pillars too
-            primaries = (self.nj + 1) * (self.ni + 1)
-            nan_mask[:, :primaries] = np.logical_or(nan_mask[:, :primaries], dot_mask.reshape((-1, primaries)))
-         else:
-            nan_mask = np.where(dot_mask, np.NaN, nan_mask)
-
-      assert not np.all(nan_mask), 'grid does not have any geometry defined'
-
-      points[:] = np.where(np.repeat(np.expand_dims(nan_mask, axis = nan_mask.ndim), 3, axis = -1), np.NaN, points)
-
-      surround_z = self.xyz_box(lazy = False)[1 if self.z_inc_down() else 0, 2]
-
-      pillar_defined_mask = np.logical_not(np.all(nan_mask, axis = 0)).flatten()
-      primary_count = (self.nj + 1) * (self.ni + 1)
-      if np.all(pillar_defined_mask):
-         self.geometry_defined_for_all_pillars_cached = True
-      else:
-         self.geometry_defined_for_all_pillars_cached = False
-         self.array_pillar_geometry_is_defined = pillar_defined_mask[:primary_count].reshape((self.nj + 1, self.ni + 1))
-      if pillar_defined_mask.size > primary_count and not np.all(pillar_defined_mask[primary_count:]):
-         log.warning('at least one split pillar has geometry undefined')
-
-      self.geometry_defined_for_all_cells_cached = False
-
-      primary_nan_mask =  \
-         nan_mask.reshape((self.nk_plus_k_gaps + 1, -1))[:, :primary_count].reshape((self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1))
-      column_nan_mask = np.logical_or(np.logical_or(primary_nan_mask[:, :-1, :-1], primary_nan_mask[:, :-1, 1:]),
-                                      np.logical_or(primary_nan_mask[:, 1:, :-1], primary_nan_mask[:, 1:, 1:]))
-      if self.k_gaps:
-         self.array_cell_geometry_is_defined = np.logical_not(
-            np.logical_or(column_nan_mask[self.k_raw_index_array], column_nan_mask[self.k_raw_index_array + 1]))
-      else:
-         self.array_cell_geometry_is_defined = np.logical_not(np.logical_or(column_nan_mask[:-1], column_nan_mask[1:]))
-
-      if hasattr(self, 'inactive') and self.inactive is not None:
-         self.inactive = np.logical_or(self.inactive, np.logical_not(self.array_cell_geometry_is_defined))
-      else:
-         self.inactive = np.logical_not(self.array_cell_geometry_is_defined)
-      self.all_inactive = np.all(self.inactive)
-
-      if self.geometry_defined_for_all_cells_cached:
-         return
-
-      cells_update_needed = False
-
-      if nullify_partial_pillars:
-         partial_pillar_mask = np.logical_and(pillar_defined_mask, np.any(nan_mask, axis = 0).flatten())
-         if np.any(partial_pillar_mask):
-            points.reshape((self.nk_plus_k_gaps + 1, -1, 3))[:, partial_pillar_mask, :] = np.NaN
-            cells_update_needed = True
-      elif complete_partial_pillars:
-         partial_pillar_mask = np.logical_and(pillar_defined_mask, np.any(nan_mask, axis = 0).flatten())
-         if np.any(partial_pillar_mask):
-            log.warning('completing geometry for partially defined pillars')
-            for pillar_index in np.where(partial_pillar_mask)[0]:
-               infill_partial_pillar(self, pillar_index)
-            cells_update_needed = True
-
-      if complete_all:
-         # note: each pillar is either fully defined or fully undefined at this point
-         top_nan_mask = np.isnan(points[0, ..., 0].flatten()[:(self.nj + 1) * (self.ni + 1)].reshape(
-            (self.nj + 1, self.ni + 1)))
-         surround_mask, coastal_mask = create_surround_masks(top_nan_mask)
-         holes_mask = np.logical_and(top_nan_mask, np.logical_not(surround_mask))
-         if np.any(holes_mask):
-            fill_holes(self, holes_mask)
-         if np.any(surround_mask):
-            fill_surround(self, surround_mask)
-         # set z values for coastal and surround to max z for grid
-         surround_mask = np.logical_or(surround_mask, coastal_mask).flatten()
-         if np.any(surround_mask):
-            points.reshape(self.nk_plus_k_gaps + 1, -1, 3)[:, :(self.nj + 1) * (self.ni + 1)][:, surround_mask,
-                                                                                              2] = surround_z
-         self.geometry_defined_for_all_pillars_cached = True
-         if hasattr(self, 'array_pillar_geometry_is_defined'):
+        self.geometry_defined_for_all_pillars_cached = None
+        if hasattr(self, 'array_pillar_geometry_is_defined'):
             del self.array_pillar_geometry_is_defined
-         cells_update_needed = False
-         assert not np.any(np.isnan(points))
-         self.geometry_defined_for_all_cells_cached = True
-         if hasattr(self, 'array_cell_geometry_is_defined'):
+        self.geometry_defined_for_all_cells_cached = None
+        if hasattr(self, 'array_cell_geometry_is_defined'):
             del self.array_cell_geometry_is_defined
 
-      if cells_update_needed:
-         # note: each pillar is either fully defined or fully undefined at this point
-         if self.geometry_defined_for_all_pillars_cached:
+        if not np.any(nan_mask) and not some_areal_dots:
+            self.geometry_defined_for_all_pillars_cached = True
+            self.geometry_defined_for_all_cells_cached = True
+            return
+
+        if some_areal_dots:
+            # inject NaNs into the pillars around any cell that has zero length in I and J
+            if self.k_gaps:
+                dot_mask = np.zeros((self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1), dtype = bool)
+                dot_mask[self.k_raw_index_array, :-1, :-1] = areal_dots
+                dot_mask[self.k_raw_index_array + 1, :-1, :-1] = np.logical_or(
+                    dot_mask[self.k_raw_index_array + 1, :-1, :-1], areal_dots)
+            else:
+                dot_mask = np.zeros((self.nk + 1, self.nj + 1, self.ni + 1), dtype = bool)
+                dot_mask[:-1, :-1, :-1] = areal_dots
+                dot_mask[1:, :-1, :-1] = np.logical_or(dot_mask[:-1, :-1, :-1], areal_dots)
+            dot_mask[:, 1:, :-1] = np.logical_or(dot_mask[:, :-1, :-1], dot_mask[:, 1:, :-1])
+            dot_mask[:, :, 1:] = np.logical_or(dot_mask[:, :, :-1], dot_mask[:, :, 1:])
+            if self.has_split_coordinate_lines:
+                # only set points in primary pillars to NaN; todo: more thorough to consider split pillars too
+                primaries = (self.nj + 1) * (self.ni + 1)
+                nan_mask[:, :primaries] = np.logical_or(nan_mask[:, :primaries], dot_mask.reshape((-1, primaries)))
+            else:
+                nan_mask = np.where(dot_mask, np.NaN, nan_mask)
+
+        assert not np.all(nan_mask), 'grid does not have any geometry defined'
+
+        points[:] = np.where(np.repeat(np.expand_dims(nan_mask, axis = nan_mask.ndim), 3, axis = -1), np.NaN, points)
+
+        surround_z = self.xyz_box(lazy = False)[1 if self.z_inc_down() else 0, 2]
+
+        pillar_defined_mask = np.logical_not(np.all(nan_mask, axis = 0)).flatten()
+        primary_count = (self.nj + 1) * (self.ni + 1)
+        if np.all(pillar_defined_mask):
+            self.geometry_defined_for_all_pillars_cached = True
+        else:
+            self.geometry_defined_for_all_pillars_cached = False
+            self.array_pillar_geometry_is_defined = pillar_defined_mask[:primary_count].reshape(
+                (self.nj + 1, self.ni + 1))
+        if pillar_defined_mask.size > primary_count and not np.all(pillar_defined_mask[primary_count:]):
+            log.warning('at least one split pillar has geometry undefined')
+
+        self.geometry_defined_for_all_cells_cached = False
+
+        primary_nan_mask =  \
+           nan_mask.reshape((self.nk_plus_k_gaps + 1, -1))[:, :primary_count].reshape((self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1))
+        column_nan_mask = np.logical_or(np.logical_or(primary_nan_mask[:, :-1, :-1], primary_nan_mask[:, :-1, 1:]),
+                                        np.logical_or(primary_nan_mask[:, 1:, :-1], primary_nan_mask[:, 1:, 1:]))
+        if self.k_gaps:
+            self.array_cell_geometry_is_defined = np.logical_not(
+                np.logical_or(column_nan_mask[self.k_raw_index_array], column_nan_mask[self.k_raw_index_array + 1]))
+        else:
+            self.array_cell_geometry_is_defined = np.logical_not(
+                np.logical_or(column_nan_mask[:-1], column_nan_mask[1:]))
+
+        if hasattr(self, 'inactive') and self.inactive is not None:
+            self.inactive = np.logical_or(self.inactive, np.logical_not(self.array_cell_geometry_is_defined))
+        else:
+            self.inactive = np.logical_not(self.array_cell_geometry_is_defined)
+        self.all_inactive = np.all(self.inactive)
+
+        if self.geometry_defined_for_all_cells_cached:
+            return
+
+        cells_update_needed = False
+
+        if nullify_partial_pillars:
+            partial_pillar_mask = np.logical_and(pillar_defined_mask, np.any(nan_mask, axis = 0).flatten())
+            if np.any(partial_pillar_mask):
+                points.reshape((self.nk_plus_k_gaps + 1, -1, 3))[:, partial_pillar_mask, :] = np.NaN
+                cells_update_needed = True
+        elif complete_partial_pillars:
+            partial_pillar_mask = np.logical_and(pillar_defined_mask, np.any(nan_mask, axis = 0).flatten())
+            if np.any(partial_pillar_mask):
+                log.warning('completing geometry for partially defined pillars')
+                for pillar_index in np.where(partial_pillar_mask)[0]:
+                    infill_partial_pillar(self, pillar_index)
+                cells_update_needed = True
+
+        if complete_all:
+            # note: each pillar is either fully defined or fully undefined at this point
+            top_nan_mask = np.isnan(points[0, ..., 0].flatten()[:(self.nj + 1) * (self.ni + 1)].reshape(
+                (self.nj + 1, self.ni + 1)))
+            surround_mask, coastal_mask = create_surround_masks(top_nan_mask)
+            holes_mask = np.logical_and(top_nan_mask, np.logical_not(surround_mask))
+            if np.any(holes_mask):
+                fill_holes(self, holes_mask)
+            if np.any(surround_mask):
+                fill_surround(self, surround_mask)
+            # set z values for coastal and surround to max z for grid
+            surround_mask = np.logical_or(surround_mask, coastal_mask).flatten()
+            if np.any(surround_mask):
+                points.reshape(self.nk_plus_k_gaps + 1, -1, 3)[:, :(self.nj + 1) * (self.ni + 1)][:, surround_mask,
+                                                                                                  2] = surround_z
+            self.geometry_defined_for_all_pillars_cached = True
+            if hasattr(self, 'array_pillar_geometry_is_defined'):
+                del self.array_pillar_geometry_is_defined
+            cells_update_needed = False
+            assert not np.any(np.isnan(points))
             self.geometry_defined_for_all_cells_cached = True
             if hasattr(self, 'array_cell_geometry_is_defined'):
-               del self.array_cell_geometry_is_defined
-         else:
-            top_nan_mask = np.isnan(points[0, ..., 0].flatten()[:(self.nj + 1) * (self.ni + 1)].reshape(
-               (self.nj + 1, self.ni + 1)))
-            column_nan_mask = np.logical_or(np.logical_or(top_nan_mask[:-1, :-1], top_nan_mask[:-1, 1:]),
-                                            np.logical_or(top_nan_mask[1:, :-1], top_nan_mask[1:, 1:]))
-            self.array_cell_geometry_is_defined = np.repeat(np.expand_dims(column_nan_mask, 0), self.nk, axis = 0)
-            self.geometry_defined_for_all_cells_cached = np.all(self.array_cell_geometry_is_defined)
-            if self.geometry_defined_for_all_cells_cached:
-               del self.array_cell_geometry_is_defined
+                del self.array_cell_geometry_is_defined
 
-   def actual_pillar_shape(self, patch_metadata = False, tolerance = 0.001):
-      """Returns actual shape of pillars.
+        if cells_update_needed:
+            # note: each pillar is either fully defined or fully undefined at this point
+            if self.geometry_defined_for_all_pillars_cached:
+                self.geometry_defined_for_all_cells_cached = True
+                if hasattr(self, 'array_cell_geometry_is_defined'):
+                    del self.array_cell_geometry_is_defined
+            else:
+                top_nan_mask = np.isnan(points[0, ..., 0].flatten()[:(self.nj + 1) * (self.ni + 1)].reshape(
+                    (self.nj + 1, self.ni + 1)))
+                column_nan_mask = np.logical_or(np.logical_or(top_nan_mask[:-1, :-1], top_nan_mask[:-1, 1:]),
+                                                np.logical_or(top_nan_mask[1:, :-1], top_nan_mask[1:, 1:]))
+                self.array_cell_geometry_is_defined = np.repeat(np.expand_dims(column_nan_mask, 0), self.nk, axis = 0)
+                self.geometry_defined_for_all_cells_cached = np.all(self.array_cell_geometry_is_defined)
+                if self.geometry_defined_for_all_cells_cached:
+                    del self.array_cell_geometry_is_defined
+
+    def actual_pillar_shape(self, patch_metadata = False, tolerance = 0.001):
+        """Returns actual shape of pillars.
 
       arguments:
          patch_metadata (boolean, default False): if True, the actual shape replaces whatever was in the metadata
@@ -1499,13 +1507,13 @@ class Grid(BaseResqpy):
          preserved unless the create_xml() method is called, followed at some point with model.store_epc()
       """
 
-      pillar_shape = gf.actual_pillar_shape(self.points_ref(masked = False), tolerance = tolerance)
-      if patch_metadata:
-         self.pillar_shape = pillar_shape
-      return pillar_shape
+        pillar_shape = gf.actual_pillar_shape(self.points_ref(masked = False), tolerance = tolerance)
+        if patch_metadata:
+            self.pillar_shape = pillar_shape
+        return pillar_shape
 
-   def cache_all_geometry_arrays(self):
-      """Loads from hdf5 into memory all the arrays defining the grid geometry.
+    def cache_all_geometry_arrays(self):
+        """Loads from hdf5 into memory all the arrays defining the grid geometry.
 
       returns:
          None
@@ -1529,54 +1537,54 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      # todo: recheck the description of split pillar arrays given in the doc string
-      self.cell_geometry_is_defined(cache_array = True)
-      self.pillar_geometry_is_defined(cache_array = True)
-      self.point(cache_array = True)
-      if self.has_split_coordinate_lines:
-         split_root = None
-         if not hasattr(self, 'split_pillar_indices_cached'):
-            split_root = self.resolve_geometry_child('SplitCoordinateLines')
-            # assert(rqet.node_type(split_root) == 'ColumnLayerSplitCoordinateLines')
-            pillar_indices_root = rqet.find_tag(split_root, 'PillarIndices')
-            h5_key_pair = self.model.h5_uuid_and_path_for_node(pillar_indices_root)
-            self.model.h5_array_element(h5_key_pair,
-                                        index = None,
-                                        cache_array = True,
-                                        object = self,
-                                        array_attribute = 'split_pillar_indices_cached',
-                                        dtype = 'int')
-         if not hasattr(self, 'cols_for_split_pillars'):
-            if split_root is None:
-               split_root = self.resolve_geometry_child('SplitCoordinateLines')
-            cpscl_root = rqet.find_tag(split_root, 'ColumnsPerSplitCoordinateLine')
-            cpscl_elements_root = rqet.find_tag(cpscl_root, 'Elements')
-            h5_key_pair = self.model.h5_uuid_and_path_for_node(cpscl_elements_root)
-            self.model.h5_array_element(h5_key_pair,
-                                        index = None,
-                                        cache_array = True,
-                                        object = self,
-                                        array_attribute = 'cols_for_split_pillars',
-                                        dtype = 'int')
-            cpscl_cum_length_root = rqet.find_tag(cpscl_root, 'CumulativeLength')
-            h5_key_pair = self.model.h5_uuid_and_path_for_node(cpscl_cum_length_root)
-            self.model.h5_array_element(h5_key_pair,
-                                        index = None,
-                                        cache_array = True,
-                                        object = self,
-                                        array_attribute = 'cols_for_split_pillars_cl',
-                                        dtype = 'int')
+        # todo: recheck the description of split pillar arrays given in the doc string
+        self.cell_geometry_is_defined(cache_array = True)
+        self.pillar_geometry_is_defined(cache_array = True)
+        self.point(cache_array = True)
+        if self.has_split_coordinate_lines:
+            split_root = None
+            if not hasattr(self, 'split_pillar_indices_cached'):
+                split_root = self.resolve_geometry_child('SplitCoordinateLines')
+                # assert(rqet.node_type(split_root) == 'ColumnLayerSplitCoordinateLines')
+                pillar_indices_root = rqet.find_tag(split_root, 'PillarIndices')
+                h5_key_pair = self.model.h5_uuid_and_path_for_node(pillar_indices_root)
+                self.model.h5_array_element(h5_key_pair,
+                                            index = None,
+                                            cache_array = True,
+                                            object = self,
+                                            array_attribute = 'split_pillar_indices_cached',
+                                            dtype = 'int')
+            if not hasattr(self, 'cols_for_split_pillars'):
+                if split_root is None:
+                    split_root = self.resolve_geometry_child('SplitCoordinateLines')
+                cpscl_root = rqet.find_tag(split_root, 'ColumnsPerSplitCoordinateLine')
+                cpscl_elements_root = rqet.find_tag(cpscl_root, 'Elements')
+                h5_key_pair = self.model.h5_uuid_and_path_for_node(cpscl_elements_root)
+                self.model.h5_array_element(h5_key_pair,
+                                            index = None,
+                                            cache_array = True,
+                                            object = self,
+                                            array_attribute = 'cols_for_split_pillars',
+                                            dtype = 'int')
+                cpscl_cum_length_root = rqet.find_tag(cpscl_root, 'CumulativeLength')
+                h5_key_pair = self.model.h5_uuid_and_path_for_node(cpscl_cum_length_root)
+                self.model.h5_array_element(h5_key_pair,
+                                            index = None,
+                                            cache_array = True,
+                                            object = self,
+                                            array_attribute = 'cols_for_split_pillars_cl',
+                                            dtype = 'int')
 
-   def set_cached_points_from_property(self,
-                                       points_property_uuid = None,
-                                       property_collection = None,
-                                       realization = None,
-                                       time_index = None,
-                                       set_grid_time_index = True,
-                                       set_inactive = True,
-                                       active_property_uuid = None,
-                                       active_collection = None):
-      """Modifies the cached points (geometry), setting the values from a points property.
+    def set_cached_points_from_property(self,
+                                        points_property_uuid = None,
+                                        property_collection = None,
+                                        realization = None,
+                                        time_index = None,
+                                        set_grid_time_index = True,
+                                        set_inactive = True,
+                                        active_property_uuid = None,
+                                        active_collection = None):
+        """Modifies the cached points (geometry), setting the values from a points property.
 
       arguments:
          points_property_uuid (uuid, optional): the uuid of the points property; if present the
@@ -1617,72 +1625,72 @@ class Grid(BaseResqpy):
          various cached data are invalidated and cleared by this method
       """
 
-      if points_property_uuid is None:
-         if property_collection is None:
-            property_collection = self.extract_property_collection()
-         part = property_collection.singleton(points = True,
-                                              indexable = 'nodes',
-                                              realization = realization,
-                                              time_index = time_index)
-         assert part is not None, 'failed to identify points property to use for grid geometry'
-         points_property_uuid = property_collection.uuid_for_part(part)
-      elif set_inactive:
-         assert active_property_uuid is not None, 'active property uuid not provided when setting points from property'
+        if points_property_uuid is None:
+            if property_collection is None:
+                property_collection = self.extract_property_collection()
+            part = property_collection.singleton(points = True,
+                                                 indexable = 'nodes',
+                                                 realization = realization,
+                                                 time_index = time_index)
+            assert part is not None, 'failed to identify points property to use for grid geometry'
+            points_property_uuid = property_collection.uuid_for_part(part)
+        elif set_inactive:
+            assert active_property_uuid is not None, 'active property uuid not provided when setting points from property'
 
-      assert points_property_uuid is not None
+        assert points_property_uuid is not None
 
-      self.cache_all_geometry_arrays()  # the split pillar information must not vary
+        self.cache_all_geometry_arrays()  # the split pillar information must not vary
 
-      # check for compatibility and overwrite cached points for grid
-      points = rprop.Property(self.model, uuid = points_property_uuid)
-      assert points is not None and points.is_points() and points.indexable_element() == 'nodes'
-      assert points.uom() == self.xy_units() and self.z_units() == self.xy_units()
-      points_array = points.array_ref(masked = False)
-      assert points_array is not None
-      assert points_array.shape == self.points_cached.shape
-      self.points_cached = points_array
+        # check for compatibility and overwrite cached points for grid
+        points = rprop.Property(self.model, uuid = points_property_uuid)
+        assert points is not None and points.is_points() and points.indexable_element() == 'nodes'
+        assert points.uom() == self.xy_units() and self.z_units() == self.xy_units()
+        points_array = points.array_ref(masked = False)
+        assert points_array is not None
+        assert points_array.shape == self.points_cached.shape
+        self.points_cached = points_array
 
-      # set grid's time index and series, if requested
-      if set_grid_time_index:
-         self.time_index = points.time_index()
-         ts_uuid = points.time_series_uuid()
-         if ts_uuid is not None and self.time_series_uuid is not None:
-            if not bu.matching_uuids(ts_uuid, self.time_series_uuid):
-               log.warning('change of time series uuid for dynamic grid geometry')
-         self.time_series_uuid = ts_uuid
+        # set grid's time index and series, if requested
+        if set_grid_time_index:
+            self.time_index = points.time_index()
+            ts_uuid = points.time_series_uuid()
+            if ts_uuid is not None and self.time_series_uuid is not None:
+                if not bu.matching_uuids(ts_uuid, self.time_series_uuid):
+                    log.warning('change of time series uuid for dynamic grid geometry')
+            self.time_series_uuid = ts_uuid
 
-      # invalidate anything cached that is derived from geometry
-      self.geometry_defined_for_all_pillars_cached = None
-      self.geometry_defined_for_all_cells_cached = None
-      for attr in ('array_unsplit_points', 'array_corner_points', 'array_centre_point', 'array_thickness',
-                   'array_volume', 'array_half_cell_t', 'array_k_transmissibility', 'array_j_transmissibility',
-                   'array_i_transmissibility', 'fgcs', 'array_fgcs_transmissibility', 'pgcs',
-                   'array_pgcs_transmissibility', 'kgcs', 'array_kgcs_transmissibility'):
-         if hasattr(self, attr):
-            delattr(self, attr)
+        # invalidate anything cached that is derived from geometry
+        self.geometry_defined_for_all_pillars_cached = None
+        self.geometry_defined_for_all_cells_cached = None
+        for attr in ('array_unsplit_points', 'array_corner_points', 'array_centre_point', 'array_thickness',
+                     'array_volume', 'array_half_cell_t', 'array_k_transmissibility', 'array_j_transmissibility',
+                     'array_i_transmissibility', 'fgcs', 'array_fgcs_transmissibility', 'pgcs',
+                     'array_pgcs_transmissibility', 'kgcs', 'array_kgcs_transmissibility'):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
-      if set_inactive:
-         if active_property_uuid is None:
-            if active_collection is None:
-               active_collection = property_collection
-               assert active_collection is not None
-            active_part = active_collection.singleton(property_kind = 'active',
-                                                      indexable = 'cells',
-                                                      continuous = False,
-                                                      realization = realization,
-                                                      time_index = time_index)
-            assert active_part is not None, 'failed to identify active property to use for grid inactive mask'
-            active_property_uuid = active_collection.uuid_for_part(active_part)
-         active = rprop.Property(self.model, uuid = active_property_uuid)
-         assert active is not None
-         active_array = active.array_ref()
-         assert active_array.shape == tuple(self.extent_kji)
-         self.inactive = np.logical_not(active_array)
-         self.all_inactive = np.all(self.inactive)
-         self.active_property_uuid = active_property_uuid
+        if set_inactive:
+            if active_property_uuid is None:
+                if active_collection is None:
+                    active_collection = property_collection
+                    assert active_collection is not None
+                active_part = active_collection.singleton(property_kind = 'active',
+                                                          indexable = 'cells',
+                                                          continuous = False,
+                                                          realization = realization,
+                                                          time_index = time_index)
+                assert active_part is not None, 'failed to identify active property to use for grid inactive mask'
+                active_property_uuid = active_collection.uuid_for_part(active_part)
+            active = rprop.Property(self.model, uuid = active_property_uuid)
+            assert active is not None
+            active_array = active.array_ref()
+            assert active_array.shape == tuple(self.extent_kji)
+            self.inactive = np.logical_not(active_array)
+            self.all_inactive = np.all(self.inactive)
+            self.active_property_uuid = active_property_uuid
 
-   def column_is_inactive(self, col_ji0):
-      """Returns True if all the cells in the specified column are inactive.
+    def column_is_inactive(self, col_ji0):
+        """Returns True if all the cells in the specified column are inactive.
 
       arguments:
          col_ji0 (int pair): the (j0, i0) column indices
@@ -1691,13 +1699,13 @@ class Grid(BaseResqpy):
          boolean: True if all the cells in the column are inactive; False if at least one cell is active
       """
 
-      self.extract_inactive_mask()
-      if self.inactive is None:
-         return False  # no inactive mask indicates all cells are active
-      return np.all(self.inactive[:, col_ji0[0], col_ji0[1]])
+        self.extract_inactive_mask()
+        if self.inactive is None:
+            return False  # no inactive mask indicates all cells are active
+        return np.all(self.inactive[:, col_ji0[0], col_ji0[1]])
 
-   def create_column_pillar_mapping(self):
-      """Creates an array attribute holding set of 4 pillar indices for each I, J column of cells.
+    def create_column_pillar_mapping(self):
+        """Creates an array attribute holding set of 4 pillar indices for each I, J column of cells.
 
       returns:
          numpy integer array of shape (nj, ni, 2, 2) where the last two indices are jp, ip;
@@ -1717,43 +1725,43 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      if hasattr(self, 'pillars_for_column') and self.pillars_for_column is not None:
-         return self.pillars_for_column
+        if hasattr(self, 'pillars_for_column') and self.pillars_for_column is not None:
+            return self.pillars_for_column
 
-      self.cache_all_geometry_arrays()
+        self.cache_all_geometry_arrays()
 
-      self.pillars_for_column = np.empty((self.nj, self.ni, 2, 2), dtype = int)
-      ni_plus_1 = self.ni + 1
+        self.pillars_for_column = np.empty((self.nj, self.ni, 2, 2), dtype = int)
+        ni_plus_1 = self.ni + 1
 
-      for j in range(self.nj):
-         self.pillars_for_column[j, :, 0, 0] = np.arange(j * ni_plus_1, (j + 1) * ni_plus_1 - 1, dtype = int)
-         self.pillars_for_column[j, :, 0, 1] = np.arange(j * ni_plus_1 + 1, (j + 1) * ni_plus_1, dtype = int)
-         self.pillars_for_column[j, :, 1, 0] = np.arange((j + 1) * ni_plus_1, (j + 2) * ni_plus_1 - 1, dtype = int)
-         self.pillars_for_column[j, :, 1, 1] = np.arange((j + 1) * ni_plus_1 + 1, (j + 2) * ni_plus_1, dtype = int)
+        for j in range(self.nj):
+            self.pillars_for_column[j, :, 0, 0] = np.arange(j * ni_plus_1, (j + 1) * ni_plus_1 - 1, dtype = int)
+            self.pillars_for_column[j, :, 0, 1] = np.arange(j * ni_plus_1 + 1, (j + 1) * ni_plus_1, dtype = int)
+            self.pillars_for_column[j, :, 1, 0] = np.arange((j + 1) * ni_plus_1, (j + 2) * ni_plus_1 - 1, dtype = int)
+            self.pillars_for_column[j, :, 1, 1] = np.arange((j + 1) * ni_plus_1 + 1, (j + 2) * ni_plus_1, dtype = int)
 
-      if self.has_split_coordinate_lines:
-         unsplit_pillar_count = (self.nj + 1) * ni_plus_1
-         extras_count = len(self.split_pillar_indices_cached)
-         for extra_index in range(extras_count):
-            primary = self.split_pillar_indices_cached[extra_index]
-            primary_ji0 = divmod(primary, self.ni + 1)
-            extra_pillar_index = unsplit_pillar_count + extra_index
-            if extra_index == 0:
-               start = 0
-            else:
-               start = self.cols_for_split_pillars_cl[extra_index - 1]
-            for cpscl_index in range(start, self.cols_for_split_pillars_cl[extra_index]):
-               col = self.cols_for_split_pillars[cpscl_index]
-               j, i = divmod(col, self.ni)
-               jp = primary_ji0[0] - j
-               ip = primary_ji0[1] - i
-               assert (jp == 0 or jp == 1) and (ip == 0 or ip == 1)
-               self.pillars_for_column[j, i, jp, ip] = extra_pillar_index
+        if self.has_split_coordinate_lines:
+            unsplit_pillar_count = (self.nj + 1) * ni_plus_1
+            extras_count = len(self.split_pillar_indices_cached)
+            for extra_index in range(extras_count):
+                primary = self.split_pillar_indices_cached[extra_index]
+                primary_ji0 = divmod(primary, self.ni + 1)
+                extra_pillar_index = unsplit_pillar_count + extra_index
+                if extra_index == 0:
+                    start = 0
+                else:
+                    start = self.cols_for_split_pillars_cl[extra_index - 1]
+                for cpscl_index in range(start, self.cols_for_split_pillars_cl[extra_index]):
+                    col = self.cols_for_split_pillars[cpscl_index]
+                    j, i = divmod(col, self.ni)
+                    jp = primary_ji0[0] - j
+                    ip = primary_ji0[1] - i
+                    assert (jp == 0 or jp == 1) and (ip == 0 or ip == 1)
+                    self.pillars_for_column[j, i, jp, ip] = extra_pillar_index
 
-      return self.pillars_for_column
+        return self.pillars_for_column
 
-   def pillar_foursome(self, ji0, none_if_unsplit = False):
-      """Returns a numpy int array of shape (2, 2) being the natural pillar indices applicable to each column around primary.
+    def pillar_foursome(self, ji0, none_if_unsplit = False):
+        """Returns a numpy int array of shape (2, 2) being the natural pillar indices applicable to each column around primary.
 
       arguments:
          ji0 (pair of ints): the pillar indices (j0, i0) of the primary pillar of interest
@@ -1767,222 +1775,226 @@ class Grid(BaseResqpy):
          usual
       """
 
-      j0, i0 = ji0
+        j0, i0 = ji0
 
-      self.cache_all_geometry_arrays()
+        self.cache_all_geometry_arrays()
 
-      primary = (self.ni + 1) * j0 + i0
-      foursome = np.full((2, 2), primary, dtype = int)  # axes are: jp, ip
-      if not self.has_split_coordinate_lines:
-         return None if none_if_unsplit else foursome
-      extras = np.where(self.split_pillar_indices_cached == primary)[0]
-      if len(extras) == 0:
-         return None if none_if_unsplit else foursome
+        primary = (self.ni + 1) * j0 + i0
+        foursome = np.full((2, 2), primary, dtype = int)  # axes are: jp, ip
+        if not self.has_split_coordinate_lines:
+            return None if none_if_unsplit else foursome
+        extras = np.where(self.split_pillar_indices_cached == primary)[0]
+        if len(extras) == 0:
+            return None if none_if_unsplit else foursome
 
-      primary_count = (self.nj + 1) * (self.ni + 1)
-      assert len(self.cols_for_split_pillars) == self.cols_for_split_pillars_cl[-1]
-      for cpscl_index in extras:
-         if cpscl_index == 0:
-            start_index = 0
-         else:
-            start_index = self.cols_for_split_pillars_cl[cpscl_index - 1]
-         for csp_index in range(start_index, self.cols_for_split_pillars_cl[cpscl_index]):
-            natural_col = self.cols_for_split_pillars[csp_index]
-            col_j0_e, col_i0_e = divmod(natural_col, self.ni)
-            col_j0_e -= (j0 - 1)
-            col_i0_e -= (i0 - 1)
-            assert col_j0_e in [0, 1] and col_i0_e in [0, 1]
-            foursome[col_j0_e, col_i0_e] = primary_count + cpscl_index
+        primary_count = (self.nj + 1) * (self.ni + 1)
+        assert len(self.cols_for_split_pillars) == self.cols_for_split_pillars_cl[-1]
+        for cpscl_index in extras:
+            if cpscl_index == 0:
+                start_index = 0
+            else:
+                start_index = self.cols_for_split_pillars_cl[cpscl_index - 1]
+            for csp_index in range(start_index, self.cols_for_split_pillars_cl[cpscl_index]):
+                natural_col = self.cols_for_split_pillars[csp_index]
+                col_j0_e, col_i0_e = divmod(natural_col, self.ni)
+                col_j0_e -= (j0 - 1)
+                col_i0_e -= (i0 - 1)
+                assert col_j0_e in [0, 1] and col_i0_e in [0, 1]
+                foursome[col_j0_e, col_i0_e] = primary_count + cpscl_index
 
-      return foursome
+        return foursome
 
-   def is_split_column_face(self, j0, i0, axis, polarity):
-      """Returns True if the I or J column face is split; False otherwise."""
+    def is_split_column_face(self, j0, i0, axis, polarity):
+        """Returns True if the I or J column face is split; False otherwise."""
 
-      if not self.has_split_coordinate_lines:
-         return False
-      assert axis in (1, 2)
-      if axis == 1:  # J
-         ip = i0
-         if polarity:
-            if j0 == self.nj - 1:
-               return False
-            jp = j0 + 1
-         else:
-            if j0 == 0:
-               return False
-            jp = j0 - 1
-      else:  # I
-         jp = j0
-         if polarity:
-            if i0 == self.ni - 1:
-               return False
-            ip = i0 + 1
-         else:
-            if i0 == 0:
-               return False
-            ip = i0 - 1
-      cpm = self.create_column_pillar_mapping()
-      if axis == 1:
-         return ((cpm[j0, i0, polarity, 0] != cpm[jp, ip, 1 - polarity, 0]) or
-                 (cpm[j0, i0, polarity, 1] != cpm[jp, ip, 1 - polarity, 1]))
-      else:
-         return ((cpm[j0, i0, 0, polarity] != cpm[jp, ip, 0, 1 - polarity]) or
-                 (cpm[j0, i0, 1, polarity] != cpm[jp, ip, 1, 1 - polarity]))
+        if not self.has_split_coordinate_lines:
+            return False
+        assert axis in (1, 2)
+        if axis == 1:  # J
+            ip = i0
+            if polarity:
+                if j0 == self.nj - 1:
+                    return False
+                jp = j0 + 1
+            else:
+                if j0 == 0:
+                    return False
+                jp = j0 - 1
+        else:  # I
+            jp = j0
+            if polarity:
+                if i0 == self.ni - 1:
+                    return False
+                ip = i0 + 1
+            else:
+                if i0 == 0:
+                    return False
+                ip = i0 - 1
+        cpm = self.create_column_pillar_mapping()
+        if axis == 1:
+            return ((cpm[j0, i0, polarity, 0] != cpm[jp, ip, 1 - polarity, 0]) or
+                    (cpm[j0, i0, polarity, 1] != cpm[jp, ip, 1 - polarity, 1]))
+        else:
+            return ((cpm[j0, i0, 0, polarity] != cpm[jp, ip, 0, 1 - polarity]) or
+                    (cpm[j0, i0, 1, polarity] != cpm[jp, ip, 1, 1 - polarity]))
 
-   def split_column_faces(self):
-      """Returns a pair of numpy boolean arrays indicating which internal column faces (column edges) are split."""
+    def split_column_faces(self):
+        """Returns a pair of numpy boolean arrays indicating which internal column faces (column edges) are split."""
 
-      if not self.has_split_coordinate_lines:
-         return None, None
-      if (hasattr(self, 'array_j_column_face_split') and self.array_j_column_face_split is not None and
-          hasattr(self, 'array_i_column_face_split') and self.array_i_column_face_split is not None):
-         return self.array_j_column_face_split, self.array_i_column_face_split
-      if self.nj == 1:
-         self.array_j_column_face_split = None
-      else:
-         self.array_j_column_face_split = np.zeros((self.nj - 1, self.ni),
-                                                   dtype = bool)  # NB. internal faces only, index for +ve face
-      if self.ni == 1:
-         self.array_i_column_face_split = None
-      else:
-         self.array_i_column_face_split = np.zeros((self.nj, self.ni - 1),
-                                                   dtype = bool)  # NB. internal faces only, index for +ve face
-      self.create_column_pillar_mapping()
-      for spi in self.split_pillar_indices_cached:
-         j_p, i_p = divmod(spi, self.ni + 1)
-         if j_p > 0 and j_p < self.nj:
-            if i_p > 0 and self.is_split_column_face(j_p, i_p - 1, 1, 0):
-               self.array_j_column_face_split[j_p - 1, i_p - 1] = True
-            if i_p < self.ni - 1 and self.is_split_column_face(j_p, i_p, 1, 0):
-               self.array_j_column_face_split[j_p - 1, i_p] = True
-         if i_p > 0 and i_p < self.ni:
-            if j_p > 0 and self.is_split_column_face(j_p - 1, i_p, 2, 0):
-               self.array_i_column_face_split[j_p - 1, i_p - 1] = True
-            if j_p < self.nj - 1 and self.is_split_column_face(j_p, i_p, 2, 0):
-               self.array_i_column_face_split[j_p, i_p - 1] = True
-      return self.array_j_column_face_split, self.array_i_column_face_split
+        if not self.has_split_coordinate_lines:
+            return None, None
+        if (hasattr(self, 'array_j_column_face_split') and self.array_j_column_face_split is not None and
+                hasattr(self, 'array_i_column_face_split') and self.array_i_column_face_split is not None):
+            return self.array_j_column_face_split, self.array_i_column_face_split
+        if self.nj == 1:
+            self.array_j_column_face_split = None
+        else:
+            self.array_j_column_face_split = np.zeros((self.nj - 1, self.ni),
+                                                      dtype = bool)  # NB. internal faces only, index for +ve face
+        if self.ni == 1:
+            self.array_i_column_face_split = None
+        else:
+            self.array_i_column_face_split = np.zeros((self.nj, self.ni - 1),
+                                                      dtype = bool)  # NB. internal faces only, index for +ve face
+        self.create_column_pillar_mapping()
+        for spi in self.split_pillar_indices_cached:
+            j_p, i_p = divmod(spi, self.ni + 1)
+            if j_p > 0 and j_p < self.nj:
+                if i_p > 0 and self.is_split_column_face(j_p, i_p - 1, 1, 0):
+                    self.array_j_column_face_split[j_p - 1, i_p - 1] = True
+                if i_p < self.ni - 1 and self.is_split_column_face(j_p, i_p, 1, 0):
+                    self.array_j_column_face_split[j_p - 1, i_p] = True
+            if i_p > 0 and i_p < self.ni:
+                if j_p > 0 and self.is_split_column_face(j_p - 1, i_p, 2, 0):
+                    self.array_i_column_face_split[j_p - 1, i_p - 1] = True
+                if j_p < self.nj - 1 and self.is_split_column_face(j_p, i_p, 2, 0):
+                    self.array_i_column_face_split[j_p, i_p - 1] = True
+        return self.array_j_column_face_split, self.array_i_column_face_split
 
-   def find_faults(self, set_face_sets = False, create_organizing_objects_where_needed = False):
-      """Searches for column-faces that are faulted and assigns fault ids; creates list of column-faces per fault id.
-
-      note:
-         this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
-         GridConnectionSet class
-      """
-
-      # note:the logic to group kelp into distinct fault ids is simplistic and won't always give the right grouping
-
-      if set_face_sets:
-         self.clear_face_sets()
-
-      if hasattr(self, 'fault_dict') and self.fault_dict is not None and len(self.fault_dict.keys()) > 0:
-         if set_face_sets:
-            for f, (j_list, i_list) in self.fault_dict.items():
-               self.face_set_dict[f] = (j_list, i_list, 'K')
-            self.set_face_set_gcs_list_from_dict(self.fault_dict, create_organizing_objects_where_needed)
-         return None
-
-      log.info('looking for faults in grid')
-      self.create_column_pillar_mapping()
-      if not self.has_split_coordinate_lines:
-         log.info('grid does not have split coordinate lines, ie. is unfaulted')
-         self.fault_dict = None
-         return None
-
-      # note: if Ni or Nj is 1, the kelp array has zero size, but that seems to be handled okay
-      kelp_j = np.zeros((self.extent_kji[1] - 1, self.extent_kji[2]), dtype = 'int')  # fault id between cols j, j+1
-      kelp_i = np.zeros((self.extent_kji[1], self.extent_kji[2] - 1), dtype = 'int')  # fault id between cols i, i+1
-
-      last_fault_id = 0
-
-      # look for splits affecting j faces
-      for j in range(self.extent_kji[1] - 1):
-         for i in range(self.extent_kji[2]):
-            if i == 0 and (self.pillars_for_column[j, i, 1, 0] != self.pillars_for_column[j + 1, i, 0, 0] or
-                           self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j + 1, i, 0, 1]):
-               last_fault_id += 1
-               kelp_j[j, i] = last_fault_id
-            elif self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j + 1, i, 0, 1]:
-               if i > 0 and kelp_j[j, i - 1] > 0:
-                  kelp_j[j, i] = kelp_j[j, i - 1]
-               else:
-                  last_fault_id += 1
-                  kelp_j[j, i] = last_fault_id
-
-      # look for splits affecting i faces
-      for i in range(self.extent_kji[2] - 1):
-         for j in range(self.extent_kji[1]):
-            if j == 0 and (self.pillars_for_column[j, i, 0, 1] != self.pillars_for_column[j, i + 1, 0, 0] or
-                           self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j, i + 1, 1, 0]):
-               last_fault_id += 1
-               kelp_i[j, i] = last_fault_id
-            elif self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j, i + 1, 1, 0]:
-               if j > 0 and kelp_i[j - 1, i] > 0:
-                  kelp_i[j, i] = kelp_i[j - 1, i]
-               else:
-                  last_fault_id += 1
-                  kelp_i[j, i] = last_fault_id
-
-      # make pass over kelp to reduce distinct ids: combine where pillar has exactly 2 kelps, one in each of i and j
-      if kelp_j.size and kelp_i.size:
-         for j in range(self.extent_kji[1] - 1):
-            for i in range(self.extent_kji[2] - 1):
-               if (bool(kelp_j[j, i]) != bool(kelp_j[j, i + 1])) and (bool(kelp_i[j, i]) != bool(kelp_i[j + 1, i])):
-                  j_id = kelp_j[j, i] + kelp_j[j, i + 1]  # ie. the non-zero value
-                  i_id = kelp_i[j, i] + kelp_i[j + 1, i]
-                  if j_id == i_id:
-                     continue
-                  #                  log.debug('merging fault id {} into {}'.format(i_id, j_id))
-                  kelp_i = np.where(kelp_i == i_id, j_id, kelp_i)
-                  kelp_j = np.where(kelp_j == i_id, j_id, kelp_j)
-
-      fault_id_list = np.unique(np.concatenate(
-         (np.unique(kelp_i.flatten()), np.unique(kelp_j.flatten()))))[1:]  # discard zero from list
-      log.info('number of distinct faults: ' + str(fault_id_list.size))
-      # for each fault id, make pair of tuples of kelp locations
-      self.fault_dict = {}  # maps fault_id to pair (j faces, i faces) of array of [j, i] kelp indices for that fault_id
-      for fault_id in fault_id_list:
-         self.fault_dict[fault_id] = (np.stack(np.where(kelp_j == fault_id),
-                                               axis = 1), np.stack(np.where(kelp_i == fault_id), axis = 1))
-      self.fault_id_j = kelp_j.copy()  # fault_id for each internal j kelp, zero is none; extent nj-1, ni
-      self.fault_id_i = kelp_i.copy()  # fault_id for each internal i kelp, zero is none; extent nj, ni-1
-      if set_face_sets:
-         for f, (j_list, i_list) in self.fault_dict.items():
-            self.face_set_dict[f] = (j_list, i_list, 'K')
-         self.set_face_set_gcs_list_from_dict(self.fault_dict, create_organizing_objects_where_needed)
-      return (self.fault_id_j, self.fault_id_i)
-
-   def fault_throws(self):
-      """Finds mean throw of each J and I face; adds throw arrays as attributes to this grid and returns them.
+    def find_faults(self, set_face_sets = False, create_organizing_objects_where_needed = False):
+        """Searches for column-faces that are faulted and assigns fault ids; creates list of column-faces per fault id.
 
       note:
          this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
          GridConnectionSet class
       """
 
-      if hasattr(self, 'fault_throw_j') and self.fault_throw_j is not None and hasattr(
-            self, 'fault_throw_i') and self.fault_throw_i is not None:
-         return (self.fault_throw_j, self.fault_throw_i)
-      if not self.has_split_coordinate_lines:
-         return None
-      if not hasattr(self, 'fault_id_j') or self.fault_id_j is None or not hasattr(
-            self, 'fault_id_i') or self.fault_id_i is None:
-         self.find_faults()
-         if not hasattr(self, 'fault_id_j'):
+        # note:the logic to group kelp into distinct fault ids is simplistic and won't always give the right grouping
+
+        if set_face_sets:
+            self.clear_face_sets()
+
+        if hasattr(self, 'fault_dict') and self.fault_dict is not None and len(self.fault_dict.keys()) > 0:
+            if set_face_sets:
+                for f, (j_list, i_list) in self.fault_dict.items():
+                    self.face_set_dict[f] = (j_list, i_list, 'K')
+                self.set_face_set_gcs_list_from_dict(self.fault_dict, create_organizing_objects_where_needed)
             return None
-      log.debug('computing fault throws (deprecated method)')
-      cp = self.corner_points(cache_cp_array = True)
-      self.fault_throw_j = np.zeros((self.nk, self.nj - 1, self.ni))
-      self.fault_throw_i = np.zeros((self.nk, self.nj, self.ni - 1))
-      self.fault_throw_j = np.where(self.fault_id_j == 0, 0.0,
-                                    0.25 * np.sum(cp[:, 1:, :, :, 0, :, 2] - cp[:, :-1, :, :, 1, :, 2], axis = (3, 4)))
-      self.fault_throw_i = np.where(self.fault_id_i == 0, 0.0,
-                                    0.25 * np.sum(cp[:, :, 1:, :, :, 0, 2] - cp[:, :, -1:, :, :, 1, 2], axis = (3, 4)))
-      return (self.fault_throw_j, self.fault_throw_i)
 
-   def fault_throws_per_edge_per_column(self, mode = 'maximum', simple_z = False, axis_polarity_mode = True):
-      """Returns numpy array of shape (nj, ni, 2, 2) or (nj, ni, 4) holding max, mean or min throw based on split node separations.
+        log.info('looking for faults in grid')
+        self.create_column_pillar_mapping()
+        if not self.has_split_coordinate_lines:
+            log.info('grid does not have split coordinate lines, ie. is unfaulted')
+            self.fault_dict = None
+            return None
+
+        # note: if Ni or Nj is 1, the kelp array has zero size, but that seems to be handled okay
+        kelp_j = np.zeros((self.extent_kji[1] - 1, self.extent_kji[2]), dtype = 'int')  # fault id between cols j, j+1
+        kelp_i = np.zeros((self.extent_kji[1], self.extent_kji[2] - 1), dtype = 'int')  # fault id between cols i, i+1
+
+        last_fault_id = 0
+
+        # look for splits affecting j faces
+        for j in range(self.extent_kji[1] - 1):
+            for i in range(self.extent_kji[2]):
+                if i == 0 and (self.pillars_for_column[j, i, 1, 0] != self.pillars_for_column[j + 1, i, 0, 0] or
+                               self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j + 1, i, 0, 1]):
+                    last_fault_id += 1
+                    kelp_j[j, i] = last_fault_id
+                elif self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j + 1, i, 0, 1]:
+                    if i > 0 and kelp_j[j, i - 1] > 0:
+                        kelp_j[j, i] = kelp_j[j, i - 1]
+                    else:
+                        last_fault_id += 1
+                        kelp_j[j, i] = last_fault_id
+
+        # look for splits affecting i faces
+        for i in range(self.extent_kji[2] - 1):
+            for j in range(self.extent_kji[1]):
+                if j == 0 and (self.pillars_for_column[j, i, 0, 1] != self.pillars_for_column[j, i + 1, 0, 0] or
+                               self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j, i + 1, 1, 0]):
+                    last_fault_id += 1
+                    kelp_i[j, i] = last_fault_id
+                elif self.pillars_for_column[j, i, 1, 1] != self.pillars_for_column[j, i + 1, 1, 0]:
+                    if j > 0 and kelp_i[j - 1, i] > 0:
+                        kelp_i[j, i] = kelp_i[j - 1, i]
+                    else:
+                        last_fault_id += 1
+                        kelp_i[j, i] = last_fault_id
+
+        # make pass over kelp to reduce distinct ids: combine where pillar has exactly 2 kelps, one in each of i and j
+        if kelp_j.size and kelp_i.size:
+            for j in range(self.extent_kji[1] - 1):
+                for i in range(self.extent_kji[2] - 1):
+                    if (bool(kelp_j[j, i]) != bool(kelp_j[j, i + 1])) and (bool(kelp_i[j, i]) != bool(kelp_i[j + 1,
+                                                                                                             i])):
+                        j_id = kelp_j[j, i] + kelp_j[j, i + 1]  # ie. the non-zero value
+                        i_id = kelp_i[j, i] + kelp_i[j + 1, i]
+                        if j_id == i_id:
+                            continue
+                        #                  log.debug('merging fault id {} into {}'.format(i_id, j_id))
+                        kelp_i = np.where(kelp_i == i_id, j_id, kelp_i)
+                        kelp_j = np.where(kelp_j == i_id, j_id, kelp_j)
+
+        fault_id_list = np.unique(np.concatenate(
+            (np.unique(kelp_i.flatten()), np.unique(kelp_j.flatten()))))[1:]  # discard zero from list
+        log.info('number of distinct faults: ' + str(fault_id_list.size))
+        # for each fault id, make pair of tuples of kelp locations
+        self.fault_dict = {
+        }  # maps fault_id to pair (j faces, i faces) of array of [j, i] kelp indices for that fault_id
+        for fault_id in fault_id_list:
+            self.fault_dict[fault_id] = (np.stack(np.where(kelp_j == fault_id),
+                                                  axis = 1), np.stack(np.where(kelp_i == fault_id), axis = 1))
+        self.fault_id_j = kelp_j.copy()  # fault_id for each internal j kelp, zero is none; extent nj-1, ni
+        self.fault_id_i = kelp_i.copy()  # fault_id for each internal i kelp, zero is none; extent nj, ni-1
+        if set_face_sets:
+            for f, (j_list, i_list) in self.fault_dict.items():
+                self.face_set_dict[f] = (j_list, i_list, 'K')
+            self.set_face_set_gcs_list_from_dict(self.fault_dict, create_organizing_objects_where_needed)
+        return (self.fault_id_j, self.fault_id_i)
+
+    def fault_throws(self):
+        """Finds mean throw of each J and I face; adds throw arrays as attributes to this grid and returns them.
+
+      note:
+         this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
+         GridConnectionSet class
+      """
+
+        if hasattr(self, 'fault_throw_j') and self.fault_throw_j is not None and hasattr(
+                self, 'fault_throw_i') and self.fault_throw_i is not None:
+            return (self.fault_throw_j, self.fault_throw_i)
+        if not self.has_split_coordinate_lines:
+            return None
+        if not hasattr(self, 'fault_id_j') or self.fault_id_j is None or not hasattr(
+                self, 'fault_id_i') or self.fault_id_i is None:
+            self.find_faults()
+            if not hasattr(self, 'fault_id_j'):
+                return None
+        log.debug('computing fault throws (deprecated method)')
+        cp = self.corner_points(cache_cp_array = True)
+        self.fault_throw_j = np.zeros((self.nk, self.nj - 1, self.ni))
+        self.fault_throw_i = np.zeros((self.nk, self.nj, self.ni - 1))
+        self.fault_throw_j = np.where(
+            self.fault_id_j == 0, 0.0,
+            0.25 * np.sum(cp[:, 1:, :, :, 0, :, 2] - cp[:, :-1, :, :, 1, :, 2], axis = (3, 4)))
+        self.fault_throw_i = np.where(
+            self.fault_id_i == 0, 0.0,
+            0.25 * np.sum(cp[:, :, 1:, :, :, 0, 2] - cp[:, :, -1:, :, :, 1, 2], axis = (3, 4)))
+        return (self.fault_throw_j, self.fault_throw_i)
+
+    def fault_throws_per_edge_per_column(self, mode = 'maximum', simple_z = False, axis_polarity_mode = True):
+        """Returns numpy array of shape (nj, ni, 2, 2) or (nj, ni, 4) holding max, mean or min throw based on split node separations.
 
       arguments:
          mode (string, default 'maximum'): one of 'minimum', 'mean', 'maximum'; determines how to resolve variation in throw for
@@ -2011,156 +2023,157 @@ class Grid(BaseResqpy):
          minimum and maximum modes work on the absolute throws
       """
 
-      assert mode in ['maximum', 'mean', 'minimum']
-      if not simple_z:
-         assert self.z_units() == self.xy_units()
+        assert mode in ['maximum', 'mean', 'minimum']
+        if not simple_z:
+            assert self.z_units() == self.xy_units()
 
-      log.debug('computing fault throws per edge per column based on corner point geometry')
-      if not self.has_split_coordinate_lines:  # note: no NaNs returned in this situation
-         if axis_polarity_mode:
-            return np.zeros((self.nj, self.ni, 2, 2))
-         return np.zeros((self.nj, self.ni, 4))
-      self.create_column_pillar_mapping()
-      i_pillar_throws = (
-         self.points_cached[:, self.pillars_for_column[:, :-1, :, 1], 2]
-         -  # (nk+1, nj, ni-1, jp) +ve dz I- cell > I+ cell
-         self.points_cached[:, self.pillars_for_column[:, 1:, :, 0], 2])
-      j_pillar_throws = (self.points_cached[:, self.pillars_for_column[:-1, :, 1, :], 2] -
-                         self.points_cached[:, self.pillars_for_column[1:, :, 0, :], 2])
-      if not simple_z:
-         i_pillar_throws = np.sign(
-            i_pillar_throws)  # note: will return zero if displacement is purely horizontal wrt. z axis
-         j_pillar_throws = np.sign(j_pillar_throws)
-         i_pillar_throws *= vec.naive_lengths(self.points_cached[:, self.pillars_for_column[:, :-1, :, 1], :] -
-                                              self.points_cached[:, self.pillars_for_column[:, 1:, :, 0], :])
-         j_pillar_throws *= vec.naive_lengths(self.points_cached[:, self.pillars_for_column[:-1, :, 1, :], :] -
-                                              self.points_cached[:, self.pillars_for_column[1:, :, 0, :], :])
+        log.debug('computing fault throws per edge per column based on corner point geometry')
+        if not self.has_split_coordinate_lines:  # note: no NaNs returned in this situation
+            if axis_polarity_mode:
+                return np.zeros((self.nj, self.ni, 2, 2))
+            return np.zeros((self.nj, self.ni, 4))
+        self.create_column_pillar_mapping()
+        i_pillar_throws = (
+            self.points_cached[:, self.pillars_for_column[:, :-1, :, 1], 2]
+            -  # (nk+1, nj, ni-1, jp) +ve dz I- cell > I+ cell
+            self.points_cached[:, self.pillars_for_column[:, 1:, :, 0], 2])
+        j_pillar_throws = (self.points_cached[:, self.pillars_for_column[:-1, :, 1, :], 2] -
+                           self.points_cached[:, self.pillars_for_column[1:, :, 0, :], 2])
+        if not simple_z:
+            i_pillar_throws = np.sign(
+                i_pillar_throws)  # note: will return zero if displacement is purely horizontal wrt. z axis
+            j_pillar_throws = np.sign(j_pillar_throws)
+            i_pillar_throws *= vec.naive_lengths(self.points_cached[:, self.pillars_for_column[:, :-1, :, 1], :] -
+                                                 self.points_cached[:, self.pillars_for_column[:, 1:, :, 0], :])
+            j_pillar_throws *= vec.naive_lengths(self.points_cached[:, self.pillars_for_column[:-1, :, 1, :], :] -
+                                                 self.points_cached[:, self.pillars_for_column[1:, :, 0, :], :])
 
-      if mode == 'mean':
-         i_edge_throws = np.nanmean(i_pillar_throws, axis = (0, -1))  # (nj, ni-1)
-         j_edge_throws = np.nanmean(j_pillar_throws, axis = (0, -1))  # (nj-1, ni)
-      else:
-         min_i_edge_throws = np.nanmean(np.nanmin(i_pillar_throws, axis = 0), axis = -1)
-         max_i_edge_throws = np.nanmean(np.nanmax(i_pillar_throws, axis = 0), axis = -1)
-         min_j_edge_throws = np.nanmean(np.nanmin(j_pillar_throws, axis = 0), axis = -1)
-         max_j_edge_throws = np.nanmean(np.nanmax(j_pillar_throws, axis = 0), axis = -1)
-         i_flip_mask = (np.abs(min_i_edge_throws) > np.abs(max_i_edge_throws))
-         j_flip_mask = (np.abs(min_j_edge_throws) > np.abs(max_j_edge_throws))
-         if mode == 'maximum':
-            i_edge_throws = np.where(i_flip_mask, min_i_edge_throws, max_i_edge_throws)
-            j_edge_throws = np.where(j_flip_mask, min_j_edge_throws, max_j_edge_throws)
-         elif mode == 'minimum':
-            i_edge_throws = np.where(i_flip_mask, max_i_edge_throws, min_i_edge_throws)
-            j_edge_throws = np.where(j_flip_mask, max_j_edge_throws, min_j_edge_throws)
-         else:
-            raise Exception('code failure')
+        if mode == 'mean':
+            i_edge_throws = np.nanmean(i_pillar_throws, axis = (0, -1))  # (nj, ni-1)
+            j_edge_throws = np.nanmean(j_pillar_throws, axis = (0, -1))  # (nj-1, ni)
+        else:
+            min_i_edge_throws = np.nanmean(np.nanmin(i_pillar_throws, axis = 0), axis = -1)
+            max_i_edge_throws = np.nanmean(np.nanmax(i_pillar_throws, axis = 0), axis = -1)
+            min_j_edge_throws = np.nanmean(np.nanmin(j_pillar_throws, axis = 0), axis = -1)
+            max_j_edge_throws = np.nanmean(np.nanmax(j_pillar_throws, axis = 0), axis = -1)
+            i_flip_mask = (np.abs(min_i_edge_throws) > np.abs(max_i_edge_throws))
+            j_flip_mask = (np.abs(min_j_edge_throws) > np.abs(max_j_edge_throws))
+            if mode == 'maximum':
+                i_edge_throws = np.where(i_flip_mask, min_i_edge_throws, max_i_edge_throws)
+                j_edge_throws = np.where(j_flip_mask, min_j_edge_throws, max_j_edge_throws)
+            elif mode == 'minimum':
+                i_edge_throws = np.where(i_flip_mask, max_i_edge_throws, min_i_edge_throws)
+                j_edge_throws = np.where(j_flip_mask, max_j_edge_throws, min_j_edge_throws)
+            else:
+                raise Exception('code failure')
 
-      # positive values indicate column has greater z values, ie. downthrown if z increases with depth
-      if axis_polarity_mode:
-         throws = np.zeros((self.nj, self.ni, 2, 2))  # first 2 is I (0) or J (1); final 2 is -ve or +ve face
-         throws[1:, :, 0, 0] = -j_edge_throws  # J-
-         throws[:-1, :, 0, 1] = j_edge_throws  # J+
-         throws[:, 1:, 1, 0] = -i_edge_throws  # I-
-         throws[:, :-1, 1, 1] = i_edge_throws  # I+
+        # positive values indicate column has greater z values, ie. downthrown if z increases with depth
+        if axis_polarity_mode:
+            throws = np.zeros((self.nj, self.ni, 2, 2))  # first 2 is I (0) or J (1); final 2 is -ve or +ve face
+            throws[1:, :, 0, 0] = -j_edge_throws  # J-
+            throws[:-1, :, 0, 1] = j_edge_throws  # J+
+            throws[:, 1:, 1, 0] = -i_edge_throws  # I-
+            throws[:, :-1, 1, 1] = i_edge_throws  # I+
 
-      else:  # resqml protocol
-         # order I-, J+, I+, J- as required for properties with 'edges per column' indexable element
-         throws = np.zeros((self.nj, self.ni, 4))
-         throws[:, 1:, 0] = -i_edge_throws  # I-
-         throws[:-1, :, 1] = j_edge_throws  # J+
-         throws[:, :-1, 2] = i_edge_throws  # I+
-         throws[1:, :, 3] = -j_edge_throws  # J-
+        else:  # resqml protocol
+            # order I-, J+, I+, J- as required for properties with 'edges per column' indexable element
+            throws = np.zeros((self.nj, self.ni, 4))
+            throws[:, 1:, 0] = -i_edge_throws  # I-
+            throws[:-1, :, 1] = j_edge_throws  # J+
+            throws[:, :-1, 2] = i_edge_throws  # I+
+            throws[1:, :, 3] = -j_edge_throws  # J-
 
-      return throws
+        return throws
 
-   def clear_face_sets(self):
-      """Discard face sets."""
-      # following maps face_set_id to (j faces, i faces, 'K') of array of [j, i] kelp indices for that face_set_id
-      # or equivalent for axes 'J' or 'I'
-      self.face_set_dict = {}
-      self.face_set_gcs_list = []
+    def clear_face_sets(self):
+        """Discard face sets."""
+        # following maps face_set_id to (j faces, i faces, 'K') of array of [j, i] kelp indices for that face_set_id
+        # or equivalent for axes 'J' or 'I'
+        self.face_set_dict = {}
+        self.face_set_gcs_list = []
 
-   def set_face_set_gcs_list_from_dict(self, face_set_dict = None, create_organizing_objects_where_needed = False):
-      """Creates a grid connection set for each feature in the face set dictionary, based on kelp list pairs."""
+    def set_face_set_gcs_list_from_dict(self, face_set_dict = None, create_organizing_objects_where_needed = False):
+        """Creates a grid connection set for each feature in the face set dictionary, based on kelp list pairs."""
 
-      if face_set_dict is None:
-         face_set_dict = self.face_set_dict
-      self.face_set_gcs_list = []
-      for feature in face_set_dict:
-         gcs = rqf.GridConnectionSet(self.model, grid = self)
-         kelp_j, kelp_i, axis = face_set_dict[feature]
-         log.debug(f'creating gcs for: {feature} {axis}')
-         gcs.set_pairs_from_kelp(kelp_j, kelp_i, feature, create_organizing_objects_where_needed, axis = axis)
-         self.face_set_gcs_list.append(gcs)
+        if face_set_dict is None:
+            face_set_dict = self.face_set_dict
+        self.face_set_gcs_list = []
+        for feature in face_set_dict:
+            gcs = rqf.GridConnectionSet(self.model, grid = self)
+            kelp_j, kelp_i, axis = face_set_dict[feature]
+            log.debug(f'creating gcs for: {feature} {axis}')
+            gcs.set_pairs_from_kelp(kelp_j, kelp_i, feature, create_organizing_objects_where_needed, axis = axis)
+            self.face_set_gcs_list.append(gcs)
 
-   # TODO: make separate curtain and K-face versions of following function
-   def make_face_set_from_dataframe(self, df):
-      """Creates a curtain face set for each named fault in dataframe.
+    # TODO: make separate curtain and K-face versions of following function
+    def make_face_set_from_dataframe(self, df):
+        """Creates a curtain face set for each named fault in dataframe.
 
       note:
          this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
          GridConnectionSet class
       """
 
-      # df columns: name, i1, i2, j1, j2, k1, k2, face
-      self.clear_face_sets()
-      names = pd.unique(df.name)
-      count = 0
-      box_kji0 = np.zeros((2, 3), dtype = int)
-      k_warning_given = False
-      for fs_name in names:
-         i_kelp_list = []
-         j_kelp_list = []
-         # ignore k faces for now
-         fs_ds = df[df.name == fs_name]
-         for row in range(len(fs_ds)):
-            face = fs_ds.iloc[row]['face']
-            fl = face[0].upper()
-            if fl in 'IJK':
-               axis = 'KJI'.index(fl)
-            elif fl in 'XYZ':
-               axis = 'ZYX'.index(fl)
-            else:
-               raise ValueError('fault data face not recognized: ' + face)
-            if axis == 0:
-               continue  # ignore k faces for now
-            box_kji0[0, 0] = fs_ds.iloc[row]['k1'] - 1  # k1
-            box_kji0[1, 0] = fs_ds.iloc[row]['k2'] - 1  # k2
-            box_kji0[0, 1] = fs_ds.iloc[row]['j1'] - 1  # j1
-            box_kji0[1, 1] = fs_ds.iloc[row]['j2'] - 1  # j2
-            box_kji0[0, 2] = fs_ds.iloc[row]['i1'] - 1  # i1
-            box_kji0[1, 2] = fs_ds.iloc[row]['i2'] - 1  # i2
-            box_kji0[1, 0] = min(box_kji0[1, 0], self.extent_kji[0] - 1)
-            if not k_warning_given and (box_kji0[0, 0] != 0 or box_kji0[1, 0] != self.extent_kji[0] - 1):
-               log.warning(
-                  'one or more entries in face set dataframe does not cover entire layer range: extended to all layers')
-               k_warning_given = True
-            if len(face) > 1 and face[1] == '-':  # treat negative faces as positive faces of neighbouring cell
-               box_kji0[0, axis] = max(box_kji0[0, axis] - 1, 0)
-               box_kji0[1, axis] -= 1
-            else:
-               box_kji0[1, axis] = min(box_kji0[1, axis], self.extent_kji[axis] - 2)
-            if box_kji0[1, axis] < box_kji0[0, axis]:
-               continue  # faces are all on edge of grid
-            # for now ignore layer range and create curtain of j and i kelp
-            for j in range(box_kji0[0, 1], box_kji0[1, 1] + 1):
-               for i in range(box_kji0[0, 2], box_kji0[1, 2] + 1):
-                  if axis == 1:
-                     _add_to_kelp_list(self.extent_kji, j_kelp_list, True, (j, i))
-                  elif axis == 2:
-                     _add_to_kelp_list(self.extent_kji, i_kelp_list, False, (j, i))
-         self.face_set_dict[fs_name] = (j_kelp_list, i_kelp_list, 'K')
-         count += 1
-      log.info(str(count) + ' face sets extracted from dataframe')
+        # df columns: name, i1, i2, j1, j2, k1, k2, face
+        self.clear_face_sets()
+        names = pd.unique(df.name)
+        count = 0
+        box_kji0 = np.zeros((2, 3), dtype = int)
+        k_warning_given = False
+        for fs_name in names:
+            i_kelp_list = []
+            j_kelp_list = []
+            # ignore k faces for now
+            fs_ds = df[df.name == fs_name]
+            for row in range(len(fs_ds)):
+                face = fs_ds.iloc[row]['face']
+                fl = face[0].upper()
+                if fl in 'IJK':
+                    axis = 'KJI'.index(fl)
+                elif fl in 'XYZ':
+                    axis = 'ZYX'.index(fl)
+                else:
+                    raise ValueError('fault data face not recognized: ' + face)
+                if axis == 0:
+                    continue  # ignore k faces for now
+                box_kji0[0, 0] = fs_ds.iloc[row]['k1'] - 1  # k1
+                box_kji0[1, 0] = fs_ds.iloc[row]['k2'] - 1  # k2
+                box_kji0[0, 1] = fs_ds.iloc[row]['j1'] - 1  # j1
+                box_kji0[1, 1] = fs_ds.iloc[row]['j2'] - 1  # j2
+                box_kji0[0, 2] = fs_ds.iloc[row]['i1'] - 1  # i1
+                box_kji0[1, 2] = fs_ds.iloc[row]['i2'] - 1  # i2
+                box_kji0[1, 0] = min(box_kji0[1, 0], self.extent_kji[0] - 1)
+                if not k_warning_given and (box_kji0[0, 0] != 0 or box_kji0[1, 0] != self.extent_kji[0] - 1):
+                    log.warning(
+                        'one or more entries in face set dataframe does not cover entire layer range: extended to all layers'
+                    )
+                    k_warning_given = True
+                if len(face) > 1 and face[1] == '-':  # treat negative faces as positive faces of neighbouring cell
+                    box_kji0[0, axis] = max(box_kji0[0, axis] - 1, 0)
+                    box_kji0[1, axis] -= 1
+                else:
+                    box_kji0[1, axis] = min(box_kji0[1, axis], self.extent_kji[axis] - 2)
+                if box_kji0[1, axis] < box_kji0[0, axis]:
+                    continue  # faces are all on edge of grid
+                # for now ignore layer range and create curtain of j and i kelp
+                for j in range(box_kji0[0, 1], box_kji0[1, 1] + 1):
+                    for i in range(box_kji0[0, 2], box_kji0[1, 2] + 1):
+                        if axis == 1:
+                            _add_to_kelp_list(self.extent_kji, j_kelp_list, True, (j, i))
+                        elif axis == 2:
+                            _add_to_kelp_list(self.extent_kji, i_kelp_list, False, (j, i))
+            self.face_set_dict[fs_name] = (j_kelp_list, i_kelp_list, 'K')
+            count += 1
+        log.info(str(count) + ' face sets extracted from dataframe')
 
-   def make_face_sets_from_pillar_lists(self,
-                                        pillar_list_list,
-                                        face_set_id,
-                                        axis = 'K',
-                                        ref_slice0 = 0,
-                                        plus_face = False,
-                                        projection = 'xy'):
-      """Creates a curtain face set for each pillar (or rod) list.
+    def make_face_sets_from_pillar_lists(self,
+                                         pillar_list_list,
+                                         face_set_id,
+                                         axis = 'K',
+                                         ref_slice0 = 0,
+                                         plus_face = False,
+                                         projection = 'xy'):
+        """Creates a curtain face set for each pillar (or rod) list.
 
       returns:
          (face_set_dict, full_pillar_list_dict)
@@ -2169,123 +2182,125 @@ class Grid(BaseResqpy):
          'xz' and 'yz' projections currently only supported for unsplit grids
       """
 
-      # NB. this code was originally written for axis K and projection xy, working with horizon points
-      # it has since been reworked for the cross sectional cases, so variables named 'pillar...' may refer to rods
-      # and i_... and j_... may actually represent i,j or i,k or j,k
+        # NB. this code was originally written for axis K and projection xy, working with horizon points
+        # it has since been reworked for the cross sectional cases, so variables named 'pillar...' may refer to rods
+        # and i_... and j_... may actually represent i,j or i,k or j,k
 
-      assert axis in ['K', 'J', 'I']
-      assert projection in ['xy', 'xz', 'yz']
+        assert axis in ['K', 'J', 'I']
+        assert projection in ['xy', 'xz', 'yz']
 
-      local_face_set_dict = {}
-      full_pillar_list_dict = {}
+        local_face_set_dict = {}
+        full_pillar_list_dict = {}
 
-      if not hasattr(self, 'face_set_dict'):
-         self.clear_face_sets()
+        if not hasattr(self, 'face_set_dict'):
+            self.clear_face_sets()
 
-      if axis.upper() == 'K':
-         assert projection == 'xy'
-         pillar_xy = self.horizon_points(ref_k0 = ref_slice0, kp = 1 if plus_face else 0)[:, :, 0:2]
-         kelp_axes = 'JI'
-      else:
-         if projection == 'xz':
-            pillar_xy = self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0,
-                                                      plus_face = plus_face)[:, :, 0:3:2]  # x,z
-         else:  # projection == 'yz'
-            pillar_xy = self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)[:, :,
-                                                                                                            1:]  # y,z
-         if axis.upper() == 'J':
-            kelp_axes = 'KI'
-         else:
-            kelp_axes = 'KJ'
-      kelp_axes_int = np.empty((2,), dtype = int)
-      for a in range(2):
-         kelp_axes_int[a] = 'KJI'.index(kelp_axes[a])
+        if axis.upper() == 'K':
+            assert projection == 'xy'
+            pillar_xy = self.horizon_points(ref_k0 = ref_slice0, kp = 1 if plus_face else 0)[:, :, 0:2]
+            kelp_axes = 'JI'
+        else:
+            if projection == 'xz':
+                pillar_xy = self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0,
+                                                          plus_face = plus_face)[:, :, 0:3:2]  # x,z
+            else:  # projection == 'yz'
+                pillar_xy = self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0,
+                                                          plus_face = plus_face)[:, :, 1:]  # y,z
+            if axis.upper() == 'J':
+                kelp_axes = 'KI'
+            else:
+                kelp_axes = 'KJ'
+        kelp_axes_int = np.empty((2,), dtype = int)
+        for a in range(2):
+            kelp_axes_int[a] = 'KJI'.index(kelp_axes[a])
 #     self.clear_face_sets()  # now accumulating sets
-      face_set_count = 0
-      here = np.zeros(2, dtype = int)
-      side_step = np.zeros(2, dtype = int)
-      for pillar_list in pillar_list_list:
-         if len(pillar_list) < 2:
-            continue
-         full_pillar_list = [pillar_list[0]]
-         face_set_count += 1
-         if len(pillar_list_list) > 1:
-            id_suffix = '_line_' + str(face_set_count)
-         else:
-            id_suffix = ''
-         # i,j are as stated if axis is 'K'; for axis 'J', i,j are actually i,k; for axis 'I', i,j are actually j,k
-         i_kelp_list = []
-         j_kelp_list = []
-         for p in range(len(pillar_list) - 1):
-            ji_0 = pillar_list[p]
-            ji_1 = pillar_list[p + 1]
-            if np.all(ji_0 == ji_1):
-               continue
-            # xy might actually be xy, xz or yz depending on projection
-            xy_0 = pillar_xy[tuple(ji_0)]
-            xy_1 = pillar_xy[tuple(ji_1)]
-            if vec.isclose(xy_0, xy_1):
-               continue
-            dj = ji_1[0] - ji_0[0]
-            di = ji_1[1] - ji_0[1]
-            abs_dj = abs(dj)
-            abs_di = abs(di)
-            if dj < 0:
-               j_sign = -1
+        face_set_count = 0
+        here = np.zeros(2, dtype = int)
+        side_step = np.zeros(2, dtype = int)
+        for pillar_list in pillar_list_list:
+            if len(pillar_list) < 2:
+                continue
+            full_pillar_list = [pillar_list[0]]
+            face_set_count += 1
+            if len(pillar_list_list) > 1:
+                id_suffix = '_line_' + str(face_set_count)
             else:
-               j_sign = 1
-            if di < 0:
-               i_sign = -1
-            else:
-               i_sign = 1
-            here[:] = ji_0
-            while np.any(here != ji_1):
-               previous = here.copy()  # debug
-               if abs_dj >= abs_di:
-                  j = here[0]
-                  if j != ji_1[0]:
-                     jp = j + j_sign
-                     _add_to_kelp_list(self.extent_kji, i_kelp_list, kelp_axes[1], (min(j, jp), here[1] - 1))
-                     here[0] = jp
-                     full_pillar_list.append(tuple(here))
-                  if di != 0:
-                     divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(here)], xy_0, xy_1)
-                     side_step[:] = here
-                     side_step[1] += i_sign
-                     if side_step[1] >= 0 and side_step[1] <= self.extent_kji[kelp_axes_int[1]]:
-                        stepped_divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(side_step)], xy_0, xy_1)
-                        if stepped_divergence < divergence:
-                           here[:] = side_step
-                           _add_to_kelp_list(self.extent_kji, j_kelp_list, kelp_axes[0],
-                                             (here[0] - 1, min(here[1], here[1] - i_sign)))
-                           full_pillar_list.append(tuple(here))
-               else:
-                  i = here[1]
-                  if i != ji_1[1]:
-                     ip = i + i_sign
-                     _add_to_kelp_list(self.extent_kji, j_kelp_list, kelp_axes[0], (here[0] - 1, min(i, ip)))
-                     here[1] = ip
-                     full_pillar_list.append(tuple(here))
-                  if dj != 0:
-                     divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(here)], xy_0, xy_1)
-                     side_step[:] = here
-                     side_step[0] += j_sign
-                     if side_step[0] >= 0 and side_step[0] <= self.extent_kji[kelp_axes_int[0]]:
-                        stepped_divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(side_step)], xy_0, xy_1)
-                        if stepped_divergence < divergence:
-                           here[:] = side_step
-                           _add_to_kelp_list(self.extent_kji, i_kelp_list, kelp_axes[1],
-                                             (min(here[0], here[0] - j_sign), here[1] - 1))
-                           full_pillar_list.append(tuple(here))
-               assert np.any(here != previous), 'failed to move'
-         self.face_set_dict[face_set_id + id_suffix] = (j_kelp_list, i_kelp_list, axis)
-         local_face_set_dict[face_set_id + id_suffix] = (j_kelp_list, i_kelp_list, axis)
-         full_pillar_list_dict[face_set_id + id_suffix] = full_pillar_list.copy()
+                id_suffix = ''
+            # i,j are as stated if axis is 'K'; for axis 'J', i,j are actually i,k; for axis 'I', i,j are actually j,k
+            i_kelp_list = []
+            j_kelp_list = []
+            for p in range(len(pillar_list) - 1):
+                ji_0 = pillar_list[p]
+                ji_1 = pillar_list[p + 1]
+                if np.all(ji_0 == ji_1):
+                    continue
+                # xy might actually be xy, xz or yz depending on projection
+                xy_0 = pillar_xy[tuple(ji_0)]
+                xy_1 = pillar_xy[tuple(ji_1)]
+                if vec.isclose(xy_0, xy_1):
+                    continue
+                dj = ji_1[0] - ji_0[0]
+                di = ji_1[1] - ji_0[1]
+                abs_dj = abs(dj)
+                abs_di = abs(di)
+                if dj < 0:
+                    j_sign = -1
+                else:
+                    j_sign = 1
+                if di < 0:
+                    i_sign = -1
+                else:
+                    i_sign = 1
+                here[:] = ji_0
+                while np.any(here != ji_1):
+                    previous = here.copy()  # debug
+                    if abs_dj >= abs_di:
+                        j = here[0]
+                        if j != ji_1[0]:
+                            jp = j + j_sign
+                            _add_to_kelp_list(self.extent_kji, i_kelp_list, kelp_axes[1], (min(j, jp), here[1] - 1))
+                            here[0] = jp
+                            full_pillar_list.append(tuple(here))
+                        if di != 0:
+                            divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(here)], xy_0, xy_1)
+                            side_step[:] = here
+                            side_step[1] += i_sign
+                            if side_step[1] >= 0 and side_step[1] <= self.extent_kji[kelp_axes_int[1]]:
+                                stepped_divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(side_step)], xy_0,
+                                                                                   xy_1)
+                                if stepped_divergence < divergence:
+                                    here[:] = side_step
+                                    _add_to_kelp_list(self.extent_kji, j_kelp_list, kelp_axes[0],
+                                                      (here[0] - 1, min(here[1], here[1] - i_sign)))
+                                    full_pillar_list.append(tuple(here))
+                    else:
+                        i = here[1]
+                        if i != ji_1[1]:
+                            ip = i + i_sign
+                            _add_to_kelp_list(self.extent_kji, j_kelp_list, kelp_axes[0], (here[0] - 1, min(i, ip)))
+                            here[1] = ip
+                            full_pillar_list.append(tuple(here))
+                        if dj != 0:
+                            divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(here)], xy_0, xy_1)
+                            side_step[:] = here
+                            side_step[0] += j_sign
+                            if side_step[0] >= 0 and side_step[0] <= self.extent_kji[kelp_axes_int[0]]:
+                                stepped_divergence = vec.point_distance_to_line_2d(pillar_xy[tuple(side_step)], xy_0,
+                                                                                   xy_1)
+                                if stepped_divergence < divergence:
+                                    here[:] = side_step
+                                    _add_to_kelp_list(self.extent_kji, i_kelp_list, kelp_axes[1],
+                                                      (min(here[0], here[0] - j_sign), here[1] - 1))
+                                    full_pillar_list.append(tuple(here))
+                    assert np.any(here != previous), 'failed to move'
+            self.face_set_dict[face_set_id + id_suffix] = (j_kelp_list, i_kelp_list, axis)
+            local_face_set_dict[face_set_id + id_suffix] = (j_kelp_list, i_kelp_list, axis)
+            full_pillar_list_dict[face_set_id + id_suffix] = full_pillar_list.copy()
 
-      return local_face_set_dict, full_pillar_list_dict
+        return local_face_set_dict, full_pillar_list_dict
 
-   def check_top_and_base_cell_edge_directions(self):
-      """checks grid top face I & J edge vectors (in x,y) against basal equivalents: max 90 degree angle tolerated
+    def check_top_and_base_cell_edge_directions(self):
+        """checks grid top face I & J edge vectors (in x,y) against basal equivalents: max 90 degree angle tolerated
 
       returns: boolean: True if all checks pass; False if one or more checks fail
 
@@ -2295,69 +2310,71 @@ class Grid(BaseResqpy):
          logs a warning if a check is not passed
       """
 
-      log.debug('deriving cell edge vectors at top and base (for checking)')
-      self.point(cache_array = True)
-      good = True
-      if self.has_split_coordinate_lines:
-         # build top and base I & J cell edge vectors
-         self.create_column_pillar_mapping()  # pillar indices for 4 columns around interior pillars
-         top_j_edge_vectors_p = np.zeros((self.nj, self.ni, 2, 2))  # third axis is ip
-         top_i_edge_vectors_p = np.zeros((self.nj, 2, self.ni, 2))  # second axis is jp
-         base_j_edge_vectors_p = np.zeros((self.nj, self.ni, 2, 2))  # third axis is ip
-         base_i_edge_vectors_p = np.zeros((self.nj, 2, self.ni, 2))  # second axis is jp
-         # todo: rework as numpy operations across nj & ni
-         for j in range(self.nj):
-            for i in range(self.ni):
-               for jip in range(2):  # serves as either jp or ip
-                  top_j_edge_vectors_p[j, i,
-                                       jip, :] = (self.points_cached[0, self.pillars_for_column[j, i, 1, jip], :2] -
-                                                  self.points_cached[0, self.pillars_for_column[j, i, 0, jip], :2])
-                  base_j_edge_vectors_p[j, i, jip, :] = (
-                     self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, 1, jip], :2] -
-                     self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, 0, jip], :2])
-                  top_i_edge_vectors_p[j, jip,
-                                       i, :] = (self.points_cached[0, self.pillars_for_column[j, i, jip, 1], :2] -
-                                                self.points_cached[0, self.pillars_for_column[j, i, jip, 0], :2])
-                  base_i_edge_vectors_p[j, jip, i, :] = (
-                     self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, jip, 1], :2] -
-                     self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, jip, 0], :2])
-         # reshape to allow common checking code with unsplit grid vectors (below)
-         top_j_edge_vectors = top_j_edge_vectors_p.reshape((self.nj, 2 * self.ni, 2))
-         top_i_edge_vectors = top_i_edge_vectors_p.reshape((2 * self.nj, self.ni, 2))
-         base_j_edge_vectors = base_j_edge_vectors_p.reshape((self.nj, 2 * self.ni, 2))
-         base_i_edge_vectors = base_i_edge_vectors_p.reshape((2 * self.nj, self.ni, 2))
-      else:
-         top_j_edge_vectors = (self.points_cached[0, 1:, :, :2] - self.points_cached[0, :-1, :, :2]).reshape(
-            (self.nj, self.ni + 1, 2))
-         top_i_edge_vectors = (self.points_cached[0, :, 1:, :2] - self.points_cached[0, :, :-1, :2]).reshape(
-            (self.nj + 1, self.ni, 2))
-         base_j_edge_vectors = (self.points_cached[-1, 1:, :, :2] - self.points_cached[-1, :-1, :, :2]).reshape(
-            (self.nj, self.ni + 1, 2))
-         base_i_edge_vectors = (self.points_cached[-1, :, 1:, :2] - self.points_cached[-1, :, :-1, :2]).reshape(
-            (self.nj + 1, self.ni, 2))
-      log.debug('checking relative direction of top and base edges')
-      # check direction of top edges against corresponding base edges, tolerate upto 90 degree difference
-      dot_j = np.sum(top_j_edge_vectors * base_j_edge_vectors, axis = 2)
-      dot_i = np.sum(top_i_edge_vectors * base_i_edge_vectors, axis = 2)
-      if not np.all(dot_j >= 0.0) and np.all(dot_i >= 0.0):
-         log.warning('one or more columns of cell edges flip direction: this grid is probably unusable')
-         good = False
-      log.debug('checking relative direction of edges in neighbouring cells at top of grid (and base)')
-      # check direction of similar edges on neighbouring cells, tolerate upto 90 degree difference
-      dot_jp = np.sum(top_j_edge_vectors[1:, :, :] * top_j_edge_vectors[:-1, :, :], axis = 2)
-      dot_ip = np.sum(top_i_edge_vectors[1:, :, :] * top_i_edge_vectors[:-1, :, :], axis = 2)
-      if not np.all(dot_jp >= 0.0) and np.all(dot_ip >= 0.0):
-         log.warning('top cell edges for neighbouring cells flip direction somewhere: this grid is probably unusable')
-         good = False
-      dot_jp = np.sum(base_j_edge_vectors[1:, :, :] * base_j_edge_vectors[:-1, :, :], axis = 2)
-      dot_ip = np.sum(base_i_edge_vectors[1:, :, :] * base_i_edge_vectors[:-1, :, :], axis = 2)
-      if not np.all(dot_jp >= 0.0) and np.all(dot_ip >= 0.0):
-         log.warning('base cell edges for neighbouring cells flip direction somewhere: this grid is probably unusable')
-         good = False
-      return good
+        log.debug('deriving cell edge vectors at top and base (for checking)')
+        self.point(cache_array = True)
+        good = True
+        if self.has_split_coordinate_lines:
+            # build top and base I & J cell edge vectors
+            self.create_column_pillar_mapping()  # pillar indices for 4 columns around interior pillars
+            top_j_edge_vectors_p = np.zeros((self.nj, self.ni, 2, 2))  # third axis is ip
+            top_i_edge_vectors_p = np.zeros((self.nj, 2, self.ni, 2))  # second axis is jp
+            base_j_edge_vectors_p = np.zeros((self.nj, self.ni, 2, 2))  # third axis is ip
+            base_i_edge_vectors_p = np.zeros((self.nj, 2, self.ni, 2))  # second axis is jp
+            # todo: rework as numpy operations across nj & ni
+            for j in range(self.nj):
+                for i in range(self.ni):
+                    for jip in range(2):  # serves as either jp or ip
+                        top_j_edge_vectors_p[j, i, jip, :] = (
+                            self.points_cached[0, self.pillars_for_column[j, i, 1, jip], :2] -
+                            self.points_cached[0, self.pillars_for_column[j, i, 0, jip], :2])
+                        base_j_edge_vectors_p[j, i, jip, :] = (
+                            self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, 1, jip], :2] -
+                            self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, 0, jip], :2])
+                        top_i_edge_vectors_p[j, jip,
+                                             i, :] = (self.points_cached[0, self.pillars_for_column[j, i, jip, 1], :2] -
+                                                      self.points_cached[0, self.pillars_for_column[j, i, jip, 0], :2])
+                        base_i_edge_vectors_p[j, jip, i, :] = (
+                            self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, jip, 1], :2] -
+                            self.points_cached[self.nk_plus_k_gaps, self.pillars_for_column[j, i, jip, 0], :2])
+            # reshape to allow common checking code with unsplit grid vectors (below)
+            top_j_edge_vectors = top_j_edge_vectors_p.reshape((self.nj, 2 * self.ni, 2))
+            top_i_edge_vectors = top_i_edge_vectors_p.reshape((2 * self.nj, self.ni, 2))
+            base_j_edge_vectors = base_j_edge_vectors_p.reshape((self.nj, 2 * self.ni, 2))
+            base_i_edge_vectors = base_i_edge_vectors_p.reshape((2 * self.nj, self.ni, 2))
+        else:
+            top_j_edge_vectors = (self.points_cached[0, 1:, :, :2] - self.points_cached[0, :-1, :, :2]).reshape(
+                (self.nj, self.ni + 1, 2))
+            top_i_edge_vectors = (self.points_cached[0, :, 1:, :2] - self.points_cached[0, :, :-1, :2]).reshape(
+                (self.nj + 1, self.ni, 2))
+            base_j_edge_vectors = (self.points_cached[-1, 1:, :, :2] - self.points_cached[-1, :-1, :, :2]).reshape(
+                (self.nj, self.ni + 1, 2))
+            base_i_edge_vectors = (self.points_cached[-1, :, 1:, :2] - self.points_cached[-1, :, :-1, :2]).reshape(
+                (self.nj + 1, self.ni, 2))
+        log.debug('checking relative direction of top and base edges')
+        # check direction of top edges against corresponding base edges, tolerate upto 90 degree difference
+        dot_j = np.sum(top_j_edge_vectors * base_j_edge_vectors, axis = 2)
+        dot_i = np.sum(top_i_edge_vectors * base_i_edge_vectors, axis = 2)
+        if not np.all(dot_j >= 0.0) and np.all(dot_i >= 0.0):
+            log.warning('one or more columns of cell edges flip direction: this grid is probably unusable')
+            good = False
+        log.debug('checking relative direction of edges in neighbouring cells at top of grid (and base)')
+        # check direction of similar edges on neighbouring cells, tolerate upto 90 degree difference
+        dot_jp = np.sum(top_j_edge_vectors[1:, :, :] * top_j_edge_vectors[:-1, :, :], axis = 2)
+        dot_ip = np.sum(top_i_edge_vectors[1:, :, :] * top_i_edge_vectors[:-1, :, :], axis = 2)
+        if not np.all(dot_jp >= 0.0) and np.all(dot_ip >= 0.0):
+            log.warning(
+                'top cell edges for neighbouring cells flip direction somewhere: this grid is probably unusable')
+            good = False
+        dot_jp = np.sum(base_j_edge_vectors[1:, :, :] * base_j_edge_vectors[:-1, :, :], axis = 2)
+        dot_ip = np.sum(base_i_edge_vectors[1:, :, :] * base_i_edge_vectors[:-1, :, :], axis = 2)
+        if not np.all(dot_jp >= 0.0) and np.all(dot_ip >= 0.0):
+            log.warning(
+                'base cell edges for neighbouring cells flip direction somewhere: this grid is probably unusable')
+            good = False
+        return good
 
-   def point_raw(self, index = None, points_root = None, cache_array = True):
-      """Returns element from points data, indexed as in the hdf5 file; can optionally be used to cache points data.
+    def point_raw(self, index = None, points_root = None, cache_array = True):
+        """Returns element from points data, indexed as in the hdf5 file; can optionally be used to cache points data.
 
       arguments:
          index (2 or 3 integers, optional): if not None, the index into the raw points data for the point of interest
@@ -2376,46 +2393,50 @@ class Grid(BaseResqpy):
          any k gaps; if the grid object does not include geometry then None is returned
       """
 
-      # NB: shape of index depends on whether grid has split pillars
-      if index is not None and not self.geometry_defined_for_all_pillars(cache_array = cache_array):
-         if len(index) == 3:
-            ji = tuple(index[1:])
-         else:
-            ji = tuple(divmod(index[1], self.ni))
-         if ji[0] < self.nj and not self.pillar_geometry_is_defined(ji, cache_array = cache_array):
+        # NB: shape of index depends on whether grid has split pillars
+        if index is not None and not self.geometry_defined_for_all_pillars(cache_array = cache_array):
+            if len(index) == 3:
+                ji = tuple(index[1:])
+            else:
+                ji = tuple(divmod(index[1], self.ni))
+            if ji[0] < self.nj and not self.pillar_geometry_is_defined(ji, cache_array = cache_array):
+                return None
+        if self.points_cached is not None:
+            if index is None:
+                return self.points_cached
+            return self.points_cached[tuple(index)]
+        p_root = self.resolve_geometry_child('Points', child_node = points_root)
+        if p_root is None:
+            log.debug('point_raw() returning None as geometry not present')
+            return None  # geometry not present
+        assert rqet.node_type(p_root) == 'Point3dHdf5Array'
+        h5_key_pair = self.model.h5_uuid_and_path_for_node(p_root, tag = 'Coordinates')
+        if h5_key_pair is None:
             return None
-      if self.points_cached is not None:
-         if index is None:
+        if self.has_split_coordinate_lines:
+            required_shape = None
+        else:
+            required_shape = (self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1, 3)
+        try:
+            value = self.model.h5_array_element(h5_key_pair,
+                                                index = index,
+                                                cache_array = cache_array,
+                                                object = self,
+                                                array_attribute = 'points_cached',
+                                                required_shape = required_shape)
+        except Exception:
+            log.error('hdf5 points failure for index: ' + str(index))
+            raise
+        if index is None:
             return self.points_cached
-         return self.points_cached[tuple(index)]
-      p_root = self.resolve_geometry_child('Points', child_node = points_root)
-      if p_root is None:
-         log.debug('point_raw() returning None as geometry not present')
-         return None  # geometry not present
-      assert rqet.node_type(p_root) == 'Point3dHdf5Array'
-      h5_key_pair = self.model.h5_uuid_and_path_for_node(p_root, tag = 'Coordinates')
-      if h5_key_pair is None:
-         return None
-      if self.has_split_coordinate_lines:
-         required_shape = None
-      else:
-         required_shape = (self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1, 3)
-      try:
-         value = self.model.h5_array_element(h5_key_pair,
-                                             index = index,
-                                             cache_array = cache_array,
-                                             object = self,
-                                             array_attribute = 'points_cached',
-                                             required_shape = required_shape)
-      except Exception:
-         log.error('hdf5 points failure for index: ' + str(index))
-         raise
-      if index is None:
-         return self.points_cached
-      return value
+        return value
 
-   def point(self, cell_kji0 = None, corner_index = np.zeros(3, dtype = 'int'), points_root = None, cache_array = True):
-      """Return a cell corner point xyz; can optionally be used to cache points data.
+    def point(self,
+              cell_kji0 = None,
+              corner_index = np.zeros(3, dtype = 'int'),
+              points_root = None,
+              cache_array = True):
+        """Return a cell corner point xyz; can optionally be used to cache points data.
 
       arguments:
          cell_kji0 (3 integers, optional): if not None, the index of the cell for the point of interest, in kji0 protocol
@@ -2431,32 +2452,32 @@ class Grid(BaseResqpy):
          method will apply
       """
 
-      if cache_array and self.points_cached is None:
-         self.point_raw(points_root = points_root, cache_array = True)
-      if cell_kji0 is None:
-         return None
-      if self.k_raw_index_array is None:
-         self.extract_k_gaps()
-      if not self.geometry_defined_for_all_cells():
-         if not self.cell_geometry_is_defined(cell_kji0, cache_array = cache_array):
+        if cache_array and self.points_cached is None:
+            self.point_raw(points_root = points_root, cache_array = True)
+        if cell_kji0 is None:
             return None
-      p_root = self.resolve_geometry_child('Points', child_node = points_root)
-      #      if p_root is None: return None  # geometry not present
-      index = np.zeros(3, dtype = int)
-      index[:] = cell_kji0
-      index[0] = self.k_raw_index_array[index[0]]  # adjust for k gaps
-      if self.has_split_coordinate_lines:
-         self.create_column_pillar_mapping()
-         pillar_index = self.pillars_for_column[index[1], index[2], corner_index[1], corner_index[2]]
-         return self.point_raw(index = (index[0] + corner_index[0], pillar_index),
-                               points_root = p_root,
-                               cache_array = cache_array)
-      else:
-         index[:] += corner_index
-         return self.point_raw(index = index, points_root = p_root, cache_array = cache_array)
+        if self.k_raw_index_array is None:
+            self.extract_k_gaps()
+        if not self.geometry_defined_for_all_cells():
+            if not self.cell_geometry_is_defined(cell_kji0, cache_array = cache_array):
+                return None
+        p_root = self.resolve_geometry_child('Points', child_node = points_root)
+        #      if p_root is None: return None  # geometry not present
+        index = np.zeros(3, dtype = int)
+        index[:] = cell_kji0
+        index[0] = self.k_raw_index_array[index[0]]  # adjust for k gaps
+        if self.has_split_coordinate_lines:
+            self.create_column_pillar_mapping()
+            pillar_index = self.pillars_for_column[index[1], index[2], corner_index[1], corner_index[2]]
+            return self.point_raw(index = (index[0] + corner_index[0], pillar_index),
+                                  points_root = p_root,
+                                  cache_array = cache_array)
+        else:
+            index[:] += corner_index
+            return self.point_raw(index = index, points_root = p_root, cache_array = cache_array)
 
-   def points_ref(self, masked = True):
-      """Returns an in-memory numpy array containing the xyz data for points used in the grid geometry.
+    def points_ref(self, masked = True):
+        """Returns an in-memory numpy array containing the xyz data for points used in the grid geometry.
 
       argument:
          masked (boolean, default True): if True, a masked array is returned with NaN points masked out;
@@ -2476,28 +2497,28 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      if self.points_cached is None:
-         self.point_raw(cache_array = True)
-         if self.points_cached is None:
-            return None
-      if not masked:
-         return self.points_cached
-      return ma.masked_invalid(self.points_cached)
+        if self.points_cached is None:
+            self.point_raw(cache_array = True)
+            if self.points_cached is None:
+                return None
+        if not masked:
+            return self.points_cached
+        return ma.masked_invalid(self.points_cached)
 
-   def uncache_points(self):
-      """Frees up memory by removing the cached copy of the grid's points data.
+    def uncache_points(self):
+        """Frees up memory by removing the cached copy of the grid's points data.
 
       note:
          the memory will only actually become free when any other references to it pass out of scope
          or are deleted
       """
 
-      if self.points_cached is not None:
-         del self.points_cached
-         self.points_cached = None
+        if self.points_cached is not None:
+            del self.points_cached
+            self.points_cached = None
 
-   def unsplit_points_ref(self, cache_array = False, masked = False):
-      """Returns a copy of the points array that has split pillars merged back into an unsplit configuration.
+    def unsplit_points_ref(self, cache_array = False, masked = False):
+        """Returns a copy of the points array that has split pillars merged back into an unsplit configuration.
 
       arguments:
          cache_array (boolean, default False): if True, a copy of the unsplit points array is added as
@@ -2514,52 +2535,52 @@ class Grid(BaseResqpy):
          contributions to each pillar from the surrounding cell columns
       """
 
-      if hasattr(self, 'array_unsplit_points'):
-         return self.array_unsplit_points
-      points = self.points_ref(masked = masked)
-      if not self.has_split_coordinate_lines:
-         if cache_array:
-            self.array_unsplit_points = points.copy()
+        if hasattr(self, 'array_unsplit_points'):
             return self.array_unsplit_points
-         return points
-      # todo: finish version that copies primaries and only modifies split pillars?
-      # njkp1 = (self.nj + 1) * (self.ni + 1)
-      # merged_points = np.empty((self.nk + 1, njkp1, 3))   # shaped somewhat like split points array
-      # merged_points[:, :, :] = points[:, :njkp1, :]       # copy primary data
-      result = np.empty((self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1, 3))
-      # todo: if not geometry defined for all cells, take nanmean of four points?
-      # compute for internal pillars
-      self.create_column_pillar_mapping()  # pillar indices for 4 columns around interior pillars
-      pfc_11 = self.pillars_for_column[:-1, :-1, 1, 1]
-      pfc_10 = self.pillars_for_column[:-1, 1:, 1, 0]
-      pfc_01 = self.pillars_for_column[1:, :-1, 0, 1]
-      pfc_00 = self.pillars_for_column[1:, 1:, 0, 0]
-      result[:, 1:-1, 1:-1, :] = 0.25 * (points[:, pfc_11, :] + points[:, pfc_10, :] + points[:, pfc_01, :] +
-                                         points[:, pfc_00, :])
-      # edges
-      # todo: use numpy array operations instead of for loops (see lines above for example code)
-      for j in range(1, self.nj):
-         result[:, j, 0, :] = 0.5 * (points[:, self.pillars_for_column[j - 1, 0, 1, 0], :] +
-                                     points[:, self.pillars_for_column[j, 0, 0, 0], :])
-         result[:, j, self.ni, :] = 0.5 * (points[:, self.pillars_for_column[j - 1, self.ni - 1, 1, 1], :] +
-                                           points[:, self.pillars_for_column[j, self.ni - 1, 0, 1], :])
-      for i in range(1, self.ni):
-         result[:, 0, i, :] = 0.5 * (points[:, self.pillars_for_column[0, i - 1, 0, 1], :] +
-                                     points[:, self.pillars_for_column[0, i, 0, 0], :])
-         result[:, self.nj, i, :] = 0.5 * (points[:, self.pillars_for_column[self.nj - 1, i - 1, 1, 1], :] +
-                                           points[:, self.pillars_for_column[self.nj - 1, i, 1, 0], :])
-      # corners (could optimise as these should always be primaries
-      result[:, 0, 0, :] = points[:, self.pillars_for_column[0, 0, 0, 0], :]
-      result[:, 0, self.ni, :] = points[:, self.pillars_for_column[0, self.ni - 1, 0, 1], :]
-      result[:, self.nj, 0, :] = points[:, self.pillars_for_column[self.nj - 1, 0, 1, 0], :]
-      result[:, self.nj, self.ni, :] = points[:, self.pillars_for_column[self.nj - 1, self.ni - 1, 1, 1], :]
-      if cache_array:
-         self.array_unsplit_points = result
-         return self.array_unsplit_points
-      return result
+        points = self.points_ref(masked = masked)
+        if not self.has_split_coordinate_lines:
+            if cache_array:
+                self.array_unsplit_points = points.copy()
+                return self.array_unsplit_points
+            return points
+        # todo: finish version that copies primaries and only modifies split pillars?
+        # njkp1 = (self.nj + 1) * (self.ni + 1)
+        # merged_points = np.empty((self.nk + 1, njkp1, 3))   # shaped somewhat like split points array
+        # merged_points[:, :, :] = points[:, :njkp1, :]       # copy primary data
+        result = np.empty((self.nk_plus_k_gaps + 1, self.nj + 1, self.ni + 1, 3))
+        # todo: if not geometry defined for all cells, take nanmean of four points?
+        # compute for internal pillars
+        self.create_column_pillar_mapping()  # pillar indices for 4 columns around interior pillars
+        pfc_11 = self.pillars_for_column[:-1, :-1, 1, 1]
+        pfc_10 = self.pillars_for_column[:-1, 1:, 1, 0]
+        pfc_01 = self.pillars_for_column[1:, :-1, 0, 1]
+        pfc_00 = self.pillars_for_column[1:, 1:, 0, 0]
+        result[:, 1:-1, 1:-1, :] = 0.25 * (points[:, pfc_11, :] + points[:, pfc_10, :] + points[:, pfc_01, :] +
+                                           points[:, pfc_00, :])
+        # edges
+        # todo: use numpy array operations instead of for loops (see lines above for example code)
+        for j in range(1, self.nj):
+            result[:, j, 0, :] = 0.5 * (points[:, self.pillars_for_column[j - 1, 0, 1, 0], :] +
+                                        points[:, self.pillars_for_column[j, 0, 0, 0], :])
+            result[:, j, self.ni, :] = 0.5 * (points[:, self.pillars_for_column[j - 1, self.ni - 1, 1, 1], :] +
+                                              points[:, self.pillars_for_column[j, self.ni - 1, 0, 1], :])
+        for i in range(1, self.ni):
+            result[:, 0, i, :] = 0.5 * (points[:, self.pillars_for_column[0, i - 1, 0, 1], :] +
+                                        points[:, self.pillars_for_column[0, i, 0, 0], :])
+            result[:, self.nj, i, :] = 0.5 * (points[:, self.pillars_for_column[self.nj - 1, i - 1, 1, 1], :] +
+                                              points[:, self.pillars_for_column[self.nj - 1, i, 1, 0], :])
+        # corners (could optimise as these should always be primaries
+        result[:, 0, 0, :] = points[:, self.pillars_for_column[0, 0, 0, 0], :]
+        result[:, 0, self.ni, :] = points[:, self.pillars_for_column[0, self.ni - 1, 0, 1], :]
+        result[:, self.nj, 0, :] = points[:, self.pillars_for_column[self.nj - 1, 0, 1, 0], :]
+        result[:, self.nj, self.ni, :] = points[:, self.pillars_for_column[self.nj - 1, self.ni - 1, 1, 1], :]
+        if cache_array:
+            self.array_unsplit_points = result
+            return self.array_unsplit_points
+        return result
 
-   def xyz_box(self, points_root = None, lazy = True, local = False):
-      """Returns the minimum and maximum xyz for the grid geometry.
+    def xyz_box(self, points_root = None, lazy = True, local = False):
+        """Returns the minimum and maximum xyz for the grid geometry.
 
       arguments:
          points_root (optional): if not None, the xml root node for the points data (speed optimization)
@@ -2578,38 +2599,39 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      if self.xyz_box_cached is None or (not lazy and not self.xyz_box_cached_thoroughly):
-         self.xyz_box_cached = np.zeros((2, 3))
-         if lazy:
-            eight_corners = np.zeros((2, 2, 2, 3))
-            for kp in [0, 1]:
-               for jp in [0, 1]:
-                  for ip in [0, 1]:
-                     eight_corners[kp, jp, ip] = self.point(cell_kji0 = [
-                        kp * (self.extent_kji[0] - 1), jp * (self.extent_kji[1] - 1), ip * (self.extent_kji[2] - 1)
-                     ],
-                                                            corner_index = [kp, jp, ip],
-                                                            points_root = points_root,
-                                                            cache_array = False)
-            self.xyz_box_cached[0, :] = np.nanmin(eight_corners, axis = (0, 1, 2))
-            self.xyz_box_cached[1, :] = np.nanmax(eight_corners, axis = (0, 1, 2))
-         else:
-            ps = self.points_ref()
-            if self.has_split_coordinate_lines:
-               self.xyz_box_cached[0, :] = np.nanmin(ps, axis = (0, 1))
-               self.xyz_box_cached[1, :] = np.nanmax(ps, axis = (0, 1))
+        if self.xyz_box_cached is None or (not lazy and not self.xyz_box_cached_thoroughly):
+            self.xyz_box_cached = np.zeros((2, 3))
+            if lazy:
+                eight_corners = np.zeros((2, 2, 2, 3))
+                for kp in [0, 1]:
+                    for jp in [0, 1]:
+                        for ip in [0, 1]:
+                            eight_corners[kp, jp, ip] = self.point(cell_kji0 = [
+                                kp * (self.extent_kji[0] - 1), jp * (self.extent_kji[1] - 1),
+                                ip * (self.extent_kji[2] - 1)
+                            ],
+                                                                   corner_index = [kp, jp, ip],
+                                                                   points_root = points_root,
+                                                                   cache_array = False)
+                self.xyz_box_cached[0, :] = np.nanmin(eight_corners, axis = (0, 1, 2))
+                self.xyz_box_cached[1, :] = np.nanmax(eight_corners, axis = (0, 1, 2))
             else:
-               self.xyz_box_cached[0, :] = np.nanmin(ps, axis = (0, 1, 2))
-               self.xyz_box_cached[1, :] = np.nanmax(ps, axis = (0, 1, 2))
-         self.xyz_box_cached_thoroughly = not lazy
-      if local:
-         return self.xyz_box_cached
-      global_xyz_box = self.xyz_box_cached.copy()
-      self.local_to_global_crs(global_xyz_box, self.crs_root)
-      return global_xyz_box
+                ps = self.points_ref()
+                if self.has_split_coordinate_lines:
+                    self.xyz_box_cached[0, :] = np.nanmin(ps, axis = (0, 1))
+                    self.xyz_box_cached[1, :] = np.nanmax(ps, axis = (0, 1))
+                else:
+                    self.xyz_box_cached[0, :] = np.nanmin(ps, axis = (0, 1, 2))
+                    self.xyz_box_cached[1, :] = np.nanmax(ps, axis = (0, 1, 2))
+            self.xyz_box_cached_thoroughly = not lazy
+        if local:
+            return self.xyz_box_cached
+        global_xyz_box = self.xyz_box_cached.copy()
+        self.local_to_global_crs(global_xyz_box, self.crs_root)
+        return global_xyz_box
 
-   def xyz_box_centre(self, points_root = None, lazy = False, local = False):
-      """Returns the (x,y,z) point (as 3 element numpy) at the centre of the xyz box for the grid.
+    def xyz_box_centre(self, points_root = None, lazy = False, local = False):
+        """Returns the (x,y,z) point (as 3 element numpy) at the centre of the xyz box for the grid.
 
       arguments:
          points_root (optional): if not None, the xml root node for the points data (speed optimization)
@@ -2626,10 +2648,10 @@ class Grid(BaseResqpy):
          the centre point returned is simply the midpoint of the x, y & z ranges of the grid
       """
 
-      return np.nanmean(self.xyz_box(points_root = points_root, lazy = lazy, local = local), axis = 0)
+        return np.nanmean(self.xyz_box(points_root = points_root, lazy = lazy, local = local), axis = 0)
 
-   def horizon_points(self, ref_k0 = 0, heal_faults = False, kp = 0):
-      """Returns reference to a points layer array of shape ((nj + 1), (ni + 1), 3) based on primary pillars.
+    def horizon_points(self, ref_k0 = 0, heal_faults = False, kp = 0):
+        """Returns reference to a points layer array of shape ((nj + 1), (ni + 1), 3) based on primary pillars.
 
       arguments:
          ref_k0 (integer): the horizon layer number, in the range 0 to nk (or layer number in range 0..nk-1
@@ -2655,25 +2677,25 @@ class Grid(BaseResqpy):
          with kp being passed the value 0 (default) for the top of the layer, or 1 for the base of the layer
       """
 
-      # note: if heal_faults is False, primary pillars only are used
-      pe_j = self.nj + 1
-      pe_i = self.ni + 1
-      if self.k_gaps:
-         ref_k0 = self.k_raw_index_array[ref_k0]
-      ref_k0 += kp
-      if self.has_split_coordinate_lines:
-         if heal_faults:
-            points = self.unsplit_points_ref()  # expensive operation: would be better to cache the unsplit points
-            return points[ref_k0, :, :, :].reshape((pe_j, pe_i, 3))
-         else:
-            points = self.points_ref(masked = False)
-            return points[ref_k0, :pe_j * pe_i, :].reshape((pe_j, pe_i, 3))
-      # unfaulted grid
-      points = self.points_ref(masked = False)
-      return points[ref_k0, :, :, :].reshape((pe_j, pe_i, 3))
+        # note: if heal_faults is False, primary pillars only are used
+        pe_j = self.nj + 1
+        pe_i = self.ni + 1
+        if self.k_gaps:
+            ref_k0 = self.k_raw_index_array[ref_k0]
+        ref_k0 += kp
+        if self.has_split_coordinate_lines:
+            if heal_faults:
+                points = self.unsplit_points_ref()  # expensive operation: would be better to cache the unsplit points
+                return points[ref_k0, :, :, :].reshape((pe_j, pe_i, 3))
+            else:
+                points = self.points_ref(masked = False)
+                return points[ref_k0, :pe_j * pe_i, :].reshape((pe_j, pe_i, 3))
+        # unfaulted grid
+        points = self.points_ref(masked = False)
+        return points[ref_k0, :, :, :].reshape((pe_j, pe_i, 3))
 
-   def split_horizon_points(self, ref_k0 = 0, masked = False, kp = 0):
-      """Returns reference to a corner points for a horizon, of shape (nj, ni, 2, 2, 3).
+    def split_horizon_points(self, ref_k0 = 0, masked = False, kp = 0):
+        """Returns reference to a corner points for a horizon, of shape (nj, ni, 2, 2, 3).
 
       arguments:
          ref_k0 (integer): the horizon layer number, in the range 0 to nk (or layer number in range 0..nk-1
@@ -2693,32 +2715,32 @@ class Grid(BaseResqpy):
          with kp being passed the value 0 (default) for the top of the layer, or 1 for the base of the layer
       """
 
-      if self.k_gaps:
-         ref_k0 = self.k_raw_index_array[ref_k0]
-      ref_k0 += kp
-      points = self.points_ref(masked = masked)
-      hp = np.empty((self.nj, self.ni, 2, 2, 3))
-      if self.has_split_coordinate_lines:
-         assert points.ndim == 3
-         # todo: replace for loops with numpy slice indexing
-         self.create_column_pillar_mapping()
-         assert self.pillars_for_column.ndim == 4 and self.pillars_for_column.shape == (self.nj, self.ni, 2, 2)
-         for j in range(self.nj):
-            for i in range(self.ni):
-               hp[j, i, 0, 0, :] = points[ref_k0, self.pillars_for_column[j, i, 0, 0], :]
-               hp[j, i, 1, 0, :] = points[ref_k0, self.pillars_for_column[j, i, 1, 0], :]
-               hp[j, i, 0, 1, :] = points[ref_k0, self.pillars_for_column[j, i, 0, 1], :]
-               hp[j, i, 1, 1, :] = points[ref_k0, self.pillars_for_column[j, i, 1, 1], :]
-      else:
-         assert points.ndim == 4
-         hp[:, :, 0, 0, :] = points[ref_k0, :-1, :-1, :]
-         hp[:, :, 1, 0, :] = points[ref_k0, 1:, :-1, :]
-         hp[:, :, 0, 1, :] = points[ref_k0, :-1, 1:, :]
-         hp[:, :, 1, 1, :] = points[ref_k0, 1:, 1:, :]
-      return hp
+        if self.k_gaps:
+            ref_k0 = self.k_raw_index_array[ref_k0]
+        ref_k0 += kp
+        points = self.points_ref(masked = masked)
+        hp = np.empty((self.nj, self.ni, 2, 2, 3))
+        if self.has_split_coordinate_lines:
+            assert points.ndim == 3
+            # todo: replace for loops with numpy slice indexing
+            self.create_column_pillar_mapping()
+            assert self.pillars_for_column.ndim == 4 and self.pillars_for_column.shape == (self.nj, self.ni, 2, 2)
+            for j in range(self.nj):
+                for i in range(self.ni):
+                    hp[j, i, 0, 0, :] = points[ref_k0, self.pillars_for_column[j, i, 0, 0], :]
+                    hp[j, i, 1, 0, :] = points[ref_k0, self.pillars_for_column[j, i, 1, 0], :]
+                    hp[j, i, 0, 1, :] = points[ref_k0, self.pillars_for_column[j, i, 0, 1], :]
+                    hp[j, i, 1, 1, :] = points[ref_k0, self.pillars_for_column[j, i, 1, 1], :]
+        else:
+            assert points.ndim == 4
+            hp[:, :, 0, 0, :] = points[ref_k0, :-1, :-1, :]
+            hp[:, :, 1, 0, :] = points[ref_k0, 1:, :-1, :]
+            hp[:, :, 0, 1, :] = points[ref_k0, :-1, 1:, :]
+            hp[:, :, 1, 1, :] = points[ref_k0, 1:, 1:, :]
+        return hp
 
-   def split_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
-      """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid.
+    def split_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
+        """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid.
 
       arguments:
          axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
@@ -2735,22 +2757,22 @@ class Grid(BaseResqpy):
          function for unsplit grids; use split_gap_x_section_points() if k gaps are present
       """
 
-      log.debug(f'x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
-      assert axis.upper() in ['I', 'J']
-      assert not self.k_gaps, 'split_x_section_points() method is for grids without k gaps; use split_gap_x_section_points()'
+        log.debug(f'x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
+        assert axis.upper() in ['I', 'J']
+        assert not self.k_gaps, 'split_x_section_points() method is for grids without k gaps; use split_gap_x_section_points()'
 
-      points = self.points_ref(masked = masked)
-      cpm = self.create_column_pillar_mapping()
+        points = self.points_ref(masked = masked)
+        cpm = self.create_column_pillar_mapping()
 
-      ij_p = 1 if plus_face else 0
+        ij_p = 1 if plus_face else 0
 
-      if axis.upper() == 'I':
-         return points[:, cpm[:, ref_slice0, :, ij_p], :]
-      else:
-         return points[:, cpm[ref_slice0, :, ij_p, :], :]
+        if axis.upper() == 'I':
+            return points[:, cpm[:, ref_slice0, :, ij_p], :]
+        else:
+            return points[:, cpm[ref_slice0, :, ij_p, :], :]
 
-   def split_gap_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
-      """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid with k gaps.
+    def split_gap_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
+        """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid with k gaps.
 
       arguments:
          axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
@@ -2767,34 +2789,34 @@ class Grid(BaseResqpy):
          without k gaps
       """
 
-      log.debug(f'k gap x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
-      assert axis.upper() in ['I', 'J']
+        log.debug(f'k gap x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
+        assert axis.upper() in ['I', 'J']
 
-      if self.has_split_coordinate_lines:
-         points = self.points_ref(masked = masked)
-      else:
-         points = self.points_ref(masked = masked).reshape((self.nk_plus_k_gaps, (self.nj + 1) * (self.ni + 1), 3))
-      cpm = self.create_column_pillar_mapping()
+        if self.has_split_coordinate_lines:
+            points = self.points_ref(masked = masked)
+        else:
+            points = self.points_ref(masked = masked).reshape((self.nk_plus_k_gaps, (self.nj + 1) * (self.ni + 1), 3))
+        cpm = self.create_column_pillar_mapping()
 
-      ij_p = 1 if plus_face else 0
+        ij_p = 1 if plus_face else 0
 
-      if self.k_gaps:
-         top_points = points[self.k_raw_index_array]
-         base_points = points[self.k_raw_index_array + 1]
-         if axis.upper() == 'I':
-            top = top_points[:, cpm[:, ref_slice0, :, ij_p], :]
-            base = base_points[:, cpm[:, ref_slice0, :, ij_p], :]
-         else:
-            top = top_points[:, cpm[ref_slice0, :, ij_p, :], :]
-            base = base_points[:, cpm[ref_slice0, :, ij_p, :], :]
-      else:
-         p = self.split_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face, masked = masked)
-         top = p[:-1]
-         base = p[1:]
-      return np.stack((top, base), axis = 2)
+        if self.k_gaps:
+            top_points = points[self.k_raw_index_array]
+            base_points = points[self.k_raw_index_array + 1]
+            if axis.upper() == 'I':
+                top = top_points[:, cpm[:, ref_slice0, :, ij_p], :]
+                base = base_points[:, cpm[:, ref_slice0, :, ij_p], :]
+            else:
+                top = top_points[:, cpm[ref_slice0, :, ij_p, :], :]
+                base = base_points[:, cpm[ref_slice0, :, ij_p, :], :]
+        else:
+            p = self.split_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face, masked = masked)
+            top = p[:-1]
+            base = p[1:]
+        return np.stack((top, base), axis = 2)
 
-   def unsplit_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
-      """Returns a 2D (+1 for xyz) array of points representing cell corners from an I or J interface slice.
+    def unsplit_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
+        """Returns a 2D (+1 for xyz) array of points representing cell corners from an I or J interface slice.
 
       arguments:
          axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
@@ -2812,34 +2834,34 @@ class Grid(BaseResqpy):
          or split_gap_x_section_points() for split grids with k gaps or x_section_corner_points() for any grid
       """
 
-      log.debug(f'x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
-      assert axis.upper() in ['I', 'J']
-      assert not self.has_split_coordinate_lines, 'cross sectional points for unsplit grids require split_x_section_points()'
-      assert not self.k_gaps, 'cross sectional points with k gaps require split_gap_x_section_points()'
+        log.debug(f'x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
+        assert axis.upper() in ['I', 'J']
+        assert not self.has_split_coordinate_lines, 'cross sectional points for unsplit grids require split_x_section_points()'
+        assert not self.k_gaps, 'cross sectional points with k gaps require split_gap_x_section_points()'
 
-      if plus_face:
-         ref_slice0 += 1
+        if plus_face:
+            ref_slice0 += 1
 
-      points = self.points_ref(masked = masked)
+        points = self.points_ref(masked = masked)
 
-      if axis.upper() == 'I':
-         return points[:, :, ref_slice0, :]
-      else:
-         return points[:, ref_slice0, :, :]
+        if axis.upper() == 'I':
+            return points[:, :, ref_slice0, :]
+        else:
+            return points[:, ref_slice0, :, :]
 
-   def x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
-      """Deprecated: please use unsplit_x_section_points() instead."""
+    def x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
+        """Deprecated: please use unsplit_x_section_points() instead."""
 
-      return self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face, masked = masked)
+        return self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face, masked = masked)
 
-   def x_section_corner_points(self,
-                               axis,
-                               ref_slice0 = 0,
-                               plus_face = False,
-                               masked = False,
-                               rotate = False,
-                               azimuth = None):
-      """Returns a fully expanded array of points representing cell corners from an I or J interface slice.
+    def x_section_corner_points(self,
+                                axis,
+                                ref_slice0 = 0,
+                                plus_face = False,
+                                masked = False,
+                                rotate = False,
+                                azimuth = None):
+        """Returns a fully expanded array of points representing cell corners from an I or J interface slice.
 
       arguments:
          axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
@@ -2863,44 +2885,47 @@ class Grid(BaseResqpy):
          units for relative purposes
       """
 
-      assert axis.upper() in ['I', 'J']
-      nj_or_ni = self.nj if axis.upper() == 'I' else self.ni
+        assert axis.upper() in ['I', 'J']
+        nj_or_ni = self.nj if axis.upper() == 'I' else self.ni
 
-      if self.k_gaps:
-         x_sect = self.split_gap_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face, masked = masked)
-      else:
-         if self.has_split_coordinate_lines:
-            no_k_gap_xs = self.split_x_section_points(axis,
-                                                      ref_slice0 = ref_slice0,
-                                                      plus_face = plus_face,
-                                                      masked = masked)
-            x_sect = np.empty((self.nk, nj_or_ni, 2, 2, 3))
-            x_sect[:, :, 0, :, :] = no_k_gap_xs[:-1, :, :, :]
-            x_sect[:, :, 1, :, :] = no_k_gap_xs[1:, :, :, :]
-         else:
-            simple_xs = self.unsplit_x_section_points(axis,
-                                                      ref_slice0 = ref_slice0,
-                                                      plus_face = plus_face,
-                                                      masked = masked)
-            x_sect = np.empty((self.nk, nj_or_ni, 2, 2, 3))
-            x_sect[:, :, 0, 0, :] = simple_xs[:-1, :-1, :]
-            x_sect[:, :, 1, 0, :] = simple_xs[1:, :-1, :]
-            x_sect[:, :, 0, 1, :] = simple_xs[:-1, 1:, :]
-            x_sect[:, :, 1, 1, :] = simple_xs[1:, 1:, :]
+        if self.k_gaps:
+            x_sect = self.split_gap_x_section_points(axis,
+                                                     ref_slice0 = ref_slice0,
+                                                     plus_face = plus_face,
+                                                     masked = masked)
+        else:
+            if self.has_split_coordinate_lines:
+                no_k_gap_xs = self.split_x_section_points(axis,
+                                                          ref_slice0 = ref_slice0,
+                                                          plus_face = plus_face,
+                                                          masked = masked)
+                x_sect = np.empty((self.nk, nj_or_ni, 2, 2, 3))
+                x_sect[:, :, 0, :, :] = no_k_gap_xs[:-1, :, :, :]
+                x_sect[:, :, 1, :, :] = no_k_gap_xs[1:, :, :, :]
+            else:
+                simple_xs = self.unsplit_x_section_points(axis,
+                                                          ref_slice0 = ref_slice0,
+                                                          plus_face = plus_face,
+                                                          masked = masked)
+                x_sect = np.empty((self.nk, nj_or_ni, 2, 2, 3))
+                x_sect[:, :, 0, 0, :] = simple_xs[:-1, :-1, :]
+                x_sect[:, :, 1, 0, :] = simple_xs[1:, :-1, :]
+                x_sect[:, :, 0, 1, :] = simple_xs[:-1, 1:, :]
+                x_sect[:, :, 1, 1, :] = simple_xs[1:, 1:, :]
 
-      if rotate:
-         if azimuth is None:
-            direction = vec.points_direction_vector(x_sect, axis = 1)
-         else:
-            direction = vec.unit_vector_from_azimuth(azimuth)
-         x_sect = vec.rotate_xyz_array_around_z_axis(x_sect, direction)
-         x_sect[..., 0] -= np.nanmin(x_sect[..., 0])
-         x_sect[..., 1] -= np.nanmin(x_sect[..., 1])
+        if rotate:
+            if azimuth is None:
+                direction = vec.points_direction_vector(x_sect, axis = 1)
+            else:
+                direction = vec.unit_vector_from_azimuth(azimuth)
+            x_sect = vec.rotate_xyz_array_around_z_axis(x_sect, direction)
+            x_sect[..., 0] -= np.nanmin(x_sect[..., 0])
+            x_sect[..., 1] -= np.nanmin(x_sect[..., 1])
 
-      return x_sect
+        return x_sect
 
-   def pixel_map_for_split_horizon_points(self, horizon_points, origin, width, height, dx, dy = None):
-      """Makes a mapping from pixels to cell j, i indices, based on split horizon points for a single horizon.
+    def pixel_map_for_split_horizon_points(self, horizon_points, origin, width, height, dx, dy = None):
+        """Makes a mapping from pixels to cell j, i indices, based on split horizon points for a single horizon.
 
       args:
          horizon_points (numpy array of shape (nj, ni, 2, 2, 2+)): corner point x,y,z values for cell
@@ -2916,53 +2941,53 @@ class Grid(BaseResqpy):
          values of -1 are used as null (ie. pixel not within any cell)
       """
 
-      if dy is None:
-         dy = dx
-      half_dx = 0.5 * dx
-      half_dy = 0.5 * dy
-      d = np.array((dx, dy))
-      half_d = np.array((half_dx, half_dy))
+        if dy is None:
+            dy = dx
+        half_dx = 0.5 * dx
+        half_dy = 0.5 * dy
+        d = np.array((dx, dy))
+        half_d = np.array((half_dx, half_dy))
 
-      #     north_east = np.array(origin) + np.array((width * dx, height * dy))
+        #     north_east = np.array(origin) + np.array((width * dx, height * dy))
 
-      p_map = np.full((height, width, 2), -1, dtype = int)
+        p_map = np.full((height, width, 2), -1, dtype = int)
 
-      # switch from logical corner ordering to polygon ordering
-      poly_points = horizon_points[..., :2].copy()
-      poly_points[:, :, 1, 1] = horizon_points[:, :, 1, 0, :2]
-      poly_points[:, :, 1, 0] = horizon_points[:, :, 1, 1, :2]
-      poly_points = poly_points.reshape(horizon_points.shape[0], horizon_points.shape[1], 4, 2)
+        # switch from logical corner ordering to polygon ordering
+        poly_points = horizon_points[..., :2].copy()
+        poly_points[:, :, 1, 1] = horizon_points[:, :, 1, 0, :2]
+        poly_points[:, :, 1, 0] = horizon_points[:, :, 1, 1, :2]
+        poly_points = poly_points.reshape(horizon_points.shape[0], horizon_points.shape[1], 4, 2)
 
-      poly_box = np.empty((2, 2))
-      patch_p_origin = np.empty((2,), dtype = int)  # NB. ordering is (ncol, nrow)
-      patch_origin = np.empty((2,))
-      patch_extent = np.empty((2,), dtype = int)  # NB. ordering is (ncol, nrow)
+        poly_box = np.empty((2, 2))
+        patch_p_origin = np.empty((2,), dtype = int)  # NB. ordering is (ncol, nrow)
+        patch_origin = np.empty((2,))
+        patch_extent = np.empty((2,), dtype = int)  # NB. ordering is (ncol, nrow)
 
-      for j in range(poly_points.shape[0]):
-         for i in range(poly_points.shape[1]):
-            if np.any(np.isnan(poly_points[j, i])):
-               continue
-            poly_box[0] = np.min(poly_points[j, i], axis = 0) - half_d
-            poly_box[1] = np.max(poly_points[j, i], axis = 0) + half_d
-            patch_p_origin[:] = (poly_box[0] - origin) / (dx, dy)
-            if patch_p_origin[0] < 0 or patch_p_origin[1] < 0:
-               continue
-            patch_extent[:] = np.ceil((poly_box[1] - poly_box[0]) / (dx, dy))
-            if patch_p_origin[0] + patch_extent[0] > width or patch_p_origin[1] + patch_extent[1] > height:
-               continue
-            patch_origin = origin + d * patch_p_origin + half_d
-            scan_mask = pip.scan(patch_origin, patch_extent[0], patch_extent[1], dx, dy, poly_points[j, i])
-            patch_mask = np.stack((scan_mask, scan_mask), axis = -1)
-            old_patch = p_map[patch_p_origin[1]:patch_p_origin[1] + patch_extent[1],
-                              patch_p_origin[0]:patch_p_origin[0] + patch_extent[0], :].copy()
-            new_patch = np.empty(old_patch.shape, dtype = int)
-            new_patch[:, :] = (j, i)
-            p_map[patch_p_origin[1]:patch_p_origin[1] + patch_extent[1], patch_p_origin[0]:patch_p_origin[0] + patch_extent[0], :] =  \
-               np.where(patch_mask, new_patch, old_patch)
-      return p_map
+        for j in range(poly_points.shape[0]):
+            for i in range(poly_points.shape[1]):
+                if np.any(np.isnan(poly_points[j, i])):
+                    continue
+                poly_box[0] = np.min(poly_points[j, i], axis = 0) - half_d
+                poly_box[1] = np.max(poly_points[j, i], axis = 0) + half_d
+                patch_p_origin[:] = (poly_box[0] - origin) / (dx, dy)
+                if patch_p_origin[0] < 0 or patch_p_origin[1] < 0:
+                    continue
+                patch_extent[:] = np.ceil((poly_box[1] - poly_box[0]) / (dx, dy))
+                if patch_p_origin[0] + patch_extent[0] > width or patch_p_origin[1] + patch_extent[1] > height:
+                    continue
+                patch_origin = origin + d * patch_p_origin + half_d
+                scan_mask = pip.scan(patch_origin, patch_extent[0], patch_extent[1], dx, dy, poly_points[j, i])
+                patch_mask = np.stack((scan_mask, scan_mask), axis = -1)
+                old_patch = p_map[patch_p_origin[1]:patch_p_origin[1] + patch_extent[1],
+                                  patch_p_origin[0]:patch_p_origin[0] + patch_extent[0], :].copy()
+                new_patch = np.empty(old_patch.shape, dtype = int)
+                new_patch[:, :] = (j, i)
+                p_map[patch_p_origin[1]:patch_p_origin[1] + patch_extent[1], patch_p_origin[0]:patch_p_origin[0] + patch_extent[0], :] =  \
+                   np.where(patch_mask, new_patch, old_patch)
+        return p_map
 
-   def pixel_maps(self, origin, width, height, dx, dy = None, k0 = None, vertical_ref = 'top'):
-      """Makes a mapping from pixels to cell j, i indices, based on split horizon points for a single horizon.
+    def pixel_maps(self, origin, width, height, dx, dy = None, k0 = None, vertical_ref = 'top'):
+        """Makes a mapping from pixels to cell j, i indices, based on split horizon points for a single horizon.
 
       args:
          origin (float pair): x, y of south west corner of area covered by pixel rectangle, in local crs
@@ -2979,32 +3004,32 @@ class Grid(BaseResqpy):
          that the pixel centres lie within; values of -1 are used as null (ie. pixel not within any cell)
       """
 
-      if len(origin) == 3:
-         origin = tuple(origin[0:2])
-      assert len(origin) == 2
-      assert width > 0 and height > 0
-      if dy is None:
-         dy = dx
-      assert dx > 0.0 and dy > 0.0
-      if k0 is not None:
-         assert 0 <= k0 < self.nk
-      assert vertical_ref in ['top', 'base']
+        if len(origin) == 3:
+            origin = tuple(origin[0:2])
+        assert len(origin) == 2
+        assert width > 0 and height > 0
+        if dy is None:
+            dy = dx
+        assert dx > 0.0 and dy > 0.0
+        if k0 is not None:
+            assert 0 <= k0 < self.nk
+        assert vertical_ref in ['top', 'base']
 
-      kp = 0 if vertical_ref == 'top' else 1
-      if k0 is not None:
-         hp = self.split_horizon_points(ref_k0 = k0, masked = False, kp = kp)
-         p_map = self.pixel_map_for_split_horizon_points(hp, origin, width, height, dx, dy = dy)
-      else:
-         _, _, raw_k = self.extract_k_gaps()
-         hp = self.split_horizons_points(masked = False)
-         p_map = np.empty((self.nk, height, width, 2), dtype = int)
-         for k0 in range(self.nk):
-            rk0 = raw_k[k0] + kp
-            p_map[k0] = self.pixel_map_for_split_horizon_points(hp[rk0], origin, width, height, dx, dy = dy)
-      return p_map
+        kp = 0 if vertical_ref == 'top' else 1
+        if k0 is not None:
+            hp = self.split_horizon_points(ref_k0 = k0, masked = False, kp = kp)
+            p_map = self.pixel_map_for_split_horizon_points(hp, origin, width, height, dx, dy = dy)
+        else:
+            _, _, raw_k = self.extract_k_gaps()
+            hp = self.split_horizons_points(masked = False)
+            p_map = np.empty((self.nk, height, width, 2), dtype = int)
+            for k0 in range(self.nk):
+                rk0 = raw_k[k0] + kp
+                p_map[k0] = self.pixel_map_for_split_horizon_points(hp[rk0], origin, width, height, dx, dy = dy)
+        return p_map
 
-   def split_horizons_points(self, min_k0 = None, max_k0 = None, masked = False):
-      """Returns reference to a corner points layer of shape (nh, nj, ni, 2, 2, 3) where nh is number of horizons.
+    def split_horizons_points(self, min_k0 = None, max_k0 = None, masked = False):
+        """Returns reference to a corner points layer of shape (nh, nj, ni, 2, 2, 3) where nh is number of horizons.
 
       arguments:
          min_k0 (integer): the lowest horizon layer number to be included, in the range 0 to nk + k_gaps; defaults to zero
@@ -3024,34 +3049,34 @@ class Grid(BaseResqpy):
          of the horizons points array
       """
 
-      if min_k0 is None:
-         min_k0 = 0
-      else:
-         assert min_k0 >= 0 and min_k0 <= self.nk_plus_k_gaps
-      if max_k0 is None:
-         max_k0 = self.nk_plus_k_gaps
-      else:
-         assert max_k0 >= min_k0 and max_k0 <= self.nk_plus_k_gaps
-      end_k0 = max_k0 + 1
-      points = self.points_ref(masked = False)
-      hp = np.empty((end_k0 - min_k0, self.nj, self.ni, 2, 2, 3))
-      if self.has_split_coordinate_lines:
-         self.create_column_pillar_mapping()
-         for j in range(self.nj):
-            for i in range(self.ni):
-               hp[:, j, i, 0, 0, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 0, 0], :]
-               hp[:, j, i, 1, 0, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 1, 0], :]
-               hp[:, j, i, 0, 1, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 0, 1], :]
-               hp[:, j, i, 1, 1, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 1, 1], :]
-      else:
-         hp[:, :, :, 0, 0, :] = points[min_k0:end_k0, :-1, :-1, :]
-         hp[:, :, :, 1, 0, :] = points[min_k0:end_k0, 1:, :-1, :]
-         hp[:, :, :, 0, 1, :] = points[min_k0:end_k0, :-1, 1:, :]
-         hp[:, :, :, 1, 1, :] = points[min_k0:end_k0, 1:, 1:, :]
-      return hp
+        if min_k0 is None:
+            min_k0 = 0
+        else:
+            assert min_k0 >= 0 and min_k0 <= self.nk_plus_k_gaps
+        if max_k0 is None:
+            max_k0 = self.nk_plus_k_gaps
+        else:
+            assert max_k0 >= min_k0 and max_k0 <= self.nk_plus_k_gaps
+        end_k0 = max_k0 + 1
+        points = self.points_ref(masked = False)
+        hp = np.empty((end_k0 - min_k0, self.nj, self.ni, 2, 2, 3))
+        if self.has_split_coordinate_lines:
+            self.create_column_pillar_mapping()
+            for j in range(self.nj):
+                for i in range(self.ni):
+                    hp[:, j, i, 0, 0, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 0, 0], :]
+                    hp[:, j, i, 1, 0, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 1, 0], :]
+                    hp[:, j, i, 0, 1, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 0, 1], :]
+                    hp[:, j, i, 1, 1, :] = points[min_k0:end_k0, self.pillars_for_column[j, i, 1, 1], :]
+        else:
+            hp[:, :, :, 0, 0, :] = points[min_k0:end_k0, :-1, :-1, :]
+            hp[:, :, :, 1, 0, :] = points[min_k0:end_k0, 1:, :-1, :]
+            hp[:, :, :, 0, 1, :] = points[min_k0:end_k0, :-1, 1:, :]
+            hp[:, :, :, 1, 1, :] = points[min_k0:end_k0, 1:, 1:, :]
+        return hp
 
-   def pillar_distances_sqr(self, xy, ref_k0 = 0, kp = 0, horizon_points = None):
-      """Returns array of the square of the distances of primary pillars in x,y plane to point xy.
+    def pillar_distances_sqr(self, xy, ref_k0 = 0, kp = 0, horizon_points = None):
+        """Returns array of the square of the distances of primary pillars in x,y plane to point xy.
 
       arguments:
          xy (float pair): the xy coordinate to compute the pillar distances to
@@ -3060,61 +3085,61 @@ class Grid(BaseResqpy):
             horizon_points() method; pass for efficiency in case of multiple calls
       """
 
-      # note: currently works with unmasked data and using primary pillars only
-      pe_j = self.extent_kji[1] + 1
-      pe_i = self.extent_kji[2] + 1
-      if horizon_points is None:
-         horizon_points = self.horizon_points(ref_k0 = ref_k0, kp = kp)
-      pillar_xy = horizon_points[:, :, 0:2]
-      dxy = pillar_xy - xy
-      dxy2 = dxy * dxy
-      return (dxy2[:, :, 0] + dxy2[:, :, 1]).reshape((pe_j, pe_i))
+        # note: currently works with unmasked data and using primary pillars only
+        pe_j = self.extent_kji[1] + 1
+        pe_i = self.extent_kji[2] + 1
+        if horizon_points is None:
+            horizon_points = self.horizon_points(ref_k0 = ref_k0, kp = kp)
+        pillar_xy = horizon_points[:, :, 0:2]
+        dxy = pillar_xy - xy
+        dxy2 = dxy * dxy
+        return (dxy2[:, :, 0] + dxy2[:, :, 1]).reshape((pe_j, pe_i))
 
-   def nearest_pillar(self, xy, ref_k0 = 0, kp = 0):
-      """Returns the (j0, i0) indices of the primary pillar with point closest in x,y plane to point xy."""
+    def nearest_pillar(self, xy, ref_k0 = 0, kp = 0):
+        """Returns the (j0, i0) indices of the primary pillar with point closest in x,y plane to point xy."""
 
-      # note: currently works with unmasked data and using primary pillars only
-      pe_i = self.extent_kji[2] + 1
-      sum_dxy2 = self.pillar_distances_sqr(xy, ref_k0 = ref_k0, kp = kp)
-      ji = np.nanargmin(sum_dxy2)
-      j, i = divmod(ji, pe_i)
-      return (j, i)
+        # note: currently works with unmasked data and using primary pillars only
+        pe_i = self.extent_kji[2] + 1
+        sum_dxy2 = self.pillar_distances_sqr(xy, ref_k0 = ref_k0, kp = kp)
+        ji = np.nanargmin(sum_dxy2)
+        j, i = divmod(ji, pe_i)
+        return (j, i)
 
-   def nearest_rod(self, xyz, projection, axis, ref_slice0 = 0, plus_face = False):
-      """Returns the (k0, j0) or (k0 ,i0) indices of the closest point(s) to xyz(s); projection is 'xy', 'xz' or 'yz'.
+    def nearest_rod(self, xyz, projection, axis, ref_slice0 = 0, plus_face = False):
+        """Returns the (k0, j0) or (k0 ,i0) indices of the closest point(s) to xyz(s); projection is 'xy', 'xz' or 'yz'.
 
       note:
          currently only for unsplit grids
       """
 
-      x_sect = self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
-      if type(xyz) is np.ndarray and xyz.ndim > 1:
-         assert xyz.shape[-1] == 3
-         result_shape = list(xyz.shape)
-         result_shape[-1] = 2
-         nearest = np.empty(tuple(result_shape), dtype = int).reshape((-1, 2))
-         for i, p in enumerate(xyz.reshape((-1, 3))):
-            nearest[i] = vec.nearest_point_projected(p, x_sect, projection)
-         return nearest.reshape(tuple(result_shape))
-      else:
-         return vec.nearest_point_projected(xyz, x_sect, projection)
+        x_sect = self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
+        if type(xyz) is np.ndarray and xyz.ndim > 1:
+            assert xyz.shape[-1] == 3
+            result_shape = list(xyz.shape)
+            result_shape[-1] = 2
+            nearest = np.empty(tuple(result_shape), dtype = int).reshape((-1, 2))
+            for i, p in enumerate(xyz.reshape((-1, 3))):
+                nearest[i] = vec.nearest_point_projected(p, x_sect, projection)
+            return nearest.reshape(tuple(result_shape))
+        else:
+            return vec.nearest_point_projected(xyz, x_sect, projection)
 
-   def coordinate_line_end_points(self):
-      """Returns xyz of top and bottom of each primary pillar.
+    def coordinate_line_end_points(self):
+        """Returns xyz of top and bottom of each primary pillar.
 
       returns:
          numpy float array of shape (nj + 1, ni + 1, 2, 3)
       """
 
-      points = self.points_ref(masked = False).reshape((self.nk + 1, -1, 3))
-      primary_pillar_count = (self.nj + 1) * (self.ni + 1)
-      result = np.empty((self.nj + 1, self.ni + 1, 2, 3))
-      result[:, :, 0, :] = points[0, :primary_pillar_count, :].reshape((self.nj + 1, self.ni + 1, 3))
-      result[:, :, 1, :] = points[-1, :primary_pillar_count, :].reshape((self.nj + 1, self.ni + 1, 3))
-      return result
+        points = self.points_ref(masked = False).reshape((self.nk + 1, -1, 3))
+        primary_pillar_count = (self.nj + 1) * (self.ni + 1)
+        result = np.empty((self.nj + 1, self.ni + 1, 2, 3))
+        result[:, :, 0, :] = points[0, :primary_pillar_count, :].reshape((self.nj + 1, self.ni + 1, 3))
+        result[:, :, 1, :] = points[-1, :primary_pillar_count, :].reshape((self.nj + 1, self.ni + 1, 3))
+        return result
 
-   def z_corner_point_depths(self, order = 'cellular'):
-      """Returns the z (depth) values of each corner of each cell.
+    def z_corner_point_depths(self, order = 'cellular'):
+        """Returns the z (depth) values of each corner of each cell.
 
       arguments:
          order (string, default 'cellular'): either 'cellular' or 'linear'; if 'cellular' the resulting array has
@@ -3127,61 +3152,65 @@ class Grid(BaseResqpy):
          keyword formats
       """
 
-      assert order in ['cellular', 'linear']
+        assert order in ['cellular', 'linear']
 
-      z_cp = np.empty((self.nk, self.nj, self.ni, 2, 2, 2))
-      points = self.points_ref()
-      if self.has_split_coordinate_lines:
-         self.create_column_pillar_mapping()
-         # todo: replace j,i for loops with numpy broadcasting
-         if self.k_gaps:
-            for j in range(self.nj):
-               for i in range(self.ni):
-                  z_cp[:, j, i, 0, 0, 0] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 0], 2]
-                  z_cp[:, j, i, 1, 0, 0] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 0], 2]
-                  z_cp[:, j, i, 0, 1, 0] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 0], 2]
-                  z_cp[:, j, i, 1, 1, 0] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 0], 2]
-                  z_cp[:, j, i, 0, 0, 1] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 1], 2]
-                  z_cp[:, j, i, 1, 0, 1] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 1], 2]
-                  z_cp[:, j, i, 0, 1, 1] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 1], 2]
-                  z_cp[:, j, i, 1, 1, 1] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 1], 2]
-         else:
-            for j in range(self.nj):
-               for i in range(self.ni):
-                  z_cp[:, j, i, 0, 0, 0] = points[:-1, self.pillars_for_column[j, i, 0, 0], 2]
-                  z_cp[:, j, i, 1, 0, 0] = points[1:, self.pillars_for_column[j, i, 0, 0], 2]
-                  z_cp[:, j, i, 0, 1, 0] = points[:-1, self.pillars_for_column[j, i, 1, 0], 2]
-                  z_cp[:, j, i, 1, 1, 0] = points[1:, self.pillars_for_column[j, i, 1, 0], 2]
-                  z_cp[:, j, i, 0, 0, 1] = points[:-1, self.pillars_for_column[j, i, 0, 1], 2]
-                  z_cp[:, j, i, 1, 0, 1] = points[1:, self.pillars_for_column[j, i, 0, 1], 2]
-                  z_cp[:, j, i, 0, 1, 1] = points[:-1, self.pillars_for_column[j, i, 1, 1], 2]
-                  z_cp[:, j, i, 1, 1, 1] = points[1:, self.pillars_for_column[j, i, 1, 1], 2]
-      else:
-         if self.k_gaps:
-            z_cp[:, :, :, 0, 0, 0] = points[self.k_raw_index_array, :-1, :-1, 2]
-            z_cp[:, :, :, 1, 0, 0] = points[self.k_raw_index_array + 1, :-1, :-1, 2]
-            z_cp[:, :, :, 0, 1, 0] = points[self.k_raw_index_array, 1:, :-1, 2]
-            z_cp[:, :, :, 1, 1, 0] = points[self.k_raw_index_array + 1, 1:, :-1, 2]
-            z_cp[:, :, :, 0, 0, 1] = points[self.k_raw_index_array, :-1, 1:, 2]
-            z_cp[:, :, :, 1, 0, 1] = points[self.k_raw_index_array + 1, :-1, 1:, 2]
-            z_cp[:, :, :, 0, 1, 1] = points[self.k_raw_index_array, 1:, 1:, 2]
-            z_cp[:, :, :, 1, 1, 1] = points[self.k_raw_index_array + 1, 1:, 1:, 2]
-         else:
-            z_cp[:, :, :, 0, 0, 0] = points[:-1, :-1, :-1, 2]
-            z_cp[:, :, :, 1, 0, 0] = points[1:, :-1, :-1, 2]
-            z_cp[:, :, :, 0, 1, 0] = points[:-1, 1:, :-1, 2]
-            z_cp[:, :, :, 1, 1, 0] = points[1:, 1:, :-1, 2]
-            z_cp[:, :, :, 0, 0, 1] = points[:-1, :-1, 1:, 2]
-            z_cp[:, :, :, 1, 0, 1] = points[1:, :-1, 1:, 2]
-            z_cp[:, :, :, 0, 1, 1] = points[:-1, 1:, 1:, 2]
-            z_cp[:, :, :, 1, 1, 1] = points[1:, 1:, 1:, 2]
+        z_cp = np.empty((self.nk, self.nj, self.ni, 2, 2, 2))
+        points = self.points_ref()
+        if self.has_split_coordinate_lines:
+            self.create_column_pillar_mapping()
+            # todo: replace j,i for loops with numpy broadcasting
+            if self.k_gaps:
+                for j in range(self.nj):
+                    for i in range(self.ni):
+                        z_cp[:, j, i, 0, 0, 0] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 0], 2]
+                        z_cp[:, j, i, 1, 0, 0] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 0],
+                                                        2]
+                        z_cp[:, j, i, 0, 1, 0] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 0], 2]
+                        z_cp[:, j, i, 1, 1, 0] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 0],
+                                                        2]
+                        z_cp[:, j, i, 0, 0, 1] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 1], 2]
+                        z_cp[:, j, i, 1, 0, 1] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 1],
+                                                        2]
+                        z_cp[:, j, i, 0, 1, 1] = points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 1], 2]
+                        z_cp[:, j, i, 1, 1, 1] = points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 1],
+                                                        2]
+            else:
+                for j in range(self.nj):
+                    for i in range(self.ni):
+                        z_cp[:, j, i, 0, 0, 0] = points[:-1, self.pillars_for_column[j, i, 0, 0], 2]
+                        z_cp[:, j, i, 1, 0, 0] = points[1:, self.pillars_for_column[j, i, 0, 0], 2]
+                        z_cp[:, j, i, 0, 1, 0] = points[:-1, self.pillars_for_column[j, i, 1, 0], 2]
+                        z_cp[:, j, i, 1, 1, 0] = points[1:, self.pillars_for_column[j, i, 1, 0], 2]
+                        z_cp[:, j, i, 0, 0, 1] = points[:-1, self.pillars_for_column[j, i, 0, 1], 2]
+                        z_cp[:, j, i, 1, 0, 1] = points[1:, self.pillars_for_column[j, i, 0, 1], 2]
+                        z_cp[:, j, i, 0, 1, 1] = points[:-1, self.pillars_for_column[j, i, 1, 1], 2]
+                        z_cp[:, j, i, 1, 1, 1] = points[1:, self.pillars_for_column[j, i, 1, 1], 2]
+        else:
+            if self.k_gaps:
+                z_cp[:, :, :, 0, 0, 0] = points[self.k_raw_index_array, :-1, :-1, 2]
+                z_cp[:, :, :, 1, 0, 0] = points[self.k_raw_index_array + 1, :-1, :-1, 2]
+                z_cp[:, :, :, 0, 1, 0] = points[self.k_raw_index_array, 1:, :-1, 2]
+                z_cp[:, :, :, 1, 1, 0] = points[self.k_raw_index_array + 1, 1:, :-1, 2]
+                z_cp[:, :, :, 0, 0, 1] = points[self.k_raw_index_array, :-1, 1:, 2]
+                z_cp[:, :, :, 1, 0, 1] = points[self.k_raw_index_array + 1, :-1, 1:, 2]
+                z_cp[:, :, :, 0, 1, 1] = points[self.k_raw_index_array, 1:, 1:, 2]
+                z_cp[:, :, :, 1, 1, 1] = points[self.k_raw_index_array + 1, 1:, 1:, 2]
+            else:
+                z_cp[:, :, :, 0, 0, 0] = points[:-1, :-1, :-1, 2]
+                z_cp[:, :, :, 1, 0, 0] = points[1:, :-1, :-1, 2]
+                z_cp[:, :, :, 0, 1, 0] = points[:-1, 1:, :-1, 2]
+                z_cp[:, :, :, 1, 1, 0] = points[1:, 1:, :-1, 2]
+                z_cp[:, :, :, 0, 0, 1] = points[:-1, :-1, 1:, 2]
+                z_cp[:, :, :, 1, 0, 1] = points[1:, :-1, 1:, 2]
+                z_cp[:, :, :, 0, 1, 1] = points[:-1, 1:, 1:, 2]
+                z_cp[:, :, :, 1, 1, 1] = points[1:, 1:, 1:, 2]
 
-      if order == 'linear':
-         return np.transpose(z_cp, axes = (0, 3, 1, 4, 2, 5))
-      return z_cp
+        if order == 'linear':
+            return np.transpose(z_cp, axes = (0, 3, 1, 4, 2, 5))
+        return z_cp
 
-   def corner_points(self, cell_kji0 = None, points_root = None, cache_resqml_array = True, cache_cp_array = False):
-      """Returns a numpy array of corner points for a single cell or the whole grid.
+    def corner_points(self, cell_kji0 = None, points_root = None, cache_resqml_array = True, cache_cp_array = False):
+        """Returns a numpy array of corner points for a single cell or the whole grid.
 
       notes:
          if cell_kji0 is not None, a 4D array of shape (2, 2, 2, 3) holding single cell corner points in logical order
@@ -3195,113 +3224,129 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      # note: this function returns a derived object rather than a native resqml object
+        # note: this function returns a derived object rather than a native resqml object
 
-      def one_cell_cp(grid, cell_kji0, points_root, cache_array):
-         cp = np.full((2, 2, 2, 3), np.NaN)
-         if not grid.geometry_defined_for_all_cells():
-            if not grid.cell_geometry_is_defined(cell_kji0, cache_array = cache_array):
-               return cp
-         corner_index = np.zeros(3, dtype = 'int')
-         for kp in range(2):
-            corner_index[0] = kp
-            for jp in range(2):
-               corner_index[1] = jp
-               for ip in range(2):
-                  corner_index[2] = ip
-                  one_point = self.point(cell_kji0,
-                                         corner_index = corner_index,
-                                         points_root = points_root,
-                                         cache_array = cache_array)
-                  if one_point is not None:
-                     cp[kp, jp, ip] = one_point
-         return cp
+        def one_cell_cp(grid, cell_kji0, points_root, cache_array):
+            cp = np.full((2, 2, 2, 3), np.NaN)
+            if not grid.geometry_defined_for_all_cells():
+                if not grid.cell_geometry_is_defined(cell_kji0, cache_array = cache_array):
+                    return cp
+            corner_index = np.zeros(3, dtype = 'int')
+            for kp in range(2):
+                corner_index[0] = kp
+                for jp in range(2):
+                    corner_index[1] = jp
+                    for ip in range(2):
+                        corner_index[2] = ip
+                        one_point = self.point(cell_kji0,
+                                               corner_index = corner_index,
+                                               points_root = points_root,
+                                               cache_array = cache_array)
+                        if one_point is not None:
+                            cp[kp, jp, ip] = one_point
+            return cp
 
-      if cell_kji0 is None:
-         cache_cp_array = True
-      if hasattr(self, 'array_corner_points'):
-         if cell_kji0 is None:
+        if cell_kji0 is None:
+            cache_cp_array = True
+        if hasattr(self, 'array_corner_points'):
+            if cell_kji0 is None:
+                return self.array_corner_points
+            return self.array_corner_points[tuple(cell_kji0)]
+        points_root = self.resolve_geometry_child('Points', child_node = points_root)
+        #      if points_root is None: return None  # geometry not present
+        if cache_resqml_array:
+            self.point_raw(points_root = points_root, cache_array = True)
+        if cache_cp_array:
+            self.array_corner_points = np.zeros((self.nk, self.nj, self.ni, 2, 2, 2, 3))
+            points = self.points_ref()
+            if points is None:
+                return None  # geometry not present
+            if self.has_split_coordinate_lines:
+                self.create_column_pillar_mapping()
+                # todo: replace j,i for loops with numpy broadcasting
+                if self.k_gaps:
+                    for j in range(self.nj):
+                        for i in range(self.ni):
+                            self.array_corner_points[:, j, i, 0, 0, 0, :] = points[self.k_raw_index_array,
+                                                                                   self.pillars_for_column[j, i, 0,
+                                                                                                           0], :]
+                            self.array_corner_points[:, j, i, 1, 0, 0, :] = points[self.k_raw_index_array + 1,
+                                                                                   self.pillars_for_column[j, i, 0,
+                                                                                                           0], :]
+                            self.array_corner_points[:, j, i, 0, 1, 0, :] = points[self.k_raw_index_array,
+                                                                                   self.pillars_for_column[j, i, 1,
+                                                                                                           0], :]
+                            self.array_corner_points[:, j, i, 1, 1, 0, :] = points[self.k_raw_index_array + 1,
+                                                                                   self.pillars_for_column[j, i, 1,
+                                                                                                           0], :]
+                            self.array_corner_points[:, j, i, 0, 0, 1, :] = points[self.k_raw_index_array,
+                                                                                   self.pillars_for_column[j, i, 0,
+                                                                                                           1], :]
+                            self.array_corner_points[:, j, i, 1, 0, 1, :] = points[self.k_raw_index_array + 1,
+                                                                                   self.pillars_for_column[j, i, 0,
+                                                                                                           1], :]
+                            self.array_corner_points[:, j, i, 0, 1, 1, :] = points[self.k_raw_index_array,
+                                                                                   self.pillars_for_column[j, i, 1,
+                                                                                                           1], :]
+                            self.array_corner_points[:, j, i, 1, 1, 1, :] = points[self.k_raw_index_array + 1,
+                                                                                   self.pillars_for_column[j, i, 1,
+                                                                                                           1], :]
+                else:
+                    for j in range(self.nj):
+                        for i in range(self.ni):
+                            self.array_corner_points[:, j, i, 0, 0, 0, :] = points[:-1, self.pillars_for_column[j, i, 0,
+                                                                                                                0], :]
+                            self.array_corner_points[:, j, i, 1, 0, 0, :] = points[1:, self.pillars_for_column[j, i, 0,
+                                                                                                               0], :]
+                            self.array_corner_points[:, j, i, 0, 1, 0, :] = points[:-1, self.pillars_for_column[j, i, 1,
+                                                                                                                0], :]
+                            self.array_corner_points[:, j, i, 1, 1, 0, :] = points[1:, self.pillars_for_column[j, i, 1,
+                                                                                                               0], :]
+                            self.array_corner_points[:, j, i, 0, 0, 1, :] = points[:-1, self.pillars_for_column[j, i, 0,
+                                                                                                                1], :]
+                            self.array_corner_points[:, j, i, 1, 0, 1, :] = points[1:, self.pillars_for_column[j, i, 0,
+                                                                                                               1], :]
+                            self.array_corner_points[:, j, i, 0, 1, 1, :] = points[:-1, self.pillars_for_column[j, i, 1,
+                                                                                                                1], :]
+                            self.array_corner_points[:, j, i, 1, 1, 1, :] = points[1:, self.pillars_for_column[j, i, 1,
+                                                                                                               1], :]
+            else:
+                if self.k_gaps:
+                    self.array_corner_points[:, :, :, 0, 0, 0, :] = points[self.k_raw_index_array, :-1, :-1, :]
+                    self.array_corner_points[:, :, :, 1, 0, 0, :] = points[self.k_raw_index_array + 1, :-1, :-1, :]
+                    self.array_corner_points[:, :, :, 0, 1, 0, :] = points[self.k_raw_index_array, 1:, :-1, :]
+                    self.array_corner_points[:, :, :, 1, 1, 0, :] = points[self.k_raw_index_array + 1, 1:, :-1, :]
+                    self.array_corner_points[:, :, :, 0, 0, 1, :] = points[self.k_raw_index_array, :-1, 1:, :]
+                    self.array_corner_points[:, :, :, 1, 0, 1, :] = points[self.k_raw_index_array + 1, :-1, 1:, :]
+                    self.array_corner_points[:, :, :, 0, 1, 1, :] = points[self.k_raw_index_array, 1:, 1:, :]
+                    self.array_corner_points[:, :, :, 1, 1, 1, :] = points[self.k_raw_index_array + 1, 1:, 1:, :]
+                else:
+                    self.array_corner_points[:, :, :, 0, 0, 0, :] = points[:-1, :-1, :-1, :]
+                    self.array_corner_points[:, :, :, 1, 0, 0, :] = points[1:, :-1, :-1, :]
+                    self.array_corner_points[:, :, :, 0, 1, 0, :] = points[:-1, 1:, :-1, :]
+                    self.array_corner_points[:, :, :, 1, 1, 0, :] = points[1:, 1:, :-1, :]
+                    self.array_corner_points[:, :, :, 0, 0, 1, :] = points[:-1, :-1, 1:, :]
+                    self.array_corner_points[:, :, :, 1, 0, 1, :] = points[1:, :-1, 1:, :]
+                    self.array_corner_points[:, :, :, 0, 1, 1, :] = points[:-1, 1:, 1:, :]
+                    self.array_corner_points[:, :, :, 1, 1, 1, :] = points[1:, 1:, 1:, :]
+        if cell_kji0 is None:
             return self.array_corner_points
-         return self.array_corner_points[tuple(cell_kji0)]
-      points_root = self.resolve_geometry_child('Points', child_node = points_root)
-      #      if points_root is None: return None  # geometry not present
-      if cache_resqml_array:
-         self.point_raw(points_root = points_root, cache_array = True)
-      if cache_cp_array:
-         self.array_corner_points = np.zeros((self.nk, self.nj, self.ni, 2, 2, 2, 3))
-         points = self.points_ref()
-         if points is None:
-            return None  # geometry not present
-         if self.has_split_coordinate_lines:
-            self.create_column_pillar_mapping()
-            # todo: replace j,i for loops with numpy broadcasting
-            if self.k_gaps:
-               for j in range(self.nj):
-                  for i in range(self.ni):
-                     self.array_corner_points[:, j, i, 0, 0, 0, :] = points[self.k_raw_index_array,
-                                                                            self.pillars_for_column[j, i, 0, 0], :]
-                     self.array_corner_points[:, j, i, 1, 0, 0, :] = points[self.k_raw_index_array + 1,
-                                                                            self.pillars_for_column[j, i, 0, 0], :]
-                     self.array_corner_points[:, j, i, 0, 1, 0, :] = points[self.k_raw_index_array,
-                                                                            self.pillars_for_column[j, i, 1, 0], :]
-                     self.array_corner_points[:, j, i, 1, 1, 0, :] = points[self.k_raw_index_array + 1,
-                                                                            self.pillars_for_column[j, i, 1, 0], :]
-                     self.array_corner_points[:, j, i, 0, 0, 1, :] = points[self.k_raw_index_array,
-                                                                            self.pillars_for_column[j, i, 0, 1], :]
-                     self.array_corner_points[:, j, i, 1, 0, 1, :] = points[self.k_raw_index_array + 1,
-                                                                            self.pillars_for_column[j, i, 0, 1], :]
-                     self.array_corner_points[:, j, i, 0, 1, 1, :] = points[self.k_raw_index_array,
-                                                                            self.pillars_for_column[j, i, 1, 1], :]
-                     self.array_corner_points[:, j, i, 1, 1, 1, :] = points[self.k_raw_index_array + 1,
-                                                                            self.pillars_for_column[j, i, 1, 1], :]
-            else:
-               for j in range(self.nj):
-                  for i in range(self.ni):
-                     self.array_corner_points[:, j, i, 0, 0, 0, :] = points[:-1, self.pillars_for_column[j, i, 0, 0], :]
-                     self.array_corner_points[:, j, i, 1, 0, 0, :] = points[1:, self.pillars_for_column[j, i, 0, 0], :]
-                     self.array_corner_points[:, j, i, 0, 1, 0, :] = points[:-1, self.pillars_for_column[j, i, 1, 0], :]
-                     self.array_corner_points[:, j, i, 1, 1, 0, :] = points[1:, self.pillars_for_column[j, i, 1, 0], :]
-                     self.array_corner_points[:, j, i, 0, 0, 1, :] = points[:-1, self.pillars_for_column[j, i, 0, 1], :]
-                     self.array_corner_points[:, j, i, 1, 0, 1, :] = points[1:, self.pillars_for_column[j, i, 0, 1], :]
-                     self.array_corner_points[:, j, i, 0, 1, 1, :] = points[:-1, self.pillars_for_column[j, i, 1, 1], :]
-                     self.array_corner_points[:, j, i, 1, 1, 1, :] = points[1:, self.pillars_for_column[j, i, 1, 1], :]
-         else:
-            if self.k_gaps:
-               self.array_corner_points[:, :, :, 0, 0, 0, :] = points[self.k_raw_index_array, :-1, :-1, :]
-               self.array_corner_points[:, :, :, 1, 0, 0, :] = points[self.k_raw_index_array + 1, :-1, :-1, :]
-               self.array_corner_points[:, :, :, 0, 1, 0, :] = points[self.k_raw_index_array, 1:, :-1, :]
-               self.array_corner_points[:, :, :, 1, 1, 0, :] = points[self.k_raw_index_array + 1, 1:, :-1, :]
-               self.array_corner_points[:, :, :, 0, 0, 1, :] = points[self.k_raw_index_array, :-1, 1:, :]
-               self.array_corner_points[:, :, :, 1, 0, 1, :] = points[self.k_raw_index_array + 1, :-1, 1:, :]
-               self.array_corner_points[:, :, :, 0, 1, 1, :] = points[self.k_raw_index_array, 1:, 1:, :]
-               self.array_corner_points[:, :, :, 1, 1, 1, :] = points[self.k_raw_index_array + 1, 1:, 1:, :]
-            else:
-               self.array_corner_points[:, :, :, 0, 0, 0, :] = points[:-1, :-1, :-1, :]
-               self.array_corner_points[:, :, :, 1, 0, 0, :] = points[1:, :-1, :-1, :]
-               self.array_corner_points[:, :, :, 0, 1, 0, :] = points[:-1, 1:, :-1, :]
-               self.array_corner_points[:, :, :, 1, 1, 0, :] = points[1:, 1:, :-1, :]
-               self.array_corner_points[:, :, :, 0, 0, 1, :] = points[:-1, :-1, 1:, :]
-               self.array_corner_points[:, :, :, 1, 0, 1, :] = points[1:, :-1, 1:, :]
-               self.array_corner_points[:, :, :, 0, 1, 1, :] = points[:-1, 1:, 1:, :]
-               self.array_corner_points[:, :, :, 1, 1, 1, :] = points[1:, 1:, 1:, :]
-      if cell_kji0 is None:
-         return self.array_corner_points
-      if not self.geometry_defined_for_all_cells():
-         if not self.cell_geometry_is_defined(cell_kji0, cache_array = cache_resqml_array):
-            return None
-      if hasattr(self, 'array_corner_points'):
-         return self.array_corner_points[tuple(cell_kji0)]
-      cp = one_cell_cp(self, cell_kji0, points_root = points_root, cache_array = cache_resqml_array)
-      return cp
+        if not self.geometry_defined_for_all_cells():
+            if not self.cell_geometry_is_defined(cell_kji0, cache_array = cache_resqml_array):
+                return None
+        if hasattr(self, 'array_corner_points'):
+            return self.array_corner_points[tuple(cell_kji0)]
+        cp = one_cell_cp(self, cell_kji0, points_root = points_root, cache_array = cache_resqml_array)
+        return cp
 
-   def invalidate_corner_points(self):
-      """Deletes cached copy of corner points, if present; use if any pillar geometry changes, or to reclaim memory."""
+    def invalidate_corner_points(self):
+        """Deletes cached copy of corner points, if present; use if any pillar geometry changes, or to reclaim memory."""
 
-      if hasattr(self, 'array_corner_points'):
-         delattr(self, 'array_corner_points')
+        if hasattr(self, 'array_corner_points'):
+            delattr(self, 'array_corner_points')
 
-   def centre_point(self, cell_kji0 = None, cache_centre_array = False):
-      """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all cells.
+    def centre_point(self, cell_kji0 = None, cache_centre_array = False):
+        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all cells.
 
       arguments:
          cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
@@ -3319,74 +3364,75 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      if cell_kji0 is None:
-         cache_centre_array = True
+        if cell_kji0 is None:
+            cache_centre_array = True
 
-      # note: this function returns a derived object rather than a native resqml object
-      if hasattr(self, 'array_centre_point'):
-         if cell_kji0 is None:
-            return self.array_centre_point
-         return self.array_centre_point[tuple(cell_kji0)]  # could check for nan here and return None
-      if cache_centre_array:
-         # todo: turn off nan warnings
-         self.array_centre_point = np.empty((self.nk, self.nj, self.ni, 3))
-         points = self.points_ref(masked = False)  # todo: think about masking
-         if hasattr(self, 'array_corner_points'):
-            self.array_centre_point = 0.125 * np.sum(self.array_corner_points,
-                                                     axis = (3, 4, 5))  # mean of eight corner points for each cell
-         elif self.has_split_coordinate_lines:
-            # todo: replace j,i for loops with numpy broadcasting
-            self.create_column_pillar_mapping()
-            if self.k_gaps:
-               for j in range(self.nj):
-                  for i in range(self.ni):
-                     self.array_centre_point[:, j, i, :] = 0.125 * (
-                        points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 0], :] +
-                        points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 0], :] +
-                        points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 0], :] +
-                        points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 0], :] +
-                        points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 1], :] +
-                        points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 1], :] +
-                        points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 1], :] +
-                        points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 1], :])
+        # note: this function returns a derived object rather than a native resqml object
+        if hasattr(self, 'array_centre_point'):
+            if cell_kji0 is None:
+                return self.array_centre_point
+            return self.array_centre_point[tuple(cell_kji0)]  # could check for nan here and return None
+        if cache_centre_array:
+            # todo: turn off nan warnings
+            self.array_centre_point = np.empty((self.nk, self.nj, self.ni, 3))
+            points = self.points_ref(masked = False)  # todo: think about masking
+            if hasattr(self, 'array_corner_points'):
+                self.array_centre_point = 0.125 * np.sum(self.array_corner_points,
+                                                         axis = (3, 4, 5))  # mean of eight corner points for each cell
+            elif self.has_split_coordinate_lines:
+                # todo: replace j,i for loops with numpy broadcasting
+                self.create_column_pillar_mapping()
+                if self.k_gaps:
+                    for j in range(self.nj):
+                        for i in range(self.ni):
+                            self.array_centre_point[:, j, i, :] = 0.125 * (
+                                points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 0], :] +
+                                points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 0], :] +
+                                points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 0], :] +
+                                points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 0], :] +
+                                points[self.k_raw_index_array, self.pillars_for_column[j, i, 0, 1], :] +
+                                points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 0, 1], :] +
+                                points[self.k_raw_index_array, self.pillars_for_column[j, i, 1, 1], :] +
+                                points[self.k_raw_index_array + 1, self.pillars_for_column[j, i, 1, 1], :])
+                else:
+                    for j in range(self.nj):
+                        for i in range(self.ni):
+                            self.array_centre_point[:, j, i, :] = 0.125 * (
+                                points[:-1, self.pillars_for_column[j, i, 0, 0], :] +
+                                points[1:, self.pillars_for_column[j, i, 0, 0], :] +
+                                points[:-1, self.pillars_for_column[j, i, 1, 0], :] +
+                                points[1:, self.pillars_for_column[j, i, 1, 0], :] +
+                                points[:-1, self.pillars_for_column[j, i, 0, 1], :] +
+                                points[1:, self.pillars_for_column[j, i, 0, 1], :] +
+                                points[:-1, self.pillars_for_column[j, i, 1, 1], :] +
+                                points[1:, self.pillars_for_column[j, i, 1, 1], :])
             else:
-               for j in range(self.nj):
-                  for i in range(self.ni):
-                     self.array_centre_point[:, j,
-                                             i, :] = 0.125 * (points[:-1, self.pillars_for_column[j, i, 0, 0], :] +
-                                                              points[1:, self.pillars_for_column[j, i, 0, 0], :] +
-                                                              points[:-1, self.pillars_for_column[j, i, 1, 0], :] +
-                                                              points[1:, self.pillars_for_column[j, i, 1, 0], :] +
-                                                              points[:-1, self.pillars_for_column[j, i, 0, 1], :] +
-                                                              points[1:, self.pillars_for_column[j, i, 0, 1], :] +
-                                                              points[:-1, self.pillars_for_column[j, i, 1, 1], :] +
-                                                              points[1:, self.pillars_for_column[j, i, 1, 1], :])
-         else:
-            if self.k_gaps:
-               self.array_centre_point[:, :, :, :] = 0.125 * (
-                  points[self.k_raw_index_array, :-1, :-1, :] + points[self.k_raw_index_array, :-1, 1:, :] +
-                  points[self.k_raw_index_array, 1:, :-1, :] + points[self.k_raw_index_array, 1:, 1:, :] +
-                  points[self.k_raw_index_array + 1, :-1, :-1, :] + points[self.k_raw_index_array + 1, :-1, 1:, :] +
-                  points[self.k_raw_index_array + 1, 1:, :-1, :] + points[self.k_raw_index_array + 1, 1:, 1:, :])
-            else:
-               self.array_centre_point[:, :, :, :] = 0.125 * (points[:-1, :-1, :-1, :] + points[:-1, :-1, 1:, :] +
-                                                              points[:-1, 1:, :-1, :] + points[:-1, 1:, 1:, :] +
-                                                              points[1:, :-1, :-1, :] + points[1:, :-1, 1:, :] +
-                                                              points[1:, 1:, :-1, :] + points[1:, 1:, 1:, :])
-         if cell_kji0 is None:
-            return self.array_centre_point
-         return self.array_centre_point[cell_kji0[0], cell_kji0[1],
-                                        cell_kji0[2]]  # could check for nan here and return None
-      cp = self.corner_points(cell_kji0 = cell_kji0, cache_cp_array = False)
-      if cp is None:
-         return None
-      centre = np.zeros(3)
-      for axis in range(3):
-         centre[axis] = np.mean(cp[:, :, :, axis])
-      return centre
+                if self.k_gaps:
+                    self.array_centre_point[:, :, :, :] = 0.125 * (
+                        points[self.k_raw_index_array, :-1, :-1, :] + points[self.k_raw_index_array, :-1, 1:, :] +
+                        points[self.k_raw_index_array, 1:, :-1, :] + points[self.k_raw_index_array, 1:, 1:, :] +
+                        points[self.k_raw_index_array + 1, :-1, :-1, :] +
+                        points[self.k_raw_index_array + 1, :-1, 1:, :] +
+                        points[self.k_raw_index_array + 1, 1:, :-1, :] + points[self.k_raw_index_array + 1, 1:, 1:, :])
+                else:
+                    self.array_centre_point[:, :, :, :] = 0.125 * (points[:-1, :-1, :-1, :] + points[:-1, :-1, 1:, :] +
+                                                                   points[:-1, 1:, :-1, :] + points[:-1, 1:, 1:, :] +
+                                                                   points[1:, :-1, :-1, :] + points[1:, :-1, 1:, :] +
+                                                                   points[1:, 1:, :-1, :] + points[1:, 1:, 1:, :])
+            if cell_kji0 is None:
+                return self.array_centre_point
+            return self.array_centre_point[cell_kji0[0], cell_kji0[1],
+                                           cell_kji0[2]]  # could check for nan here and return None
+        cp = self.corner_points(cell_kji0 = cell_kji0, cache_cp_array = False)
+        if cp is None:
+            return None
+        centre = np.zeros(3)
+        for axis in range(3):
+            centre[axis] = np.mean(cp[:, :, :, axis])
+        return centre
 
-   def centre_point_list(self, cell_kji0s):
-      """Returns centre points for a list of cells; caches centre points for all cells.
+    def centre_point_list(self, cell_kji0s):
+        """Returns centre points for a list of cells; caches centre points for all cells.
 
       arguments:
          cell_kji0s (numpy int array of shape (N, 3)): the (k, j, i) indices of the individual cells for which the
@@ -3399,20 +3445,20 @@ class Grid(BaseResqpy):
          resulting coordinates are in the same (local) crs as the grid points
       """
 
-      assert cell_kji0s.ndim == 2 and cell_kji0s.shape[1] == 3
-      centres_list = np.empty(cell_kji0s.shape)
-      for cell in range(len(cell_kji0s)):
-         centres_list[cell] = self.centre_point(cell_kji0 = cell_kji0s[cell], cache_centre_array = True)
-      return centres_list
+        assert cell_kji0s.ndim == 2 and cell_kji0s.shape[1] == 3
+        centres_list = np.empty(cell_kji0s.shape)
+        for cell in range(len(cell_kji0s)):
+            centres_list[cell] = self.centre_point(cell_kji0 = cell_kji0s[cell], cache_centre_array = True)
+        return centres_list
 
-   def thickness(self,
-                 cell_kji0 = None,
-                 points_root = None,
-                 cache_resqml_array = True,
-                 cache_cp_array = False,
-                 cache_thickness_array = True,
-                 property_collection = None):
-      """Returns vertical (z) thickness of cell and/or caches thicknesses for all cells.
+    def thickness(self,
+                  cell_kji0 = None,
+                  points_root = None,
+                  cache_resqml_array = True,
+                  cache_cp_array = False,
+                  cache_thickness_array = True,
+                  property_collection = None):
+        """Returns vertical (z) thickness of cell and/or caches thicknesses for all cells.
 
       arguments:
          cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
@@ -3443,127 +3489,132 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      def load_from_property(collection):
-         if collection is None:
+        def load_from_property(collection):
+            if collection is None:
+                return None
+            parts = collection.selective_parts_list(property_kind = 'thickness',
+                                                    facet_type = 'netgross',
+                                                    facet = 'gross')
+            if len(parts) == 1:
+                return collection.cached_part_array_ref(parts[0])
+            parts = collection.selective_parts_list(property_kind = 'thickness')
+            if len(parts) == 1 and collection.facet_for_part(parts[0]) is None:
+                return collection.cached_part_array_ref(parts[0])
+            parts = collection.selective_parts_list(property_kind = 'cell length',
+                                                    facet_type = 'direction',
+                                                    facet = 'K')
+            if len(parts) == 1:
+                return collection.cached_part_array_ref(parts[0])
             return None
-         parts = collection.selective_parts_list(property_kind = 'thickness', facet_type = 'netgross', facet = 'gross')
-         if len(parts) == 1:
-            return collection.cached_part_array_ref(parts[0])
-         parts = collection.selective_parts_list(property_kind = 'thickness')
-         if len(parts) == 1 and collection.facet_for_part(parts[0]) is None:
-            return collection.cached_part_array_ref(parts[0])
-         parts = collection.selective_parts_list(property_kind = 'cell length', facet_type = 'direction', facet = 'K')
-         if len(parts) == 1:
-            return collection.cached_part_array_ref(parts[0])
-         return None
 
-      # note: this function optionally looks for a suitable thickness property, otherwise calculates from geometry
-      # note: for some geometries, thickness might need to be defined as length of vector between -k & +k face centres (TST)
-      # todo: give more control over source of data through optional args; offer TST or TVT option
-      # todo: if cp array is not already cached, compute directly from points without generating cp
-      # todo: cache uom
-      assert cache_thickness_array or (cell_kji0 is not None)
+        # note: this function optionally looks for a suitable thickness property, otherwise calculates from geometry
+        # note: for some geometries, thickness might need to be defined as length of vector between -k & +k face centres (TST)
+        # todo: give more control over source of data through optional args; offer TST or TVT option
+        # todo: if cp array is not already cached, compute directly from points without generating cp
+        # todo: cache uom
+        assert cache_thickness_array or (cell_kji0 is not None)
 
-      if hasattr(self, 'array_thickness'):
-         if cell_kji0 is None:
-            return self.array_thickness
-         return self.array_thickness[tuple(cell_kji0)]  # could check for nan here and return None
-
-      thick = load_from_property(property_collection)
-      if thick is not None:
-         log.debug('thickness array loaded from property')
-         if cache_thickness_array:
-            self.array_thickness = thick.copy()
-         if cell_kji0 is None:
-            return self.array_thickness
-         return self.array_thickness[tuple(cell_kji0)]  # could check for nan here and return None
-
-      points_root = self.resolve_geometry_child('Points', child_node = points_root)
-      if cache_thickness_array:
-         if cache_cp_array:
-            self.corner_points(points_root = points_root, cache_cp_array = True)
-         if hasattr(self, 'array_corner_points'):
-            self.array_thickness = np.abs(
-               np.mean(self.array_corner_points[:, :, :, 1, :, :, 2] - self.array_corner_points[:, :, :, 0, :, :, 2],
-                       axis = (3, 4)))
+        if hasattr(self, 'array_thickness'):
             if cell_kji0 is None:
-               return self.array_thickness
+                return self.array_thickness
             return self.array_thickness[tuple(cell_kji0)]  # could check for nan here and return None
-         self.array_thickness = np.empty(tuple(self.extent_kji))
-         points = self.point_raw(cache_array = True)  # cache points regardless
-         if points is None:
-            return None  # geometry not present
-         if self.k_gaps:
-            pillar_thickness = points[self.k_raw_index_array + 1, ..., 2] - points[self.k_raw_index_array, ..., 2]
-         else:
-            pillar_thickness = points[1:, ..., 2] - points[:-1, ..., 2]
-         if self.has_split_coordinate_lines:
-            pillar_for_col = self.create_column_pillar_mapping()
-            self.array_thickness = np.abs(
-               0.25 *
-               (pillar_thickness[:, pillar_for_col[:, :, 0, 0]] + pillar_thickness[:, pillar_for_col[:, :, 0, 1]] +
-                pillar_thickness[:, pillar_for_col[:, :, 1, 0]] + pillar_thickness[:, pillar_for_col[:, :, 1, 1]]))
-         else:
-            self.array_thickness = np.abs(0.25 * (pillar_thickness[:, :-1, :-1] + pillar_thickness[:, :-1, 1:] +
-                                                  pillar_thickness[:, 1:, :-1] + pillar_thickness[:, 1:, 1:]))
-         if cell_kji0 is None:
-            return self.array_thickness
-         return self.array_thickness[tuple(cell_kji0)]  # could check for nan here and return None
 
-      cp = self.corner_points(cell_kji0 = cell_kji0,
-                              points_root = points_root,
-                              cache_resqml_array = cache_resqml_array,
-                              cache_cp_array = cache_cp_array)
-      if cp is None:
-         return None
-      return abs(np.mean(cp[1, :, :, 2]) - np.mean(cp[0, :, :, 2]))
+        thick = load_from_property(property_collection)
+        if thick is not None:
+            log.debug('thickness array loaded from property')
+            if cache_thickness_array:
+                self.array_thickness = thick.copy()
+            if cell_kji0 is None:
+                return self.array_thickness
+            return self.array_thickness[tuple(cell_kji0)]  # could check for nan here and return None
 
-   def point_areally(self, tolerance = 0.001):
-      """Returns a numpy boolean array of shape extent_kji indicating which cells are reduced to a point in both I & J axes.
+        points_root = self.resolve_geometry_child('Points', child_node = points_root)
+        if cache_thickness_array:
+            if cache_cp_array:
+                self.corner_points(points_root = points_root, cache_cp_array = True)
+            if hasattr(self, 'array_corner_points'):
+                self.array_thickness = np.abs(
+                    np.mean(self.array_corner_points[:, :, :, 1, :, :, 2] -
+                            self.array_corner_points[:, :, :, 0, :, :, 2],
+                            axis = (3, 4)))
+                if cell_kji0 is None:
+                    return self.array_thickness
+                return self.array_thickness[tuple(cell_kji0)]  # could check for nan here and return None
+            self.array_thickness = np.empty(tuple(self.extent_kji))
+            points = self.point_raw(cache_array = True)  # cache points regardless
+            if points is None:
+                return None  # geometry not present
+            if self.k_gaps:
+                pillar_thickness = points[self.k_raw_index_array + 1, ..., 2] - points[self.k_raw_index_array, ..., 2]
+            else:
+                pillar_thickness = points[1:, ..., 2] - points[:-1, ..., 2]
+            if self.has_split_coordinate_lines:
+                pillar_for_col = self.create_column_pillar_mapping()
+                self.array_thickness = np.abs(
+                    0.25 *
+                    (pillar_thickness[:, pillar_for_col[:, :, 0, 0]] + pillar_thickness[:, pillar_for_col[:, :, 0, 1]] +
+                     pillar_thickness[:, pillar_for_col[:, :, 1, 0]] + pillar_thickness[:, pillar_for_col[:, :, 1, 1]]))
+            else:
+                self.array_thickness = np.abs(0.25 * (pillar_thickness[:, :-1, :-1] + pillar_thickness[:, :-1, 1:] +
+                                                      pillar_thickness[:, 1:, :-1] + pillar_thickness[:, 1:, 1:]))
+            if cell_kji0 is None:
+                return self.array_thickness
+            return self.array_thickness[tuple(cell_kji0)]  # could check for nan here and return None
+
+        cp = self.corner_points(cell_kji0 = cell_kji0,
+                                points_root = points_root,
+                                cache_resqml_array = cache_resqml_array,
+                                cache_cp_array = cache_cp_array)
+        if cp is None:
+            return None
+        return abs(np.mean(cp[1, :, :, 2]) - np.mean(cp[0, :, :, 2]))
+
+    def point_areally(self, tolerance = 0.001):
+        """Returns a numpy boolean array of shape extent_kji indicating which cells are reduced to a point in both I & J axes.
 
       Note:
          Any NaN point values will yield True for a cell
       """
 
-      points = self.points_ref(masked = False)
-      # todo: turn off NaN warning for numpy > ?
-      if self.has_split_coordinate_lines:
-         pillar_for_col = self.create_column_pillar_mapping()
-         j_pair_vectors = points[:, pillar_for_col[:, :, 1, :], :] - points[:, pillar_for_col[:, :, 0, :], :]
-         i_pair_vectors = points[:, pillar_for_col[:, :, :, 1], :] - points[:, pillar_for_col[:, :, :, 0], :]
-         j_pair_nans = np.isnan(j_pair_vectors)
-         i_pair_nans = np.isnan(i_pair_vectors)
-         any_nans = np.any(np.logical_or(j_pair_nans, i_pair_nans), axis = (3, 4))
-         j_pair_extant = np.any(np.abs(j_pair_vectors) > tolerance, axis = -1)
-         i_pair_extant = np.any(np.abs(i_pair_vectors) > tolerance, axis = -1)
-         any_extant = np.any(np.logical_or(j_pair_extant, i_pair_extant), axis = 3)
-      else:
-         j_vectors = points[:, 1:, :, :] - points[:, :-1, :, :]
-         i_vectors = points[:, :, 1:, :] - points[:, :, :-1, :]
-         j_nans = np.any(np.isnan(j_vectors), axis = -1)
-         i_nans = np.any(np.isnan(i_vectors), axis = -1)
-         j_pair_nans = np.logical_or(j_nans[:, :, :-1], j_nans[:, :, 1:])
-         i_pair_nans = np.logical_or(i_nans[:, :-1, :], i_nans[:, 1:, :])
-         any_nans = np.logical_or(j_pair_nans, i_pair_nans)
-         j_extant = np.any(np.abs(j_vectors) > tolerance, axis = -1)
-         i_extant = np.any(np.abs(i_vectors) > tolerance, axis = -1)
-         j_pair_extant = np.logical_or(j_extant[:, :, :-1], j_extant[:, :, 1:])
-         i_pair_extant = np.logical_or(i_extant[:, :-1, :], i_extant[:, 1:, :])
-         any_extant = np.logical_or(j_pair_extant, i_pair_extant)
-      layered = np.logical_or(any_nans, np.logical_not(any_extant))
-      if self.k_gaps:
-         return np.logical_and(layered[self.k_raw_index_array], layered[self.k_raw_index_array + 1])
-      return np.logical_and(layered[:-1], layered[1:])
+        points = self.points_ref(masked = False)
+        # todo: turn off NaN warning for numpy > ?
+        if self.has_split_coordinate_lines:
+            pillar_for_col = self.create_column_pillar_mapping()
+            j_pair_vectors = points[:, pillar_for_col[:, :, 1, :], :] - points[:, pillar_for_col[:, :, 0, :], :]
+            i_pair_vectors = points[:, pillar_for_col[:, :, :, 1], :] - points[:, pillar_for_col[:, :, :, 0], :]
+            j_pair_nans = np.isnan(j_pair_vectors)
+            i_pair_nans = np.isnan(i_pair_vectors)
+            any_nans = np.any(np.logical_or(j_pair_nans, i_pair_nans), axis = (3, 4))
+            j_pair_extant = np.any(np.abs(j_pair_vectors) > tolerance, axis = -1)
+            i_pair_extant = np.any(np.abs(i_pair_vectors) > tolerance, axis = -1)
+            any_extant = np.any(np.logical_or(j_pair_extant, i_pair_extant), axis = 3)
+        else:
+            j_vectors = points[:, 1:, :, :] - points[:, :-1, :, :]
+            i_vectors = points[:, :, 1:, :] - points[:, :, :-1, :]
+            j_nans = np.any(np.isnan(j_vectors), axis = -1)
+            i_nans = np.any(np.isnan(i_vectors), axis = -1)
+            j_pair_nans = np.logical_or(j_nans[:, :, :-1], j_nans[:, :, 1:])
+            i_pair_nans = np.logical_or(i_nans[:, :-1, :], i_nans[:, 1:, :])
+            any_nans = np.logical_or(j_pair_nans, i_pair_nans)
+            j_extant = np.any(np.abs(j_vectors) > tolerance, axis = -1)
+            i_extant = np.any(np.abs(i_vectors) > tolerance, axis = -1)
+            j_pair_extant = np.logical_or(j_extant[:, :, :-1], j_extant[:, :, 1:])
+            i_pair_extant = np.logical_or(i_extant[:, :-1, :], i_extant[:, 1:, :])
+            any_extant = np.logical_or(j_pair_extant, i_pair_extant)
+        layered = np.logical_or(any_nans, np.logical_not(any_extant))
+        if self.k_gaps:
+            return np.logical_and(layered[self.k_raw_index_array], layered[self.k_raw_index_array + 1])
+        return np.logical_and(layered[:-1], layered[1:])
 
-   def volume(self,
-              cell_kji0 = None,
-              points_root = None,
-              cache_resqml_array = True,
-              cache_cp_array = False,
-              cache_centre_array = False,
-              cache_volume_array = True,
-              property_collection = None):
-      """Returns bulk rock volume of cell or numpy array of bulk rock volumes for all cells.
+    def volume(self,
+               cell_kji0 = None,
+               points_root = None,
+               cache_resqml_array = True,
+               cache_cp_array = False,
+               cache_centre_array = False,
+               cache_volume_array = True,
+               property_collection = None):
+        """Returns bulk rock volume of cell or numpy array of bulk rock volumes for all cells.
 
       arguments:
          cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
@@ -3595,113 +3646,113 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      def load_from_property(collection):
-         if collection is None:
+        def load_from_property(collection):
+            if collection is None:
+                return None
+            parts = collection.selective_parts_list(property_kind = 'rock volume',
+                                                    facet_type = 'netgross',
+                                                    facet = 'gross')
+            if len(parts) == 1:
+                return collection.cached_part_array_ref(parts[0])
+            parts = collection.selective_parts_list(property_kind = 'rock volume')
+            if len(parts) == 1 and collection.facet_for_part(parts[0]) is None:
+                return collection.cached_part_array_ref(parts[0])
             return None
-         parts = collection.selective_parts_list(property_kind = 'rock volume',
-                                                 facet_type = 'netgross',
-                                                 facet = 'gross')
-         if len(parts) == 1:
-            return collection.cached_part_array_ref(parts[0])
-         parts = collection.selective_parts_list(property_kind = 'rock volume')
-         if len(parts) == 1 and collection.facet_for_part(parts[0]) is None:
-            return collection.cached_part_array_ref(parts[0])
-         return None
 
-      # note: this function optionally looks for a suitable volume property, otherwise calculates from geometry
-      # todo: modify z units if needed, to match xy units
-      # todo: give control over source with optional arguments
-      # todo: cache uom
-      assert (cache_volume_array is not None) or (cell_kji0 is not None)
+        # note: this function optionally looks for a suitable volume property, otherwise calculates from geometry
+        # todo: modify z units if needed, to match xy units
+        # todo: give control over source with optional arguments
+        # todo: cache uom
+        assert (cache_volume_array is not None) or (cell_kji0 is not None)
 
-      if hasattr(self, 'array_volume'):
-         if cell_kji0 is None:
-            return self.array_volume
-         return self.array_volume[tuple(cell_kji0)]  # could check for nan here and return None
+        if hasattr(self, 'array_volume'):
+            if cell_kji0 is None:
+                return self.array_volume
+            return self.array_volume[tuple(cell_kji0)]  # could check for nan here and return None
 
-      vol_array = load_from_property(property_collection)
-      if vol_array is not None:
-         if cache_volume_array:
-            self.array_volume = vol_array.copy()
-         if cell_kji0 is None:
-            return vol_array
-         return vol_array[tuple(cell_kji0)]  # could check for nan here and return None
+        vol_array = load_from_property(property_collection)
+        if vol_array is not None:
+            if cache_volume_array:
+                self.array_volume = vol_array.copy()
+            if cell_kji0 is None:
+                return vol_array
+            return vol_array[tuple(cell_kji0)]  # could check for nan here and return None
 
-      cache_cp_array = cache_cp_array or cell_kji0 is None
-      cache_volume_array = cache_volume_array or cell_kji0 is None
+        cache_cp_array = cache_cp_array or cell_kji0 is None
+        cache_volume_array = cache_volume_array or cell_kji0 is None
 
-      off_hand = self.off_handed()
+        off_hand = self.off_handed()
 
-      points_root = self.resolve_geometry_child('Points', child_node = points_root)
-      if points_root is None:
-         return None  # geometry not present
-      centre_array = None
-      if cache_volume_array or cell_kji0 is None:
-         self.corner_points(points_root = points_root, cache_cp_array = True)
-         if cache_centre_array:
-            self.centre_point(cache_centre_array = True)
-            centre_array = self.array_centre_point
-         vol_array = vol.tetra_volumes(self.array_corner_points, centres = centre_array, off_hand = off_hand)
-         if cache_volume_array:
-            self.array_volume = vol_array
-         if cell_kji0 is None:
-            return vol_array
-         return vol_array[tuple(cell_kji0)]  # could check for nan here and return None
+        points_root = self.resolve_geometry_child('Points', child_node = points_root)
+        if points_root is None:
+            return None  # geometry not present
+        centre_array = None
+        if cache_volume_array or cell_kji0 is None:
+            self.corner_points(points_root = points_root, cache_cp_array = True)
+            if cache_centre_array:
+                self.centre_point(cache_centre_array = True)
+                centre_array = self.array_centre_point
+            vol_array = vol.tetra_volumes(self.array_corner_points, centres = centre_array, off_hand = off_hand)
+            if cache_volume_array:
+                self.array_volume = vol_array
+            if cell_kji0 is None:
+                return vol_array
+            return vol_array[tuple(cell_kji0)]  # could check for nan here and return None
 
-      cp = self.corner_points(cell_kji0 = cell_kji0,
-                              points_root = points_root,
-                              cache_resqml_array = cache_resqml_array,
-                              cache_cp_array = cache_cp_array)
-      if cp is None:
-         return None
-      return vol.tetra_cell_volume(cp, off_hand = off_hand)
+        cp = self.corner_points(cell_kji0 = cell_kji0,
+                                points_root = points_root,
+                                cache_resqml_array = cache_resqml_array,
+                                cache_cp_array = cache_cp_array)
+        if cp is None:
+            return None
+        return vol.tetra_cell_volume(cp, off_hand = off_hand)
 
-   def pinched_out(self,
-                   cell_kji0 = None,
-                   tolerance = 0.001,
-                   points_root = None,
-                   cache_resqml_array = True,
-                   cache_cp_array = False,
-                   cache_thickness_array = False,
-                   cache_pinchout_array = None):
-      """Returns boolean or boolean array indicating whether cell is pinched out; ie. has a thickness less than tolerance.
+    def pinched_out(self,
+                    cell_kji0 = None,
+                    tolerance = 0.001,
+                    points_root = None,
+                    cache_resqml_array = True,
+                    cache_cp_array = False,
+                    cache_thickness_array = False,
+                    cache_pinchout_array = None):
+        """Returns boolean or boolean array indicating whether cell is pinched out; ie. has a thickness less than tolerance.
 
       :meta common:
       """
 
-      # note: this function returns a derived object rather than a native resqml object
-      # note: returns True for cells without geometry
-      # todo: check behaviour in response to NaNs and undefined geometry
-      if cache_pinchout_array is None:
-         cache_pinchout_array = (cell_kji0 is None)
+        # note: this function returns a derived object rather than a native resqml object
+        # note: returns True for cells without geometry
+        # todo: check behaviour in response to NaNs and undefined geometry
+        if cache_pinchout_array is None:
+            cache_pinchout_array = (cell_kji0 is None)
 
-      if self.pinchout is not None:
-         if cell_kji0 is None:
-            return self.pinchout
-         return self.pinchout[tuple(cell_kji0)]
+        if self.pinchout is not None:
+            if cell_kji0 is None:
+                return self.pinchout
+            return self.pinchout[tuple(cell_kji0)]
 
-      if points_root is None:
-         points_root = self.resolve_geometry_child('Points', child_node = points_root)
+        if points_root is None:
+            points_root = self.resolve_geometry_child('Points', child_node = points_root)
 #         if points_root is None: return None  # geometry not present
 
-      thick = self.thickness(
-         cell_kji0,
-         points_root = points_root,
-         cache_resqml_array = cache_resqml_array,
-         cache_cp_array = cache_cp_array,  # deprecated
-         cache_thickness_array = cache_thickness_array or cache_pinchout_array)
-      if cache_pinchout_array:
-         self.pinchout = np.where(np.isnan(self.array_thickness), True,
-                                  np.logical_not(self.array_thickness > tolerance))
-         if cell_kji0 is None:
-            return self.pinchout
-         return self.pinchout[tuple(cell_kji0)]
-      if thick is not None:
-         return thick <= tolerance
-      return None
+        thick = self.thickness(
+            cell_kji0,
+            points_root = points_root,
+            cache_resqml_array = cache_resqml_array,
+            cache_cp_array = cache_cp_array,  # deprecated
+            cache_thickness_array = cache_thickness_array or cache_pinchout_array)
+        if cache_pinchout_array:
+            self.pinchout = np.where(np.isnan(self.array_thickness), True,
+                                     np.logical_not(self.array_thickness > tolerance))
+            if cell_kji0 is None:
+                return self.pinchout
+            return self.pinchout[tuple(cell_kji0)]
+        if thick is not None:
+            return thick <= tolerance
+        return None
 
-   def half_cell_transmissibility(self, use_property = True, realization = None, tolerance = 1.0e-6):
-      """Returns (and caches if realization is None) half cell transmissibilities for this grid.
+    def half_cell_transmissibility(self, use_property = True, realization = None, tolerance = 1.0e-6):
+        """Returns (and caches if realization is None) half cell transmissibilities for this grid.
 
       arguments:
          use_property (boolean, default True): if True, the grid's property collection is inspected for
@@ -3724,35 +3775,35 @@ class Grid(BaseResqpy):
          used if the half cell transmissibilities are actually computed
       """
 
-      # todo: allow passing of property uuids for ntg, k_k, j, i
+        # todo: allow passing of property uuids for ntg, k_k, j, i
 
-      if realization is None and hasattr(self, 'array_half_cell_t'):
-         return self.array_half_cell_t
+        if realization is None and hasattr(self, 'array_half_cell_t'):
+            return self.array_half_cell_t
 
-      half_t = None
+        half_t = None
 
-      if use_property:
-         pc = self.property_collection
-         half_t_resqml = pc.single_array_ref(property_kind = 'transmissibility',
-                                             realization = realization,
-                                             continuous = True,
-                                             count = 1,
-                                             indexable = 'faces per cell')
-         if half_t_resqml:
-            assert half_t_resqml.shape == (self.nk, self.nj, self.ni, 6)
-            half_t = pc.combobulate(half_t_resqml)
+        if use_property:
+            pc = self.property_collection
+            half_t_resqml = pc.single_array_ref(property_kind = 'transmissibility',
+                                                realization = realization,
+                                                continuous = True,
+                                                count = 1,
+                                                indexable = 'faces per cell')
+            if half_t_resqml:
+                assert half_t_resqml.shape == (self.nk, self.nj, self.ni, 6)
+                half_t = pc.combobulate(half_t_resqml)
 
-      if half_t is None:
-         # note: properties must be identifiable in property_collection
-         half_t = rqtr.half_cell_t(self, realization = realization)
+        if half_t is None:
+            # note: properties must be identifiable in property_collection
+            half_t = rqtr.half_cell_t(self, realization = realization)
 
-      if realization is None:
-         self.array_half_cell_t = half_t
+        if realization is None:
+            self.array_half_cell_t = half_t
 
-      return half_t
+        return half_t
 
-   def transmissibility(self, tolerance = 1.0e-6, use_tr_properties = True, realization = None, modifier_mode = None):
-      """Returns transmissibilities for standard (IJK neighbouring) connections within this grid.
+    def transmissibility(self, tolerance = 1.0e-6, use_tr_properties = True, realization = None, modifier_mode = None):
+        """Returns transmissibilities for standard (IJK neighbouring) connections within this grid.
 
       arguments:
          tolerance (float, default 1.0e-6): the minimum half cell transmissibility below which zero inter-cell
@@ -3798,238 +3849,241 @@ class Grid(BaseResqpy):
          which should be handled elsewhere
       """
 
-      # todo: improve handling of units: check uom for half cell transmissibility property and for absolute modifiers
+        # todo: improve handling of units: check uom for half cell transmissibility property and for absolute modifiers
 
-      k_tr = j_tr = i_tr = None
+        k_tr = j_tr = i_tr = None
 
-      if realization is None:
-         if hasattr(self, 'array_k_transmissibility') and self.array_k_transmissibility is not None:
-            k_tr = self.array_k_transmissibility
-         if hasattr(self, 'array_j_transmissibility') and self.array_j_transmissibility is not None:
-            j_tr = self.array_j_transmissibility
-         if hasattr(self, 'array_i_transmissibility') and self.array_i_transmissibility is not None:
-            i_tr = self.array_i_transmissibility
+        if realization is None:
+            if hasattr(self, 'array_k_transmissibility') and self.array_k_transmissibility is not None:
+                k_tr = self.array_k_transmissibility
+            if hasattr(self, 'array_j_transmissibility') and self.array_j_transmissibility is not None:
+                j_tr = self.array_j_transmissibility
+            if hasattr(self, 'array_i_transmissibility') and self.array_i_transmissibility is not None:
+                i_tr = self.array_i_transmissibility
 
-      if use_tr_properties and (k_tr is None or j_tr is None or i_tr is None):
+        if use_tr_properties and (k_tr is None or j_tr is None or i_tr is None):
 
-         pc = self.extract_property_collection()
-
-         if k_tr is None:
-            k_tr = pc.single_array_ref(property_kind = 'transmissibility',
-                                       realization = realization,
-                                       continuous = True,
-                                       count = 1,
-                                       indexable = 'faces',
-                                       facet_type = 'direction',
-                                       facet = 'K')
-            if k_tr is not None:
-               assert k_tr.shape == (self.nk + 1, self.nj, self.ni)
-               if realization is None:
-                  self.array_k_transmissibility = k_tr
-
-         if j_tr is None:
-            j_tr = pc.single_array_ref(property_kind = 'transmissibility',
-                                       realization = realization,
-                                       continuous = True,
-                                       count = 1,
-                                       indexable = 'faces',
-                                       facet_type = 'direction',
-                                       facet = 'J')
-            if j_tr is not None:
-               assert j_tr.shape == (self.nk, self.nj + 1, self.ni)
-               if realization is None:
-                  self.array_j_transmissibility = j_tr
-
-         if i_tr is None:
-            i_tr = pc.single_array_ref(property_kind = 'transmissibility',
-                                       realization = realization,
-                                       continuous = True,
-                                       count = 1,
-                                       indexable = 'faces',
-                                       facet_type = 'direction',
-                                       facet = 'I')
-            if i_tr is not None:
-               assert i_tr.shape == (self.nk, self.nj, self.ni + 1)
-               if realization is None:
-                  self.array_i_transmissibility = i_tr
-
-      if k_tr is None or j_tr is None or i_tr is None:
-
-         half_t = self.half_cell_transmissibility(use_property = use_tr_properties, realization = realization)
-
-         if modifier_mode == 'faces per cell multiplier':
             pc = self.extract_property_collection()
-            half_t_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
-                                              realization = realization,
-                                              continuous = True,
-                                              count = 1,
-                                              indexable = 'faces per cell')
-            if half_t_mult is None:
-               log.warning('no faces per cell transmissibility multiplier found when calculating transmissibilities')
+
+            if k_tr is None:
+                k_tr = pc.single_array_ref(property_kind = 'transmissibility',
+                                           realization = realization,
+                                           continuous = True,
+                                           count = 1,
+                                           indexable = 'faces',
+                                           facet_type = 'direction',
+                                           facet = 'K')
+                if k_tr is not None:
+                    assert k_tr.shape == (self.nk + 1, self.nj, self.ni)
+                    if realization is None:
+                        self.array_k_transmissibility = k_tr
+
+            if j_tr is None:
+                j_tr = pc.single_array_ref(property_kind = 'transmissibility',
+                                           realization = realization,
+                                           continuous = True,
+                                           count = 1,
+                                           indexable = 'faces',
+                                           facet_type = 'direction',
+                                           facet = 'J')
+                if j_tr is not None:
+                    assert j_tr.shape == (self.nk, self.nj + 1, self.ni)
+                    if realization is None:
+                        self.array_j_transmissibility = j_tr
+
+            if i_tr is None:
+                i_tr = pc.single_array_ref(property_kind = 'transmissibility',
+                                           realization = realization,
+                                           continuous = True,
+                                           count = 1,
+                                           indexable = 'faces',
+                                           facet_type = 'direction',
+                                           facet = 'I')
+                if i_tr is not None:
+                    assert i_tr.shape == (self.nk, self.nj, self.ni + 1)
+                    if realization is None:
+                        self.array_i_transmissibility = i_tr
+
+        if k_tr is None or j_tr is None or i_tr is None:
+
+            half_t = self.half_cell_transmissibility(use_property = use_tr_properties, realization = realization)
+
+            if modifier_mode == 'faces per cell multiplier':
+                pc = self.extract_property_collection()
+                half_t_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
+                                                  realization = realization,
+                                                  continuous = True,
+                                                  count = 1,
+                                                  indexable = 'faces per cell')
+                if half_t_mult is None:
+                    log.warning(
+                        'no faces per cell transmissibility multiplier found when calculating transmissibilities')
+                else:
+                    log.debug('applying faces per cell transmissibility multipliers')
+                    half_t = np.where(np.isnan(half_t_mult), half_t, half_t * half_t_mult)
+
+            if self.has_split_coordinate_lines and (j_tr is None or i_tr is None):
+                split_column_edges_j, split_column_edges_i = self.split_column_faces()
             else:
-               log.debug('applying faces per cell transmissibility multipliers')
-               half_t = np.where(np.isnan(half_t_mult), half_t, half_t * half_t_mult)
+                split_column_edges_j, split_column_edges_i = None, None
 
-         if self.has_split_coordinate_lines and (j_tr is None or i_tr is None):
-            split_column_edges_j, split_column_edges_i = self.split_column_faces()
-         else:
-            split_column_edges_j, split_column_edges_i = None, None
+            np.seterr(divide = 'ignore')
 
-         np.seterr(divide = 'ignore')
+            if k_tr is None:
+                k_tr = np.zeros((self.nk + 1, self.nj, self.ni))
+                slice_a = half_t[:-1, :, :, 0, 1]  # note: internal faces only
+                slice_b = half_t[1:, :, :, 0, 0]
+                internal_zero_mask = np.logical_or(np.logical_or(np.isnan(slice_a), slice_a < tolerance),
+                                                   np.logical_or(np.isnan(slice_b), slice_b < tolerance))
+                if self.k_gaps:  # todo: scan K gaps for zero thickness gaps and allow transmission there
+                    internal_zero_mask[self.k_gap_after_array, :, :] = True
+                tr_mult = None
+                if modifier_mode == 'faces multiplier':
+                    tr_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
+                                                  realization = realization,
+                                                  facet_type = 'direction',
+                                                  facet = 'K',
+                                                  continuous = True,
+                                                  count = 1,
+                                                  indexable = 'faces')
+                    if tr_mult is not None:
+                        assert tr_mult.shape == (self.nk + 1, self.nj, self.ni)
+                        internal_zero_mask = np.logical_or(internal_zero_mask, np.isnan(tr_mult[1:-1, :, :]))
+                if tr_mult is None:
+                    tr_mult = 1.0
+                tr_abs_r = 0.0
+                if modifier_mode == 'absolute':
+                    tr_abs = pc.single_array_ref(property_kind = 'mat transmissibility',
+                                                 realization = realization,
+                                                 facet_type = 'direction',
+                                                 facet = 'K',
+                                                 continuous = True,
+                                                 count = 1,
+                                                 indexable = 'faces')
+                    if tr_abs is None:
+                        tr_abs = pc.single_array_ref(property_kind = 'mat transmissibility',
+                                                     realization = realization,
+                                                     continuous = True,
+                                                     count = 1,
+                                                     indexable = 'faces')
+                    if tr_abs is None:
+                        tr_abs = pc.single_array_ref(property_kind = 'fault transmissibility',
+                                                     realization = realization,
+                                                     facet_type = 'direction',
+                                                     facet = 'K',
+                                                     continuous = True,
+                                                     count = 1,
+                                                     indexable = 'faces')
+                    if tr_abs is not None:
+                        log.debug('applying absolute K face transmissibility modification')
+                        assert tr_abs.shape == (self.nk + 1, self.nj, self.ni)
+                        internal_zero_mask = np.logical_or(internal_zero_mask, tr_abs[1:-1, :, :] <= 0.0)
+                        tr_abs_r = np.where(np.logical_or(np.isinf(tr_abs), np.isnan(tr_abs)), 0.0, 1.0 / tr_abs)
+                k_tr[1:-1, :, :] = np.where(internal_zero_mask, 0.0,
+                                            tr_mult / ((1.0 / slice_a) + tr_abs_r + (1.0 / slice_b)))
+                if realization is None:
+                    self.array_k_transmissibility = k_tr
 
-         if k_tr is None:
-            k_tr = np.zeros((self.nk + 1, self.nj, self.ni))
-            slice_a = half_t[:-1, :, :, 0, 1]  # note: internal faces only
-            slice_b = half_t[1:, :, :, 0, 0]
-            internal_zero_mask = np.logical_or(np.logical_or(np.isnan(slice_a), slice_a < tolerance),
-                                               np.logical_or(np.isnan(slice_b), slice_b < tolerance))
-            if self.k_gaps:  # todo: scan K gaps for zero thickness gaps and allow transmission there
-               internal_zero_mask[self.k_gap_after_array, :, :] = True
-            tr_mult = None
-            if modifier_mode == 'faces multiplier':
-               tr_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
-                                             realization = realization,
-                                             facet_type = 'direction',
-                                             facet = 'K',
-                                             continuous = True,
-                                             count = 1,
-                                             indexable = 'faces')
-               if tr_mult is not None:
-                  assert tr_mult.shape == (self.nk + 1, self.nj, self.ni)
-                  internal_zero_mask = np.logical_or(internal_zero_mask, np.isnan(tr_mult[1:-1, :, :]))
-            if tr_mult is None:
-               tr_mult = 1.0
-            tr_abs_r = 0.0
-            if modifier_mode == 'absolute':
-               tr_abs = pc.single_array_ref(property_kind = 'mat transmissibility',
-                                            realization = realization,
-                                            facet_type = 'direction',
-                                            facet = 'K',
-                                            continuous = True,
-                                            count = 1,
-                                            indexable = 'faces')
-               if tr_abs is None:
-                  tr_abs = pc.single_array_ref(property_kind = 'mat transmissibility',
-                                               realization = realization,
-                                               continuous = True,
-                                               count = 1,
-                                               indexable = 'faces')
-               if tr_abs is None:
-                  tr_abs = pc.single_array_ref(property_kind = 'fault transmissibility',
-                                               realization = realization,
-                                               facet_type = 'direction',
-                                               facet = 'K',
-                                               continuous = True,
-                                               count = 1,
-                                               indexable = 'faces')
-               if tr_abs is not None:
-                  log.debug('applying absolute K face transmissibility modification')
-                  assert tr_abs.shape == (self.nk + 1, self.nj, self.ni)
-                  internal_zero_mask = np.logical_or(internal_zero_mask, tr_abs[1:-1, :, :] <= 0.0)
-                  tr_abs_r = np.where(np.logical_or(np.isinf(tr_abs), np.isnan(tr_abs)), 0.0, 1.0 / tr_abs)
-            k_tr[1:-1, :, :] = np.where(internal_zero_mask, 0.0,
-                                        tr_mult / ((1.0 / slice_a) + tr_abs_r + (1.0 / slice_b)))
-            if realization is None:
-               self.array_k_transmissibility = k_tr
+            if j_tr is None:
+                j_tr = np.zeros((self.nk, self.nj + 1, self.ni))
+                slice_a = half_t[:, :-1, :, 1, 1]  # note: internal faces only
+                slice_b = half_t[:, 1:, :, 1, 0]
+                internal_zero_mask = np.logical_or(np.logical_or(np.isnan(slice_a), slice_a < tolerance),
+                                                   np.logical_or(np.isnan(slice_b), slice_b < tolerance))
+                if split_column_edges_j is not None:
+                    internal_zero_mask[:, split_column_edges_j] = True
+                tr_mult = None
+                if modifier_mode == 'faces multiplier':
+                    tr_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
+                                                  realization = realization,
+                                                  facet_type = 'direction',
+                                                  facet = 'J',
+                                                  continuous = True,
+                                                  count = 1,
+                                                  indexable = 'faces')
+                    if tr_mult is None:
+                        log.warning(
+                            'no J direction faces transmissibility multiplier found when calculating transmissibilities'
+                        )
+                    else:
+                        assert tr_mult.shape == (self.nk, self.nj + 1, self.ni)
+                        internal_zero_mask = np.logical_or(internal_zero_mask, np.isnan(tr_mult[:, 1:-1, :]))
+                if tr_mult is None:
+                    tr_mult = 1.0
+                tr_abs_r = 0.0
+                if modifier_mode == 'absolute':
+                    tr_abs = pc.single_array_ref(property_kind = 'fault transmissibility',
+                                                 realization = realization,
+                                                 facet_type = 'direction',
+                                                 facet = 'J',
+                                                 continuous = True,
+                                                 count = 1,
+                                                 indexable = 'faces')
+                    if tr_abs is not None:
+                        log.debug('applying absolute J face transmissibility modification')
+                        assert tr_abs.shape == (self.nk, self.nj + 1, self.ni)
+                        internal_zero_mask = np.logical_or(internal_zero_mask, tr_abs[:, 1:-1, :] <= 0.0)
+                        tr_abs_r = np.where(np.logical_or(np.isinf(tr_abs), np.isnan(tr_abs)), 0.0, 1.0 / tr_abs)
+                j_tr[:, 1:-1, :] = np.where(internal_zero_mask, 0.0,
+                                            tr_mult / ((1.0 / slice_a) + tr_abs_r + (1.0 / slice_b)))
+                if realization is None:
+                    self.array_j_transmissibility = j_tr
 
-         if j_tr is None:
-            j_tr = np.zeros((self.nk, self.nj + 1, self.ni))
-            slice_a = half_t[:, :-1, :, 1, 1]  # note: internal faces only
-            slice_b = half_t[:, 1:, :, 1, 0]
-            internal_zero_mask = np.logical_or(np.logical_or(np.isnan(slice_a), slice_a < tolerance),
-                                               np.logical_or(np.isnan(slice_b), slice_b < tolerance))
-            if split_column_edges_j is not None:
-               internal_zero_mask[:, split_column_edges_j] = True
-            tr_mult = None
-            if modifier_mode == 'faces multiplier':
-               tr_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
-                                             realization = realization,
-                                             facet_type = 'direction',
-                                             facet = 'J',
-                                             continuous = True,
-                                             count = 1,
-                                             indexable = 'faces')
-               if tr_mult is None:
-                  log.warning(
-                     'no J direction faces transmissibility multiplier found when calculating transmissibilities')
-               else:
-                  assert tr_mult.shape == (self.nk, self.nj + 1, self.ni)
-                  internal_zero_mask = np.logical_or(internal_zero_mask, np.isnan(tr_mult[:, 1:-1, :]))
-            if tr_mult is None:
-               tr_mult = 1.0
-            tr_abs_r = 0.0
-            if modifier_mode == 'absolute':
-               tr_abs = pc.single_array_ref(property_kind = 'fault transmissibility',
-                                            realization = realization,
-                                            facet_type = 'direction',
-                                            facet = 'J',
-                                            continuous = True,
-                                            count = 1,
-                                            indexable = 'faces')
-               if tr_abs is not None:
-                  log.debug('applying absolute J face transmissibility modification')
-                  assert tr_abs.shape == (self.nk, self.nj + 1, self.ni)
-                  internal_zero_mask = np.logical_or(internal_zero_mask, tr_abs[:, 1:-1, :] <= 0.0)
-                  tr_abs_r = np.where(np.logical_or(np.isinf(tr_abs), np.isnan(tr_abs)), 0.0, 1.0 / tr_abs)
-            j_tr[:, 1:-1, :] = np.where(internal_zero_mask, 0.0,
-                                        tr_mult / ((1.0 / slice_a) + tr_abs_r + (1.0 / slice_b)))
-            if realization is None:
-               self.array_j_transmissibility = j_tr
+            if i_tr is None:
+                i_tr = np.zeros((self.nk, self.nj, self.ni + 1))
+                slice_a = half_t[:, :, :-1, 2, 1]  # note: internal faces only
+                slice_b = half_t[:, :, 1:, 2, 0]
+                internal_zero_mask = np.logical_or(np.logical_or(np.isnan(slice_a), slice_a < tolerance),
+                                                   np.logical_or(np.isnan(slice_b), slice_b < tolerance))
+                if split_column_edges_i is not None:
+                    internal_zero_mask[:, split_column_edges_i] = True
+                tr_mult = None
+                if modifier_mode == 'faces multiplier':
+                    tr_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
+                                                  realization = realization,
+                                                  facet_type = 'direction',
+                                                  facet = 'I',
+                                                  continuous = True,
+                                                  count = 1,
+                                                  indexable = 'faces')
+                    if tr_mult is None:
+                        log.warning(
+                            'no I direction faces transmissibility multiplier found when calculating transmissibilities'
+                        )
+                    else:
+                        assert tr_mult.shape == (self.nk, self.nj, self.ni + 1)
+                        internal_zero_mask = np.logical_or(internal_zero_mask, np.isnan(tr_mult[:, :, 1:-1]))
+                if tr_mult is None:
+                    tr_mult = 1.0
+                tr_abs_r = 0.0
+                if modifier_mode == 'absolute':
+                    tr_abs = pc.single_array_ref(property_kind = 'fault transmissibility',
+                                                 realization = realization,
+                                                 facet_type = 'direction',
+                                                 facet = 'I',
+                                                 continuous = True,
+                                                 count = 1,
+                                                 indexable = 'faces')
+                    if tr_abs is not None:
+                        log.debug('applying absolute I face transmissibility modification')
+                        assert tr_abs.shape == (self.nk, self.nj, self.ni + 1)
+                        internal_zero_mask = np.logical_or(internal_zero_mask, tr_abs[:, :, 1:-1] <= 0.0)
+                        tr_abs_r = np.where(np.logical_or(np.isinf(tr_abs), np.isnan(tr_abs)), 0.0, 1.0 / tr_abs)
+                i_tr[:, :, 1:-1] = np.where(internal_zero_mask, 0.0,
+                                            tr_mult / ((1.0 / slice_a) + tr_abs_r + (1.0 / slice_b)))
 
-         if i_tr is None:
-            i_tr = np.zeros((self.nk, self.nj, self.ni + 1))
-            slice_a = half_t[:, :, :-1, 2, 1]  # note: internal faces only
-            slice_b = half_t[:, :, 1:, 2, 0]
-            internal_zero_mask = np.logical_or(np.logical_or(np.isnan(slice_a), slice_a < tolerance),
-                                               np.logical_or(np.isnan(slice_b), slice_b < tolerance))
-            if split_column_edges_i is not None:
-               internal_zero_mask[:, split_column_edges_i] = True
-            tr_mult = None
-            if modifier_mode == 'faces multiplier':
-               tr_mult = pc.single_array_ref(property_kind = 'transmissibility multiplier',
-                                             realization = realization,
-                                             facet_type = 'direction',
-                                             facet = 'I',
-                                             continuous = True,
-                                             count = 1,
-                                             indexable = 'faces')
-               if tr_mult is None:
-                  log.warning(
-                     'no I direction faces transmissibility multiplier found when calculating transmissibilities')
-               else:
-                  assert tr_mult.shape == (self.nk, self.nj, self.ni + 1)
-                  internal_zero_mask = np.logical_or(internal_zero_mask, np.isnan(tr_mult[:, :, 1:-1]))
-            if tr_mult is None:
-               tr_mult = 1.0
-            tr_abs_r = 0.0
-            if modifier_mode == 'absolute':
-               tr_abs = pc.single_array_ref(property_kind = 'fault transmissibility',
-                                            realization = realization,
-                                            facet_type = 'direction',
-                                            facet = 'I',
-                                            continuous = True,
-                                            count = 1,
-                                            indexable = 'faces')
-               if tr_abs is not None:
-                  log.debug('applying absolute I face transmissibility modification')
-                  assert tr_abs.shape == (self.nk, self.nj, self.ni + 1)
-                  internal_zero_mask = np.logical_or(internal_zero_mask, tr_abs[:, :, 1:-1] <= 0.0)
-                  tr_abs_r = np.where(np.logical_or(np.isinf(tr_abs), np.isnan(tr_abs)), 0.0, 1.0 / tr_abs)
-            i_tr[:, :, 1:-1] = np.where(internal_zero_mask, 0.0,
-                                        tr_mult / ((1.0 / slice_a) + tr_abs_r + (1.0 / slice_b)))
+            np.seterr(divide = 'warn')
 
-         np.seterr(divide = 'warn')
+        return k_tr, j_tr, i_tr
 
-      return k_tr, j_tr, i_tr
-
-   def fault_connection_set(self,
-                            skip_inactive = True,
-                            compute_transmissibility = False,
-                            add_to_model = False,
-                            realization = None,
-                            inherit_features_from = None,
-                            title = 'fault juxtaposition set'):
-      """Returns (and caches) a GridConnectionSet representing juxtaposition across faces with split pillars.
+    def fault_connection_set(self,
+                             skip_inactive = True,
+                             compute_transmissibility = False,
+                             add_to_model = False,
+                             realization = None,
+                             inherit_features_from = None,
+                             title = 'fault juxtaposition set'):
+        """Returns (and caches) a GridConnectionSet representing juxtaposition across faces with split pillars.
 
       arguments:
          skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
@@ -4051,51 +4105,51 @@ class Grid(BaseResqpy):
          are no qualifying connections, (None, None) is returned
       """
 
-      if not hasattr(self, 'fgcs') or self.fgcs_skip_inactive != skip_inactive:
-         self.fgcs, self.fgcs_fractional_area = rqtr.fault_connection_set(self, skip_inactive = skip_inactive)
-         self.fgcs_skip_inactive = skip_inactive
+        if not hasattr(self, 'fgcs') or self.fgcs_skip_inactive != skip_inactive:
+            self.fgcs, self.fgcs_fractional_area = rqtr.fault_connection_set(self, skip_inactive = skip_inactive)
+            self.fgcs_skip_inactive = skip_inactive
 
-      if self.fgcs is None:
-         return None, None
+        if self.fgcs is None:
+            return None, None
 
-      new_tr = False
-      if compute_transmissibility and not hasattr(self, 'array_fgcs_transmissibility'):
-         self.array_fgcs_transmissibility = self.fgcs.tr_property_array(self.fgcs_fractional_area)
-         new_tr = True
+        new_tr = False
+        if compute_transmissibility and not hasattr(self, 'array_fgcs_transmissibility'):
+            self.array_fgcs_transmissibility = self.fgcs.tr_property_array(self.fgcs_fractional_area)
+            new_tr = True
 
-      tr = self.array_fgcs_transmissibility if hasattr(self, 'array_fgcs_transmissibility') else None
+        tr = self.array_fgcs_transmissibility if hasattr(self, 'array_fgcs_transmissibility') else None
 
-      if inherit_features_from is not None:
-         self.fgcs.inherit_features(inherit_features_from)
+        if inherit_features_from is not None:
+            self.fgcs.inherit_features(inherit_features_from)
 
-      if add_to_model:
-         if self.model.uuid(uuid = self.fgcs.uuid) is None:
-            self.fgcs.write_hdf5()
-            self.fgcs.create_xml(title = title)
-         if new_tr:
-            tr_pc = rprop.PropertyCollection()
-            tr_pc.set_support(support = self.fgcs)
-            tr_pc.add_cached_array_to_imported_list(
-               self.array_fgcs_transmissibility,
-               'computed for faces with split pillars',
-               'fault transmissibility',
-               discrete = False,
-               uom = 'm3.cP/(kPa.d)' if self.xy_units() == 'm' else 'bbl.cP/(psi.d)',
-               property_kind = 'transmissibility',
-               realization = realization,
-               indexable_element = 'faces',
-               count = 1)
-            tr_pc.write_hdf5_for_imported_list()
-            tr_pc.create_xml_for_imported_list_and_add_parts_to_model()
+        if add_to_model:
+            if self.model.uuid(uuid = self.fgcs.uuid) is None:
+                self.fgcs.write_hdf5()
+                self.fgcs.create_xml(title = title)
+            if new_tr:
+                tr_pc = rprop.PropertyCollection()
+                tr_pc.set_support(support = self.fgcs)
+                tr_pc.add_cached_array_to_imported_list(
+                    self.array_fgcs_transmissibility,
+                    'computed for faces with split pillars',
+                    'fault transmissibility',
+                    discrete = False,
+                    uom = 'm3.cP/(kPa.d)' if self.xy_units() == 'm' else 'bbl.cP/(psi.d)',
+                    property_kind = 'transmissibility',
+                    realization = realization,
+                    indexable_element = 'faces',
+                    count = 1)
+                tr_pc.write_hdf5_for_imported_list()
+                tr_pc.create_xml_for_imported_list_and_add_parts_to_model()
 
-      return self.fgcs, tr
+        return self.fgcs, tr
 
-   def pinchout_connection_set(self,
-                               skip_inactive = True,
-                               compute_transmissibility = False,
-                               add_to_model = False,
-                               realization = None):
-      """Returns (and caches) a GridConnectionSet representing juxtaposition across pinched out cells.
+    def pinchout_connection_set(self,
+                                skip_inactive = True,
+                                compute_transmissibility = False,
+                                add_to_model = False,
+                                realization = None):
+        """Returns (and caches) a GridConnectionSet representing juxtaposition across pinched out cells.
 
       arguments:
          skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
@@ -4114,49 +4168,49 @@ class Grid(BaseResqpy):
          connections) then (None, None) will be returned
       """
 
-      if not hasattr(self, 'pgcs') or self.pgcs_skip_inactive != skip_inactive:
-         self.pgcs = rqf.pinchout_connection_set(self, skip_inactive = skip_inactive)
-         self.pgcs_skip_inactive = skip_inactive
+        if not hasattr(self, 'pgcs') or self.pgcs_skip_inactive != skip_inactive:
+            self.pgcs = rqf.pinchout_connection_set(self, skip_inactive = skip_inactive)
+            self.pgcs_skip_inactive = skip_inactive
 
-      if self.pgcs is None:
-         return None, None
+        if self.pgcs is None:
+            return None, None
 
-      new_tr = False
-      if compute_transmissibility and not hasattr(self, 'array_pgcs_transmissibility'):
-         self.array_pgcs_transmissibility = self.pgcs.tr_property_array()
-         new_tr = True
+        new_tr = False
+        if compute_transmissibility and not hasattr(self, 'array_pgcs_transmissibility'):
+            self.array_pgcs_transmissibility = self.pgcs.tr_property_array()
+            new_tr = True
 
-      tr = self.array_pgcs_transmissibility if hasattr(self, 'array_pgcs_transmissibility') else None
+        tr = self.array_pgcs_transmissibility if hasattr(self, 'array_pgcs_transmissibility') else None
 
-      if add_to_model:
-         if self.model.uuid(uuid = self.pgcs.uuid) is None:
-            self.pgcs.write_hdf5()
-            self.pgcs.create_xml()
-         if new_tr:
-            tr_pc = rprop.PropertyCollection()
-            tr_pc.set_support(support = self.pgcs)
-            tr_pc.add_cached_array_to_imported_list(
-               tr,
-               'computed for faces across pinchouts',
-               'pinchout transmissibility',
-               discrete = False,
-               uom = 'm3.cP/(kPa.d)' if self.xy_units() == 'm' else 'bbl.cP/(psi.d)',
-               property_kind = 'transmissibility',
-               realization = realization,
-               indexable_element = 'faces',
-               count = 1)
-            tr_pc.write_hdf5_for_imported_list()
-            tr_pc.create_xml_for_imported_list_and_add_parts_to_model()
+        if add_to_model:
+            if self.model.uuid(uuid = self.pgcs.uuid) is None:
+                self.pgcs.write_hdf5()
+                self.pgcs.create_xml()
+            if new_tr:
+                tr_pc = rprop.PropertyCollection()
+                tr_pc.set_support(support = self.pgcs)
+                tr_pc.add_cached_array_to_imported_list(
+                    tr,
+                    'computed for faces across pinchouts',
+                    'pinchout transmissibility',
+                    discrete = False,
+                    uom = 'm3.cP/(kPa.d)' if self.xy_units() == 'm' else 'bbl.cP/(psi.d)',
+                    property_kind = 'transmissibility',
+                    realization = realization,
+                    indexable_element = 'faces',
+                    count = 1)
+                tr_pc.write_hdf5_for_imported_list()
+                tr_pc.create_xml_for_imported_list_and_add_parts_to_model()
 
-      return self.pgcs, tr
+        return self.pgcs, tr
 
-   def k_gap_connection_set(self,
-                            skip_inactive = True,
-                            compute_transmissibility = False,
-                            add_to_model = False,
-                            realization = None,
-                            tolerance = 0.001):
-      """Returns (and caches) a GridConnectionSet representing juxtaposition across zero thickness K gaps.
+    def k_gap_connection_set(self,
+                             skip_inactive = True,
+                             compute_transmissibility = False,
+                             add_to_model = False,
+                             realization = None,
+                             tolerance = 0.001):
+        """Returns (and caches) a GridConnectionSet representing juxtaposition across zero thickness K gaps.
 
       arguments:
          skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
@@ -4180,107 +4234,108 @@ class Grid(BaseResqpy):
          if cached values are found they are returned regardless of the specified tolerance
       """
 
-      if not hasattr(self, 'kgcs') or self.kgcs_skip_inactive != skip_inactive:
-         self.kgcs = rqf.k_gap_connection_set(self, skip_inactive = skip_inactive, tolerance = tolerance)
-         self.kgcs_skip_inactive = skip_inactive
+        if not hasattr(self, 'kgcs') or self.kgcs_skip_inactive != skip_inactive:
+            self.kgcs = rqf.k_gap_connection_set(self, skip_inactive = skip_inactive, tolerance = tolerance)
+            self.kgcs_skip_inactive = skip_inactive
 
-      if self.kgcs is None:
-         return None, None
+        if self.kgcs is None:
+            return None, None
 
-      new_tr = False
-      if compute_transmissibility and not hasattr(self, 'array_kgcs_transmissibility'):
-         self.array_kgcs_transmissibility = self.kgcs.tr_property_array()
-         new_tr = True
+        new_tr = False
+        if compute_transmissibility and not hasattr(self, 'array_kgcs_transmissibility'):
+            self.array_kgcs_transmissibility = self.kgcs.tr_property_array()
+            new_tr = True
 
-      tr = self.array_kgcs_transmissibility if hasattr(self, 'array_kgcs_transmissibility') else None
+        tr = self.array_kgcs_transmissibility if hasattr(self, 'array_kgcs_transmissibility') else None
 
-      if add_to_model:
-         if self.model.uuid(uuid = self.kgcs.uuid) is None:
-            self.kgcs.write_hdf5()
-            self.kgcs.create_xml()
-         if new_tr:
-            tr_pc = rprop.PropertyCollection()
-            tr_pc.set_support(support = self.kgcs)
-            tr_pc.add_cached_array_to_imported_list(
-               tr,
-               'computed for faces across zero thickness K gaps',
-               'K gap transmissibility',
-               discrete = False,
-               uom = 'm3.cP/(kPa.d)' if self.xy_units() == 'm' else 'bbl.cP/(psi.d)',
-               property_kind = 'transmissibility',
-               realization = realization,
-               indexable_element = 'faces',
-               count = 1)
-            tr_pc.write_hdf5_for_imported_list()
-            tr_pc.create_xml_for_imported_list_and_add_parts_to_model()
+        if add_to_model:
+            if self.model.uuid(uuid = self.kgcs.uuid) is None:
+                self.kgcs.write_hdf5()
+                self.kgcs.create_xml()
+            if new_tr:
+                tr_pc = rprop.PropertyCollection()
+                tr_pc.set_support(support = self.kgcs)
+                tr_pc.add_cached_array_to_imported_list(
+                    tr,
+                    'computed for faces across zero thickness K gaps',
+                    'K gap transmissibility',
+                    discrete = False,
+                    uom = 'm3.cP/(kPa.d)' if self.xy_units() == 'm' else 'bbl.cP/(psi.d)',
+                    property_kind = 'transmissibility',
+                    realization = realization,
+                    indexable_element = 'faces',
+                    count = 1)
+                tr_pc.write_hdf5_for_imported_list()
+                tr_pc.create_xml_for_imported_list_and_add_parts_to_model()
 
-      return self.kgcs, tr
+        return self.kgcs, tr
 
-   def cell_inactive(self, cell_kji0, pv_array = None, pv_tol = 0.01):
-      """Returns True if the cell is inactive."""
+    def cell_inactive(self, cell_kji0, pv_array = None, pv_tol = 0.01):
+        """Returns True if the cell is inactive."""
 
-      if self.inactive is not None:
-         return self.inactive[tuple(cell_kji0)]
-      self.extract_inactive_mask()
-      if self.inactive is not None:
-         return self.inactive[tuple(cell_kji0)]
-      if pv_array is not None:  # fabricate an inactive mask from pore volume data
-         self.inactive = not (pv_array > pv_tol)  # NaN in pv array will end up inactive
-         return self.inactive[tuple(cell_kji0)]
-      return (not self.cell_geometry_is_defined(cell_kji0)) or self.pinched_out(cell_kji0, cache_pinchout_array = True)
+        if self.inactive is not None:
+            return self.inactive[tuple(cell_kji0)]
+        self.extract_inactive_mask()
+        if self.inactive is not None:
+            return self.inactive[tuple(cell_kji0)]
+        if pv_array is not None:  # fabricate an inactive mask from pore volume data
+            self.inactive = not (pv_array > pv_tol)  # NaN in pv array will end up inactive
+            return self.inactive[tuple(cell_kji0)]
+        return (not self.cell_geometry_is_defined(cell_kji0)) or self.pinched_out(cell_kji0,
+                                                                                  cache_pinchout_array = True)
 
-   def bounding_box(self, cell_kji0, points_root = None, cache_cp_array = False):
-      """Returns the xyz box which envelopes the specified cell, as a numpy array of shape (2, 3)."""
+    def bounding_box(self, cell_kji0, points_root = None, cache_cp_array = False):
+        """Returns the xyz box which envelopes the specified cell, as a numpy array of shape (2, 3)."""
 
-      result = np.zeros((2, 3))
-      cp = self.corner_points(cell_kji0, points_root = points_root, cache_cp_array = cache_cp_array)
-      result[0] = np.min(cp, axis = (0, 1, 2))
-      result[1] = np.max(cp, axis = (0, 1, 2))
-      return result
+        result = np.zeros((2, 3))
+        cp = self.corner_points(cell_kji0, points_root = points_root, cache_cp_array = cache_cp_array)
+        result[0] = np.min(cp, axis = (0, 1, 2))
+        result[1] = np.max(cp, axis = (0, 1, 2))
+        return result
 
-   def composite_bounding_box(self, bounding_box_list):
-      """Returns the xyz box which envelopes all the boxes in the list, as a numpy array of shape (2, 3)."""
+    def composite_bounding_box(self, bounding_box_list):
+        """Returns the xyz box which envelopes all the boxes in the list, as a numpy array of shape (2, 3)."""
 
-      result = bounding_box_list[0]
-      for box in bounding_box_list[1:]:
-         result[0] = np.minimum(result[0], box[0])
-         result[1] = np.maximum(result[1], box[1])
-      return result
+        result = bounding_box_list[0]
+        for box in bounding_box_list[1:]:
+            result[0] = np.minimum(result[0], box[0])
+            result[1] = np.maximum(result[1], box[1])
+        return result
 
-   def interpolated_point(self,
-                          cell_kji0,
-                          interpolation_fraction,
-                          points_root = None,
-                          cache_resqml_array = True,
-                          cache_cp_array = False):
-      """Returns xyz point interpolated from corners of cell depending on 3 interpolation fractions in range 0 to 1."""
-
-      # todo: think about best ordering of axes operations given high aspect ratio of cells (for best accuracy)
-      fp = np.empty(3)
-      fm = np.empty(3)
-      for axis in range(3):
-         fp[axis] = max(min(interpolation_fraction[axis], 1.0), 0.0)
-         fm[axis] = 1.0 - fp[axis]
-      cp = self.corner_points(cell_kji0,
-                              points_root = points_root,
-                              cache_resqml_array = cache_resqml_array,
-                              cache_cp_array = cache_cp_array)
-      c00 = (cp[0, 0, 0] * fm[0] + cp[1, 0, 0] * fp[0])
-      c01 = (cp[0, 0, 1] * fm[0] + cp[1, 0, 1] * fp[0])
-      c10 = (cp[0, 1, 0] * fm[0] + cp[1, 1, 0] * fp[0])
-      c11 = (cp[0, 1, 1] * fm[0] + cp[1, 1, 1] * fp[0])
-      c0 = c00 * fm[1] + c10 * fp[1]
-      c1 = c01 * fm[1] + c11 * fp[1]
-      c = c0 * fm[2] + c1 * fp[2]
-      return c
-
-   def interpolated_points(self,
+    def interpolated_point(self,
                            cell_kji0,
-                           interpolation_fractions,
+                           interpolation_fraction,
                            points_root = None,
                            cache_resqml_array = True,
                            cache_cp_array = False):
-      """Returns xyz points interpolated from corners of cell depending on 3 interpolation fraction numpy vectors, each value in range 0 to 1.
+        """Returns xyz point interpolated from corners of cell depending on 3 interpolation fractions in range 0 to 1."""
+
+        # todo: think about best ordering of axes operations given high aspect ratio of cells (for best accuracy)
+        fp = np.empty(3)
+        fm = np.empty(3)
+        for axis in range(3):
+            fp[axis] = max(min(interpolation_fraction[axis], 1.0), 0.0)
+            fm[axis] = 1.0 - fp[axis]
+        cp = self.corner_points(cell_kji0,
+                                points_root = points_root,
+                                cache_resqml_array = cache_resqml_array,
+                                cache_cp_array = cache_cp_array)
+        c00 = (cp[0, 0, 0] * fm[0] + cp[1, 0, 0] * fp[0])
+        c01 = (cp[0, 0, 1] * fm[0] + cp[1, 0, 1] * fp[0])
+        c10 = (cp[0, 1, 0] * fm[0] + cp[1, 1, 0] * fp[0])
+        c11 = (cp[0, 1, 1] * fm[0] + cp[1, 1, 1] * fp[0])
+        c0 = c00 * fm[1] + c10 * fp[1]
+        c1 = c01 * fm[1] + c11 * fp[1]
+        c = c0 * fm[2] + c1 * fp[2]
+        return c
+
+    def interpolated_points(self,
+                            cell_kji0,
+                            interpolation_fractions,
+                            points_root = None,
+                            cache_resqml_array = True,
+                            cache_cp_array = False):
+        """Returns xyz points interpolated from corners of cell depending on 3 interpolation fraction numpy vectors, each value in range 0 to 1.
 
       arguments:
          cell_kji0 (triple int): indices of individual cell whose corner points are to be interpolated
@@ -4300,547 +4355,551 @@ class Grid(BaseResqpy):
          must redistribute to corner points of individual fine cells if that is the intention
       """
 
-      assert len(interpolation_fractions) == 3
-      fp = interpolation_fractions
-      fm = []
-      for axis in range(3):
-         fm.append(1.0 - fp[axis])
+        assert len(interpolation_fractions) == 3
+        fp = interpolation_fractions
+        fm = []
+        for axis in range(3):
+            fm.append(1.0 - fp[axis])
 
-      cp = self.corner_points(cell_kji0,
-                              points_root = points_root,
-                              cache_resqml_array = cache_resqml_array,
-                              cache_cp_array = cache_cp_array)
+        cp = self.corner_points(cell_kji0,
+                                points_root = points_root,
+                                cache_resqml_array = cache_resqml_array,
+                                cache_cp_array = cache_cp_array)
 
-      c00 = (np.outer(fm[2], cp[0, 0, 0]) + np.outer(fp[2], cp[0, 0, 1]))
-      c01 = (np.outer(fm[2], cp[0, 1, 0]) + np.outer(fp[2], cp[0, 1, 1]))
-      c10 = (np.outer(fm[2], cp[1, 0, 0]) + np.outer(fp[2], cp[1, 0, 1]))
-      c11 = (np.outer(fm[2], cp[1, 1, 0]) + np.outer(fp[2], cp[1, 1, 1]))
-      c0 = (np.multiply.outer(fm[1], c00) + np.multiply.outer(fp[1], c01))
-      c1 = (np.multiply.outer(fm[1], c10) + np.multiply.outer(fp[1], c11))
-      c = (np.multiply.outer(fm[0], c0) + np.multiply.outer(fp[0], c1))
+        c00 = (np.outer(fm[2], cp[0, 0, 0]) + np.outer(fp[2], cp[0, 0, 1]))
+        c01 = (np.outer(fm[2], cp[0, 1, 0]) + np.outer(fp[2], cp[0, 1, 1]))
+        c10 = (np.outer(fm[2], cp[1, 0, 0]) + np.outer(fp[2], cp[1, 0, 1]))
+        c11 = (np.outer(fm[2], cp[1, 1, 0]) + np.outer(fp[2], cp[1, 1, 1]))
+        c0 = (np.multiply.outer(fm[1], c00) + np.multiply.outer(fp[1], c01))
+        c1 = (np.multiply.outer(fm[1], c10) + np.multiply.outer(fp[1], c11))
+        c = (np.multiply.outer(fm[0], c0) + np.multiply.outer(fp[0], c1))
 
-      return c
+        return c
 
-   def face_centre(self,
-                   cell_kji0,
-                   axis,
-                   zero_or_one,
-                   points_root = None,
-                   cache_resqml_array = True,
-                   cache_cp_array = False):
-      """Returns xyz location of the centre point of a face of the cell (or all cells)."""
+    def face_centre(self,
+                    cell_kji0,
+                    axis,
+                    zero_or_one,
+                    points_root = None,
+                    cache_resqml_array = True,
+                    cache_cp_array = False):
+        """Returns xyz location of the centre point of a face of the cell (or all cells)."""
 
-      # todo: optionally compute for all cells and cache
-      cp = self.corner_points(cell_kji0,
-                              points_root = points_root,
-                              cache_resqml_array = cache_resqml_array,
-                              cache_cp_array = cache_cp_array)
-      if cell_kji0 is None:
-         if axis == 0:
-            return 0.25 * np.sum(cp[:, :, :, zero_or_one, :, :], axis = (3, 4))
-         elif axis == 1:
-            return 0.25 * np.sum(cp[:, :, :, :, zero_or_one, :], axis = (3, 4))
-         else:
-            return 0.25 * np.sum(cp[:, :, :, :, :, zero_or_one], axis = (3, 4))
-      else:
-         if axis == 0:
-            return 0.25 * np.sum(cp[zero_or_one, :, :], axis = (0, 1))
-         elif axis == 1:
-            return 0.25 * np.sum(cp[:, zero_or_one, :], axis = (0, 1))
-         else:
-            return 0.25 * np.sum(cp[:, :, zero_or_one], axis = (0, 1))
+        # todo: optionally compute for all cells and cache
+        cp = self.corner_points(cell_kji0,
+                                points_root = points_root,
+                                cache_resqml_array = cache_resqml_array,
+                                cache_cp_array = cache_cp_array)
+        if cell_kji0 is None:
+            if axis == 0:
+                return 0.25 * np.sum(cp[:, :, :, zero_or_one, :, :], axis = (3, 4))
+            elif axis == 1:
+                return 0.25 * np.sum(cp[:, :, :, :, zero_or_one, :], axis = (3, 4))
+            else:
+                return 0.25 * np.sum(cp[:, :, :, :, :, zero_or_one], axis = (3, 4))
+        else:
+            if axis == 0:
+                return 0.25 * np.sum(cp[zero_or_one, :, :], axis = (0, 1))
+            elif axis == 1:
+                return 0.25 * np.sum(cp[:, zero_or_one, :], axis = (0, 1))
+            else:
+                return 0.25 * np.sum(cp[:, :, zero_or_one], axis = (0, 1))
 
-   def face_centres_kji_01(self, cell_kji0, points_root = None, cache_resqml_array = True, cache_cp_array = False):
-      """Returns an array of shape (3, 2, 3) being (axis, 0 or 1, xyz) of face centre points for cell."""
+    def face_centres_kji_01(self, cell_kji0, points_root = None, cache_resqml_array = True, cache_cp_array = False):
+        """Returns an array of shape (3, 2, 3) being (axis, 0 or 1, xyz) of face centre points for cell."""
 
-      assert cell_kji0 is not None
-      result = np.zeros((3, 2, 3))
-      for axis in range(3):
-         for zero_or_one in range(2):
-            result[axis, zero_or_one] = self.face_centre(cell_kji0,
-                                                         axis,
-                                                         zero_or_one,
-                                                         points_root = points_root,
-                                                         cache_resqml_array = cache_resqml_array,
-                                                         cache_cp_array = cache_cp_array)
-      return result
+        assert cell_kji0 is not None
+        result = np.zeros((3, 2, 3))
+        for axis in range(3):
+            for zero_or_one in range(2):
+                result[axis, zero_or_one] = self.face_centre(cell_kji0,
+                                                             axis,
+                                                             zero_or_one,
+                                                             points_root = points_root,
+                                                             cache_resqml_array = cache_resqml_array,
+                                                             cache_cp_array = cache_cp_array)
+        return result
 
-   def interface_vector(self, cell_kji0, axis, points_root = None, cache_resqml_array = True, cache_cp_array = False):
-      """Returns an xyz vector between centres of an opposite pair of faces of the cell (or vectors for all cells)."""
+    def interface_vector(self, cell_kji0, axis, points_root = None, cache_resqml_array = True, cache_cp_array = False):
+        """Returns an xyz vector between centres of an opposite pair of faces of the cell (or vectors for all cells)."""
 
-      face_0_centre = self.face_centre(cell_kji0,
-                                       axis,
-                                       0,
-                                       points_root = points_root,
-                                       cache_resqml_array = cache_resqml_array,
-                                       cache_cp_array = cache_cp_array)
-      face_1_centre = self.face_centre(cell_kji0,
-                                       axis,
-                                       1,
-                                       points_root = points_root,
-                                       cache_resqml_array = cache_resqml_array,
-                                       cache_cp_array = cache_cp_array)
-      return face_1_centre - face_0_centre
+        face_0_centre = self.face_centre(cell_kji0,
+                                         axis,
+                                         0,
+                                         points_root = points_root,
+                                         cache_resqml_array = cache_resqml_array,
+                                         cache_cp_array = cache_cp_array)
+        face_1_centre = self.face_centre(cell_kji0,
+                                         axis,
+                                         1,
+                                         points_root = points_root,
+                                         cache_resqml_array = cache_resqml_array,
+                                         cache_cp_array = cache_cp_array)
+        return face_1_centre - face_0_centre
 
-   def interface_length(self, cell_kji0, axis, points_root = None, cache_resqml_array = True, cache_cp_array = False):
-      """Returns the length between centres of an opposite pair of faces of the cell.
-
-      note:
-         assumes that x,y and z units are the same
-      """
-
-      assert cell_kji0 is not None
-      return vec.naive_length(
-         self.interface_vector(cell_kji0,
-                               axis,
-                               points_root = points_root,
-                               cache_resqml_array = cache_resqml_array,
-                               cache_cp_array = cache_cp_array))
-
-   def interface_vectors_kji(self, cell_kji0, points_root = None, cache_resqml_array = True, cache_cp_array = False):
-      """Returns 3 interface centre point difference vectors for axes k, j, i."""
-
-      result = np.zeros((3, 3))
-      for axis in range(3):
-         result[axis] = self.interface_vector(cell_kji0,
-                                              axis,
-                                              points_root = points_root,
-                                              cache_resqml_array = cache_resqml_array,
-                                              cache_cp_array = cache_cp_array)
-      return result
-
-   def interface_lengths_kji(self, cell_kji0, points_root = None, cache_resqml_array = True, cache_cp_array = False):
-      """Returns 3 interface centre point separation lengths for axes k, j, i.
+    def interface_length(self, cell_kji0, axis, points_root = None, cache_resqml_array = True, cache_cp_array = False):
+        """Returns the length between centres of an opposite pair of faces of the cell.
 
       note:
          assumes that x,y and z units are the same
       """
-      result = np.zeros(3)
-      for axis in range(3):
-         result[axis] = self.interface_length(cell_kji0,
-                                              axis,
-                                              points_root = points_root,
-                                              cache_resqml_array = cache_resqml_array,
-                                              cache_cp_array = cache_cp_array)
-      return result
 
-   def local_to_global_crs(self,
-                           a,
-                           crs_root = None,
-                           global_xy_units = None,
-                           global_z_units = None,
-                           global_z_increasing_downward = None):
-      """Converts array of points in situ from local coordinate system to global one."""
+        assert cell_kji0 is not None
+        return vec.naive_length(
+            self.interface_vector(cell_kji0,
+                                  axis,
+                                  points_root = points_root,
+                                  cache_resqml_array = cache_resqml_array,
+                                  cache_cp_array = cache_cp_array))
 
-      # todo: replace with crs module calls
+    def interface_vectors_kji(self, cell_kji0, points_root = None, cache_resqml_array = True, cache_cp_array = False):
+        """Returns 3 interface centre point difference vectors for axes k, j, i."""
 
-      if crs_root is None:
-         crs_root = self.crs_root
-         if crs_root is None:
-            return
-      flat_a = a.reshape((-1, 3))  # flattened view of array a as vector of (x, y, z) points, in situ
-      x_offset = float(rqet.find_tag(crs_root, 'XOffset').text)
-      y_offset = float(rqet.find_tag(crs_root, 'YOffset').text)
-      z_offset = float(rqet.find_tag(crs_root, 'ZOffset').text)
-      areal_rotation = float(rqet.find_tag(crs_root, 'ArealRotation').text)
-      assert (areal_rotation == 0.0)
-      # todo: check resqml definition for order of rotation and translation
-      # todo: apply rotation
-      if global_z_increasing_downward is not None:  # note: here negation is made in local crs; if z_offset is not zero, this might not be what is intended
-         crs_z_increasing_downward_text = rqet.find_tag(crs_root, 'ZIncreasingDownward').text
-         if crs_z_increasing_downward_text in ['true', 'false']:  # todo: otherwise could raise exception
-            crs_z_increasing_downward = (crs_z_increasing_downward_text == 'true')
+        result = np.zeros((3, 3))
+        for axis in range(3):
+            result[axis] = self.interface_vector(cell_kji0,
+                                                 axis,
+                                                 points_root = points_root,
+                                                 cache_resqml_array = cache_resqml_array,
+                                                 cache_cp_array = cache_cp_array)
+        return result
+
+    def interface_lengths_kji(self, cell_kji0, points_root = None, cache_resqml_array = True, cache_cp_array = False):
+        """Returns 3 interface centre point separation lengths for axes k, j, i.
+
+      note:
+         assumes that x,y and z units are the same
+      """
+        result = np.zeros(3)
+        for axis in range(3):
+            result[axis] = self.interface_length(cell_kji0,
+                                                 axis,
+                                                 points_root = points_root,
+                                                 cache_resqml_array = cache_resqml_array,
+                                                 cache_cp_array = cache_cp_array)
+        return result
+
+    def local_to_global_crs(self,
+                            a,
+                            crs_root = None,
+                            global_xy_units = None,
+                            global_z_units = None,
+                            global_z_increasing_downward = None):
+        """Converts array of points in situ from local coordinate system to global one."""
+
+        # todo: replace with crs module calls
+
+        if crs_root is None:
+            crs_root = self.crs_root
+            if crs_root is None:
+                return
+        flat_a = a.reshape((-1, 3))  # flattened view of array a as vector of (x, y, z) points, in situ
+        x_offset = float(rqet.find_tag(crs_root, 'XOffset').text)
+        y_offset = float(rqet.find_tag(crs_root, 'YOffset').text)
+        z_offset = float(rqet.find_tag(crs_root, 'ZOffset').text)
+        areal_rotation = float(rqet.find_tag(crs_root, 'ArealRotation').text)
+        assert (areal_rotation == 0.0)
+        # todo: check resqml definition for order of rotation and translation
+        # todo: apply rotation
+        if global_z_increasing_downward is not None:  # note: here negation is made in local crs; if z_offset is not zero, this might not be what is intended
+            crs_z_increasing_downward_text = rqet.find_tag(crs_root, 'ZIncreasingDownward').text
+            if crs_z_increasing_downward_text in ['true', 'false']:  # todo: otherwise could raise exception
+                crs_z_increasing_downward = (crs_z_increasing_downward_text == 'true')
+                if global_z_increasing_downward != crs_z_increasing_downward:
+                    negated_z = np.negative(flat_a[:, 2])
+                    flat_a[:, 2] = negated_z
+        flat_a[:, 0] += x_offset
+        flat_a[:, 1] += y_offset
+        if z_offset != 0.0:
+            flat_a[:, 2] += z_offset
+        if global_xy_units is not None:
+            crs_xy_units_text = rqet.find_tag(crs_root, 'ProjectedUom').text
+            if crs_xy_units_text in ['ft', 'm']:  # todo: else raise exception
+                bwam.convert_lengths(flat_a[:, 0], crs_xy_units_text, global_xy_units)  # x
+                bwam.convert_lengths(flat_a[:, 1], crs_xy_units_text, global_xy_units)  # y
+        if global_z_units is not None:
+            crs_z_units_text = rqet.find_tag(crs_root, 'VerticalUom').text
+            if crs_z_units_text in ['ft', 'm']:  # todo: else raise exception
+                bwam.convert_lengths(flat_a[:, 2], crs_z_units_text, global_z_units)  # z
+
+    def z_inc_down(self):
+        """Returns True if z increases downwards in the coordinate reference system used by the grid geometry, False otherwise.
+
+      :meta common:
+      """
+
+        assert self.crs_root is not None
+        return rqet.find_tag_bool(self.crs_root, 'ZIncreasingDownward')
+
+    def global_to_local_crs(self,
+                            a,
+                            crs_root = None,
+                            global_xy_units = None,
+                            global_z_units = None,
+                            global_z_increasing_downward = None):
+        """Converts array of points in situ from global coordinate system to established local one."""
+
+        # todo: replace with crs module calls
+
+        if crs_root is None:
+            crs_root = self.crs_root
+            if crs_root is None:
+                return
+        flat_a = a.reshape((-1, 3))  # flattened view of array a as vector of (x, y, z) points, in situ
+        x_offset = float(rqet.find_tag(crs_root, 'XOffset').text)
+        y_offset = float(rqet.find_tag(crs_root, 'YOffset').text)
+        z_offset = float(rqet.find_tag(crs_root, 'ZOffset').text)
+        areal_rotation = float(rqet.find_tag(crs_root, 'ArealRotation').text)
+        assert (areal_rotation == 0.0)
+        # todo: check resqml definition for order of rotation and translation and apply rotation if not zero
+        if global_xy_units is not None:
+            crs_xy_units_text = rqet.find_tag(crs_root, 'ProjectedUom').text
+            if crs_xy_units_text in ['ft', 'm']:  # todo: else raise exception
+                bwam.convert_lengths(flat_a[:, 0], global_xy_units, crs_xy_units_text)  # x
+                bwam.convert_lengths(flat_a[:, 1], global_xy_units, crs_xy_units_text)  # y
+        if global_z_units is not None:
+            crs_z_units_text = rqet.find_tag(crs_root, 'VerticalUom').text
+            if crs_z_units_text in ['ft', 'm']:  # todo: else raise exception
+                bwam.convert_lengths(flat_a[:, 2], global_z_units, crs_z_units_text)  # z
+        flat_a[:, 0] -= x_offset
+        flat_a[:, 1] -= y_offset
+        if z_offset != 0.0:
+            flat_a[:, 2] -= z_offset
+        if global_z_increasing_downward is not None:  # note: here negation is made in local crs; if z_offset is not zero, this might not be what is intended
+            crs_z_increasing_downward = self.z_inc_down()
+            assert crs_z_increasing_downward is not None
             if global_z_increasing_downward != crs_z_increasing_downward:
-               negated_z = np.negative(flat_a[:, 2])
-               flat_a[:, 2] = negated_z
-      flat_a[:, 0] += x_offset
-      flat_a[:, 1] += y_offset
-      if z_offset != 0.0:
-         flat_a[:, 2] += z_offset
-      if global_xy_units is not None:
-         crs_xy_units_text = rqet.find_tag(crs_root, 'ProjectedUom').text
-         if crs_xy_units_text in ['ft', 'm']:  # todo: else raise exception
-            bwam.convert_lengths(flat_a[:, 0], crs_xy_units_text, global_xy_units)  # x
-            bwam.convert_lengths(flat_a[:, 1], crs_xy_units_text, global_xy_units)  # y
-      if global_z_units is not None:
-         crs_z_units_text = rqet.find_tag(crs_root, 'VerticalUom').text
-         if crs_z_units_text in ['ft', 'm']:  # todo: else raise exception
-            bwam.convert_lengths(flat_a[:, 2], crs_z_units_text, global_z_units)  # z
+                negated_z = np.negative(flat_a[:, 2])
+                flat_a[:, 2] = negated_z
 
-   def z_inc_down(self):
-      """Returns True if z increases downwards in the coordinate reference system used by the grid geometry, False otherwise.
+    def write_hdf5_from_caches(self,
+                               file = None,
+                               mode = 'a',
+                               geometry = True,
+                               imported_properties = None,
+                               write_active = None,
+                               stratigraphy = True,
+                               expand_const_arrays = False):
+        """Create or append to an hdf5 file, writing datasets for the grid geometry (and parent grid mapping) and properties from cached arrays."""
 
-      :meta common:
-      """
+        # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
+        # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
+        # xml is not created here for property objects
 
-      assert self.crs_root is not None
-      return rqet.find_tag_bool(self.crs_root, 'ZIncreasingDownward')
+        if write_active is None:
+            write_active = geometry
 
-   def global_to_local_crs(self,
-                           a,
-                           crs_root = None,
-                           global_xy_units = None,
-                           global_z_units = None,
-                           global_z_increasing_downward = None):
-      """Converts array of points in situ from global coordinate system to established local one."""
+        self.cache_all_geometry_arrays()
 
-      # todo: replace with crs module calls
+        if not file:
+            file = self.model.h5_file_name()
+        h5_reg = rwh5.H5Register(self.model)
 
-      if crs_root is None:
-         crs_root = self.crs_root
-         if crs_root is None:
-            return
-      flat_a = a.reshape((-1, 3))  # flattened view of array a as vector of (x, y, z) points, in situ
-      x_offset = float(rqet.find_tag(crs_root, 'XOffset').text)
-      y_offset = float(rqet.find_tag(crs_root, 'YOffset').text)
-      z_offset = float(rqet.find_tag(crs_root, 'ZOffset').text)
-      areal_rotation = float(rqet.find_tag(crs_root, 'ArealRotation').text)
-      assert (areal_rotation == 0.0)
-      # todo: check resqml definition for order of rotation and translation and apply rotation if not zero
-      if global_xy_units is not None:
-         crs_xy_units_text = rqet.find_tag(crs_root, 'ProjectedUom').text
-         if crs_xy_units_text in ['ft', 'm']:  # todo: else raise exception
-            bwam.convert_lengths(flat_a[:, 0], global_xy_units, crs_xy_units_text)  # x
-            bwam.convert_lengths(flat_a[:, 1], global_xy_units, crs_xy_units_text)  # y
-      if global_z_units is not None:
-         crs_z_units_text = rqet.find_tag(crs_root, 'VerticalUom').text
-         if crs_z_units_text in ['ft', 'm']:  # todo: else raise exception
-            bwam.convert_lengths(flat_a[:, 2], global_z_units, crs_z_units_text)  # z
-      flat_a[:, 0] -= x_offset
-      flat_a[:, 1] -= y_offset
-      if z_offset != 0.0:
-         flat_a[:, 2] -= z_offset
-      if global_z_increasing_downward is not None:  # note: here negation is made in local crs; if z_offset is not zero, this might not be what is intended
-         crs_z_increasing_downward = self.z_inc_down()
-         assert crs_z_increasing_downward is not None
-         if global_z_increasing_downward != crs_z_increasing_downward:
-            negated_z = np.negative(flat_a[:, 2])
-            flat_a[:, 2] = negated_z
+        if stratigraphy and self.stratigraphic_units is not None:
+            h5_reg.register_dataset(self.uuid, 'unitIndices', self.stratigraphic_units, dtype = 'uint32')
 
-   def write_hdf5_from_caches(self,
-                              file = None,
-                              mode = 'a',
-                              geometry = True,
-                              imported_properties = None,
-                              write_active = None,
-                              stratigraphy = True,
-                              expand_const_arrays = False):
-      """Create or append to an hdf5 file, writing datasets for the grid geometry (and parent grid mapping) and properties from cached arrays."""
+        if geometry:
+            if always_write_pillar_geometry_is_defined_array or not self.geometry_defined_for_all_pillars(
+                    cache_array = True):
+                if not hasattr(self,
+                               'array_pillar_geometry_is_defined') or self.array_pillar_geometry_is_defined is None:
+                    self.array_pillar_geometry_is_defined = np.full((self.nj + 1, self.ni + 1), True, dtype = bool)
+                h5_reg.register_dataset(self.uuid,
+                                        'PillarGeometryIsDefined',
+                                        self.array_pillar_geometry_is_defined,
+                                        dtype = 'uint8')
+            if always_write_cell_geometry_is_defined_array or not self.geometry_defined_for_all_cells(
+                    cache_array = True):
+                if not hasattr(self, 'array_cell_geometry_is_defined') or self.array_cell_geometry_is_defined is None:
+                    self.array_cell_geometry_is_defined = np.full((self.nk, self.nj, self.ni), True, dtype = bool)
+                h5_reg.register_dataset(self.uuid,
+                                        'CellGeometryIsDefined',
+                                        self.array_cell_geometry_is_defined,
+                                        dtype = 'uint8')
+            # todo: PillarGeometryIsDefined ?
+            h5_reg.register_dataset(self.uuid, 'Points', self.points_cached)
+            if self.has_split_coordinate_lines:
+                h5_reg.register_dataset(self.uuid, 'PillarIndices', self.split_pillar_indices_cached, dtype = 'uint32')
+                h5_reg.register_dataset(self.uuid,
+                                        'ColumnsPerSplitCoordinateLine/elements',
+                                        self.cols_for_split_pillars,
+                                        dtype = 'uint32')
+                h5_reg.register_dataset(self.uuid,
+                                        'ColumnsPerSplitCoordinateLine/cumulativeLength',
+                                        self.cols_for_split_pillars_cl,
+                                        dtype = 'uint32')
+            if self.k_gaps:
+                assert self.k_gap_after_array is not None
+                h5_reg.register_dataset(self.uuid, 'GapAfterLayer', self.k_gap_after_array, dtype = 'uint8')
+            if self.parent_window is not None:
+                for axis in range(3):
+                    if self.parent_window.fine_extent_kji[axis] == self.parent_window.coarse_extent_kji[axis]:
+                        continue  # one-to-noe mapping
+                    # reconstruct hdf5 arrays from FineCoarse object and register for write
+                    if self.parent_window.constant_ratios[axis] is not None:
+                        if self.is_refinement:
+                            pcpi = np.array([self.parent_window.coarse_extent_kji[axis]],
+                                            dtype = int)  # ParentCountPerInterval
+                            ccpi = np.array([self.parent_window.fine_extent_kji[axis]],
+                                            dtype = int)  # ChildCountPerInterval
+                        else:
+                            pcpi = np.array([self.parent_window.fine_extent_kji[axis]], dtype = int)
+                            ccpi = np.array([self.parent_window.coarse_extent_kji[axis]], dtype = int)
+                    else:
+                        if self.is_refinement:
+                            interval_count = self.parent_window.coarse_extent_kji[axis]
+                            pcpi = np.ones(interval_count, dtype = int)
+                            ccpi = np.array(self.parent_window.vector_ratios[axis], dtype = int)
+                        else:
+                            interval_count = self.parent_window.fine_extent_kji[axis]
+                            pcpi = np.array(self.parent_window.vector_ratios[axis], dtype = int)
+                            ccpi = np.ones(interval_count, dtype = int)
+                    h5_reg.register_dataset(self.uuid, 'KJI'[axis] + 'Regrid/ParentCountPerInterval', pcpi)
+                    h5_reg.register_dataset(self.uuid, 'KJI'[axis] + 'Regrid/ChildCountPerInterval', ccpi)
+                    if self.is_refinement and not self.parent_window.equal_proportions[axis]:
+                        child_cell_weights = np.concatenate(self.parent_window.vector_proportions[axis])
+                        h5_reg.register_dataset(self.uuid, 'KJI'[axis] + 'Regrid/ChildCellWeights', child_cell_weights)
 
-      # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
-      # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
-      # xml is not created here for property objects
+        if write_active and self.inactive is not None:
+            if imported_properties is None:
+                imported_properties = rprop.PropertyCollection()
+                imported_properties.set_support(support = self)
+            else:
+                filtered_list = []
+                for entry in imported_properties.imported_list:
+                    if entry[2].upper() == 'ACTIVE' or entry[10] == 'active':
+                        continue  # keyword or property kind
+                    filtered_list.append(entry)
+                imported_properties.imported_list = filtered_list  # might have unintended side effects elsewhere
+            active_mask = np.logical_not(self.inactive)
+            imported_properties.add_cached_array_to_imported_list(active_mask,
+                                                                  'active cell mask',
+                                                                  'ACTIVE',
+                                                                  discrete = True,
+                                                                  property_kind = 'active')
 
-      if write_active is None:
-         write_active = geometry
-
-      self.cache_all_geometry_arrays()
-
-      if not file:
-         file = self.model.h5_file_name()
-      h5_reg = rwh5.H5Register(self.model)
-
-      if stratigraphy and self.stratigraphic_units is not None:
-         h5_reg.register_dataset(self.uuid, 'unitIndices', self.stratigraphic_units, dtype = 'uint32')
-
-      if geometry:
-         if always_write_pillar_geometry_is_defined_array or not self.geometry_defined_for_all_pillars(
-               cache_array = True):
-            if not hasattr(self, 'array_pillar_geometry_is_defined') or self.array_pillar_geometry_is_defined is None:
-               self.array_pillar_geometry_is_defined = np.full((self.nj + 1, self.ni + 1), True, dtype = bool)
-            h5_reg.register_dataset(self.uuid,
-                                    'PillarGeometryIsDefined',
-                                    self.array_pillar_geometry_is_defined,
-                                    dtype = 'uint8')
-         if always_write_cell_geometry_is_defined_array or not self.geometry_defined_for_all_cells(cache_array = True):
-            if not hasattr(self, 'array_cell_geometry_is_defined') or self.array_cell_geometry_is_defined is None:
-               self.array_cell_geometry_is_defined = np.full((self.nk, self.nj, self.ni), True, dtype = bool)
-            h5_reg.register_dataset(self.uuid,
-                                    'CellGeometryIsDefined',
-                                    self.array_cell_geometry_is_defined,
-                                    dtype = 'uint8')
-         # todo: PillarGeometryIsDefined ?
-         h5_reg.register_dataset(self.uuid, 'Points', self.points_cached)
-         if self.has_split_coordinate_lines:
-            h5_reg.register_dataset(self.uuid, 'PillarIndices', self.split_pillar_indices_cached, dtype = 'uint32')
-            h5_reg.register_dataset(self.uuid,
-                                    'ColumnsPerSplitCoordinateLine/elements',
-                                    self.cols_for_split_pillars,
-                                    dtype = 'uint32')
-            h5_reg.register_dataset(self.uuid,
-                                    'ColumnsPerSplitCoordinateLine/cumulativeLength',
-                                    self.cols_for_split_pillars_cl,
-                                    dtype = 'uint32')
-         if self.k_gaps:
-            assert self.k_gap_after_array is not None
-            h5_reg.register_dataset(self.uuid, 'GapAfterLayer', self.k_gap_after_array, dtype = 'uint8')
-         if self.parent_window is not None:
-            for axis in range(3):
-               if self.parent_window.fine_extent_kji[axis] == self.parent_window.coarse_extent_kji[axis]:
-                  continue  # one-to-noe mapping
-               # reconstruct hdf5 arrays from FineCoarse object and register for write
-               if self.parent_window.constant_ratios[axis] is not None:
-                  if self.is_refinement:
-                     pcpi = np.array([self.parent_window.coarse_extent_kji[axis]],
-                                     dtype = int)  # ParentCountPerInterval
-                     ccpi = np.array([self.parent_window.fine_extent_kji[axis]], dtype = int)  # ChildCountPerInterval
-                  else:
-                     pcpi = np.array([self.parent_window.fine_extent_kji[axis]], dtype = int)
-                     ccpi = np.array([self.parent_window.coarse_extent_kji[axis]], dtype = int)
-               else:
-                  if self.is_refinement:
-                     interval_count = self.parent_window.coarse_extent_kji[axis]
-                     pcpi = np.ones(interval_count, dtype = int)
-                     ccpi = np.array(self.parent_window.vector_ratios[axis], dtype = int)
-                  else:
-                     interval_count = self.parent_window.fine_extent_kji[axis]
-                     pcpi = np.array(self.parent_window.vector_ratios[axis], dtype = int)
-                     ccpi = np.ones(interval_count, dtype = int)
-               h5_reg.register_dataset(self.uuid, 'KJI'[axis] + 'Regrid/ParentCountPerInterval', pcpi)
-               h5_reg.register_dataset(self.uuid, 'KJI'[axis] + 'Regrid/ChildCountPerInterval', ccpi)
-               if self.is_refinement and not self.parent_window.equal_proportions[axis]:
-                  child_cell_weights = np.concatenate(self.parent_window.vector_proportions[axis])
-                  h5_reg.register_dataset(self.uuid, 'KJI'[axis] + 'Regrid/ChildCellWeights', child_cell_weights)
-
-      if write_active and self.inactive is not None:
-         if imported_properties is None:
-            imported_properties = rprop.PropertyCollection()
-            imported_properties.set_support(support = self)
-         else:
-            filtered_list = []
+        if imported_properties is not None and imported_properties.imported_list is not None:
             for entry in imported_properties.imported_list:
-               if entry[2].upper() == 'ACTIVE' or entry[10] == 'active':
-                  continue  # keyword or property kind
-               filtered_list.append(entry)
-            imported_properties.imported_list = filtered_list  # might have unintended side effects elsewhere
-         active_mask = np.logical_not(self.inactive)
-         imported_properties.add_cached_array_to_imported_list(active_mask,
-                                                               'active cell mask',
-                                                               'ACTIVE',
-                                                               discrete = True,
-                                                               property_kind = 'active')
+                tail = 'points_patch0' if entry[18] else 'values_patch0'
+                # expand constant arrays if required
+                if not hasattr(imported_properties, entry[3]) and expand_const_arrays and entry[17] is not None:
+                    value = float(entry[17]) if isinstance(entry[17], str) else entry[17]
+                    assert entry[14] == 'cells' and entry[15] == 1
+                    imported_properties.__dict__[entry[3]] = np.full(self.extent_kji, value)
+                if hasattr(imported_properties, entry[3]):  # otherwise constant array not being expanded
+                    h5_reg.register_dataset(entry[0], tail, imported_properties.__dict__[entry[3]])
+                if entry[10] == 'active':
+                    self.active_property_uuid = entry[0]
+        h5_reg.write(file, mode = mode)
 
-      if imported_properties is not None and imported_properties.imported_list is not None:
-         for entry in imported_properties.imported_list:
-            tail = 'points_patch0' if entry[18] else 'values_patch0'
-            # expand constant arrays if required
-            if not hasattr(imported_properties, entry[3]) and expand_const_arrays and entry[17] is not None:
-               value = float(entry[17]) if isinstance(entry[17], str) else entry[17]
-               assert entry[14] == 'cells' and entry[15] == 1
-               imported_properties.__dict__[entry[3]] = np.full(self.extent_kji, value)
-            if hasattr(imported_properties, entry[3]):  # otherwise constant array not being expanded
-               h5_reg.register_dataset(entry[0], tail, imported_properties.__dict__[entry[3]])
-            if entry[10] == 'active':
-               self.active_property_uuid = entry[0]
-      h5_reg.write(file, mode = mode)
-
-   def write_hdf5(self, expand_const_arrays = False):
-      """Writes grid geometry arrays to hdf5 (thin wrapper around write_hdf5_from_caches().
+    def write_hdf5(self, expand_const_arrays = False):
+        """Writes grid geometry arrays to hdf5 (thin wrapper around write_hdf5_from_caches().
 
       :meta common:
       """
 
-      self.write_hdf5_from_caches(mode = 'a',
-                                  geometry = True,
-                                  imported_properties = None,
-                                  write_active = True,
-                                  stratigraphy = True,
-                                  expand_const_arrays = expand_const_arrays)
+        self.write_hdf5_from_caches(mode = 'a',
+                                    geometry = True,
+                                    imported_properties = None,
+                                    write_active = True,
+                                    stratigraphy = True,
+                                    expand_const_arrays = expand_const_arrays)
 
-   def off_handed(self):
-      """Returns False if IJK and xyz have same handedness, True if they differ."""
+    def off_handed(self):
+        """Returns False if IJK and xyz have same handedness, True if they differ."""
 
-      ijk_right_handed = self.extract_grid_is_right_handed()
-      assert rqet.find_tag_text(self.crs_root, 'ProjectedAxisOrder').lower() == 'easting northing'
-      # note: if z increases downwards, xyz is left handed
-      return ijk_right_handed == self.z_inc_down()
+        ijk_right_handed = self.extract_grid_is_right_handed()
+        assert rqet.find_tag_text(self.crs_root, 'ProjectedAxisOrder').lower() == 'easting northing'
+        # note: if z increases downwards, xyz is left handed
+        return ijk_right_handed == self.z_inc_down()
 
-   def write_nexus_corp(self,
-                        file_name,
-                        local_coords = False,
-                        global_xy_units = None,
-                        global_z_units = None,
-                        global_z_increasing_downward = True,
-                        write_nx_ny_nz = False,
-                        write_units_keyword = False,
-                        write_rh_keyword_if_needed = False,
-                        write_corp_keyword = False,
-                        use_binary = False,
-                        binary_only = False,
-                        nan_substitute_value = None):
-      """Write grid geometry to file in Nexus CORP ordering."""
+    def write_nexus_corp(self,
+                         file_name,
+                         local_coords = False,
+                         global_xy_units = None,
+                         global_z_units = None,
+                         global_z_increasing_downward = True,
+                         write_nx_ny_nz = False,
+                         write_units_keyword = False,
+                         write_rh_keyword_if_needed = False,
+                         write_corp_keyword = False,
+                         use_binary = False,
+                         binary_only = False,
+                         nan_substitute_value = None):
+        """Write grid geometry to file in Nexus CORP ordering."""
 
-      log.info('caching Nexus corner points')
-      tm.log_nexus_tm('info')
-      self.corner_points(cache_cp_array = True)
-      log.debug('duplicating Nexus corner points')
-      cp = self.array_corner_points.copy()
-      log.debug('resequencing duplicated Nexus corner points')
-      gf.resequence_nexus_corp(cp, eight_mode = False, undo = True)
-      corp_extent = np.zeros(3, dtype = 'int')
-      corp_extent[0] = self.cell_count()  # total number of cells in grid
-      corp_extent[1] = 8  # 8 corners of cell: k -/+; j -/+; i -/+
-      corp_extent[2] = 3  # x, y, z
-      ijk_right_handed = self.extract_grid_is_right_handed()
-      if ijk_right_handed is None:
-         log.warning('ijk handedness not known')
-      elif not ijk_right_handed:
-         log.warning('ijk axes are left handed; inverted (fake) xyz handedness required')
-      crs_root = self.extract_crs_root()
-      if not local_coords:
-         if not global_z_increasing_downward:
-            log.warning('global z is not increasing with depth as expected by Nexus')
-            tm.log_nexus_tm('warning')
-         if crs_root is not None:  # todo: otherwise raise exception?
-            log.info('converting corner points from local to global reference system')
-            self.local_to_global_crs(cp,
-                                     crs_root,
-                                     global_xy_units = global_xy_units,
-                                     global_z_units = global_z_units,
-                                     global_z_increasing_downward = global_z_increasing_downward)
-      log.info('writing simulator corner point file ' + file_name)
-      with open(file_name, 'w') as header:
-         header.write('! Nexus corner point data written by resqml_grid module\n')
-         header.write('! Nexus is a registered trademark of the Halliburton Company\n\n')
-         if write_units_keyword:
-            if local_coords:
-               if crs_root is not None:
-                  crs_xy_units_text = rqet.find_tag(crs_root, 'ProjectedUom').text
-                  crs_z_units_text = rqet.find_tag(crs_root, 'VerticalUom').text
-                  if crs_xy_units_text == 'm' and crs_z_units_text == 'm':
-                     header.write('METRIC\n\n')
-                  elif crs_xy_units_text == 'ft' and crs_z_units_text == 'ft':
-                     header.write('ENGLISH\n\n')
-                  else:
-                     header.write('! local coordinates mixed (or not recognized)\n\n')
-               else:
-                  header.write('! local coordinates unknown\n\n')
-            elif global_xy_units is not None and global_z_units is not None and global_xy_units == global_z_units:
-               if global_xy_units in ['m', 'metre', 'metres']:
-                  header.write('METRIC\n\n')
-               elif global_xy_units in ['ft', 'feet', 'foot']:
-                  header.write('ENGLISH\n\n')
-               else:
-                  header.write('! globsl coordinates not recognized\n\n')
-            else:
-               header.write('! global units unknown or mixed\n\n')
-         if write_nx_ny_nz:
-            header.write('NX      NY      NZ\n')
-            header.write('{0:<7d} {1:<7d} {2:<7d}\n\n'.format(self.extent_kji[2], self.extent_kji[1],
-                                                              self.extent_kji[0]))
-         if write_rh_keyword_if_needed:
-            if ijk_right_handed is None or crs_root is None:
-               log.warning('unable to determine whether RIGHTHANDED keyword is needed')
-            else:
-               xy_axes = rqet.find_tag(crs_root, 'ProjectedAxisOrder').text
-               if local_coords:
-                  z_inc_down = self.z_inc_down()
-                  if not z_inc_down:
-                     log.warning('local z is not increasing with depth as expected by Nexus')
-                     tm.log_nexus_tm('warning')
-               else:
-                  z_inc_down = global_z_increasing_downward
-               xyz_handedness = rqet.xyz_handedness(xy_axes, z_inc_down)
-               if xyz_handedness == 'unknown':
-                  log.warning('xyz handedness is not known; unable to determine whether RIGHTHANDED keyword is needed')
-               else:
-                  if ijk_right_handed == (xyz_handedness == 'right'):  # if either both True or both False
-                     header.write('RIGHTHANDED\n\n')
-      if write_corp_keyword:
-         keyword = 'CORP VALUE'
-      else:
-         keyword = None
-      wd.write_array_to_ascii_file(file_name,
-                                   corp_extent,
-                                   cp.reshape(tuple(corp_extent)),
-                                   target_simulator = 'nexus',
-                                   keyword = keyword,
-                                   columns = 3,
-                                   blank_line_after_i_block = False,
-                                   blank_line_after_j_block = True,
-                                   append = True,
-                                   use_binary = use_binary,
-                                   binary_only = binary_only,
-                                   nan_substitute_value = nan_substitute_value)
+        log.info('caching Nexus corner points')
+        tm.log_nexus_tm('info')
+        self.corner_points(cache_cp_array = True)
+        log.debug('duplicating Nexus corner points')
+        cp = self.array_corner_points.copy()
+        log.debug('resequencing duplicated Nexus corner points')
+        gf.resequence_nexus_corp(cp, eight_mode = False, undo = True)
+        corp_extent = np.zeros(3, dtype = 'int')
+        corp_extent[0] = self.cell_count()  # total number of cells in grid
+        corp_extent[1] = 8  # 8 corners of cell: k -/+; j -/+; i -/+
+        corp_extent[2] = 3  # x, y, z
+        ijk_right_handed = self.extract_grid_is_right_handed()
+        if ijk_right_handed is None:
+            log.warning('ijk handedness not known')
+        elif not ijk_right_handed:
+            log.warning('ijk axes are left handed; inverted (fake) xyz handedness required')
+        crs_root = self.extract_crs_root()
+        if not local_coords:
+            if not global_z_increasing_downward:
+                log.warning('global z is not increasing with depth as expected by Nexus')
+                tm.log_nexus_tm('warning')
+            if crs_root is not None:  # todo: otherwise raise exception?
+                log.info('converting corner points from local to global reference system')
+                self.local_to_global_crs(cp,
+                                         crs_root,
+                                         global_xy_units = global_xy_units,
+                                         global_z_units = global_z_units,
+                                         global_z_increasing_downward = global_z_increasing_downward)
+        log.info('writing simulator corner point file ' + file_name)
+        with open(file_name, 'w') as header:
+            header.write('! Nexus corner point data written by resqml_grid module\n')
+            header.write('! Nexus is a registered trademark of the Halliburton Company\n\n')
+            if write_units_keyword:
+                if local_coords:
+                    if crs_root is not None:
+                        crs_xy_units_text = rqet.find_tag(crs_root, 'ProjectedUom').text
+                        crs_z_units_text = rqet.find_tag(crs_root, 'VerticalUom').text
+                        if crs_xy_units_text == 'm' and crs_z_units_text == 'm':
+                            header.write('METRIC\n\n')
+                        elif crs_xy_units_text == 'ft' and crs_z_units_text == 'ft':
+                            header.write('ENGLISH\n\n')
+                        else:
+                            header.write('! local coordinates mixed (or not recognized)\n\n')
+                    else:
+                        header.write('! local coordinates unknown\n\n')
+                elif global_xy_units is not None and global_z_units is not None and global_xy_units == global_z_units:
+                    if global_xy_units in ['m', 'metre', 'metres']:
+                        header.write('METRIC\n\n')
+                    elif global_xy_units in ['ft', 'feet', 'foot']:
+                        header.write('ENGLISH\n\n')
+                    else:
+                        header.write('! globsl coordinates not recognized\n\n')
+                else:
+                    header.write('! global units unknown or mixed\n\n')
+            if write_nx_ny_nz:
+                header.write('NX      NY      NZ\n')
+                header.write('{0:<7d} {1:<7d} {2:<7d}\n\n'.format(self.extent_kji[2], self.extent_kji[1],
+                                                                  self.extent_kji[0]))
+            if write_rh_keyword_if_needed:
+                if ijk_right_handed is None or crs_root is None:
+                    log.warning('unable to determine whether RIGHTHANDED keyword is needed')
+                else:
+                    xy_axes = rqet.find_tag(crs_root, 'ProjectedAxisOrder').text
+                    if local_coords:
+                        z_inc_down = self.z_inc_down()
+                        if not z_inc_down:
+                            log.warning('local z is not increasing with depth as expected by Nexus')
+                            tm.log_nexus_tm('warning')
+                    else:
+                        z_inc_down = global_z_increasing_downward
+                    xyz_handedness = rqet.xyz_handedness(xy_axes, z_inc_down)
+                    if xyz_handedness == 'unknown':
+                        log.warning(
+                            'xyz handedness is not known; unable to determine whether RIGHTHANDED keyword is needed')
+                    else:
+                        if ijk_right_handed == (xyz_handedness == 'right'):  # if either both True or both False
+                            header.write('RIGHTHANDED\n\n')
+        if write_corp_keyword:
+            keyword = 'CORP VALUE'
+        else:
+            keyword = None
+        wd.write_array_to_ascii_file(file_name,
+                                     corp_extent,
+                                     cp.reshape(tuple(corp_extent)),
+                                     target_simulator = 'nexus',
+                                     keyword = keyword,
+                                     columns = 3,
+                                     blank_line_after_i_block = False,
+                                     blank_line_after_j_block = True,
+                                     append = True,
+                                     use_binary = use_binary,
+                                     binary_only = binary_only,
+                                     nan_substitute_value = nan_substitute_value)
 
-   def xy_units(self):
-      """Returns the projected view (x, y) units of measure of the coordinate reference system for the grid.
-
-      :meta common:
-      """
-
-      crs_root = self.extract_crs_root()
-      if crs_root is None:
-         return None
-      return rqet.find_tag(crs_root, 'ProjectedUom').text
-
-   def z_units(self):
-      """Returns the vertical (z) units of measure of the coordinate reference system for the grid.
+    def xy_units(self):
+        """Returns the projected view (x, y) units of measure of the coordinate reference system for the grid.
 
       :meta common:
       """
 
-      crs_root = self.extract_crs_root()
-      if crs_root is None:
-         return None
-      return rqet.find_tag(crs_root, 'VerticalUom').text
+        crs_root = self.extract_crs_root()
+        if crs_root is None:
+            return None
+        return rqet.find_tag(crs_root, 'ProjectedUom').text
 
-   def poly_line_for_cell(self, cell_kji0, vertical_ref = 'top'):
-      """Returns a numpy array of shape (4, 3) being the 4 corners in order J-I-, J-I+, J+I+, J+I-; from the top or base face."""
+    def z_units(self):
+        """Returns the vertical (z) units of measure of the coordinate reference system for the grid.
 
-      if vertical_ref == 'top':
-         kp = 0
-      elif vertical_ref == 'base':
-         kp = 1
-      else:
-         raise ValueError('vertical reference not catered for: ' + vertical_ref)
-      poly = np.empty((4, 3))
-      cp = self.corner_points(cell_kji0 = cell_kji0)
-      if cp is None:
-         return None
-      poly[0] = cp[kp, 0, 0]
-      poly[1] = cp[kp, 0, 1]
-      poly[2] = cp[kp, 1, 1]
-      poly[3] = cp[kp, 1, 0]
-      return poly
+      :meta common:
+      """
 
-   def find_cell_for_point_xy(self, x, y, k0 = 0, vertical_ref = 'top', local_coords = True):
-      """Searches in 2D for a cell containing point x,y in layer k0; return (j0, i0) or (None, None)."""
+        crs_root = self.extract_crs_root()
+        if crs_root is None:
+            return None
+        return rqet.find_tag(crs_root, 'VerticalUom').text
 
-      # find minimum of manhatten distances from xy to each corner point
-      # then check the four cells around that corner point
-      a = np.array([[x, y, 0.0]])  # extra axis needed to keep global_to_local_crs happy
-      if not local_coords:
-         self.global_to_local_crs(a)
-      if a is None:
-         return (None, None)
-      a[0, 2] = 0.0  # discard z
-      kp = 1 if vertical_ref == 'base' else 0
-      (pillar_j0, pillar_i0) = self.nearest_pillar(a[0, :2], ref_k0 = k0, kp = kp)
-      if pillar_j0 > 0 and pillar_i0 > 0:
-         cell_kji0 = np.array((k0, pillar_j0 - 1, pillar_i0 - 1))
-         poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
-         if poly is not None and pip.pip_cn(a[0, :2], poly):
-            return (cell_kji0[1], cell_kji0[2])
-      if pillar_j0 > 0 and pillar_i0 < self.ni:
-         cell_kji0 = np.array((k0, pillar_j0 - 1, pillar_i0))
-         poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
-         if poly is not None and pip.pip_cn(a[0, :2], poly):
-            return (cell_kji0[1], cell_kji0[2])
-      if pillar_j0 < self.nj and pillar_i0 > 0:
-         cell_kji0 = np.array((k0, pillar_j0, pillar_i0 - 1))
-         poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
-         if poly is not None and pip.pip_cn(a[0, :2], poly):
-            return (cell_kji0[1], cell_kji0[2])
-      if pillar_j0 < self.nj and pillar_i0 < self.ni:
-         cell_kji0 = np.array((k0, pillar_j0, pillar_i0))
-         poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
-         if poly is not None and pip.pip_cn(a[0, :2], poly):
-            return (cell_kji0[1], cell_kji0[2])
-      return (None, None)
+    def poly_line_for_cell(self, cell_kji0, vertical_ref = 'top'):
+        """Returns a numpy array of shape (4, 3) being the 4 corners in order J-I-, J-I+, J+I+, J+I-; from the top or base face."""
 
-   def find_cell_for_x_sect_xz(self, x_sect, x, z):
-      """Returns the (k0, j0) or (k0, i0) indices of the cell containing point x,z in the cross section.
+        if vertical_ref == 'top':
+            kp = 0
+        elif vertical_ref == 'base':
+            kp = 1
+        else:
+            raise ValueError('vertical reference not catered for: ' + vertical_ref)
+        poly = np.empty((4, 3))
+        cp = self.corner_points(cell_kji0 = cell_kji0)
+        if cp is None:
+            return None
+        poly[0] = cp[kp, 0, 0]
+        poly[1] = cp[kp, 0, 1]
+        poly[2] = cp[kp, 1, 1]
+        poly[3] = cp[kp, 1, 0]
+        return poly
+
+    def find_cell_for_point_xy(self, x, y, k0 = 0, vertical_ref = 'top', local_coords = True):
+        """Searches in 2D for a cell containing point x,y in layer k0; return (j0, i0) or (None, None)."""
+
+        # find minimum of manhatten distances from xy to each corner point
+        # then check the four cells around that corner point
+        a = np.array([[x, y, 0.0]])  # extra axis needed to keep global_to_local_crs happy
+        if not local_coords:
+            self.global_to_local_crs(a)
+        if a is None:
+            return (None, None)
+        a[0, 2] = 0.0  # discard z
+        kp = 1 if vertical_ref == 'base' else 0
+        (pillar_j0, pillar_i0) = self.nearest_pillar(a[0, :2], ref_k0 = k0, kp = kp)
+        if pillar_j0 > 0 and pillar_i0 > 0:
+            cell_kji0 = np.array((k0, pillar_j0 - 1, pillar_i0 - 1))
+            poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
+            if poly is not None and pip.pip_cn(a[0, :2], poly):
+                return (cell_kji0[1], cell_kji0[2])
+        if pillar_j0 > 0 and pillar_i0 < self.ni:
+            cell_kji0 = np.array((k0, pillar_j0 - 1, pillar_i0))
+            poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
+            if poly is not None and pip.pip_cn(a[0, :2], poly):
+                return (cell_kji0[1], cell_kji0[2])
+        if pillar_j0 < self.nj and pillar_i0 > 0:
+            cell_kji0 = np.array((k0, pillar_j0, pillar_i0 - 1))
+            poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
+            if poly is not None and pip.pip_cn(a[0, :2], poly):
+                return (cell_kji0[1], cell_kji0[2])
+        if pillar_j0 < self.nj and pillar_i0 < self.ni:
+            cell_kji0 = np.array((k0, pillar_j0, pillar_i0))
+            poly = self.poly_line_for_cell(cell_kji0, vertical_ref = vertical_ref)
+            if poly is not None and pip.pip_cn(a[0, :2], poly):
+                return (cell_kji0[1], cell_kji0[2])
+        return (None, None)
+
+    def find_cell_for_x_sect_xz(self, x_sect, x, z):
+        """Returns the (k0, j0) or (k0, i0) indices of the cell containing point x,z in the cross section.
 
       arguments:
          x_sect (numpy float array of shape (nk, nj or ni, 2, 2, 2 or 3): the cross section x,z or x,y,z data
@@ -4855,87 +4914,87 @@ class Grid(BaseResqpy):
          cross section plot
       """
 
-      def test_cell(p, x_sect, k0, ji0):
-         poly = np.array([
-            x_sect[k0, ji0, 0, 0, 0:3:2], x_sect[k0, ji0, 0, 1, 0:3:2], x_sect[k0, ji0, 1, 1, 0:3:2], x_sect[k0, ji0, 1,
-                                                                                                             0, 0:3:2]
-         ])
-         if np.any(np.isnan(poly)):
-            return False
-         return pip.pip_cn(p, poly)
+        def test_cell(p, x_sect, k0, ji0):
+            poly = np.array([
+                x_sect[k0, ji0, 0, 0, 0:3:2], x_sect[k0, ji0, 0, 1, 0:3:2], x_sect[k0, ji0, 1, 1, 0:3:2],
+                x_sect[k0, ji0, 1, 0, 0:3:2]
+            ])
+            if np.any(np.isnan(poly)):
+                return False
+            return pip.pip_cn(p, poly)
 
-      assert x_sect.ndim == 5 and x_sect.shape[2] == 2 and x_sect.shape[3] == 2 and 2 <= x_sect.shape[4] <= 3
-      n_k = x_sect.shape[0]
-      n_j_or_i = x_sect.shape[1]
-      tolerance = 1.0e-3
+        assert x_sect.ndim == 5 and x_sect.shape[2] == 2 and x_sect.shape[3] == 2 and 2 <= x_sect.shape[4] <= 3
+        n_k = x_sect.shape[0]
+        n_j_or_i = x_sect.shape[1]
+        tolerance = 1.0e-3
 
-      if x_sect.shape[4] == 3:
-         diffs = x_sect[:, :, :, :, 0:3:2].copy()  # x,z points only
-      else:
-         diffs = x_sect.copy()
-      diffs -= np.array((x, z))
-      diffs = np.sum(diffs * diffs, axis = -1)  # square of distance of each point from given x,z
-      flat_index = np.nanargmin(diffs)
-      min_dist_sqr = diffs.flatten()[flat_index]
-      cell_flat_k0_ji0, flat_k_ji_p = divmod(flat_index, 4)
-      found_k0, found_ji0 = divmod(cell_flat_k0_ji0, n_j_or_i)
-      found_kp, found_jip = divmod(flat_k_ji_p, 2)
+        if x_sect.shape[4] == 3:
+            diffs = x_sect[:, :, :, :, 0:3:2].copy()  # x,z points only
+        else:
+            diffs = x_sect.copy()
+        diffs -= np.array((x, z))
+        diffs = np.sum(diffs * diffs, axis = -1)  # square of distance of each point from given x,z
+        flat_index = np.nanargmin(diffs)
+        min_dist_sqr = diffs.flatten()[flat_index]
+        cell_flat_k0_ji0, flat_k_ji_p = divmod(flat_index, 4)
+        found_k0, found_ji0 = divmod(cell_flat_k0_ji0, n_j_or_i)
+        found_kp, found_jip = divmod(flat_k_ji_p, 2)
 
-      found = test_cell((x, z), x_sect, found_k0, found_ji0)
-      if found:
-         return found_k0, found_ji0
-      # check cells below whilst still close to point
-      while found_k0 < n_k - 1:
-         found_k0 += 1
-         if np.nanmin(diffs[found_k0, found_ji0]) > min_dist_sqr + tolerance:
-            break
-         found = test_cell((x, z), x_sect, found_k0, found_ji0)
-         if found:
+        found = test_cell((x, z), x_sect, found_k0, found_ji0)
+        if found:
             return found_k0, found_ji0
-
-      # try neighbouring column (in case of fault or point exactly on face)
-      ji_neighbour = 1 if found_jip == 1 else -1
-      found_ji0 += ji_neighbour
-      if 0 <= found_ji0 < n_j_or_i:
-         col_diffs = diffs[:, found_ji0]
-         flat_index = np.nanargmin(col_diffs)
-         if col_diffs.flatten()[flat_index] <= min_dist_sqr + tolerance:
-            found_k0 = flat_index // 4
+        # check cells below whilst still close to point
+        while found_k0 < n_k - 1:
+            found_k0 += 1
+            if np.nanmin(diffs[found_k0, found_ji0]) > min_dist_sqr + tolerance:
+                break
             found = test_cell((x, z), x_sect, found_k0, found_ji0)
             if found:
-               return found_k0, found_ji0
-            # check cells below whilst still close to point
-            while found_k0 < n_k - 1:
-               found_k0 += 1
-               if np.nanmin(diffs[found_k0, found_ji0]) > min_dist_sqr + tolerance:
-                  break
-               found = test_cell((x, z), x_sect, found_k0, found_ji0)
-               if found:
-                  return found_k0, found_ji0
+                return found_k0, found_ji0
 
-      return None, None
+        # try neighbouring column (in case of fault or point exactly on face)
+        ji_neighbour = 1 if found_jip == 1 else -1
+        found_ji0 += ji_neighbour
+        if 0 <= found_ji0 < n_j_or_i:
+            col_diffs = diffs[:, found_ji0]
+            flat_index = np.nanargmin(col_diffs)
+            if col_diffs.flatten()[flat_index] <= min_dist_sqr + tolerance:
+                found_k0 = flat_index // 4
+                found = test_cell((x, z), x_sect, found_k0, found_ji0)
+                if found:
+                    return found_k0, found_ji0
+                # check cells below whilst still close to point
+                while found_k0 < n_k - 1:
+                    found_k0 += 1
+                    if np.nanmin(diffs[found_k0, found_ji0]) > min_dist_sqr + tolerance:
+                        break
+                    found = test_cell((x, z), x_sect, found_k0, found_ji0)
+                    if found:
+                        return found_k0, found_ji0
 
-   def skin(self, use_single_layer_tactics = False):
-      """Returns a GridSkin composite surface object reoresenting the outer surface of the grid."""
+        return None, None
 
-      import resqpy.grid_surface as rqgs
+    def skin(self, use_single_layer_tactics = False):
+        """Returns a GridSkin composite surface object reoresenting the outer surface of the grid."""
 
-      # could cache 2 versions (with and without single layer tactics)
-      if self.grid_skin is None or self.grid_skin.use_single_layer_tactics != use_single_layer_tactics:
-         self.grid_skin = rqgs.GridSkin(self, use_single_layer_tactics = use_single_layer_tactics)
-      return self.grid_skin
+        import resqpy.grid_surface as rqgs
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  set_as_grid_root = True,
-                  title = None,
-                  originator = None,
-                  write_active = True,
-                  write_geometry = True,
-                  extra_metadata = {}):
-      """Creates an IJK grid node from a grid object and optionally adds as child of root and/or to parts forest.
+        # could cache 2 versions (with and without single layer tactics)
+        if self.grid_skin is None or self.grid_skin.use_single_layer_tactics != use_single_layer_tactics:
+            self.grid_skin = rqgs.GridSkin(self, use_single_layer_tactics = use_single_layer_tactics)
+        return self.grid_skin
+
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   set_as_grid_root = True,
+                   title = None,
+                   originator = None,
+                   write_active = True,
+                   write_geometry = True,
+                   extra_metadata = {}):
+        """Creates an IJK grid node from a grid object and optionally adds as child of root and/or to parts forest.
 
       arguments:
          ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the array data for the grid geometry
@@ -4969,412 +5028,413 @@ class Grid(BaseResqpy):
       :meta common:
       """
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
-      if title:
-         self.title = title
-      if not self.title:
-         self.title = 'ROOT'
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
+        if title:
+            self.title = title
+        if not self.title:
+            self.title = 'ROOT'
 
-      ijk = super().create_xml(add_as_part = False, originator = originator, extra_metadata = extra_metadata)
+        ijk = super().create_xml(add_as_part = False, originator = originator, extra_metadata = extra_metadata)
 
-      if self.grid_representation and not write_geometry:
-         rqet.create_metadata_xml(node = ijk, extra_metadata = {'grid_flavour': self.grid_representation})
+        if self.grid_representation and not write_geometry:
+            rqet.create_metadata_xml(node = ijk, extra_metadata = {'grid_flavour': self.grid_representation})
 
-      ni_node = rqet.SubElement(ijk, ns['resqml2'] + 'Ni')
-      ni_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      ni_node.text = str(self.extent_kji[2])
+        ni_node = rqet.SubElement(ijk, ns['resqml2'] + 'Ni')
+        ni_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        ni_node.text = str(self.extent_kji[2])
 
-      nj_node = rqet.SubElement(ijk, ns['resqml2'] + 'Nj')
-      nj_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      nj_node.text = str(self.extent_kji[1])
+        nj_node = rqet.SubElement(ijk, ns['resqml2'] + 'Nj')
+        nj_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        nj_node.text = str(self.extent_kji[1])
 
-      nk_node = rqet.SubElement(ijk, ns['resqml2'] + 'Nk')
-      nk_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      nk_node.text = str(self.extent_kji[0])
+        nk_node = rqet.SubElement(ijk, ns['resqml2'] + 'Nk')
+        nk_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        nk_node.text = str(self.extent_kji[0])
 
-      if self.k_gaps:
+        if self.k_gaps:
 
-         kg_node = rqet.SubElement(ijk, ns['resqml2'] + 'KGaps')
-         kg_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'KGaps')
-         kg_node.text = '\n'
+            kg_node = rqet.SubElement(ijk, ns['resqml2'] + 'KGaps')
+            kg_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'KGaps')
+            kg_node.text = '\n'
 
-         kgc_node = rqet.SubElement(kg_node, ns['resqml2'] + 'Count')
-         kgc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         kgc_node.text = str(self.k_gaps)
+            kgc_node = rqet.SubElement(kg_node, ns['resqml2'] + 'Count')
+            kgc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            kgc_node.text = str(self.k_gaps)
 
-         assert self.k_gap_after_array.ndim == 1 and self.k_gap_after_array.size == self.nk - 1
+            assert self.k_gap_after_array.ndim == 1 and self.k_gap_after_array.size == self.nk - 1
 
-         kgal_node = rqet.SubElement(kg_node, ns['resqml2'] + 'GapAfterLayer')
-         kgal_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
-         kgal_node.text = '\n'
+            kgal_node = rqet.SubElement(kg_node, ns['resqml2'] + 'GapAfterLayer')
+            kgal_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
+            kgal_node.text = '\n'
 
-         kgal_values = rqet.SubElement(kgal_node, ns['resqml2'] + 'Values')
-         kgal_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         kgal_values.text = '\n'
+            kgal_values = rqet.SubElement(kgal_node, ns['resqml2'] + 'Values')
+            kgal_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            kgal_values.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'GapAfterLayer', root = kgal_values)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'GapAfterLayer', root = kgal_values)
 
-      if self.stratigraphic_column_rank_uuid is not None and self.stratigraphic_units is not None:
+        if self.stratigraphic_column_rank_uuid is not None and self.stratigraphic_units is not None:
 
-         assert self.model.type_of_uuid(
-            self.stratigraphic_column_rank_uuid) == 'obj_StratigraphicColumnRankInterpretation'
+            assert self.model.type_of_uuid(
+                self.stratigraphic_column_rank_uuid) == 'obj_StratigraphicColumnRankInterpretation'
 
-         strata_node = rqet.SubElement(ijk, ns['resqml2'] + 'IntervalStratigraphicUnits')
-         strata_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntervalStratigraphicUnits')
-         strata_node.text = '\n'
+            strata_node = rqet.SubElement(ijk, ns['resqml2'] + 'IntervalStratigraphicUnits')
+            strata_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntervalStratigraphicUnits')
+            strata_node.text = '\n'
 
-         ui_node = rqet.SubElement(strata_node, ns['resqml2'] + 'UnitIndices')
-         ui_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-         ui_node.text = '\n'
+            ui_node = rqet.SubElement(strata_node, ns['resqml2'] + 'UnitIndices')
+            ui_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+            ui_node.text = '\n'
 
-         ui_null = rqet.SubElement(ui_node, ns['resqml2'] + 'NullValue')
-         ui_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         ui_null.text = '-1'
+            ui_null = rqet.SubElement(ui_node, ns['resqml2'] + 'NullValue')
+            ui_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            ui_null.text = '-1'
 
-         ui_values = rqet.SubElement(ui_node, ns['resqml2'] + 'Values')
-         ui_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         ui_values.text = '\n'
+            ui_values = rqet.SubElement(ui_node, ns['resqml2'] + 'Values')
+            ui_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            ui_values.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'unitIndices', root = ui_values)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'unitIndices', root = ui_values)
 
-         self.model.create_ref_node('StratigraphicOrganization',
-                                    self.model.title(uuid = self.stratigraphic_column_rank_uuid),
-                                    self.stratigraphic_column_rank_uuid,
-                                    content_type = 'StratigraphicColumnRankInterpretation',
-                                    root = strata_node)
+            self.model.create_ref_node('StratigraphicOrganization',
+                                       self.model.title(uuid = self.stratigraphic_column_rank_uuid),
+                                       self.stratigraphic_column_rank_uuid,
+                                       content_type = 'StratigraphicColumnRankInterpretation',
+                                       root = strata_node)
 
-      if self.parent_window is not None:
+        if self.parent_window is not None:
 
-         pw_node = rqet.SubElement(ijk, ns['resqml2'] + 'ParentWindow')
-         pw_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IjkParentWindow')
-         pw_node.text = '\n'
+            pw_node = rqet.SubElement(ijk, ns['resqml2'] + 'ParentWindow')
+            pw_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IjkParentWindow')
+            pw_node.text = '\n'
 
-         assert self.parent_grid_uuid is not None
-         parent_grid_root = self.model.root(uuid = self.parent_grid_uuid)
-         if parent_grid_root is None:
-            pg_title = 'ParentGrid'
-         else:
-            pg_title = rqet.citation_title_for_node(parent_grid_root)
-         self.model.create_ref_node('ParentGrid',
-                                    pg_title,
-                                    self.parent_grid_uuid,
-                                    content_type = 'obj_IjkGridRepresentation',
-                                    root = pw_node)
-
-         for axis in range(3):
-
-            regrid_node = rqet.SubElement(pw_node, 'KJI'[axis] + 'Regrid')
-            regrid_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Regrid')
-            regrid_node.text = '\n'
-
-            if self.is_refinement:
-               if self.parent_window.within_coarse_box is None:
-                  iiopg = 0  # InitialIndexOnParentGrid
-               else:
-                  iiopg = self.parent_window.within_coarse_box[0, axis]
+            assert self.parent_grid_uuid is not None
+            parent_grid_root = self.model.root(uuid = self.parent_grid_uuid)
+            if parent_grid_root is None:
+                pg_title = 'ParentGrid'
             else:
-               if self.parent_window.within_fine_box is None:
-                  iiopg = 0
-               else:
-                  iiopg = self.parent_window.within_fine_box[0, axis]
-            iiopg_node = rqet.SubElement(regrid_node, ns['resqml2'] + 'InitialIndexOnParentGrid')
-            iiopg_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-            iiopg_node.text = str(iiopg)
+                pg_title = rqet.citation_title_for_node(parent_grid_root)
+            self.model.create_ref_node('ParentGrid',
+                                       pg_title,
+                                       self.parent_grid_uuid,
+                                       content_type = 'obj_IjkGridRepresentation',
+                                       root = pw_node)
 
-            if self.parent_window.fine_extent_kji[axis] == self.parent_window.coarse_extent_kji[axis]:
-               continue  # one-to-noe mapping
+            for axis in range(3):
 
-            intervals_node = rqet.SubElement(regrid_node, ns['resqml2'] + 'Intervals')
-            intervals_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Intervals')
-            intervals_node.text = '\n'
+                regrid_node = rqet.SubElement(pw_node, 'KJI'[axis] + 'Regrid')
+                regrid_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Regrid')
+                regrid_node.text = '\n'
 
-            if self.parent_window.constant_ratios[axis] is not None:
-               interval_count = 1
+                if self.is_refinement:
+                    if self.parent_window.within_coarse_box is None:
+                        iiopg = 0  # InitialIndexOnParentGrid
+                    else:
+                        iiopg = self.parent_window.within_coarse_box[0, axis]
+                else:
+                    if self.parent_window.within_fine_box is None:
+                        iiopg = 0
+                    else:
+                        iiopg = self.parent_window.within_fine_box[0, axis]
+                iiopg_node = rqet.SubElement(regrid_node, ns['resqml2'] + 'InitialIndexOnParentGrid')
+                iiopg_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+                iiopg_node.text = str(iiopg)
+
+                if self.parent_window.fine_extent_kji[axis] == self.parent_window.coarse_extent_kji[axis]:
+                    continue  # one-to-noe mapping
+
+                intervals_node = rqet.SubElement(regrid_node, ns['resqml2'] + 'Intervals')
+                intervals_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Intervals')
+                intervals_node.text = '\n'
+
+                if self.parent_window.constant_ratios[axis] is not None:
+                    interval_count = 1
+                else:
+                    if self.is_refinement:
+                        interval_count = self.parent_window.coarse_extent_kji[axis]
+                    else:
+                        interval_count = self.parent_window.fine_extent_kji[axis]
+                ic_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'IntervalCount')
+                ic_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+                ic_node.text = str(interval_count)
+
+                pcpi_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'ParentCountPerInterval')
+                pcpi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+                pcpi_node.text = '\n'
+
+                pcpi_values = rqet.SubElement(pcpi_node, ns['resqml2'] + 'Values')
+                pcpi_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                pcpi_values.text = '\n'
+
+                self.model.create_hdf5_dataset_ref(ext_uuid,
+                                                   self.uuid,
+                                                   'KJI'[axis] + 'Regrid/ParentCountPerInterval',
+                                                   root = pcpi_values)
+
+                ccpi_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'ChildCountPerInterval')
+                ccpi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+                ccpi_node.text = '\n'
+
+                ccpi_values = rqet.SubElement(ccpi_node, ns['resqml2'] + 'Values')
+                ccpi_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                ccpi_values.text = '\n'
+
+                self.model.create_hdf5_dataset_ref(ext_uuid,
+                                                   self.uuid,
+                                                   'KJI'[axis] + 'Regrid/ChildCountPerInterval',
+                                                   root = ccpi_values)
+
+                if self.is_refinement and not self.parent_window.equal_proportions[axis]:
+
+                    ccw_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'ChildCellWeights')
+                    ccw_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+                    ccw_node.text = rqet.null_xml_text
+
+                    ccw_values_node = rqet.SubElement(ccw_node, ns['resqml2'] + 'Values')
+                    ccw_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
+                    ccw_values_node.text = rqet.null_xml_text
+
+                    self.model.create_hdf5_dataset_ref(ext_uuid,
+                                                       self.uuid,
+                                                       'KJI'[axis] + 'Regrid/ChildCellWeights',
+                                                       root = ccw_values_node)
+
+            # todo: handle omit and cell overlap functionality as part of parent window refining or coarsening
+
+        if write_geometry:
+
+            geom = rqet.SubElement(ijk, ns['resqml2'] + 'Geometry')
+            geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'IjkGridGeometry')
+            geom.text = '\n'
+
+            # the remainder of this function is populating the geometry node
+            self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+
+            k_dir = rqet.SubElement(geom, ns['resqml2'] + 'KDirection')
+            k_dir.set(ns['xsi'] + 'type', ns['resqml2'] + 'KDirection')
+            if self.k_direction_is_down:
+                k_dir.text = 'down'
             else:
-               if self.is_refinement:
-                  interval_count = self.parent_window.coarse_extent_kji[axis]
-               else:
-                  interval_count = self.parent_window.fine_extent_kji[axis]
-            ic_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'IntervalCount')
-            ic_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-            ic_node.text = str(interval_count)
+                k_dir.text = 'up'
 
-            pcpi_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'ParentCountPerInterval')
-            pcpi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-            pcpi_node.text = '\n'
+            handed = rqet.SubElement(geom, ns['resqml2'] + 'GridIsRighthanded')
+            handed.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+            handed.text = str(self.grid_is_right_handed).lower()
 
-            pcpi_values = rqet.SubElement(pcpi_node, ns['resqml2'] + 'Values')
-            pcpi_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            pcpi_values.text = '\n'
+            p_shape = rqet.SubElement(geom, ns['resqml2'] + 'PillarShape')
+            p_shape.set(ns['xsi'] + 'type', ns['resqml2'] + 'PillarShape')
+            p_shape.text = self.pillar_shape
 
-            self.model.create_hdf5_dataset_ref(ext_uuid,
-                                               self.uuid,
-                                               'KJI'[axis] + 'Regrid/ParentCountPerInterval',
-                                               root = pcpi_values)
+            points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
+            points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+            points_node.text = '\n'
 
-            ccpi_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'ChildCountPerInterval')
-            ccpi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-            ccpi_node.text = '\n'
+            coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
+            coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            coords.text = '\n'
 
-            ccpi_values = rqet.SubElement(ccpi_node, ns['resqml2'] + 'Values')
-            ccpi_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            ccpi_values.text = '\n'
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Points', root = coords)
 
-            self.model.create_hdf5_dataset_ref(ext_uuid,
-                                               self.uuid,
-                                               'KJI'[axis] + 'Regrid/ChildCountPerInterval',
-                                               root = ccpi_values)
+            if always_write_pillar_geometry_is_defined_array or not self.geometry_defined_for_all_pillars(
+                    cache_array = True):
 
-            if self.is_refinement and not self.parent_window.equal_proportions[axis]:
+                pillar_def = rqet.SubElement(geom, ns['resqml2'] + 'PillarGeometryIsDefined')
+                pillar_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
+                pillar_def.text = '\n'
 
-               ccw_node = rqet.SubElement(intervals_node, ns['resqml2'] + 'ChildCellWeights')
-               ccw_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-               ccw_node.text = rqet.null_xml_text
+                pd_values = rqet.SubElement(pillar_def, ns['resqml2'] + 'Values')
+                pd_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                pd_values.text = '\n'
 
-               ccw_values_node = rqet.SubElement(ccw_node, ns['resqml2'] + 'Values')
-               ccw_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
-               ccw_values_node.text = rqet.null_xml_text
+                self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'PillarGeometryIsDefined', root = pd_values)
 
-               self.model.create_hdf5_dataset_ref(ext_uuid,
-                                                  self.uuid,
-                                                  'KJI'[axis] + 'Regrid/ChildCellWeights',
-                                                  root = ccw_values_node)
+            else:
 
-         # todo: handle omit and cell overlap functionality as part of parent window refining or coarsening
+                pillar_def = rqet.SubElement(geom, ns['resqml2'] + 'PillarGeometryIsDefined')
+                pillar_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanConstantArray')
+                pillar_def.text = '\n'
 
-      if write_geometry:
+                pd_value = rqet.SubElement(pillar_def, ns['resqml2'] + 'Value')
+                pd_value.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+                pd_value.text = 'true'
 
-         geom = rqet.SubElement(ijk, ns['resqml2'] + 'Geometry')
-         geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'IjkGridGeometry')
-         geom.text = '\n'
+                pd_count = rqet.SubElement(pillar_def, ns['resqml2'] + 'Count')
+                pd_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+                pd_count.text = str((self.extent_kji[1] + 1) * (self.extent_kji[2] + 1))
 
-         # the remainder of this function is populating the geometry node
-         self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+            if always_write_cell_geometry_is_defined_array or not self.geometry_defined_for_all_cells(
+                    cache_array = True):
 
-         k_dir = rqet.SubElement(geom, ns['resqml2'] + 'KDirection')
-         k_dir.set(ns['xsi'] + 'type', ns['resqml2'] + 'KDirection')
-         if self.k_direction_is_down:
-            k_dir.text = 'down'
-         else:
-            k_dir.text = 'up'
+                cell_def = rqet.SubElement(geom, ns['resqml2'] + 'CellGeometryIsDefined')
+                cell_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
+                cell_def.text = '\n'
 
-         handed = rqet.SubElement(geom, ns['resqml2'] + 'GridIsRighthanded')
-         handed.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-         handed.text = str(self.grid_is_right_handed).lower()
+                cd_values = rqet.SubElement(cell_def, ns['resqml2'] + 'Values')
+                cd_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                cd_values.text = '\n'
 
-         p_shape = rqet.SubElement(geom, ns['resqml2'] + 'PillarShape')
-         p_shape.set(ns['xsi'] + 'type', ns['resqml2'] + 'PillarShape')
-         p_shape.text = self.pillar_shape
+                self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellGeometryIsDefined', root = cd_values)
 
-         points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
-         points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-         points_node.text = '\n'
+            else:
 
-         coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
-         coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         coords.text = '\n'
+                cell_def = rqet.SubElement(geom, ns['resqml2'] + 'CellGeometryIsDefined')
+                cell_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanConstantArray')
+                cell_def.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Points', root = coords)
+                cd_value = rqet.SubElement(cell_def, ns['resqml2'] + 'Value')
+                cd_value.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+                cd_value.text = 'true'
 
-         if always_write_pillar_geometry_is_defined_array or not self.geometry_defined_for_all_pillars(
-               cache_array = True):
+                cd_count = rqet.SubElement(cell_def, ns['resqml2'] + 'Count')
+                cd_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+                cd_count.text = str(self.nk * self.nj * self.ni)
 
-            pillar_def = rqet.SubElement(geom, ns['resqml2'] + 'PillarGeometryIsDefined')
-            pillar_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
-            pillar_def.text = '\n'
+            if self.has_split_coordinate_lines:
 
-            pd_values = rqet.SubElement(pillar_def, ns['resqml2'] + 'Values')
-            pd_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            pd_values.text = '\n'
+                scl = rqet.SubElement(geom, ns['resqml2'] + 'SplitCoordinateLines')
+                scl.set(ns['xsi'] + 'type', ns['resqml2'] + 'ColumnLayerSplitCoordinateLines')
+                scl.text = '\n'
 
-            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'PillarGeometryIsDefined', root = pd_values)
+                scl_count = rqet.SubElement(scl, ns['resqml2'] + 'Count')
+                scl_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+                scl_count.text = str(self.split_pillars_count)
 
-         else:
+                pi_node = rqet.SubElement(scl, ns['resqml2'] + 'PillarIndices')
+                pi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+                pi_node.text = '\n'
 
-            pillar_def = rqet.SubElement(geom, ns['resqml2'] + 'PillarGeometryIsDefined')
-            pillar_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanConstantArray')
-            pillar_def.text = '\n'
+                pi_null = rqet.SubElement(pi_node, ns['resqml2'] + 'NullValue')
+                pi_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+                pi_null.text = str((self.extent_kji[1] + 1) * (self.extent_kji[2] + 1))
 
-            pd_value = rqet.SubElement(pillar_def, ns['resqml2'] + 'Value')
-            pd_value.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-            pd_value.text = 'true'
+                pi_values = rqet.SubElement(pi_node, ns['resqml2'] + 'Values')
+                pi_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                pi_values.text = '\n'
 
-            pd_count = rqet.SubElement(pillar_def, ns['resqml2'] + 'Count')
-            pd_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-            pd_count.text = str((self.extent_kji[1] + 1) * (self.extent_kji[2] + 1))
+                self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'PillarIndices', root = pi_values)
 
-         if always_write_cell_geometry_is_defined_array or not self.geometry_defined_for_all_cells(cache_array = True):
+                cpscl = rqet.SubElement(scl, ns['resqml2'] + 'ColumnsPerSplitCoordinateLine')
+                cpscl.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlJaggedArray')
+                cpscl.text = '\n'
 
-            cell_def = rqet.SubElement(geom, ns['resqml2'] + 'CellGeometryIsDefined')
-            cell_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
-            cell_def.text = '\n'
+                elements = rqet.SubElement(cpscl, ns['resqml2'] + 'Elements')
+                elements.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+                elements.text = '\n'
 
-            cd_values = rqet.SubElement(cell_def, ns['resqml2'] + 'Values')
-            cd_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            cd_values.text = '\n'
+                el_null = rqet.SubElement(elements, ns['resqml2'] + 'NullValue')
+                el_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+                el_null.text = str(self.extent_kji[1] * self.extent_kji[2])
 
-            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellGeometryIsDefined', root = cd_values)
+                el_values = rqet.SubElement(elements, ns['resqml2'] + 'Values')
+                el_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                el_values.text = '\n'
 
-         else:
+                self.model.create_hdf5_dataset_ref(ext_uuid,
+                                                   self.uuid,
+                                                   'ColumnsPerSplitCoordinateLine/elements',
+                                                   root = el_values)
 
-            cell_def = rqet.SubElement(geom, ns['resqml2'] + 'CellGeometryIsDefined')
-            cell_def.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanConstantArray')
-            cell_def.text = '\n'
+                c_length = rqet.SubElement(cpscl, ns['resqml2'] + 'CumulativeLength')
+                c_length.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+                c_length.text = '\n'
 
-            cd_value = rqet.SubElement(cell_def, ns['resqml2'] + 'Value')
-            cd_value.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-            cd_value.text = 'true'
+                cl_null = rqet.SubElement(c_length, ns['resqml2'] + 'NullValue')
+                cl_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+                cl_null.text = '0'
 
-            cd_count = rqet.SubElement(cell_def, ns['resqml2'] + 'Count')
-            cd_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-            cd_count.text = str(self.nk * self.nj * self.ni)
+                cl_values = rqet.SubElement(c_length, ns['resqml2'] + 'Values')
+                cl_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                cl_values.text = '\n'
 
-         if self.has_split_coordinate_lines:
+                self.model.create_hdf5_dataset_ref(ext_uuid,
+                                                   self.uuid,
+                                                   'ColumnsPerSplitCoordinateLine/cumulativeLength',
+                                                   root = cl_values)
 
-            scl = rqet.SubElement(geom, ns['resqml2'] + 'SplitCoordinateLines')
-            scl.set(ns['xsi'] + 'type', ns['resqml2'] + 'ColumnLayerSplitCoordinateLines')
-            scl.text = '\n'
+            if self.time_index is not None:
 
-            scl_count = rqet.SubElement(scl, ns['resqml2'] + 'Count')
-            scl_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-            scl_count.text = str(self.split_pillars_count)
+                assert self.time_series_uuid is not None
 
-            pi_node = rqet.SubElement(scl, ns['resqml2'] + 'PillarIndices')
-            pi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-            pi_node.text = '\n'
+                ti_node = rqet.SubElement(geom, ns['resqml2'] + 'TimeIndex')
+                ti_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeIndex')
+                ti_node.text = '\n'
 
-            pi_null = rqet.SubElement(pi_node, ns['resqml2'] + 'NullValue')
-            pi_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-            pi_null.text = str((self.extent_kji[1] + 1) * (self.extent_kji[2] + 1))
+                index_node = rqet.SubElement(ti_node, ns['resqml2'] + 'Index')
+                index_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+                index_node.text = str(self.time_index)
 
-            pi_values = rqet.SubElement(pi_node, ns['resqml2'] + 'Values')
-            pi_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            pi_values.text = '\n'
+                self.model.create_ref_node('TimeSeries',
+                                           self.model.title(uuid = self.time_series_uuid),
+                                           self.time_series_uuid,
+                                           content_type = 'obj_TimeSeries',
+                                           root = ti_node)
 
-            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'PillarIndices', root = pi_values)
+        if add_as_part:
+            self.model.add_part('obj_IjkGridRepresentation', self.uuid, ijk)
+            if add_relationships:
+                if self.stratigraphic_column_rank_uuid is not None and self.stratigraphic_units is not None:
+                    self.model.create_reciprocal_relationship(
+                        ijk, 'destinationObject', self.model.root_for_uuid(self.stratigraphic_column_rank_uuid),
+                        'sourceObject')
+                if write_geometry:
+                    # create 2 way relationship between IjkGrid and Crs
+                    self.model.create_reciprocal_relationship(ijk, 'destinationObject', self.crs_root, 'sourceObject')
+                    # create 2 way relationship between IjkGrid and Ext
+                    ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                    ext_node = self.model.root_for_part(ext_part)
+                    self.model.create_reciprocal_relationship(ijk, 'mlToExternalPartProxy', ext_node,
+                                                              'externalPartProxyToMl')
+                # create relationship with parent grid
+                if self.parent_window is not None and self.parent_grid_uuid is not None:
+                    self.model.create_reciprocal_relationship(ijk, 'destinationObject',
+                                                              self.model.root_for_uuid(self.parent_grid_uuid),
+                                                              'sourceObject')
 
-            cpscl = rqet.SubElement(scl, ns['resqml2'] + 'ColumnsPerSplitCoordinateLine')
-            cpscl.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlJaggedArray')
-            cpscl.text = '\n'
+        if (write_active and self.active_property_uuid is not None and
+                self.model.part(uuid = self.active_property_uuid) is None):
+            # TODO: replace following with call to rprop.write_hdf5_and_create_xml_for_active_property()
+            active_collection = rprop.PropertyCollection()
+            active_collection.set_support(support = self)
+            active_collection.create_xml(None,
+                                         None,
+                                         'ACTIVE',
+                                         'active',
+                                         p_uuid = self.active_property_uuid,
+                                         discrete = True,
+                                         add_min_max = False,
+                                         find_local_property_kinds = True)
 
-            elements = rqet.SubElement(cpscl, ns['resqml2'] + 'Elements')
-            elements.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-            elements.text = '\n'
-
-            el_null = rqet.SubElement(elements, ns['resqml2'] + 'NullValue')
-            el_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-            el_null.text = str(self.extent_kji[1] * self.extent_kji[2])
-
-            el_values = rqet.SubElement(elements, ns['resqml2'] + 'Values')
-            el_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            el_values.text = '\n'
-
-            self.model.create_hdf5_dataset_ref(ext_uuid,
-                                               self.uuid,
-                                               'ColumnsPerSplitCoordinateLine/elements',
-                                               root = el_values)
-
-            c_length = rqet.SubElement(cpscl, ns['resqml2'] + 'CumulativeLength')
-            c_length.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-            c_length.text = '\n'
-
-            cl_null = rqet.SubElement(c_length, ns['resqml2'] + 'NullValue')
-            cl_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-            cl_null.text = '0'
-
-            cl_values = rqet.SubElement(c_length, ns['resqml2'] + 'Values')
-            cl_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            cl_values.text = '\n'
-
-            self.model.create_hdf5_dataset_ref(ext_uuid,
-                                               self.uuid,
-                                               'ColumnsPerSplitCoordinateLine/cumulativeLength',
-                                               root = cl_values)
-
-         if self.time_index is not None:
-
-            assert self.time_series_uuid is not None
-
-            ti_node = rqet.SubElement(geom, ns['resqml2'] + 'TimeIndex')
-            ti_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeIndex')
-            ti_node.text = '\n'
-
-            index_node = rqet.SubElement(ti_node, ns['resqml2'] + 'Index')
-            index_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-            index_node.text = str(self.time_index)
-
-            self.model.create_ref_node('TimeSeries',
-                                       self.model.title(uuid = self.time_series_uuid),
-                                       self.time_series_uuid,
-                                       content_type = 'obj_TimeSeries',
-                                       root = ti_node)
-
-      if add_as_part:
-         self.model.add_part('obj_IjkGridRepresentation', self.uuid, ijk)
-         if add_relationships:
-            if self.stratigraphic_column_rank_uuid is not None and self.stratigraphic_units is not None:
-               self.model.create_reciprocal_relationship(ijk, 'destinationObject',
-                                                         self.model.root_for_uuid(self.stratigraphic_column_rank_uuid),
-                                                         'sourceObject')
-            if write_geometry:
-               # create 2 way relationship between IjkGrid and Crs
-               self.model.create_reciprocal_relationship(ijk, 'destinationObject', self.crs_root, 'sourceObject')
-               # create 2 way relationship between IjkGrid and Ext
-               ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-               ext_node = self.model.root_for_part(ext_part)
-               self.model.create_reciprocal_relationship(ijk, 'mlToExternalPartProxy', ext_node,
-                                                         'externalPartProxyToMl')
-            # create relationship with parent grid
-            if self.parent_window is not None and self.parent_grid_uuid is not None:
-               self.model.create_reciprocal_relationship(ijk, 'destinationObject',
-                                                         self.model.root_for_uuid(self.parent_grid_uuid),
-                                                         'sourceObject')
-
-      if (write_active and self.active_property_uuid is not None and
-          self.model.part(uuid = self.active_property_uuid) is None):
-         # TODO: replace following with call to rprop.write_hdf5_and_create_xml_for_active_property()
-         active_collection = rprop.PropertyCollection()
-         active_collection.set_support(support = self)
-         active_collection.create_xml(None,
-                                      None,
-                                      'ACTIVE',
-                                      'active',
-                                      p_uuid = self.active_property_uuid,
-                                      discrete = True,
-                                      add_min_max = False,
-                                      find_local_property_kinds = True)
-
-      return ijk
+        return ijk
 
 
 # end of Grid class
 
 
 class RegularGrid(Grid):
-   """Class for completely regular block grids aligned with xyz axes."""
+    """Class for completely regular block grids aligned with xyz axes."""
 
-   # For now generate a standard unsplit pillar grid
-   # todo: use RESQML lattice like geometry specification
+    # For now generate a standard unsplit pillar grid
+    # todo: use RESQML lattice like geometry specification
 
-   def __init__(self,
-                parent_model,
-                extent_kji = None,
-                dxyz = None,
-                dxyz_dkji = None,
-                origin = (0.0, 0.0, 0.0),
-                crs_uuid = None,
-                use_vertical = False,
-                mesh = None,
-                mesh_dz_dk = 1.0,
-                uuid = None,
-                set_points_cached = False,
-                as_irregular_grid = False,
-                find_properties = True,
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Creates a regular grid object based on dxyz, or derived from a Mesh object.
+    def __init__(self,
+                 parent_model,
+                 extent_kji = None,
+                 dxyz = None,
+                 dxyz_dkji = None,
+                 origin = (0.0, 0.0, 0.0),
+                 crs_uuid = None,
+                 use_vertical = False,
+                 mesh = None,
+                 mesh_dz_dk = 1.0,
+                 uuid = None,
+                 set_points_cached = False,
+                 as_irregular_grid = False,
+                 find_properties = True,
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Creates a regular grid object based on dxyz, or derived from a Mesh object.
 
       arguments:
          parent_model (model.Model object): the model to which the new grid will be assigned
@@ -5427,119 +5487,119 @@ class RegularGrid(Grid):
       :meta common:
       """
 
-      if as_irregular_grid:
-         set_points_cached = True
+        if as_irregular_grid:
+            set_points_cached = True
 
-      if uuid is None:
-         super().__init__(parent_model, title = title, originator = originator, extra_metadata = extra_metadata)
-         self.grid_representation = 'IjkGrid' if as_irregular_grid else 'IjkBlockGrid'
-         self.extent_kji = np.array(extent_kji).copy()
-         self.nk, self.nj, self.ni = self.extent_kji
-         self.k_direction_is_down = True  # assumed direction
-         self.grid_is_right_handed = False  # todo: work it out from dxyz_dkji and crs xyz handedness
-         self.has_split_coordinate_lines = False
-         self.k_gaps = None
-         self.k_gap_after_array = None
-         self.k_raw_index_array = None
-         self.inactive = None
-         self.all_inactive = None
-         self.geometry_defined_for_all_cells_cached = True
-         self.geometry_defined_for_all_pillars_cached = True
-         self.array_cell_geometry_is_defined = np.full(tuple(self.extent_kji), True, dtype = bool)
-      else:
-         assert is_regular_grid(parent_model.root_for_uuid(uuid))
-         super().__init__(parent_model,
-                          uuid = uuid,
-                          find_properties = find_properties,
-                          geometry_required = False,
-                          title = title,
-                          originator = originator,
-                          extra_metadata = extra_metadata)
-         self.grid_representation = 'IjkBlockGrid'
-         if dxyz is None and dxyz_dkji is None:
-            # find cell length properties and populate dxyz from those values
-            assert self.property_collection is not None
-            dxi_part = self.property_collection.singleton(property_kind = 'cell length',
-                                                          facet_type = 'direction',
-                                                          facet = 'I')
-            dyj_part = self.property_collection.singleton(property_kind = 'cell length',
-                                                          facet_type = 'direction',
-                                                          facet = 'J')
-            dzk_part = self.property_collection.singleton(property_kind = 'cell length',
-                                                          facet_type = 'direction',
-                                                          facet = 'K')
-            if dxi_part is not None and dyj_part is not None and dzk_part is not None:
-               dxi = self.property_collection.constant_value_for_part(dxi_part)
-               dyj = self.property_collection.constant_value_for_part(dyj_part)
-               dzk = self.property_collection.constant_value_for_part(dzk_part)
-               if dxi is not None and dyj is not None and dzk is not None:
-                  dxyz = (float(dxi), float(dyj), float(dzk))
+        if uuid is None:
+            super().__init__(parent_model, title = title, originator = originator, extra_metadata = extra_metadata)
+            self.grid_representation = 'IjkGrid' if as_irregular_grid else 'IjkBlockGrid'
+            self.extent_kji = np.array(extent_kji).copy()
+            self.nk, self.nj, self.ni = self.extent_kji
+            self.k_direction_is_down = True  # assumed direction
+            self.grid_is_right_handed = False  # todo: work it out from dxyz_dkji and crs xyz handedness
+            self.has_split_coordinate_lines = False
+            self.k_gaps = None
+            self.k_gap_after_array = None
+            self.k_raw_index_array = None
+            self.inactive = None
+            self.all_inactive = None
+            self.geometry_defined_for_all_cells_cached = True
+            self.geometry_defined_for_all_pillars_cached = True
+            self.array_cell_geometry_is_defined = np.full(tuple(self.extent_kji), True, dtype = bool)
+        else:
+            assert is_regular_grid(parent_model.root_for_uuid(uuid))
+            super().__init__(parent_model,
+                             uuid = uuid,
+                             find_properties = find_properties,
+                             geometry_required = False,
+                             title = title,
+                             originator = originator,
+                             extra_metadata = extra_metadata)
+            self.grid_representation = 'IjkBlockGrid'
+            if dxyz is None and dxyz_dkji is None:
+                # find cell length properties and populate dxyz from those values
+                assert self.property_collection is not None
+                dxi_part = self.property_collection.singleton(property_kind = 'cell length',
+                                                              facet_type = 'direction',
+                                                              facet = 'I')
+                dyj_part = self.property_collection.singleton(property_kind = 'cell length',
+                                                              facet_type = 'direction',
+                                                              facet = 'J')
+                dzk_part = self.property_collection.singleton(property_kind = 'cell length',
+                                                              facet_type = 'direction',
+                                                              facet = 'K')
+                if dxi_part is not None and dyj_part is not None and dzk_part is not None:
+                    dxi = self.property_collection.constant_value_for_part(dxi_part)
+                    dyj = self.property_collection.constant_value_for_part(dyj_part)
+                    dzk = self.property_collection.constant_value_for_part(dzk_part)
+                    if dxi is not None and dyj is not None and dzk is not None:
+                        dxyz = (float(dxi), float(dyj), float(dzk))
 
-      if mesh is not None:
-         assert mesh.flavour == 'regular'
-         assert dxyz is None and dxyz_dkji is None
-         origin = mesh.regular_origin
-         dxyz_dkji = np.empty((3, 3))
-         dxyz_dkji[0, :] = mesh_dz_dk
-         dxyz_dkji[1, :] = mesh.regular_dxyz_dij[1]  # J axis
-         dxyz_dkji[2, :] = mesh.regular_dxyz_dij[0]  # I axis
-         if crs_uuid is None:
-            crs_uuid = mesh.crs_uuid
-         else:
-            assert bu.matching_uuids(crs_uuid, mesh.crs_uuid)
+        if mesh is not None:
+            assert mesh.flavour == 'regular'
+            assert dxyz is None and dxyz_dkji is None
+            origin = mesh.regular_origin
+            dxyz_dkji = np.empty((3, 3))
+            dxyz_dkji[0, :] = mesh_dz_dk
+            dxyz_dkji[1, :] = mesh.regular_dxyz_dij[1]  # J axis
+            dxyz_dkji[2, :] = mesh.regular_dxyz_dij[0]  # I axis
+            if crs_uuid is None:
+                crs_uuid = mesh.crs_uuid
+            else:
+                assert bu.matching_uuids(crs_uuid, mesh.crs_uuid)
 
-      assert dxyz is None or dxyz_dkji is None
-      if dxyz is None and dxyz_dkji is None:
-         dxyz = (1.0, 1.0, 1.0)
-      if dxyz_dkji is None:
-         dxyz_dkji = np.array([[0.0, 0.0, dxyz[2]], [0.0, dxyz[1], 0.0], [dxyz[0], 0.0, 0.0]])
-      self.block_origin = np.array(origin).copy()
-      self.block_dxyz_dkji = np.array(dxyz_dkji).copy()
-      if use_vertical and dxyz_dkji[0][0] == 0.0 and dxyz_dkji[0][1] == 0.0:  # ie. no x,y change with k
-         self.pillar_shape = 'vertical'
-      else:
-         self.pillar_shape = 'straight'
+        assert dxyz is None or dxyz_dkji is None
+        if dxyz is None and dxyz_dkji is None:
+            dxyz = (1.0, 1.0, 1.0)
+        if dxyz_dkji is None:
+            dxyz_dkji = np.array([[0.0, 0.0, dxyz[2]], [0.0, dxyz[1], 0.0], [dxyz[0], 0.0, 0.0]])
+        self.block_origin = np.array(origin).copy()
+        self.block_dxyz_dkji = np.array(dxyz_dkji).copy()
+        if use_vertical and dxyz_dkji[0][0] == 0.0 and dxyz_dkji[0][1] == 0.0:  # ie. no x,y change with k
+            self.pillar_shape = 'vertical'
+        else:
+            self.pillar_shape = 'straight'
 
-      if set_points_cached:
-         self.make_regular_points_cached()
+        if set_points_cached:
+            self.make_regular_points_cached()
 
-      if crs_uuid is None:
-         crs_uuid = parent_model.crs_uuid
-      if crs_uuid is None:
-         new_crs = rqc.Crs(parent_model)
-         self.crs_root = new_crs.create_xml(reuse = True)
-         self.crs_uuid = new_crs.uuid
-      else:
-         self.crs_uuid = crs_uuid
-         self.crs_root = parent_model.root_for_uuid(crs_uuid)
+        if crs_uuid is None:
+            crs_uuid = parent_model.crs_uuid
+        if crs_uuid is None:
+            new_crs = rqc.Crs(parent_model)
+            self.crs_root = new_crs.create_xml(reuse = True)
+            self.crs_uuid = new_crs.uuid
+        else:
+            self.crs_uuid = crs_uuid
+            self.crs_root = parent_model.root_for_uuid(crs_uuid)
 
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
 
-   def make_regular_points_cached(self):
-      """Set up the cached points array as an explicit representation of the regular grid geometry."""
+    def make_regular_points_cached(self):
+        """Set up the cached points array as an explicit representation of the regular grid geometry."""
 
-      if hasattr(self, 'points_cached') and self.points_cached is not None:
-         return
-      self.points_cached = np.zeros((self.nk + 1, self.nj + 1, self.ni + 1, 3))
-      # todo: replace for loops with linspace
-      for k in range(self.nk):
-         self.points_cached[k + 1, 0, 0] = self.points_cached[k, 0, 0] + self.block_dxyz_dkji[0]
-      for j in range(self.nj):
-         self.points_cached[:, j + 1, 0] = self.points_cached[:, j, 0] + self.block_dxyz_dkji[1]
-      for i in range(self.ni):
-         self.points_cached[:, :, i + 1] = self.points_cached[:, :, i] + self.block_dxyz_dkji[2]
-      self.points_cached[:, :, :] += self.block_origin
+        if hasattr(self, 'points_cached') and self.points_cached is not None:
+            return
+        self.points_cached = np.zeros((self.nk + 1, self.nj + 1, self.ni + 1, 3))
+        # todo: replace for loops with linspace
+        for k in range(self.nk):
+            self.points_cached[k + 1, 0, 0] = self.points_cached[k, 0, 0] + self.block_dxyz_dkji[0]
+        for j in range(self.nj):
+            self.points_cached[:, j + 1, 0] = self.points_cached[:, j, 0] + self.block_dxyz_dkji[1]
+        for i in range(self.ni):
+            self.points_cached[:, :, i + 1] = self.points_cached[:, :, i] + self.block_dxyz_dkji[2]
+        self.points_cached[:, :, :] += self.block_origin
 
-   def axial_lengths_kji(self):
-      """Returns a triple float being lengths of primary axes (K, J, I) for each cell."""
+    def axial_lengths_kji(self):
+        """Returns a triple float being lengths of primary axes (K, J, I) for each cell."""
 
-      return vec.naive_lengths(self.block_dxyz_dkji)
+        return vec.naive_lengths(self.block_dxyz_dkji)
 
-   # override of Grid methods
+    # override of Grid methods
 
-   def point_raw(self, index = None, points_root = None, cache_array = True):
-      """Returns element from points data, indexed as corner point (k0, j0, i0); can optionally be used to cache points data.
+    def point_raw(self, index = None, points_root = None, cache_array = True):
+        """Returns element from points data, indexed as corner point (k0, j0, i0); can optionally be used to cache points data.
 
       arguments:
          index (3 integers, optional): if not None, the index into the raw points data for the point of interest
@@ -5555,19 +5615,20 @@ class RegularGrid(Grid):
          the index should be a triple kji0 with axes ranging over the shared corners nk+1, nj+1, ni+1
       """
 
-      assert cache_array or index is not None
+        assert cache_array or index is not None
 
-      if cache_array:
-         self.make_regular_points_cached()
-         if index is None:
-            return None
-         return self.points_cached[tuple(index)]
+        if cache_array:
+            self.make_regular_points_cached()
+            if index is None:
+                return None
+            return self.points_cached[tuple(index)]
 
-      return self.block_origin + np.sum(np.repeat(np.array(index).reshape((3, 1)), 3, axis = -1) * self.block_dxyz_dkji,
-                                        axis = 0)
+        return self.block_origin + np.sum(np.repeat(np.array(index).reshape(
+            (3, 1)), 3, axis = -1) * self.block_dxyz_dkji,
+                                          axis = 0)
 
-   def half_cell_transmissibility(self, use_property = None, realization = None, tolerance = None):
-      """Returns (and caches if realization is None) half cell transmissibilities for this regular grid.
+    def half_cell_transmissibility(self, use_property = None, realization = None, tolerance = None):
+        """Returns (and caches if realization is None) half cell transmissibilities for this regular grid.
 
       arguments:
          use_property (ignored)
@@ -5588,26 +5649,26 @@ class RegularGrid(Grid):
          if realization is None, a grid attribute cached array will be used
       """
 
-      # todo: allow passing of property uuids for ntg, k_k, j, i
+        # todo: allow passing of property uuids for ntg, k_k, j, i
 
-      if realization is None and hasattr(self, 'array_half_cell_t'):
-         return self.array_half_cell_t
+        if realization is None and hasattr(self, 'array_half_cell_t'):
+            return self.array_half_cell_t
 
-      half_t = rqtr.half_cell_t(
-         self, realization = realization)  # note: properties must be identifiable in property_collection
+        half_t = rqtr.half_cell_t(
+            self, realization = realization)  # note: properties must be identifiable in property_collection
 
-      # introduce facial polarity axis for compatibility with parent Grid class
-      assert half_t.ndim == 4
-      half_t = np.expand_dims(half_t, -1)
-      half_t = np.repeat(half_t, 2, axis = -1)
+        # introduce facial polarity axis for compatibility with parent Grid class
+        assert half_t.ndim == 4
+        half_t = np.expand_dims(half_t, -1)
+        half_t = np.repeat(half_t, 2, axis = -1)
 
-      if realization is None:
-         self.array_half_cell_t = half_t
+        if realization is None:
+            self.array_half_cell_t = half_t
 
-      return half_t
+        return half_t
 
-   def centre_point(self, cell_kji0 = None, cache_centre_array = False):
-      """Returns centre point of a cell or array of centre points of all cells.
+    def centre_point(self, cell_kji0 = None, cache_centre_array = False):
+        """Returns centre point of a cell or array of centre points of all cells.
 
       arguments:
          cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
@@ -5623,33 +5684,33 @@ class RegularGrid(Grid):
          resulting coordinates are in the same (local) crs as the grid points
       """
 
-      if cell_kji0 is None:
-         cache_centre_array = True
+        if cell_kji0 is None:
+            cache_centre_array = True
 
-      if cache_centre_array and (not hasattr(self, 'array_centre_point') or self.array_centre_point is None):
-         centres = np.zeros((self.nk, self.nj, self.ni, 3))
-         # todo: replace for loops with linspace
-         for k in range(self.nk - 1):
-            centres[k + 1, 0, 0] = centres[k, 0, 0] + self.block_dxyz_dkji[0]
-         for j in range(self.nj - 1):
-            centres[:, j + 1, 0] = centres[:, j, 0] + self.block_dxyz_dkji[1]
-         for i in range(self.ni - 1):
-            centres[:, :, i + 1] = centres[:, :, i] + self.block_dxyz_dkji[2]
-         centres += self.block_origin + 0.5 * np.sum(self.block_dxyz_dkji, axis = 0)
-         self.array_centre_point = centres
+        if cache_centre_array and (not hasattr(self, 'array_centre_point') or self.array_centre_point is None):
+            centres = np.zeros((self.nk, self.nj, self.ni, 3))
+            # todo: replace for loops with linspace
+            for k in range(self.nk - 1):
+                centres[k + 1, 0, 0] = centres[k, 0, 0] + self.block_dxyz_dkji[0]
+            for j in range(self.nj - 1):
+                centres[:, j + 1, 0] = centres[:, j, 0] + self.block_dxyz_dkji[1]
+            for i in range(self.ni - 1):
+                centres[:, :, i + 1] = centres[:, :, i] + self.block_dxyz_dkji[2]
+            centres += self.block_origin + 0.5 * np.sum(self.block_dxyz_dkji, axis = 0)
+            self.array_centre_point = centres
 
-      if cell_kji0 is not None:
-         if hasattr(self, 'array_centre_point') and self.array_centre_point is not None:
-            return self.array_centre_point[tuple(cell_kji0)]
-         float_kji0 = np.array(cell_kji0, dtype = float) + 0.5
-         centre = self.block_origin + np.sum(
-            self.block_dxyz_dkji * np.expand_dims(float_kji0, axis = -1).repeat(3, axis = -1), axis = 0)
-         return centre
+        if cell_kji0 is not None:
+            if hasattr(self, 'array_centre_point') and self.array_centre_point is not None:
+                return self.array_centre_point[tuple(cell_kji0)]
+            float_kji0 = np.array(cell_kji0, dtype = float) + 0.5
+            centre = self.block_origin + np.sum(
+                self.block_dxyz_dkji * np.expand_dims(float_kji0, axis = -1).repeat(3, axis = -1), axis = 0)
+            return centre
 
-      return self.array_centre_point
+        return self.array_centre_point
 
-   def volume(self, cell_kji0 = None):
-      """Returns bulk rock volume of cell or numpy array of bulk rock volumes for all cells.
+    def volume(self, cell_kji0 = None):
+        """Returns bulk rock volume of cell or numpy array of bulk rock volumes for all cells.
 
       arguments:
          cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
@@ -5666,13 +5727,13 @@ class RegularGrid(Grid):
          the method currently assumes that the primary i, j, k axes are mutually orthogonal
       """
 
-      vol = np.product(vec.naive_lengths(self.block_dxyz_dkji))
-      if cell_kji0 is not None:
-         return vol
-      return np.full((self.nk, self.nj, self.ni), vol)
+        vol = np.product(vec.naive_lengths(self.block_dxyz_dkji))
+        if cell_kji0 is not None:
+            return vol
+        return np.full((self.nk, self.nj, self.ni), vol)
 
-   def thickness(self, cell_kji0 = None, **kwargs):
-      """Returns cell thickness (K axial length) for a single cell or full array.
+    def thickness(self, cell_kji0 = None, **kwargs):
+        """Returns cell thickness (K axial length) for a single cell or full array.
 
       arguments:
          cell_kji0 (triple int, optional): if present, the thickness for a single cell is returned;
@@ -5683,13 +5744,13 @@ class RegularGrid(Grid):
          float, or numpy float array filled with a constant
       """
 
-      thick = self.axial_lengths_kji()[0]
-      if cell_kji0 is not None:
-         return thick
-      return np.full((self.nk, self.nj, self.ni), thick, dtype = float)
+        thick = self.axial_lengths_kji()[0]
+        if cell_kji0 is not None:
+            return thick
+        return np.full((self.nk, self.nj, self.ni), thick, dtype = float)
 
-   def pinched_out(self, cell_kji0 = None, **kwargs):
-      """Returns pinched out boolean (always False) for a single cell or full array.
+    def pinched_out(self, cell_kji0 = None, **kwargs):
+        """Returns pinched out boolean (always False) for a single cell or full array.
 
       arguments:
          cell_kji0 (triple int, optional): if present, the pinched out flag for a single cell is returned;
@@ -5700,12 +5761,12 @@ class RegularGrid(Grid):
          False, or numpy array filled with False
       """
 
-      if cell_kji0 is not None:
-         return False
-      return np.full((self.nk, self.nj, self.ni), False, dtype = bool)
+        if cell_kji0 is not None:
+            return False
+        return np.full((self.nk, self.nj, self.ni), False, dtype = bool)
 
-   def actual_pillar_shape(self, patch_metadata = False, tolerance = 0.001):
-      """Returns actual shape of pillars.
+    def actual_pillar_shape(self, patch_metadata = False, tolerance = 0.001):
+        """Returns actual shape of pillars.
 
       arguments:
          patch_metadata (boolean, default False): if True, the actual shape replaces whatever was in the metadata
@@ -5719,24 +5780,24 @@ class RegularGrid(Grid):
          preserved unless the create_xml() method is called, followed at some point with model.store_epc()
       """
 
-      if np.all(self.block_dxyz_dkji[0, :2] == 0.0):
-         return 'vertical'
-      return 'straight'
+        if np.all(self.block_dxyz_dkji[0, :2] == 0.0):
+            return 'vertical'
+        return 'straight'
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  set_as_grid_root = True,
-                  root = None,
-                  title = None,
-                  originator = None,
-                  write_active = True,
-                  write_geometry = None,
-                  extra_metadata = {},
-                  expand_const_arrays = False,
-                  add_cell_length_properties = True):
-      """Creates xml for this RegularGrid object; by default the explicit geometry is not included.
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   set_as_grid_root = True,
+                   root = None,
+                   title = None,
+                   originator = None,
+                   write_active = True,
+                   write_geometry = None,
+                   extra_metadata = {},
+                   expand_const_arrays = False,
+                   add_cell_length_properties = True):
+        """Creates xml for this RegularGrid object; by default the explicit geometry is not included.
 
       see docstring for Grid.create_xml()
 
@@ -5748,123 +5809,123 @@ class RegularGrid(Grid):
       :meta common:
       """
 
-      if write_geometry is None:
-         write_geometry = (self.grid_representation == 'IjkGrid')
+        if write_geometry is None:
+            write_geometry = (self.grid_representation == 'IjkGrid')
 
-      node = super().create_xml(ext_uuid = ext_uuid,
-                                add_as_part = add_as_part,
-                                add_relationships = add_relationships,
-                                set_as_grid_root = set_as_grid_root,
-                                title = title,
-                                originator = originator,
-                                write_active = write_active,
-                                write_geometry = write_geometry,
-                                extra_metadata = extra_metadata)
+        node = super().create_xml(ext_uuid = ext_uuid,
+                                  add_as_part = add_as_part,
+                                  add_relationships = add_relationships,
+                                  set_as_grid_root = set_as_grid_root,
+                                  title = title,
+                                  originator = originator,
+                                  write_active = write_active,
+                                  write_geometry = write_geometry,
+                                  extra_metadata = extra_metadata)
 
-      if add_cell_length_properties:
-         axes_lengths_kji = self.axial_lengths_kji()
-         dpc = rprop.GridPropertyCollection()
-         dpc.set_grid(self)
-         for axis in range(3):
-            dpc.add_cached_array_to_imported_list(None,
-                                                  'regular grid',
-                                                  'D' + 'ZYX'[axis],
-                                                  discrete = False,
-                                                  uom = self.xy_units(),
-                                                  property_kind = 'cell length',
-                                                  facet_type = 'direction',
-                                                  facet = 'KJI'[axis],
-                                                  indexable_element = 'cells',
-                                                  count = 1,
-                                                  const_value = axes_lengths_kji[axis])
-         if expand_const_arrays:
-            dpc.write_hdf5_for_imported_list(expand_const_arrays = True)
-         dpc.create_xml_for_imported_list_and_add_parts_to_model(expand_const_arrays = expand_const_arrays)
-         if self.property_collection is None:
-            self.property_collection = dpc
-         else:
-            if self.property_collection.support is None:
-               self.property_collection.set_support(support = self)
-            self.property_collection.inherit_parts_from_other_collection(dpc)
+        if add_cell_length_properties:
+            axes_lengths_kji = self.axial_lengths_kji()
+            dpc = rprop.GridPropertyCollection()
+            dpc.set_grid(self)
+            for axis in range(3):
+                dpc.add_cached_array_to_imported_list(None,
+                                                      'regular grid',
+                                                      'D' + 'ZYX'[axis],
+                                                      discrete = False,
+                                                      uom = self.xy_units(),
+                                                      property_kind = 'cell length',
+                                                      facet_type = 'direction',
+                                                      facet = 'KJI'[axis],
+                                                      indexable_element = 'cells',
+                                                      count = 1,
+                                                      const_value = axes_lengths_kji[axis])
+            if expand_const_arrays:
+                dpc.write_hdf5_for_imported_list(expand_const_arrays = True)
+            dpc.create_xml_for_imported_list_and_add_parts_to_model(expand_const_arrays = expand_const_arrays)
+            if self.property_collection is None:
+                self.property_collection = dpc
+            else:
+                if self.property_collection.support is None:
+                    self.property_collection.set_support(support = self)
+                self.property_collection.inherit_parts_from_other_collection(dpc)
 
-      return node
+        return node
 
 
 def establish_zone_property_kind(model):
-   """Returns zone local property kind object, creating the xml and adding as part if not found in model."""
+    """Returns zone local property kind object, creating the xml and adding as part if not found in model."""
 
-   zone_pk_uuid = model.uuid(obj_type = 'LocalPropertyKind', title = 'zone')
-   if zone_pk_uuid is None:
-      zone_pk = rprop.PropertyKind(model, title = 'zone', parent_property_kind = 'discrete')
-      zone_pk.create_xml()
-   else:
-      zone_pk = rprop.PropertyKind(model, uuid = zone_pk_uuid)
-   return zone_pk
+    zone_pk_uuid = model.uuid(obj_type = 'LocalPropertyKind', title = 'zone')
+    if zone_pk_uuid is None:
+        zone_pk = rprop.PropertyKind(model, title = 'zone', parent_property_kind = 'discrete')
+        zone_pk.create_xml()
+    else:
+        zone_pk = rprop.PropertyKind(model, uuid = zone_pk_uuid)
+    return zone_pk
 
 
 def extent_kji_from_root(root_node):
-   """Returns kji extent as stored in xml."""
+    """Returns kji extent as stored in xml."""
 
-   return (rqet.find_tag_int(root_node, 'Nk'), rqet.find_tag_int(root_node, 'Nj'), rqet.find_tag_int(root_node, 'Ni'))
+    return (rqet.find_tag_int(root_node, 'Nk'), rqet.find_tag_int(root_node, 'Nj'), rqet.find_tag_int(root_node, 'Ni'))
 
 
 def grid_flavour(grid_root):
-   """Returns a string indicating type of grid geometry, currently 'IjkGrid' or 'IjkBlockGrid'."""
+    """Returns a string indicating type of grid geometry, currently 'IjkGrid' or 'IjkBlockGrid'."""
 
-   if grid_root is None:
-      return None
-   em = rqet.load_metadata_from_xml(grid_root)
-   flavour = em.get('grid_flavour')
-   if flavour is None:
-      node_type = rqet.node_type(grid_root, strip_obj = True)
-      if node_type == 'IjkGridRepresentation':
-         if rqet.find_tag(grid_root, 'Geometry') is not None:
-            flavour = 'IjkGrid'
-         else:
-            flavour = 'IjkBlockGrid'  # this might cause issues
-      elif node_type == 'UnstructuredGridRepresentation':
-         cell_shape = rqet.find_nested_tags_text(grid_root, ['Geometry', 'CellShape'])
-         if cell_shape is None or cell_shape == 'polyhedral':
-            flavour = 'UnstructuredGrid'
-         elif cell_shape == 'tetrahedral':
-            flavour = 'TetraGrid'
-         elif cell_shape == 'hexahedral':
-            flavour = 'HexaGrid'
-         elif cell_shape == 'pyramidal':
-            flavour = 'PyramidGrid'
-         elif cell_shape == 'prism':
-            flavour = 'PrismGrid'
-   return flavour
+    if grid_root is None:
+        return None
+    em = rqet.load_metadata_from_xml(grid_root)
+    flavour = em.get('grid_flavour')
+    if flavour is None:
+        node_type = rqet.node_type(grid_root, strip_obj = True)
+        if node_type == 'IjkGridRepresentation':
+            if rqet.find_tag(grid_root, 'Geometry') is not None:
+                flavour = 'IjkGrid'
+            else:
+                flavour = 'IjkBlockGrid'  # this might cause issues
+        elif node_type == 'UnstructuredGridRepresentation':
+            cell_shape = rqet.find_nested_tags_text(grid_root, ['Geometry', 'CellShape'])
+            if cell_shape is None or cell_shape == 'polyhedral':
+                flavour = 'UnstructuredGrid'
+            elif cell_shape == 'tetrahedral':
+                flavour = 'TetraGrid'
+            elif cell_shape == 'hexahedral':
+                flavour = 'HexaGrid'
+            elif cell_shape == 'pyramidal':
+                flavour = 'PyramidGrid'
+            elif cell_shape == 'prism':
+                flavour = 'PrismGrid'
+    return flavour
 
 
 def is_regular_grid(grid_root):
-   """Returns True if the xml root node is for a RegularGrid."""
+    """Returns True if the xml root node is for a RegularGrid."""
 
-   return grid_flavour(grid_root) == 'IjkBlockGrid'
+    return grid_flavour(grid_root) == 'IjkBlockGrid'
 
 
 def any_grid(parent_model, grid_root = None, uuid = None, find_properties = True):
-   """Returns a Grid or RegularGrid or UnstructuredGrid object depending on the extra metadata in the xml."""
+    """Returns a Grid or RegularGrid or UnstructuredGrid object depending on the extra metadata in the xml."""
 
-   import resqpy.unstructured as rug
+    import resqpy.unstructured as rug
 
-   if uuid is None and grid_root is not None:
-      uuid = rqet.uuid_for_part_root(grid_root)
-   flavour = grid_flavour(parent_model.root_for_uuid(uuid))
-   if flavour is None:
-      return None
-   if flavour == 'IjkGrid':
-      return Grid(parent_model, uuid = uuid, find_properties = find_properties)
-   if flavour == 'IjkBlockGrid':
-      return RegularGrid(parent_model, extent_kji = None, uuid = uuid, find_properties = find_properties)
-   if flavour == 'UnstructuredGrid':
-      return rug.UnstructuredGrid(parent_model, uuid = uuid, find_properties = find_properties)
-   if flavour == 'TetraGrid':
-      return rug.TetraGrid(parent_model, uuid = uuid, find_properties = find_properties)
-   if flavour == 'HexaGrid':
-      return rug.HexaGrid(parent_model, uuid = uuid, find_properties = find_properties)
-   if flavour == 'PyramidGrid':
-      return rug.PyramidGrid(parent_model, uuid = uuid, find_properties = find_properties)
-   if flavour == 'PrismGrid':
-      return rug.PrismGrid(parent_model, uuid = uuid, find_properties = find_properties)
-   return None
+    if uuid is None and grid_root is not None:
+        uuid = rqet.uuid_for_part_root(grid_root)
+    flavour = grid_flavour(parent_model.root_for_uuid(uuid))
+    if flavour is None:
+        return None
+    if flavour == 'IjkGrid':
+        return Grid(parent_model, uuid = uuid, find_properties = find_properties)
+    if flavour == 'IjkBlockGrid':
+        return RegularGrid(parent_model, extent_kji = None, uuid = uuid, find_properties = find_properties)
+    if flavour == 'UnstructuredGrid':
+        return rug.UnstructuredGrid(parent_model, uuid = uuid, find_properties = find_properties)
+    if flavour == 'TetraGrid':
+        return rug.TetraGrid(parent_model, uuid = uuid, find_properties = find_properties)
+    if flavour == 'HexaGrid':
+        return rug.HexaGrid(parent_model, uuid = uuid, find_properties = find_properties)
+    if flavour == 'PyramidGrid':
+        return rug.PyramidGrid(parent_model, uuid = uuid, find_properties = find_properties)
+    if flavour == 'PrismGrid':
+        return rug.PrismGrid(parent_model, uuid = uuid, find_properties = find_properties)
+    return None

--- a/resqpy/grid_surface.py
+++ b/resqpy/grid_surface.py
@@ -24,173 +24,175 @@ import resqpy.well as rqw
 
 
 class GridSkin:
-   """Class of object consisting of outer skin of grid (not a RESQML class in its own right)."""
+    """Class of object consisting of outer skin of grid (not a RESQML class in its own right)."""
 
-   def __init__(self, grid, quad_triangles = True, use_single_layer_tactics = True):
-      """Returns a composite surface object consisting of outer skin of grid."""
+    def __init__(self, grid, quad_triangles = True, use_single_layer_tactics = True):
+        """Returns a composite surface object consisting of outer skin of grid."""
 
-      if grid.k_gaps:
-         use_single_layer_tactics = False
+        if grid.k_gaps:
+            use_single_layer_tactics = False
 
-      self.grid = grid
-      self.k_gaps = 0 if grid.k_gaps is None else grid.k_gaps
-      self.k_gap_after_layer_list = [
-      ]  # list of layer numbers (zero based) where there is a gap after (ie. below, usually)
-      self.has_split_coordinate_lines = grid.has_split_coordinate_lines
-      self.quad_triangles = quad_triangles
-      self.use_single_layer_tactics = use_single_layer_tactics
-      self.skin = None  #: compostite surface constructed during initialisation
-      self.fault_j_face_cols_ji0 = None  # split internal J faces
-      self.fault_i_face_cols_ji0 = None  # split internal I faces
-      self.polygon = None  # not yet in use
+        self.grid = grid
+        self.k_gaps = 0 if grid.k_gaps is None else grid.k_gaps
+        self.k_gap_after_layer_list = [
+        ]  # list of layer numbers (zero based) where there is a gap after (ie. below, usually)
+        self.has_split_coordinate_lines = grid.has_split_coordinate_lines
+        self.quad_triangles = quad_triangles
+        self.use_single_layer_tactics = use_single_layer_tactics
+        self.skin = None  #: compostite surface constructed during initialisation
+        self.fault_j_face_cols_ji0 = None  # split internal J faces
+        self.fault_i_face_cols_ji0 = None  # split internal I faces
+        self.polygon = None  # not yet in use
 
-      k_gap_surf_list = self._make_k_gap_surfaces(quad_triangles = quad_triangles)
+        k_gap_surf_list = self._make_k_gap_surfaces(quad_triangles = quad_triangles)
 
-      if self.has_split_coordinate_lines:
+        if self.has_split_coordinate_lines:
 
-         top_surf = generate_torn_surface_for_layer_interface(grid,
-                                                              k0 = 0,
-                                                              ref_k_faces = 'top',
-                                                              quad_triangles = quad_triangles)
-         base_surf = generate_torn_surface_for_layer_interface(grid,
-                                                               k0 = grid.nk - 1,
-                                                               ref_k_faces = 'base',
-                                                               quad_triangles = quad_triangles)
-         j_minus_surf = generate_torn_surface_for_x_section(grid,
-                                                            'J',
-                                                            ref_slice0 = 0,
-                                                            plus_face = False,
-                                                            quad_triangles = quad_triangles,
-                                                            as_single_layer = use_single_layer_tactics)
-         j_plus_surf = generate_torn_surface_for_x_section(grid,
-                                                           'J',
-                                                           ref_slice0 = self.grid.nj - 1,
-                                                           plus_face = True,
-                                                           quad_triangles = quad_triangles,
-                                                           as_single_layer = use_single_layer_tactics)
-         i_minus_surf = generate_torn_surface_for_x_section(grid,
-                                                            'I',
-                                                            ref_slice0 = 0,
-                                                            plus_face = False,
-                                                            quad_triangles = quad_triangles,
-                                                            as_single_layer = use_single_layer_tactics)
-         i_plus_surf = generate_torn_surface_for_x_section(grid,
-                                                           'I',
-                                                           ref_slice0 = self.grid.ni - 1,
-                                                           plus_face = True,
-                                                           quad_triangles = quad_triangles,
-                                                           as_single_layer = use_single_layer_tactics)
-
-         # fault face processing
-         j_column_faces, i_column_faces = grid.split_column_faces()
-         col_j0, col_i0 = np.where(j_column_faces)
-         self.fault_j_face_cols_ji0 = np.stack((col_j0, col_i0), axis = -1)  # fault is on plus j face of these columns
-         col_j0, col_i0 = np.where(i_column_faces)
-         self.fault_i_face_cols_ji0 = np.stack((col_j0, col_i0), axis = -1)  # fault is on plus i face of these columns
-
-         j_minus_fault_surf = j_plus_fault_surf = None
-         j_minus_fault_surf_list = []
-         j_plus_fault_surf_list = []
-         for col_ji0 in self.fault_j_face_cols_ji0:
-            #            log.debug(f'fault j face col_ji0: {col_ji0}')
-            # note: use of single layer for internal fault surfaces results in some incorrect skin surface where k gaps are present
-            # find_first_intersection_of_trajectory() method takes care of this but other uses of skin might need to be aware
-            _, surf = create_column_face_mesh_and_surface(grid,
-                                                          col_ji0,
-                                                          1,
-                                                          1,
-                                                          quad_triangles = quad_triangles,
-                                                          as_single_layer = True)
-            j_plus_fault_surf_list.append(surf)
-            _, surf = create_column_face_mesh_and_surface(grid, (col_ji0[0] + 1, col_ji0[1]),
-                                                          1,
-                                                          0,
-                                                          quad_triangles = quad_triangles,
-                                                          as_single_layer = True)
-            j_minus_fault_surf_list.append(surf)
-         if len(j_minus_fault_surf_list) > 0:
-            j_minus_fault_surf = rqs.CombinedSurface(j_minus_fault_surf_list, grid.crs_uuid)
-         if len(j_plus_fault_surf_list) > 0:
-            j_plus_fault_surf = rqs.CombinedSurface(j_plus_fault_surf_list, grid.crs_uuid)
-
-         i_minus_fault_surf = i_plus_fault_surf = None
-         i_minus_fault_surf_list = []
-         i_plus_fault_surf_list = []
-         for col_ji0 in self.fault_i_face_cols_ji0:
-            #            log.debug(f'fault i face col_ji0: {col_ji0}')
-            _, surf = create_column_face_mesh_and_surface(grid,
-                                                          col_ji0,
-                                                          2,
-                                                          1,
-                                                          quad_triangles = quad_triangles,
-                                                          as_single_layer = True)
-            i_plus_fault_surf_list.append(surf)
-            _, surf = create_column_face_mesh_and_surface(grid, (col_ji0[0], col_ji0[1] + 1),
-                                                          2,
-                                                          0,
-                                                          quad_triangles = quad_triangles,
-                                                          as_single_layer = True)
-            i_minus_fault_surf_list.append(surf)
-         if len(i_minus_fault_surf_list) > 0:
-            i_minus_fault_surf = rqs.CombinedSurface(i_minus_fault_surf_list, grid.crs_uuid)
-         if len(i_plus_fault_surf_list) > 0:
-            i_plus_fault_surf = rqs.CombinedSurface(i_plus_fault_surf_list, grid.crs_uuid)
-
-         surf_list = [top_surf, base_surf, j_minus_surf, j_plus_surf, i_minus_surf, i_plus_surf]
-         for k_gap_surf in k_gap_surf_list:
-            surf_list.append(k_gap_surf)
-         for fault_surf in [j_minus_fault_surf, j_plus_fault_surf, i_minus_fault_surf, i_plus_fault_surf]:
-            if fault_surf is not None:
-               surf_list.append(fault_surf)
-
-      else:
-
-         top_surf = generate_untorn_surface_for_layer_interface(grid,
-                                                                k0 = 0,
-                                                                ref_k_faces = 'top',
-                                                                quad_triangles = quad_triangles)
-         base_surf = generate_untorn_surface_for_layer_interface(grid,
-                                                                 k0 = grid.nk - 1,
-                                                                 ref_k_faces = 'base',
+            top_surf = generate_torn_surface_for_layer_interface(grid,
+                                                                 k0 = 0,
+                                                                 ref_k_faces = 'top',
                                                                  quad_triangles = quad_triangles)
-         j_minus_surf = generate_untorn_surface_for_x_section(grid,
+            base_surf = generate_torn_surface_for_layer_interface(grid,
+                                                                  k0 = grid.nk - 1,
+                                                                  ref_k_faces = 'base',
+                                                                  quad_triangles = quad_triangles)
+            j_minus_surf = generate_torn_surface_for_x_section(grid,
+                                                               'J',
+                                                               ref_slice0 = 0,
+                                                               plus_face = False,
+                                                               quad_triangles = quad_triangles,
+                                                               as_single_layer = use_single_layer_tactics)
+            j_plus_surf = generate_torn_surface_for_x_section(grid,
                                                               'J',
-                                                              ref_slice0 = 0,
-                                                              plus_face = False,
+                                                              ref_slice0 = self.grid.nj - 1,
+                                                              plus_face = True,
                                                               quad_triangles = quad_triangles,
                                                               as_single_layer = use_single_layer_tactics)
-         j_plus_surf = generate_untorn_surface_for_x_section(grid,
-                                                             'J',
-                                                             ref_slice0 = self.grid.nj - 1,
-                                                             plus_face = True,
-                                                             quad_triangles = quad_triangles,
-                                                             as_single_layer = use_single_layer_tactics)
-         i_minus_surf = generate_untorn_surface_for_x_section(grid,
+            i_minus_surf = generate_torn_surface_for_x_section(grid,
+                                                               'I',
+                                                               ref_slice0 = 0,
+                                                               plus_face = False,
+                                                               quad_triangles = quad_triangles,
+                                                               as_single_layer = use_single_layer_tactics)
+            i_plus_surf = generate_torn_surface_for_x_section(grid,
                                                               'I',
-                                                              ref_slice0 = 0,
-                                                              plus_face = False,
+                                                              ref_slice0 = self.grid.ni - 1,
+                                                              plus_face = True,
                                                               quad_triangles = quad_triangles,
                                                               as_single_layer = use_single_layer_tactics)
-         i_plus_surf = generate_untorn_surface_for_x_section(grid,
-                                                             'I',
-                                                             ref_slice0 = self.grid.ni - 1,
-                                                             plus_face = True,
-                                                             quad_triangles = quad_triangles,
-                                                             as_single_layer = use_single_layer_tactics)
 
-         surf_list = [top_surf, base_surf, j_minus_surf, j_plus_surf, i_minus_surf, i_plus_surf]
-         for k_gap_surf in k_gap_surf_list:
-            surf_list.append(k_gap_surf)
+            # fault face processing
+            j_column_faces, i_column_faces = grid.split_column_faces()
+            col_j0, col_i0 = np.where(j_column_faces)
+            self.fault_j_face_cols_ji0 = np.stack((col_j0, col_i0),
+                                                  axis = -1)  # fault is on plus j face of these columns
+            col_j0, col_i0 = np.where(i_column_faces)
+            self.fault_i_face_cols_ji0 = np.stack((col_j0, col_i0),
+                                                  axis = -1)  # fault is on plus i face of these columns
 
-      self.skin = rqs.CombinedSurface(surf_list)
+            j_minus_fault_surf = j_plus_fault_surf = None
+            j_minus_fault_surf_list = []
+            j_plus_fault_surf_list = []
+            for col_ji0 in self.fault_j_face_cols_ji0:
+                #            log.debug(f'fault j face col_ji0: {col_ji0}')
+                # note: use of single layer for internal fault surfaces results in some incorrect skin surface where k gaps are present
+                # find_first_intersection_of_trajectory() method takes care of this but other uses of skin might need to be aware
+                _, surf = create_column_face_mesh_and_surface(grid,
+                                                              col_ji0,
+                                                              1,
+                                                              1,
+                                                              quad_triangles = quad_triangles,
+                                                              as_single_layer = True)
+                j_plus_fault_surf_list.append(surf)
+                _, surf = create_column_face_mesh_and_surface(grid, (col_ji0[0] + 1, col_ji0[1]),
+                                                              1,
+                                                              0,
+                                                              quad_triangles = quad_triangles,
+                                                              as_single_layer = True)
+                j_minus_fault_surf_list.append(surf)
+            if len(j_minus_fault_surf_list) > 0:
+                j_minus_fault_surf = rqs.CombinedSurface(j_minus_fault_surf_list, grid.crs_uuid)
+            if len(j_plus_fault_surf_list) > 0:
+                j_plus_fault_surf = rqs.CombinedSurface(j_plus_fault_surf_list, grid.crs_uuid)
 
-   def find_first_intersection_of_trajectory(self,
-                                             trajectory,
-                                             start = 0,
-                                             start_xyz = None,
-                                             nudge = None,
-                                             exclude_kji0 = None):
-      """Returns the x,y,z and K,J,I and axis, polarity & segment of the first intersection of the trajectory with the torn skin.
+            i_minus_fault_surf = i_plus_fault_surf = None
+            i_minus_fault_surf_list = []
+            i_plus_fault_surf_list = []
+            for col_ji0 in self.fault_i_face_cols_ji0:
+                #            log.debug(f'fault i face col_ji0: {col_ji0}')
+                _, surf = create_column_face_mesh_and_surface(grid,
+                                                              col_ji0,
+                                                              2,
+                                                              1,
+                                                              quad_triangles = quad_triangles,
+                                                              as_single_layer = True)
+                i_plus_fault_surf_list.append(surf)
+                _, surf = create_column_face_mesh_and_surface(grid, (col_ji0[0], col_ji0[1] + 1),
+                                                              2,
+                                                              0,
+                                                              quad_triangles = quad_triangles,
+                                                              as_single_layer = True)
+                i_minus_fault_surf_list.append(surf)
+            if len(i_minus_fault_surf_list) > 0:
+                i_minus_fault_surf = rqs.CombinedSurface(i_minus_fault_surf_list, grid.crs_uuid)
+            if len(i_plus_fault_surf_list) > 0:
+                i_plus_fault_surf = rqs.CombinedSurface(i_plus_fault_surf_list, grid.crs_uuid)
+
+            surf_list = [top_surf, base_surf, j_minus_surf, j_plus_surf, i_minus_surf, i_plus_surf]
+            for k_gap_surf in k_gap_surf_list:
+                surf_list.append(k_gap_surf)
+            for fault_surf in [j_minus_fault_surf, j_plus_fault_surf, i_minus_fault_surf, i_plus_fault_surf]:
+                if fault_surf is not None:
+                    surf_list.append(fault_surf)
+
+        else:
+
+            top_surf = generate_untorn_surface_for_layer_interface(grid,
+                                                                   k0 = 0,
+                                                                   ref_k_faces = 'top',
+                                                                   quad_triangles = quad_triangles)
+            base_surf = generate_untorn_surface_for_layer_interface(grid,
+                                                                    k0 = grid.nk - 1,
+                                                                    ref_k_faces = 'base',
+                                                                    quad_triangles = quad_triangles)
+            j_minus_surf = generate_untorn_surface_for_x_section(grid,
+                                                                 'J',
+                                                                 ref_slice0 = 0,
+                                                                 plus_face = False,
+                                                                 quad_triangles = quad_triangles,
+                                                                 as_single_layer = use_single_layer_tactics)
+            j_plus_surf = generate_untorn_surface_for_x_section(grid,
+                                                                'J',
+                                                                ref_slice0 = self.grid.nj - 1,
+                                                                plus_face = True,
+                                                                quad_triangles = quad_triangles,
+                                                                as_single_layer = use_single_layer_tactics)
+            i_minus_surf = generate_untorn_surface_for_x_section(grid,
+                                                                 'I',
+                                                                 ref_slice0 = 0,
+                                                                 plus_face = False,
+                                                                 quad_triangles = quad_triangles,
+                                                                 as_single_layer = use_single_layer_tactics)
+            i_plus_surf = generate_untorn_surface_for_x_section(grid,
+                                                                'I',
+                                                                ref_slice0 = self.grid.ni - 1,
+                                                                plus_face = True,
+                                                                quad_triangles = quad_triangles,
+                                                                as_single_layer = use_single_layer_tactics)
+
+            surf_list = [top_surf, base_surf, j_minus_surf, j_plus_surf, i_minus_surf, i_plus_surf]
+            for k_gap_surf in k_gap_surf_list:
+                surf_list.append(k_gap_surf)
+
+        self.skin = rqs.CombinedSurface(surf_list)
+
+    def find_first_intersection_of_trajectory(self,
+                                              trajectory,
+                                              start = 0,
+                                              start_xyz = None,
+                                              nudge = None,
+                                              exclude_kji0 = None):
+        """Returns the x,y,z and K,J,I and axis, polarity & segment of the first intersection of the trajectory with the torn skin.
 
       arguments:
          trajectory (well.Trajectory object): the trajectory to be intersected with the skin
@@ -212,150 +214,150 @@ class GridSkin:
          initial entry through a sidewall of the grid or through a fault face
       """
 
-      if exclude_kji0 is not None:
-         xyz_1, segment_1, tri_index_1, xyz_2, segment_2, tri_index_2 =  \
-            find_first_intersection_of_trajectory_with_surface(trajectory, self.skin, start = start, start_xyz = start_xyz,
-                                                               nudge = nudge, return_second = True)
-      else:
-         xyz_1, segment_1, tri_index_1 = find_first_intersection_of_trajectory_with_surface(trajectory,
-                                                                                            self.skin,
-                                                                                            start = start,
-                                                                                            start_xyz = start_xyz,
-                                                                                            nudge = nudge)
-         xyz_2 = segment_2 = tri_index_2 = None
-      if xyz_1 is None:
-         return None, None, None, None, None
-      if xyz_2 is None:
-         triplet_list = [(xyz_1, segment_1, tri_index_1)]
-      else:
-         triplet_list = [(xyz_1, segment_1, tri_index_1), (xyz_2, segment_2, tri_index_2)]
+        if exclude_kji0 is not None:
+            xyz_1, segment_1, tri_index_1, xyz_2, segment_2, tri_index_2 =  \
+               find_first_intersection_of_trajectory_with_surface(trajectory, self.skin, start = start, start_xyz = start_xyz,
+                                                                  nudge = nudge, return_second = True)
+        else:
+            xyz_1, segment_1, tri_index_1 = find_first_intersection_of_trajectory_with_surface(trajectory,
+                                                                                               self.skin,
+                                                                                               start = start,
+                                                                                               start_xyz = start_xyz,
+                                                                                               nudge = nudge)
+            xyz_2 = segment_2 = tri_index_2 = None
+        if xyz_1 is None:
+            return None, None, None, None, None
+        if xyz_2 is None:
+            triplet_list = [(xyz_1, segment_1, tri_index_1)]
+        else:
+            triplet_list = [(xyz_1, segment_1, tri_index_1), (xyz_2, segment_2, tri_index_2)]
 
-      for (xyz, segment, tri_index) in triplet_list:
+        for (xyz, segment, tri_index) in triplet_list:
 
-         surf_index, surf_tri_index = self.skin.surface_index_for_triangle_index(tri_index)
-         assert surf_index is not None
+            surf_index, surf_tri_index = self.skin.surface_index_for_triangle_index(tri_index)
+            assert surf_index is not None
 
-         if surf_index < 6:  # grid skin
-            # following returns j,i pair for K faces; k,i for J faces; or k,j for I faces
-            col = self.skin.surface_list[surf_index].column_from_triangle_index(surf_tri_index)
-            if surf_index == 0:
-               kji0 = (0, col[0], col[1])  # K- (top)
-            elif surf_index == 1:
-               kji0 = (self.grid.nk - 1, col[0], col[1])  # K+ (base)
-            elif surf_index == 2:
-               kji0 = (col[0], 0, col[1])  # J-
-            elif surf_index == 3:
-               kji0 = (col[0], self.grid.nj - 1, col[1])  # J+
-            elif surf_index == 4:
-               kji0 = (col[0], col[1], 0)  # I-
-            else:
-               kji0 = (col[0], col[1], self.grid.ni - 1)  # I+
-            axis, polarity = divmod(surf_index, 2)
-            if self.use_single_layer_tactics and surf_index > 1:  # now compare against layered representation of column face
-               xyz, k0 = find_intersection_of_trajectory_interval_with_column_face(trajectory,
-                                                                                   self.grid,
-                                                                                   segment,
-                                                                                   kji0[1:],
-                                                                                   axis,
-                                                                                   polarity,
-                                                                                   start_xyz = xyz,
-                                                                                   nudge = -1.0)
-               if xyz is None:
-                  log.error('unexpected failure to identify skin column face penetration point')
-                  return None, None, None, None, None
-               kji0 = (k0, kji0[1], kji0[2])
+            if surf_index < 6:  # grid skin
+                # following returns j,i pair for K faces; k,i for J faces; or k,j for I faces
+                col = self.skin.surface_list[surf_index].column_from_triangle_index(surf_tri_index)
+                if surf_index == 0:
+                    kji0 = (0, col[0], col[1])  # K- (top)
+                elif surf_index == 1:
+                    kji0 = (self.grid.nk - 1, col[0], col[1])  # K+ (base)
+                elif surf_index == 2:
+                    kji0 = (col[0], 0, col[1])  # J-
+                elif surf_index == 3:
+                    kji0 = (col[0], self.grid.nj - 1, col[1])  # J+
+                elif surf_index == 4:
+                    kji0 = (col[0], col[1], 0)  # I-
+                else:
+                    kji0 = (col[0], col[1], self.grid.ni - 1)  # I+
+                axis, polarity = divmod(surf_index, 2)
+                if self.use_single_layer_tactics and surf_index > 1:  # now compare against layered representation of column face
+                    xyz, k0 = find_intersection_of_trajectory_interval_with_column_face(trajectory,
+                                                                                        self.grid,
+                                                                                        segment,
+                                                                                        kji0[1:],
+                                                                                        axis,
+                                                                                        polarity,
+                                                                                        start_xyz = xyz,
+                                                                                        nudge = -1.0)
+                    if xyz is None:
+                        log.error('unexpected failure to identify skin column face penetration point')
+                        return None, None, None, None, None
+                    kji0 = (k0, kji0[1], kji0[2])
 
-         elif surf_index < 6 + 2 * self.k_gaps:  # top or base face of a k gap
-            col = self.skin.surface_list[surf_index].column_from_triangle_index(surf_tri_index)
-            surf_index -= 6
-            gap_index, top_base = divmod(surf_index, 2)
-            axis = 0
-            if top_base == 0:  # top of k gap (ie. base of layer before)
-               kji0 = (self.k_gap_after_layer_list[gap_index], col[0], col[1])
-               polarity = 1
-            else:  # base of k gap (top of layer after)
-               kji0 = (self.k_gap_after_layer_list[gap_index] + 1, col[0], col[1])
-               polarity = 0
+            elif surf_index < 6 + 2 * self.k_gaps:  # top or base face of a k gap
+                col = self.skin.surface_list[surf_index].column_from_triangle_index(surf_tri_index)
+                surf_index -= 6
+                gap_index, top_base = divmod(surf_index, 2)
+                axis = 0
+                if top_base == 0:  # top of k gap (ie. base of layer before)
+                    kji0 = (self.k_gap_after_layer_list[gap_index], col[0], col[1])
+                    polarity = 1
+                else:  # base of k gap (top of layer after)
+                    kji0 = (self.k_gap_after_layer_list[gap_index] + 1, col[0], col[1])
+                    polarity = 0
 
-         else:  # fault face
-            axis, polarity = divmod(surf_index - (6 + 2 * self.k_gaps), 2)
-            axis += 1
-            log.debug('penetration through fault face ' + 'KJI'[axis] + '-+'[polarity])
-            assert self.skin.is_combined_list[surf_index]
-            fault_surf_list = self.skin.surface_list[surf_index]
-            col_surf_index, _ = fault_surf_list.surface_index_for_triangle_index(surf_tri_index)
-            col_ji0 = np.empty((2,), dtype = int)
-            surf_index -= 6 + 2 * self.k_gaps
-            if surf_index in [0, 1]:  # J-/+ fault face
-               col_ji0[:] = self.fault_j_face_cols_ji0[col_surf_index]
-            elif surf_index in [2, 3]:  # I-/+ fault face
-               col_ji0[:] = self.fault_i_face_cols_ji0[col_surf_index]
-            else:  # should not be possible
-               raise Exception('code failure')
-            if polarity == 0:
-               col_ji0[axis - 1] += 1
-            xyz_f, k0 = find_intersection_of_trajectory_interval_with_column_face(trajectory,
-                                                                                  self.grid,
-                                                                                  segment,
-                                                                                  col_ji0,
-                                                                                  axis,
-                                                                                  polarity,
-                                                                                  start_xyz = xyz,
-                                                                                  nudge = -1.0)
-            if xyz_f is None:
-               if self.k_gaps:
-                  log.debug('failed to identify fault penetration point; assumed to be in k gap; nudging forward')
-                  if nudge is None or nudge < 0.0:
-                     nudge = 0.0
-                  nudge += 0.1
-                  return self.find_first_intersection_of_trajectory(trajectory,
-                                                                    start = segment,
-                                                                    start_xyz = xyz,
-                                                                    nudge = nudge,
-                                                                    exclude_kji0 = exclude_kji0)
-               log.error('unexpected failure to identify fault penetration point')
-               return None, None, None, None, None
-            xyz = xyz_f
-            kji0 = (k0, col_ji0[0], col_ji0[1])
+            else:  # fault face
+                axis, polarity = divmod(surf_index - (6 + 2 * self.k_gaps), 2)
+                axis += 1
+                log.debug('penetration through fault face ' + 'KJI'[axis] + '-+'[polarity])
+                assert self.skin.is_combined_list[surf_index]
+                fault_surf_list = self.skin.surface_list[surf_index]
+                col_surf_index, _ = fault_surf_list.surface_index_for_triangle_index(surf_tri_index)
+                col_ji0 = np.empty((2,), dtype = int)
+                surf_index -= 6 + 2 * self.k_gaps
+                if surf_index in [0, 1]:  # J-/+ fault face
+                    col_ji0[:] = self.fault_j_face_cols_ji0[col_surf_index]
+                elif surf_index in [2, 3]:  # I-/+ fault face
+                    col_ji0[:] = self.fault_i_face_cols_ji0[col_surf_index]
+                else:  # should not be possible
+                    raise Exception('code failure')
+                if polarity == 0:
+                    col_ji0[axis - 1] += 1
+                xyz_f, k0 = find_intersection_of_trajectory_interval_with_column_face(trajectory,
+                                                                                      self.grid,
+                                                                                      segment,
+                                                                                      col_ji0,
+                                                                                      axis,
+                                                                                      polarity,
+                                                                                      start_xyz = xyz,
+                                                                                      nudge = -1.0)
+                if xyz_f is None:
+                    if self.k_gaps:
+                        log.debug('failed to identify fault penetration point; assumed to be in k gap; nudging forward')
+                        if nudge is None or nudge < 0.0:
+                            nudge = 0.0
+                        nudge += 0.1
+                        return self.find_first_intersection_of_trajectory(trajectory,
+                                                                          start = segment,
+                                                                          start_xyz = xyz,
+                                                                          nudge = nudge,
+                                                                          exclude_kji0 = exclude_kji0)
+                    log.error('unexpected failure to identify fault penetration point')
+                    return None, None, None, None, None
+                xyz = xyz_f
+                kji0 = (k0, col_ji0[0], col_ji0[1])
 
-         if exclude_kji0 is None or not np.all(kji0 == exclude_kji0):
-            return xyz, kji0, axis, polarity, segment
+            if exclude_kji0 is None or not np.all(kji0 == exclude_kji0):
+                return xyz, kji0, axis, polarity, segment
 
-      return None, None, None, None, None
+        return None, None, None, None, None
 
-   def _make_k_gap_surfaces(self, quad_triangles = True):
-      """Returns a list of newly created surfaces representing top and base of each k gap."""
+    def _make_k_gap_surfaces(self, quad_triangles = True):
+        """Returns a list of newly created surfaces representing top and base of each k gap."""
 
-      k_gap_surf_list = [
-      ]  # list of layer face surfaces, 2 per gap (top of gap, ie. base of layer above, then base of gap)
-      self.k_gap_after_layer_list = []
-      if self.k_gaps > 0:
-         for k0 in range(self.grid.nk - 1):
-            if self.grid.k_gap_after_array[k0]:
-               if self.has_split_coordinate_lines:
-                  gap_top_surf = generate_torn_surface_for_layer_interface(self.grid,
-                                                                           k0 = k0,
-                                                                           ref_k_faces = 'base',
-                                                                           quad_triangles = quad_triangles)
-                  gap_base_surf = generate_torn_surface_for_layer_interface(self.grid,
-                                                                            k0 = k0 + 1,
-                                                                            ref_k_faces = 'top',
-                                                                            quad_triangles = quad_triangles)
-               else:
-                  gap_top_surf = generate_untorn_surface_for_layer_interface(self.grid,
-                                                                             k0 = k0,
-                                                                             ref_k_faces = 'base',
-                                                                             quad_triangles = quad_triangles)
-                  gap_base_surf = generate_untorn_surface_for_layer_interface(self.grid,
-                                                                              k0 = k0 + 1,
-                                                                              ref_k_faces = 'top',
-                                                                              quad_triangles = quad_triangles)
-               k_gap_surf_list.append(gap_top_surf)
-               k_gap_surf_list.append(gap_base_surf)
-               self.k_gap_after_layer_list.append(k0)
-      assert len(k_gap_surf_list) == 2 * self.k_gaps
-      assert len(self.k_gap_after_layer_list) == self.k_gaps
-      return k_gap_surf_list
+        k_gap_surf_list = [
+        ]  # list of layer face surfaces, 2 per gap (top of gap, ie. base of layer above, then base of gap)
+        self.k_gap_after_layer_list = []
+        if self.k_gaps > 0:
+            for k0 in range(self.grid.nk - 1):
+                if self.grid.k_gap_after_array[k0]:
+                    if self.has_split_coordinate_lines:
+                        gap_top_surf = generate_torn_surface_for_layer_interface(self.grid,
+                                                                                 k0 = k0,
+                                                                                 ref_k_faces = 'base',
+                                                                                 quad_triangles = quad_triangles)
+                        gap_base_surf = generate_torn_surface_for_layer_interface(self.grid,
+                                                                                  k0 = k0 + 1,
+                                                                                  ref_k_faces = 'top',
+                                                                                  quad_triangles = quad_triangles)
+                    else:
+                        gap_top_surf = generate_untorn_surface_for_layer_interface(self.grid,
+                                                                                   k0 = k0,
+                                                                                   ref_k_faces = 'base',
+                                                                                   quad_triangles = quad_triangles)
+                        gap_base_surf = generate_untorn_surface_for_layer_interface(self.grid,
+                                                                                    k0 = k0 + 1,
+                                                                                    ref_k_faces = 'top',
+                                                                                    quad_triangles = quad_triangles)
+                    k_gap_surf_list.append(gap_top_surf)
+                    k_gap_surf_list.append(gap_base_surf)
+                    self.k_gap_after_layer_list.append(k0)
+        assert len(k_gap_surf_list) == 2 * self.k_gaps
+        assert len(self.k_gap_after_layer_list) == self.k_gaps
+        return k_gap_surf_list
 
 
 def generate_untorn_surface_for_layer_interface(grid,
@@ -363,7 +365,7 @@ def generate_untorn_surface_for_layer_interface(grid,
                                                 ref_k_faces = 'top',
                                                 quad_triangles = True,
                                                 border = None):
-   """Returns a Surface object generated from the grid layer interface points after any faults are 'healed'.
+    """Returns a Surface object generated from the grid layer interface points after any faults are 'healed'.
 
    arguments:
       grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
@@ -385,36 +387,40 @@ def generate_untorn_surface_for_layer_interface(grid,
       messed up.
    """
 
-   surf = rqs.Surface(grid.model)
-   kp = 1 if ref_k_faces == 'base' else 0
-   mesh = grid.horizon_points(ref_k0 = k0, heal_faults = True, kp = kp)
-   if border is None or border <= 0.0:
-      surf.set_from_irregular_mesh(mesh, quad_triangles = quad_triangles)
-   else:
-      #      origin = np.mean(mesh, axis = (0, 1))
-      skirted_mesh = np.empty((mesh.shape[0] + 2, mesh.shape[1] + 2, 3))
-      skirted_mesh[1:-1, 1:-1, :] = mesh
-      # fill border values (other than corners)
-      for j in range(1, mesh.shape[0] + 1):
-         skirted_mesh[j, 0, :] = skirted_mesh[j, 1] + border * vec.unit_vector(skirted_mesh[j, 1] - skirted_mesh[j, 2])
-         skirted_mesh[j,
-                      -1, :] = skirted_mesh[j, -2] + border * vec.unit_vector(skirted_mesh[j, -2] - skirted_mesh[j, -3])
-      for i in range(1, mesh.shape[1] + 1):
-         skirted_mesh[0, i, :] = skirted_mesh[1, i] + border * vec.unit_vector(skirted_mesh[1, i] - skirted_mesh[2, i])
-         skirted_mesh[-1,
-                      i, :] = skirted_mesh[-2, i] + border * vec.unit_vector(skirted_mesh[-2, i] - skirted_mesh[-3, i])
-      # fill in corner values
-      skirted_mesh[0, 0, :] = skirted_mesh[0, 1] + skirted_mesh[1, 0] - skirted_mesh[1, 1]
-      skirted_mesh[0, -1, :] = skirted_mesh[0, -2] + skirted_mesh[1, -1] - skirted_mesh[1, -2]
-      skirted_mesh[-1, 0, :] = skirted_mesh[-1, 1] + skirted_mesh[-2, 0] - skirted_mesh[-2, 1]
-      skirted_mesh[-1, -1, :] = skirted_mesh[-1, -2] + skirted_mesh[-2, -1] - skirted_mesh[-2, -2]
-      surf.set_from_irregular_mesh(skirted_mesh, quad_triangles = quad_triangles)
+    surf = rqs.Surface(grid.model)
+    kp = 1 if ref_k_faces == 'base' else 0
+    mesh = grid.horizon_points(ref_k0 = k0, heal_faults = True, kp = kp)
+    if border is None or border <= 0.0:
+        surf.set_from_irregular_mesh(mesh, quad_triangles = quad_triangles)
+    else:
+        #      origin = np.mean(mesh, axis = (0, 1))
+        skirted_mesh = np.empty((mesh.shape[0] + 2, mesh.shape[1] + 2, 3))
+        skirted_mesh[1:-1, 1:-1, :] = mesh
+        # fill border values (other than corners)
+        for j in range(1, mesh.shape[0] + 1):
+            skirted_mesh[j,
+                         0, :] = skirted_mesh[j, 1] + border * vec.unit_vector(skirted_mesh[j, 1] - skirted_mesh[j, 2])
+            skirted_mesh[j,
+                         -1, :] = skirted_mesh[j,
+                                               -2] + border * vec.unit_vector(skirted_mesh[j, -2] - skirted_mesh[j, -3])
+        for i in range(1, mesh.shape[1] + 1):
+            skirted_mesh[0,
+                         i, :] = skirted_mesh[1, i] + border * vec.unit_vector(skirted_mesh[1, i] - skirted_mesh[2, i])
+            skirted_mesh[-1,
+                         i, :] = skirted_mesh[-2,
+                                              i] + border * vec.unit_vector(skirted_mesh[-2, i] - skirted_mesh[-3, i])
+        # fill in corner values
+        skirted_mesh[0, 0, :] = skirted_mesh[0, 1] + skirted_mesh[1, 0] - skirted_mesh[1, 1]
+        skirted_mesh[0, -1, :] = skirted_mesh[0, -2] + skirted_mesh[1, -1] - skirted_mesh[1, -2]
+        skirted_mesh[-1, 0, :] = skirted_mesh[-1, 1] + skirted_mesh[-2, 0] - skirted_mesh[-2, 1]
+        skirted_mesh[-1, -1, :] = skirted_mesh[-1, -2] + skirted_mesh[-2, -1] - skirted_mesh[-2, -2]
+        surf.set_from_irregular_mesh(skirted_mesh, quad_triangles = quad_triangles)
 
-   return surf
+    return surf
 
 
 def generate_torn_surface_for_layer_interface(grid, k0 = 0, ref_k_faces = 'top', quad_triangles = True):
-   """Returns a Surface object generated from the grid layer interface points.
+    """Returns a Surface object generated from the grid layer interface points.
 
    arguments:
       grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
@@ -437,12 +443,12 @@ def generate_torn_surface_for_layer_interface(grid, k0 = 0, ref_k_faces = 'top',
       single patch regardless.
    """
 
-   surf = rqs.Surface(grid.model)
-   kp = 1 if ref_k_faces == 'base' else 0
-   mesh = grid.split_horizon_points(ref_k0 = k0, kp = kp)
-   surf.set_from_torn_mesh(mesh, quad_triangles = quad_triangles)
+    surf = rqs.Surface(grid.model)
+    kp = 1 if ref_k_faces == 'base' else 0
+    mesh = grid.split_horizon_points(ref_k0 = k0, kp = kp)
+    surf.set_from_torn_mesh(mesh, quad_triangles = quad_triangles)
 
-   return surf
+    return surf
 
 
 def generate_torn_surface_for_x_section(grid,
@@ -451,7 +457,7 @@ def generate_torn_surface_for_x_section(grid,
                                         plus_face = False,
                                         quad_triangles = True,
                                         as_single_layer = False):
-   """Returns a Surface object generated from the grid cross section points.
+    """Returns a Surface object generated from the grid cross section points.
 
    arguments:
       grid (grid.Grid object): the grid object from which a cross section is to be converted to a surface
@@ -475,26 +481,26 @@ def generate_torn_surface_for_x_section(grid,
       patches; however, at present the code uses a single patch regardless.
    """
 
-   assert axis.upper() in ['I', 'J']
+    assert axis.upper() in ['I', 'J']
 
-   if grid.k_gaps is None or grid.k_gaps == 0:
-      x_sect_points = grid.split_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
-      if as_single_layer:
-         shape = np.array(x_sect_points.shape)
-         shape[0] = 1
-         x_sect_top = x_sect_points[0].reshape(tuple(shape))
-         x_sect_base = x_sect_points[-1].reshape(tuple(shape))
-      else:
-         x_sect_top = x_sect_points[:-1]
-         x_sect_base = x_sect_points[1:]
-      x_sect_mesh = np.stack((x_sect_top, x_sect_base), axis = 2)
-   else:
-      x_sect_mesh = grid.split_gap_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
+    if grid.k_gaps is None or grid.k_gaps == 0:
+        x_sect_points = grid.split_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
+        if as_single_layer:
+            shape = np.array(x_sect_points.shape)
+            shape[0] = 1
+            x_sect_top = x_sect_points[0].reshape(tuple(shape))
+            x_sect_base = x_sect_points[-1].reshape(tuple(shape))
+        else:
+            x_sect_top = x_sect_points[:-1]
+            x_sect_base = x_sect_points[1:]
+        x_sect_mesh = np.stack((x_sect_top, x_sect_base), axis = 2)
+    else:
+        x_sect_mesh = grid.split_gap_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
 
-   surf = rqs.Surface(grid.model)
-   surf.set_from_torn_mesh(x_sect_mesh, quad_triangles = quad_triangles)
+    surf = rqs.Surface(grid.model)
+    surf.set_from_torn_mesh(x_sect_mesh, quad_triangles = quad_triangles)
 
-   return surf
+    return surf
 
 
 def generate_untorn_surface_for_x_section(grid,
@@ -503,7 +509,7 @@ def generate_untorn_surface_for_x_section(grid,
                                           plus_face = False,
                                           quad_triangles = True,
                                           as_single_layer = False):
-   """Returns a Surface object generated from the grid cross section points for an unfaulted grid.
+    """Returns a Surface object generated from the grid cross section points for an unfaulted grid.
 
    arguments:
       grid (grid.Grid object): the grid object from which a cross section is to be converted to a surface
@@ -527,28 +533,28 @@ def generate_untorn_surface_for_x_section(grid,
       patches; however, at present the code uses a single patch regardless.
    """
 
-   assert axis.upper() in ['I', 'J']
+    assert axis.upper() in ['I', 'J']
 
-   x_sect_points = grid.x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
-   if as_single_layer:
-      shape = np.array(x_sect_points.shape)
-      shape[0] = 1
-      x_sect_top = x_sect_points[0]
-      x_sect_base = x_sect_points[-1]
-      x_sect_mesh = np.stack((x_sect_top, x_sect_base), axis = 0)
-   else:
-      x_sect_mesh = x_sect_points
+    x_sect_points = grid.x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
+    if as_single_layer:
+        shape = np.array(x_sect_points.shape)
+        shape[0] = 1
+        x_sect_top = x_sect_points[0]
+        x_sect_base = x_sect_points[-1]
+        x_sect_mesh = np.stack((x_sect_top, x_sect_base), axis = 0)
+    else:
+        x_sect_mesh = x_sect_points
 
-   log.debug(f'x_sect_mesh.shape: {x_sect_mesh.shape}; grid.extent_kji: {grid.extent_kji}')
+    log.debug(f'x_sect_mesh.shape: {x_sect_mesh.shape}; grid.extent_kji: {grid.extent_kji}')
 
-   surf = rqs.Surface(grid.model)
-   surf.set_from_irregular_mesh(x_sect_mesh, quad_triangles = quad_triangles)
+    surf = rqs.Surface(grid.model)
+    surf.set_from_irregular_mesh(x_sect_mesh, quad_triangles = quad_triangles)
 
-   return surf
+    return surf
 
 
 def find_intersections_of_trajectory_with_surface(trajectory, surface):
-   """Returns an array of triangle indices and an array of xyz of intersections of well trajectory with surface.
+    """Returns an array of triangle indices and an array of xyz of intersections of well trajectory with surface.
 
    arguments:
       trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersections for;
@@ -567,27 +573,27 @@ def find_intersections_of_trajectory_with_surface(trajectory, surface):
       a given triangle index might appear more than once in the first returned array
    """
 
-   if isinstance(trajectory, list):
-      trajectory_list = trajectory
-   else:
-      trajectory_list = [trajectory]
+    if isinstance(trajectory, list):
+        trajectory_list = trajectory
+    else:
+        trajectory_list = [trajectory]
 
-   t, p = surface.triangles_and_points()
-   triangles = p[t]
-   #   log.debug('finding intersections of wellbore trajectory(ies) with layer: ' + str(k0) + ' ' + ref_k_faces)
-   results_list = []
-   for traj in trajectory_list:
-      all_intersects = meet.poly_line_triangles_intersects(traj.control_points, triangles)
-      _, triangle_indices, intersect_points = meet.distilled_intersects(
-         all_intersects)  # discard trajectory segment info
-      if len(triangle_indices) == 0:
-         results_list.append((None, None))
-      else:
-         results_list.append((triangle_indices, intersect_points))
+    t, p = surface.triangles_and_points()
+    triangles = p[t]
+    #   log.debug('finding intersections of wellbore trajectory(ies) with layer: ' + str(k0) + ' ' + ref_k_faces)
+    results_list = []
+    for traj in trajectory_list:
+        all_intersects = meet.poly_line_triangles_intersects(traj.control_points, triangles)
+        _, triangle_indices, intersect_points = meet.distilled_intersects(
+            all_intersects)  # discard trajectory segment info
+        if len(triangle_indices) == 0:
+            results_list.append((None, None))
+        else:
+            results_list.append((triangle_indices, intersect_points))
 
-   if isinstance(trajectory, list):
-      return results_list
-   return results_list[0]
+    if isinstance(trajectory, list):
+        return results_list
+    return results_list[0]
 
 
 def find_intersections_of_trajectory_with_layer_interface(trajectory,
@@ -596,7 +602,7 @@ def find_intersections_of_trajectory_with_layer_interface(trajectory,
                                                           ref_k_faces = 'top',
                                                           heal_faults = True,
                                                           quad_triangles = True):
-   """Returns an array of column indices and an array of xyz of intersections of well trajectory with layer interface.
+    """Returns an array of column indices and an array of xyz of intersections of well trajectory with layer interface.
 
    arguments:
       trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersections for;
@@ -624,39 +630,39 @@ def find_intersections_of_trajectory_with_layer_interface(trajectory,
       a given (j0, i0) column might appear more than once in the first returned array
    """
 
-   if isinstance(trajectory, list):
-      trajectory_list = trajectory
-   else:
-      trajectory_list = [trajectory]
+    if isinstance(trajectory, list):
+        trajectory_list = trajectory
+    else:
+        trajectory_list = [trajectory]
 
-   log.debug('generating surface for layer: ' + str(k0) + ' ' + ref_k_faces)
-   if grid.has_split_coordinate_lines and not heal_faults:
-      surface = generate_torn_surface_for_layer_interface(grid,
-                                                          k0 = k0,
-                                                          ref_k_faces = ref_k_faces,
-                                                          quad_triangles = quad_triangles)
-   else:
-      surface = generate_untorn_surface_for_layer_interface(grid,
+    log.debug('generating surface for layer: ' + str(k0) + ' ' + ref_k_faces)
+    if grid.has_split_coordinate_lines and not heal_faults:
+        surface = generate_torn_surface_for_layer_interface(grid,
                                                             k0 = k0,
                                                             ref_k_faces = ref_k_faces,
                                                             quad_triangles = quad_triangles)
+    else:
+        surface = generate_untorn_surface_for_layer_interface(grid,
+                                                              k0 = k0,
+                                                              ref_k_faces = ref_k_faces,
+                                                              quad_triangles = quad_triangles)
 
-   tri_intersect_list = find_intersections_of_trajectory_with_surface(trajectory_list, surface)
+    tri_intersect_list = find_intersections_of_trajectory_with_surface(trajectory_list, surface)
 
-   results_list = []
-   for triangle_indices, intersect_points in tri_intersect_list:
-      if triangle_indices is None or intersect_points is None:
-         results_list.append((None, None))
-      else:
-         j_list, i_list = surface.column_from_triangle_index(
-            triangle_indices)  # todo: check this is valid for torn surfaces
-         assert j_list is not None, 'failed to derive column indices from triangle indices'
-         cols = np.stack((j_list, i_list), axis = -1)
-         results_list.append((cols, intersect_points))
+    results_list = []
+    for triangle_indices, intersect_points in tri_intersect_list:
+        if triangle_indices is None or intersect_points is None:
+            results_list.append((None, None))
+        else:
+            j_list, i_list = surface.column_from_triangle_index(
+                triangle_indices)  # todo: check this is valid for torn surfaces
+            assert j_list is not None, 'failed to derive column indices from triangle indices'
+            cols = np.stack((j_list, i_list), axis = -1)
+            results_list.append((cols, intersect_points))
 
-   if isinstance(trajectory, list):
-      return results_list
-   return results_list[0]
+    if isinstance(trajectory, list):
+        return results_list
+    return results_list[0]
 
 
 def find_first_intersection_of_trajectory_with_surface(trajectory,
@@ -665,7 +671,7 @@ def find_first_intersection_of_trajectory_with_surface(trajectory,
                                                        start_xyz = None,
                                                        nudge = None,
                                                        return_second = False):
-   """Returns xyz and other info of the first intersection of well trajectory with layer interface.
+    """Returns xyz and other info of the first intersection of well trajectory with layer interface.
 
    arguments:
       trajectory (well.Trajectory object): the wellbore trajectory object(s) to find the intersection for
@@ -690,67 +696,67 @@ def find_first_intersection_of_trajectory_with_surface(trajectory,
       in errors where there is significant curvature between neighbouring control points
    """
 
-   if start >= trajectory.knot_count - 1:
-      if return_second:
-         return None, None, None, None, None, None
-      return None, None, None
+    if start >= trajectory.knot_count - 1:
+        if return_second:
+            return None, None, None, None, None, None
+        return None, None, None
 
-   t, p = surface.triangles_and_points()
-   triangles = p[t]
+    t, p = surface.triangles_and_points()
+    triangles = p[t]
 
-   xyz = None
-   tri = None
-   knot = start
-   xyz_2 = tri_2 = None
-   if start_xyz is None:
-      start_xyz = trajectory.control_points[knot]
-   if knot < trajectory.knot_count - 2 and vec.isclose(start_xyz, trajectory.control_points[knot + 1]):
-      knot += 1
-   if nudge is not None and nudge != 0.0:
-      remaining = trajectory.control_points[knot + 1] - start_xyz
-      if vec.naive_length(remaining) <= nudge:
-         start_xyz += 0.9 * remaining
-      else:
-         start_xyz += nudge * vec.unit_vector(remaining)
-   while knot < trajectory.knot_count - 1:
-      if start_xyz is None:
-         line_p = trajectory.control_points[knot]
-      else:
-         line_p = start_xyz
-      start_xyz = None
-      line_v = trajectory.control_points[knot + 1] - line_p
-      intersects = meet.line_triangles_intersects(line_p, line_v, triangles, line_segment = True)
-      if not np.all(np.isnan(intersects)):
-         intersects_indices = meet.intersects_indices(intersects)
-         tri = intersects_indices[0]
-         xyz = intersects[tri]
-         if len(intersects_indices) > 1:
-            best_manhattan = vec.manhattan_distance(line_p, xyz)
-            runner_up = None
-            for other_intersect_index_index in range(1, len(intersects_indices)):
-               other_tri = intersects_indices[other_intersect_index_index]
-               other_xyz = intersects[other_tri]
-               other_manhattan = vec.manhattan_distance(line_p, other_xyz)
-               if other_manhattan < best_manhattan:
-                  if return_second:
-                     tri_2 = tri
-                     xyz_2 = xyz
-                     runner_up = best_manhattan
-                  tri = other_tri
-                  xyz = other_xyz
-                  best_manhattan = other_manhattan
-               elif return_second and (runner_up is None or other_manhattan < runner_up):
-                  tri_2 = other_tri
-                  xyz_2 = other_xyz
-                  runner_up = other_manhattan
-         break
-      knot += 1
-   if knot == trajectory.knot_count - 1:
-      knot = None
+    xyz = None
+    tri = None
+    knot = start
+    xyz_2 = tri_2 = None
+    if start_xyz is None:
+        start_xyz = trajectory.control_points[knot]
+    if knot < trajectory.knot_count - 2 and vec.isclose(start_xyz, trajectory.control_points[knot + 1]):
+        knot += 1
+    if nudge is not None and nudge != 0.0:
+        remaining = trajectory.control_points[knot + 1] - start_xyz
+        if vec.naive_length(remaining) <= nudge:
+            start_xyz += 0.9 * remaining
+        else:
+            start_xyz += nudge * vec.unit_vector(remaining)
+    while knot < trajectory.knot_count - 1:
+        if start_xyz is None:
+            line_p = trajectory.control_points[knot]
+        else:
+            line_p = start_xyz
+        start_xyz = None
+        line_v = trajectory.control_points[knot + 1] - line_p
+        intersects = meet.line_triangles_intersects(line_p, line_v, triangles, line_segment = True)
+        if not np.all(np.isnan(intersects)):
+            intersects_indices = meet.intersects_indices(intersects)
+            tri = intersects_indices[0]
+            xyz = intersects[tri]
+            if len(intersects_indices) > 1:
+                best_manhattan = vec.manhattan_distance(line_p, xyz)
+                runner_up = None
+                for other_intersect_index_index in range(1, len(intersects_indices)):
+                    other_tri = intersects_indices[other_intersect_index_index]
+                    other_xyz = intersects[other_tri]
+                    other_manhattan = vec.manhattan_distance(line_p, other_xyz)
+                    if other_manhattan < best_manhattan:
+                        if return_second:
+                            tri_2 = tri
+                            xyz_2 = xyz
+                            runner_up = best_manhattan
+                        tri = other_tri
+                        xyz = other_xyz
+                        best_manhattan = other_manhattan
+                    elif return_second and (runner_up is None or other_manhattan < runner_up):
+                        tri_2 = other_tri
+                        xyz_2 = other_xyz
+                        runner_up = other_manhattan
+            break
+        knot += 1
+    if knot == trajectory.knot_count - 1:
+        knot = None
 
-   if return_second:
-      return xyz, knot, tri, xyz_2, knot, tri_2
-   return xyz, knot, tri
+    if return_second:
+        return xyz, knot, tri, xyz_2, knot, tri_2
+    return xyz, knot, tri
 
 
 def find_first_intersection_of_trajectory_with_layer_interface(trajectory,
@@ -760,7 +766,7 @@ def find_first_intersection_of_trajectory_with_layer_interface(trajectory,
                                                                start = 0,
                                                                heal_faults = False,
                                                                quad_triangles = True):
-   """Returns xyz and other info of the first intersection of well trajectory (or list of trajectories) with layer interface.
+    """Returns xyz and other info of the first intersection of well trajectory (or list of trajectories) with layer interface.
 
    arguments:
       trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersection for;
@@ -790,38 +796,38 @@ def find_first_intersection_of_trajectory_with_layer_interface(trajectory,
       in errors where there is significant curvature between neighbouring control points
    """
 
-   if isinstance(trajectory, list):
-      trajectory_list = trajectory
-   else:
-      trajectory_list = [trajectory]
+    if isinstance(trajectory, list):
+        trajectory_list = trajectory
+    else:
+        trajectory_list = [trajectory]
 
-   #   log.debug('generating surface for layer: ' + str(k0) + ' ' + ref_k_faces)
-   if grid.has_split_coordinate_lines and not heal_faults:
-      surface = generate_torn_surface_for_layer_interface(grid,
-                                                          k0 = k0,
-                                                          ref_k_faces = ref_k_faces,
-                                                          quad_triangles = quad_triangles)
-   else:
-      surface = generate_untorn_surface_for_layer_interface(grid,
+    #   log.debug('generating surface for layer: ' + str(k0) + ' ' + ref_k_faces)
+    if grid.has_split_coordinate_lines and not heal_faults:
+        surface = generate_torn_surface_for_layer_interface(grid,
                                                             k0 = k0,
                                                             ref_k_faces = ref_k_faces,
                                                             quad_triangles = quad_triangles)
+    else:
+        surface = generate_untorn_surface_for_layer_interface(grid,
+                                                              k0 = k0,
+                                                              ref_k_faces = ref_k_faces,
+                                                              quad_triangles = quad_triangles)
 
 
 #   log.debug('finding intersections of wellbore trajectory(ies) with layer: ' + str(k0) + ' ' + ref_k_faces)
-   results_list = []
-   segment_list = []
-   col_list = []
-   for traj in trajectory_list:
-      xyz, knot, tri = find_first_intersection_of_trajectory_with_surface(traj, surface, start = start)
-      col = surface.column_from_triangle_index(tri)  # j, i pair returned
-      results_list.append(xyz)
-      segment_list.append(knot)
-      col_list.append(col)
+    results_list = []
+    segment_list = []
+    col_list = []
+    for traj in trajectory_list:
+        xyz, knot, tri = find_first_intersection_of_trajectory_with_surface(traj, surface, start = start)
+        col = surface.column_from_triangle_index(tri)  # j, i pair returned
+        results_list.append(xyz)
+        segment_list.append(knot)
+        col_list.append(col)
 
-   if isinstance(trajectory, list):
-      return results_list, segment_list, col_list
-   return results_list[0], segment_list[0], col_list[0]
+    if isinstance(trajectory, list):
+        return results_list, segment_list, col_list
+    return results_list[0], segment_list[0], col_list[0]
 
 
 def find_first_intersection_of_trajectory_with_cell_surface(trajectory,
@@ -831,68 +837,68 @@ def find_first_intersection_of_trajectory_with_cell_surface(trajectory,
                                                             start_xyz = None,
                                                             nudge = 0.001,
                                                             quad_triangles = True):
-   """Searches along the trajectory from a starting point until the first intersection with the cell's surface is encountered."""
+    """Searches along the trajectory from a starting point until the first intersection with the cell's surface is encountered."""
 
-   cp = grid.corner_points(kji0)
-   cell_surface = rqs.Surface(grid.model)
-   cell_surface.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
-   t, p = cell_surface.triangles_and_points()
-   triangles = p[t]
-   knot = start_knot
-   xyz = None
-   axis = polarity = None
-   if start_xyz is not None:
-      start_xyz = np.array(start_xyz)
-   while knot < trajectory.knot_count - 1:
-      if knot == start_knot and start_xyz is not None:
-         if knot < trajectory.knot_count - 2 and vec.isclose(start_xyz, trajectory.control_points[knot + 1]):
-            knot += 1
-         if nudge is not None and nudge != 0.0:
-            remaining = trajectory.control_points[knot + 1] - start_xyz
-            if vec.naive_length(remaining) <= nudge:
-               start_xyz += 0.9 * remaining
-            else:
-               start_xyz += nudge * vec.unit_vector(remaining)
-         line_p = start_xyz
-      else:
-         line_p = trajectory.control_points[knot]
-      line_v = trajectory.control_points[knot + 1] - line_p
-      #      log.debug('kji0: ' + str(kji0) + '; knot: ' + str(knot) + '; line p: ' + str(line_p) + '; v: ' + str(line_v))
-      intersects = meet.line_triangles_intersects(line_p, line_v, triangles, line_segment = True)
-      if not np.all(np.isnan(intersects)):
-         # if more than one intersect, could find one closest to line_p; should not be needed when starting inside cell
-         tri = meet.intersects_indices(intersects)[0]
-         xyz = intersects[tri]
-         _, axis, polarity = cell_surface.cell_axis_and_polarity_from_triangle_index(tri)
-         log.debug('intersection xyz: ' + str(xyz) + '; tri: ' + str(tri) + '; axis: ' + str(axis) + '; polarity: ' +
-                   str(polarity))
-         break
-      knot += 1
+    cp = grid.corner_points(kji0)
+    cell_surface = rqs.Surface(grid.model)
+    cell_surface.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
+    t, p = cell_surface.triangles_and_points()
+    triangles = p[t]
+    knot = start_knot
+    xyz = None
+    axis = polarity = None
+    if start_xyz is not None:
+        start_xyz = np.array(start_xyz)
+    while knot < trajectory.knot_count - 1:
+        if knot == start_knot and start_xyz is not None:
+            if knot < trajectory.knot_count - 2 and vec.isclose(start_xyz, trajectory.control_points[knot + 1]):
+                knot += 1
+            if nudge is not None and nudge != 0.0:
+                remaining = trajectory.control_points[knot + 1] - start_xyz
+                if vec.naive_length(remaining) <= nudge:
+                    start_xyz += 0.9 * remaining
+                else:
+                    start_xyz += nudge * vec.unit_vector(remaining)
+            line_p = start_xyz
+        else:
+            line_p = trajectory.control_points[knot]
+        line_v = trajectory.control_points[knot + 1] - line_p
+        #      log.debug('kji0: ' + str(kji0) + '; knot: ' + str(knot) + '; line p: ' + str(line_p) + '; v: ' + str(line_v))
+        intersects = meet.line_triangles_intersects(line_p, line_v, triangles, line_segment = True)
+        if not np.all(np.isnan(intersects)):
+            # if more than one intersect, could find one closest to line_p; should not be needed when starting inside cell
+            tri = meet.intersects_indices(intersects)[0]
+            xyz = intersects[tri]
+            _, axis, polarity = cell_surface.cell_axis_and_polarity_from_triangle_index(tri)
+            log.debug('intersection xyz: ' + str(xyz) + '; tri: ' + str(tri) + '; axis: ' + str(axis) + '; polarity: ' +
+                      str(polarity))
+            break
+        knot += 1
 
-   if knot == trajectory.knot_count - 1:
-      knot = None
-   return xyz, knot, axis, polarity
+    if knot == trajectory.knot_count - 1:
+        knot = None
+    return xyz, knot, axis, polarity
 
 
 def point_is_within_cell(xyz, grid, kji0, cell_surface = None, false_on_pinchout = True):
-   """Returns True if point xyz is within cell kji0, but not on its surface."""
+    """Returns True if point xyz is within cell kji0, but not on its surface."""
 
-   if false_on_pinchout and grid.pinched_out(kji0, cache_pinchout_array = False):
-      return False
-   if cell_surface is None:
-      cp = grid.corner_points(kji0)
-      cell_surface = rqs.Surface(grid.model)
-      cell_surface.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = True)
-   t, p = cell_surface.triangles_and_points()
-   triangles = p[t]
-   centre = grid.centre_point(kji0)
-   line_v = centre - xyz
-   intersects = meet.line_triangles_intersects(xyz, line_v, triangles, line_segment = True)
-   return np.all(np.isnan(intersects))
+    if false_on_pinchout and grid.pinched_out(kji0, cache_pinchout_array = False):
+        return False
+    if cell_surface is None:
+        cp = grid.corner_points(kji0)
+        cell_surface = rqs.Surface(grid.model)
+        cell_surface.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = True)
+    t, p = cell_surface.triangles_and_points()
+    triangles = p[t]
+    centre = grid.centre_point(kji0)
+    line_v = centre - xyz
+    intersects = meet.line_triangles_intersects(xyz, line_v, triangles, line_segment = True)
+    return np.all(np.isnan(intersects))
 
 
 def create_column_face_mesh_and_surface(grid, col_ji0, axis, polarity, quad_triangles = True, as_single_layer = False):
-   """Creates a Mesh and corresponding Surface representing a column face.
+    """Creates a Mesh and corresponding Surface representing a column face.
 
    arguments:
       grid (grid.Grid object)
@@ -907,47 +913,47 @@ def create_column_face_mesh_and_surface(grid, col_ji0, axis, polarity, quad_tria
       surface.Mesh, surface.Surface (or None, surface.Surface if grid has k gaps)
    """
 
-   assert axis in (1, 2)
+    assert axis in (1, 2)
 
-   col_pm = grid.create_column_pillar_mapping()[col_ji0[0], col_ji0[1]]
-   if axis == 1:  # J face
-      pillar_index_pair = col_pm[polarity, :]
-   else:  # I face
-      pillar_index_pair = col_pm[:, polarity]
-   if grid.k_gaps:
-      points = grid.points_ref(masked = False).reshape(grid.nk_plus_k_gaps + 1, -1, 3)
-   else:
-      points = grid.points_ref(masked = False).reshape(grid.nk + 1, -1, 3)
-   # note, here col_face_xyz is indexed by (j or i, k, xyz) whereas elsewhere (k, j or i, xyz) would be more typical
-   # this protocol needs to align with re-use of Surface.column_for_triangle_index() method for layer identification
+    col_pm = grid.create_column_pillar_mapping()[col_ji0[0], col_ji0[1]]
+    if axis == 1:  # J face
+        pillar_index_pair = col_pm[polarity, :]
+    else:  # I face
+        pillar_index_pair = col_pm[:, polarity]
+    if grid.k_gaps:
+        points = grid.points_ref(masked = False).reshape(grid.nk_plus_k_gaps + 1, -1, 3)
+    else:
+        points = grid.points_ref(masked = False).reshape(grid.nk + 1, -1, 3)
+    # note, here col_face_xyz is indexed by (j or i, k, xyz) whereas elsewhere (k, j or i, xyz) would be more typical
+    # this protocol needs to align with re-use of Surface.column_for_triangle_index() method for layer identification
 
-   if not as_single_layer and grid.k_gaps:
-      col_face_mesh = None
-      col_face_surface = rqs.Surface(grid.model)
-      mesh = np.empty((1, grid.nk, 2, 2, 3))
-      mesh[0, :, 0, 0, :] = points[grid.k_raw_index_array, pillar_index_pair[0], :]
-      mesh[0, :, 1, 0, :] = points[grid.k_raw_index_array, pillar_index_pair[1], :]
-      mesh[0, :, 0, 1, :] = points[grid.k_raw_index_array + 1, pillar_index_pair[0], :]
-      mesh[0, :, 1, 1, :] = points[grid.k_raw_index_array + 1, pillar_index_pair[1], :]
-      col_face_surface.set_from_torn_mesh(mesh, quad_triangles = quad_triangles)
+    if not as_single_layer and grid.k_gaps:
+        col_face_mesh = None
+        col_face_surface = rqs.Surface(grid.model)
+        mesh = np.empty((1, grid.nk, 2, 2, 3))
+        mesh[0, :, 0, 0, :] = points[grid.k_raw_index_array, pillar_index_pair[0], :]
+        mesh[0, :, 1, 0, :] = points[grid.k_raw_index_array, pillar_index_pair[1], :]
+        mesh[0, :, 0, 1, :] = points[grid.k_raw_index_array + 1, pillar_index_pair[0], :]
+        mesh[0, :, 1, 1, :] = points[grid.k_raw_index_array + 1, pillar_index_pair[1], :]
+        col_face_surface.set_from_torn_mesh(mesh, quad_triangles = quad_triangles)
 
-   else:
-      if as_single_layer:
-         col_face_xyz = np.empty((2, 2, 3))
-         col_face_xyz[0, 0] = points[0, pillar_index_pair[0]]
-         col_face_xyz[0, 1] = points[-1, pillar_index_pair[0]]
-         col_face_xyz[1, 0] = points[0, pillar_index_pair[1]]
-         col_face_xyz[1, 1] = points[-1, pillar_index_pair[1]]
-      else:
-         col_face_xyz = np.empty((2, grid.nk + 1, 3))
-         col_face_xyz[0] = points[:, pillar_index_pair[0]]
-         col_face_xyz[1] = points[:, pillar_index_pair[1]]
-      col_face_mesh = rqs.Mesh(grid.model, xyz_values = col_face_xyz, crs_uuid = grid.crs_uuid)
-      title = 'column face for j0,i0: ' + str(col_ji0[0]) + ',' + str(
-         col_ji0[1]) + ' face ' + 'KJI'[axis] + '-+'[polarity]
-      col_face_surface = rqs.Surface(grid.model, mesh = col_face_mesh, quad_triangles = quad_triangles, title = title)
+    else:
+        if as_single_layer:
+            col_face_xyz = np.empty((2, 2, 3))
+            col_face_xyz[0, 0] = points[0, pillar_index_pair[0]]
+            col_face_xyz[0, 1] = points[-1, pillar_index_pair[0]]
+            col_face_xyz[1, 0] = points[0, pillar_index_pair[1]]
+            col_face_xyz[1, 1] = points[-1, pillar_index_pair[1]]
+        else:
+            col_face_xyz = np.empty((2, grid.nk + 1, 3))
+            col_face_xyz[0] = points[:, pillar_index_pair[0]]
+            col_face_xyz[1] = points[:, pillar_index_pair[1]]
+        col_face_mesh = rqs.Mesh(grid.model, xyz_values = col_face_xyz, crs_uuid = grid.crs_uuid)
+        title = 'column face for j0,i0: ' + str(col_ji0[0]) + ',' + str(
+            col_ji0[1]) + ' face ' + 'KJI'[axis] + '-+'[polarity]
+        col_face_surface = rqs.Surface(grid.model, mesh = col_face_mesh, quad_triangles = quad_triangles, title = title)
 
-   return col_face_mesh, col_face_surface
+    return col_face_mesh, col_face_surface
 
 
 def find_intersection_of_trajectory_interval_with_column_face(trajectory,
@@ -959,7 +965,7 @@ def find_intersection_of_trajectory_interval_with_column_face(trajectory,
                                                               start_xyz = None,
                                                               nudge = None,
                                                               quad_triangles = True):
-   """Searches for intersection of a single trajectory segment with an I or J column face.
+    """Searches for intersection of a single trajectory segment with an I or J column face.
 
    returns:
       xyz, k0
@@ -968,174 +974,174 @@ def find_intersection_of_trajectory_interval_with_column_face(trajectory,
       does not support k gaps
    """
 
-   # build a set of faces for the column face
-   # extract column face points into a shape ready to become a mesh
-   _, col_face_surface = create_column_face_mesh_and_surface(grid,
-                                                             col_ji0,
-                                                             axis,
-                                                             polarity,
-                                                             quad_triangles = quad_triangles)
-   t, p = col_face_surface.triangles_and_points()
-   triangles = p[t]
-   log.debug(f"intersecting trajectory segment with column face ji0 {col_ji0} face {'KJI'[axis]}{'-+'[polarity]}")
-   if start_xyz is not None:
-      if nudge is not None and nudge != 0.0:  # here we typically nudge back up the wellbore
-         start_xyz += nudge * vec.unit_vector(trajectory.control_points[start_knot + 1] - start_xyz)
-      line_p = start_xyz
-   else:
-      line_p = trajectory.control_points[start_knot]
-   line_v = trajectory.control_points[start_knot + 1] - line_p
-   intersects = meet.line_triangles_intersects(line_p, line_v, triangles, line_segment = True)
-   if np.all(np.isnan(intersects)):
-      return None, None
-   tri = meet.intersects_indices(intersects)[0]  # todo: if more than one, find one closest to line_p
-   xyz = intersects[tri]
-   _, k0 = col_face_surface.column_from_triangle_index(tri)  # 'column' in method name here maps to layers!
-   return xyz, k0
+    # build a set of faces for the column face
+    # extract column face points into a shape ready to become a mesh
+    _, col_face_surface = create_column_face_mesh_and_surface(grid,
+                                                              col_ji0,
+                                                              axis,
+                                                              polarity,
+                                                              quad_triangles = quad_triangles)
+    t, p = col_face_surface.triangles_and_points()
+    triangles = p[t]
+    log.debug(f"intersecting trajectory segment with column face ji0 {col_ji0} face {'KJI'[axis]}{'-+'[polarity]}")
+    if start_xyz is not None:
+        if nudge is not None and nudge != 0.0:  # here we typically nudge back up the wellbore
+            start_xyz += nudge * vec.unit_vector(trajectory.control_points[start_knot + 1] - start_xyz)
+        line_p = start_xyz
+    else:
+        line_p = trajectory.control_points[start_knot]
+    line_v = trajectory.control_points[start_knot + 1] - line_p
+    intersects = meet.line_triangles_intersects(line_p, line_v, triangles, line_segment = True)
+    if np.all(np.isnan(intersects)):
+        return None, None
+    tri = meet.intersects_indices(intersects)[0]  # todo: if more than one, find one closest to line_p
+    xyz = intersects[tri]
+    _, k0 = col_face_surface.column_from_triangle_index(tri)  # 'column' in method name here maps to layers!
+    return xyz, k0
 
 
 def find_faces_to_represent_surface_staffa(grid, surface, name, progress_fn = None):
-   """Returns a grid connection set containing those cell faces which are deemed to represent the surface."""
+    """Returns a grid connection set containing those cell faces which are deemed to represent the surface."""
 
-   #   log.debug('computing cell centres')
-   centre_points = grid.centre_point()
-   #   log.debug('computing inter cell centre vectors and boxes')
-   if grid.nk > 1:
-      v = centre_points[:-1, :, :]
-      u = centre_points[1:, :, :]
-      k_vectors = u - v
-      combo = np.stack((v, u))
-      k_vector_boxes = np.empty((grid.nk - 1, grid.nj, grid.ni, 2, 3))
-      k_vector_boxes[:, :, :, 0, :] = np.amin(combo, axis = 0)
-      k_vector_boxes[:, :, :, 1, :] = np.amax(combo, axis = 0)
-      column_k_vector_boxes = np.empty((grid.nj, grid.ni, 2, 3))
-      column_k_vector_boxes[:, :, 0, :] = np.amin(k_vector_boxes[:, :, :, 0, :], axis = 0)
-      column_k_vector_boxes[:, :, 1, :] = np.amax(k_vector_boxes[:, :, :, 1, :], axis = 0)
-      k_faces = np.zeros((grid.nk - 1, grid.nj, grid.ni), dtype = bool)
-   else:
-      k_vectors = None
-      k_vector_boxes = None
-      column_k_vector_boxes = None
-      k_faces = None
-   if grid.nj > 1:
-      v = centre_points[:, :-1, :]
-      u = centre_points[:, 1:, :]
-      j_vectors = u - v
-      combo = np.stack((v, u))
-      j_vector_boxes = np.empty((grid.nk, grid.nj - 1, grid.ni, 2, 3))
-      j_vector_boxes[:, :, :, 0, :] = np.amin(combo, axis = 0)
-      j_vector_boxes[:, :, :, 1, :] = np.amax(combo, axis = 0)
-      column_j_vector_boxes = np.empty((grid.nj - 1, grid.ni, 2, 3))
-      column_j_vector_boxes[:, :, 0, :] = np.amin(j_vector_boxes[:, :, :, 0, :], axis = 0)
-      column_j_vector_boxes[:, :, 1, :] = np.amax(j_vector_boxes[:, :, :, 1, :], axis = 0)
-      j_faces = np.zeros((grid.nk, grid.nj - 1, grid.ni), dtype = bool)
-   else:
-      j_vectors = None
-      j_vector_boxes = None
-      column_j_vector_boxes = None
-      j_faces = None
-   if grid.ni > 1:
-      i_vectors = centre_points[:, :, 1:] - centre_points[:, :, :-1]
-      v = centre_points[:, :, :-1]
-      u = centre_points[:, :, 1:]
-      i_vectors = u - v
-      combo = np.stack((v, u))
-      i_vector_boxes = np.empty((grid.nk, grid.nj, grid.ni - 1, 2, 3))
-      i_vector_boxes[:, :, :, 0, :] = np.amin(combo, axis = 0)
-      i_vector_boxes[:, :, :, 1, :] = np.amax(combo, axis = 0)
-      column_i_vector_boxes = np.empty((grid.nj, grid.ni - 1, 2, 3))
-      column_i_vector_boxes[:, :, 0, :] = np.amin(i_vector_boxes[:, :, :, 0, :], axis = 0)
-      column_i_vector_boxes[:, :, 1, :] = np.amax(i_vector_boxes[:, :, :, 1, :], axis = 0)
-      i_faces = np.zeros((grid.nk, grid.nj, grid.ni - 1), dtype = bool)
-   else:
-      i_vectors = None
-      i_vector_boxes = None
-      column_i_vector_boxes = None
-      i_faces = None
+    #   log.debug('computing cell centres')
+    centre_points = grid.centre_point()
+    #   log.debug('computing inter cell centre vectors and boxes')
+    if grid.nk > 1:
+        v = centre_points[:-1, :, :]
+        u = centre_points[1:, :, :]
+        k_vectors = u - v
+        combo = np.stack((v, u))
+        k_vector_boxes = np.empty((grid.nk - 1, grid.nj, grid.ni, 2, 3))
+        k_vector_boxes[:, :, :, 0, :] = np.amin(combo, axis = 0)
+        k_vector_boxes[:, :, :, 1, :] = np.amax(combo, axis = 0)
+        column_k_vector_boxes = np.empty((grid.nj, grid.ni, 2, 3))
+        column_k_vector_boxes[:, :, 0, :] = np.amin(k_vector_boxes[:, :, :, 0, :], axis = 0)
+        column_k_vector_boxes[:, :, 1, :] = np.amax(k_vector_boxes[:, :, :, 1, :], axis = 0)
+        k_faces = np.zeros((grid.nk - 1, grid.nj, grid.ni), dtype = bool)
+    else:
+        k_vectors = None
+        k_vector_boxes = None
+        column_k_vector_boxes = None
+        k_faces = None
+    if grid.nj > 1:
+        v = centre_points[:, :-1, :]
+        u = centre_points[:, 1:, :]
+        j_vectors = u - v
+        combo = np.stack((v, u))
+        j_vector_boxes = np.empty((grid.nk, grid.nj - 1, grid.ni, 2, 3))
+        j_vector_boxes[:, :, :, 0, :] = np.amin(combo, axis = 0)
+        j_vector_boxes[:, :, :, 1, :] = np.amax(combo, axis = 0)
+        column_j_vector_boxes = np.empty((grid.nj - 1, grid.ni, 2, 3))
+        column_j_vector_boxes[:, :, 0, :] = np.amin(j_vector_boxes[:, :, :, 0, :], axis = 0)
+        column_j_vector_boxes[:, :, 1, :] = np.amax(j_vector_boxes[:, :, :, 1, :], axis = 0)
+        j_faces = np.zeros((grid.nk, grid.nj - 1, grid.ni), dtype = bool)
+    else:
+        j_vectors = None
+        j_vector_boxes = None
+        column_j_vector_boxes = None
+        j_faces = None
+    if grid.ni > 1:
+        i_vectors = centre_points[:, :, 1:] - centre_points[:, :, :-1]
+        v = centre_points[:, :, :-1]
+        u = centre_points[:, :, 1:]
+        i_vectors = u - v
+        combo = np.stack((v, u))
+        i_vector_boxes = np.empty((grid.nk, grid.nj, grid.ni - 1, 2, 3))
+        i_vector_boxes[:, :, :, 0, :] = np.amin(combo, axis = 0)
+        i_vector_boxes[:, :, :, 1, :] = np.amax(combo, axis = 0)
+        column_i_vector_boxes = np.empty((grid.nj, grid.ni - 1, 2, 3))
+        column_i_vector_boxes[:, :, 0, :] = np.amin(i_vector_boxes[:, :, :, 0, :], axis = 0)
+        column_i_vector_boxes[:, :, 1, :] = np.amax(i_vector_boxes[:, :, :, 1, :], axis = 0)
+        i_faces = np.zeros((grid.nk, grid.nj, grid.ni - 1), dtype = bool)
+    else:
+        i_vectors = None
+        i_vector_boxes = None
+        column_i_vector_boxes = None
+        i_faces = None
 
 #   log.debug('finding surface triangle boxes')
-   t, p = surface.triangles_and_points()
-   triangles = p[t]
-   assert triangles.size > 0, 'no triangles in surface'
-   triangle_boxes = np.empty((triangles.shape[0], 2, 3))
-   triangle_boxes[:, 0, :] = np.amin(triangles, axis = 1)
-   triangle_boxes[:, 1, :] = np.amax(triangles, axis = 1)
+    t, p = surface.triangles_and_points()
+    triangles = p[t]
+    assert triangles.size > 0, 'no triangles in surface'
+    triangle_boxes = np.empty((triangles.shape[0], 2, 3))
+    triangle_boxes[:, 0, :] = np.amin(triangles, axis = 1)
+    triangle_boxes[:, 1, :] = np.amax(triangles, axis = 1)
 
-   grid_box = grid.xyz_box(lazy = False)
+    grid_box = grid.xyz_box(lazy = False)
 
-   #   log.debug('looking for cell faces for each triangle')
-   batch_size = 1000
-   triangle_count = triangles.shape[0]
-   progress_batch = min(1.0, float(batch_size) / float(triangle_count))
-   progress_base = 0.0
-   ti_base = 0
-   if progress_fn is not None:
-      progress_fn(0.0)
-   while ti_base < triangle_count:
-      ti_end = min(ti_base + batch_size, triangle_count)
-      batch_box = np.empty((2, 3))
-      batch_box[0, :] = np.amin(triangle_boxes[ti_base:ti_end, 0, :], axis = 0)
-      batch_box[1, :] = np.amax(triangle_boxes[ti_base:ti_end, 1, :], axis = 0)
-      if bx.boxes_overlap(grid_box, batch_box):
-         for j in range(grid.nj):
-            if progress_fn is not None:
-               progress_fn(progress_base + progress_batch * (float(j) / float(grid.nj)))
-            for i in range(grid.ni):
-               if column_k_vector_boxes is not None and bx.boxes_overlap(batch_box, column_k_vector_boxes[j, i]):
-                  full_intersects = meet.line_set_triangles_intersects(centre_points[:-1, j, i],
-                                                                       k_vectors[:, j, i],
-                                                                       triangles[ti_base:ti_end],
-                                                                       line_segment = True)
-                  distilled_intersects, _, _ = meet.distilled_intersects(full_intersects)
-                  k_faces[distilled_intersects, j, i] = True
-               if j < grid.nj - 1 and column_j_vector_boxes is not None and bx.boxes_overlap(
-                     batch_box, column_j_vector_boxes[j, i]):
-                  full_intersects = meet.line_set_triangles_intersects(centre_points[:, j, i],
-                                                                       j_vectors[:, j, i],
-                                                                       triangles[ti_base:ti_end],
-                                                                       line_segment = True)
-                  distilled_intersects, _, _ = meet.distilled_intersects(full_intersects)
-                  j_faces[distilled_intersects, j, i] = True
-               if i < grid.ni - 1 and column_i_vector_boxes is not None and bx.boxes_overlap(
-                     batch_box, column_i_vector_boxes[j, i]):
-                  full_intersects = meet.line_set_triangles_intersects(centre_points[:, j, i],
-                                                                       i_vectors[:, j, i],
-                                                                       triangles[ti_base:ti_end],
-                                                                       line_segment = True)
-                  distilled_intersects, _, _ = meet.distilled_intersects(full_intersects)
-                  i_faces[distilled_intersects, j, i] = True
-      ti_base = ti_end
-      #      log.debug('triangles processed: ' + str(ti_base))
-      #      log.debug('interim face counts: K: ' + str(np.count_nonzero(k_faces)) +
-      #                                   '; J: ' + str(np.count_nonzero(j_faces)) +
-      #                                   '; I: ' + str(np.count_nonzero(i_faces)))
-      progress_base = min(1.0, progress_base + progress_batch)
+    #   log.debug('looking for cell faces for each triangle')
+    batch_size = 1000
+    triangle_count = triangles.shape[0]
+    progress_batch = min(1.0, float(batch_size) / float(triangle_count))
+    progress_base = 0.0
+    ti_base = 0
+    if progress_fn is not None:
+        progress_fn(0.0)
+    while ti_base < triangle_count:
+        ti_end = min(ti_base + batch_size, triangle_count)
+        batch_box = np.empty((2, 3))
+        batch_box[0, :] = np.amin(triangle_boxes[ti_base:ti_end, 0, :], axis = 0)
+        batch_box[1, :] = np.amax(triangle_boxes[ti_base:ti_end, 1, :], axis = 0)
+        if bx.boxes_overlap(grid_box, batch_box):
+            for j in range(grid.nj):
+                if progress_fn is not None:
+                    progress_fn(progress_base + progress_batch * (float(j) / float(grid.nj)))
+                for i in range(grid.ni):
+                    if column_k_vector_boxes is not None and bx.boxes_overlap(batch_box, column_k_vector_boxes[j, i]):
+                        full_intersects = meet.line_set_triangles_intersects(centre_points[:-1, j, i],
+                                                                             k_vectors[:, j, i],
+                                                                             triangles[ti_base:ti_end],
+                                                                             line_segment = True)
+                        distilled_intersects, _, _ = meet.distilled_intersects(full_intersects)
+                        k_faces[distilled_intersects, j, i] = True
+                    if j < grid.nj - 1 and column_j_vector_boxes is not None and bx.boxes_overlap(
+                            batch_box, column_j_vector_boxes[j, i]):
+                        full_intersects = meet.line_set_triangles_intersects(centre_points[:, j, i],
+                                                                             j_vectors[:, j, i],
+                                                                             triangles[ti_base:ti_end],
+                                                                             line_segment = True)
+                        distilled_intersects, _, _ = meet.distilled_intersects(full_intersects)
+                        j_faces[distilled_intersects, j, i] = True
+                    if i < grid.ni - 1 and column_i_vector_boxes is not None and bx.boxes_overlap(
+                            batch_box, column_i_vector_boxes[j, i]):
+                        full_intersects = meet.line_set_triangles_intersects(centre_points[:, j, i],
+                                                                             i_vectors[:, j, i],
+                                                                             triangles[ti_base:ti_end],
+                                                                             line_segment = True)
+                        distilled_intersects, _, _ = meet.distilled_intersects(full_intersects)
+                        i_faces[distilled_intersects, j, i] = True
+        ti_base = ti_end
+        #      log.debug('triangles processed: ' + str(ti_base))
+        #      log.debug('interim face counts: K: ' + str(np.count_nonzero(k_faces)) +
+        #                                   '; J: ' + str(np.count_nonzero(j_faces)) +
+        #                                   '; I: ' + str(np.count_nonzero(i_faces)))
+        progress_base = min(1.0, progress_base + progress_batch)
 
 
 #   log.debug('face counts: K: ' + str(np.count_nonzero(k_faces)) +
 #                        '; J: ' + str(np.count_nonzero(j_faces)) +
 #                        '; I: ' + str(np.count_nonzero(i_faces)))
-   if progress_fn is not None:
-      progress_fn(1.0)
+    if progress_fn is not None:
+        progress_fn(1.0)
 
-   gcs = rqf.GridConnectionSet(grid.model,
-                               grid = grid,
-                               k_faces = k_faces,
-                               j_faces = j_faces,
-                               i_faces = i_faces,
-                               feature_name = name,
-                               create_organizing_objects_where_needed = True)
-   return gcs
+    gcs = rqf.GridConnectionSet(grid.model,
+                                grid = grid,
+                                k_faces = k_faces,
+                                j_faces = j_faces,
+                                i_faces = i_faces,
+                                feature_name = name,
+                                create_organizing_objects_where_needed = True)
+    return gcs
 
 
 def find_faces_to_represent_surface(grid, surface, name, mode = 'staffa', progress_fn = None):
-   """Returns a grid connection set containing those cell faces which are deemed to represent the surface."""
+    """Returns a grid connection set containing those cell faces which are deemed to represent the surface."""
 
-   log.debug('finding cell faces for surface')
-   if mode == 'staffa':
-      return find_faces_to_represent_surface_staffa(grid, surface, name, progress_fn = progress_fn)
-   log.critical('unrecognised mode: ' + str(mode))
-   return None
+    log.debug('finding cell faces for surface')
+    if mode == 'staffa':
+        return find_faces_to_represent_surface_staffa(grid, surface, name, progress_fn = progress_fn)
+    log.critical('unrecognised mode: ' + str(mode))
+    return None
 
 
 def generate_surface_for_blocked_well_cells(blocked_well,
@@ -1145,66 +1151,66 @@ def generate_surface_for_blocked_well_cells(blocked_well,
                                             max_k0 = None,
                                             depth_limit = None,
                                             quad_triangles = True):
-   """Returns a surface or list of surfaces representing the faces of the cells visited by the well."""
+    """Returns a surface or list of surfaces representing the faces of the cells visited by the well."""
 
-   assert blocked_well is not None and type(blocked_well) is rqw.BlockedWell
-   cells_kji0, grid_list = blocked_well.cell_indices_and_grid_list()
-   assert len(cells_kji0) == len(grid_list)
-   cell_count = len(cells_kji0)
-   if cell_count == 0:
-      return None
+    assert blocked_well is not None and type(blocked_well) is rqw.BlockedWell
+    cells_kji0, grid_list = blocked_well.cell_indices_and_grid_list()
+    assert len(cells_kji0) == len(grid_list)
+    cell_count = len(cells_kji0)
+    if cell_count == 0:
+        return None
 
-   surface_list = []
-   if combined:
-      composite_cp = np.zeros((cell_count, 2, 2, 2, 3))
+    surface_list = []
+    if combined:
+        composite_cp = np.zeros((cell_count, 2, 2, 2, 3))
 
-   cell_p = 0
-   for cell in range(cell_count):
-      grid = grid_list[cell]
-      cell_kji0 = cells_kji0[cell]
-      if active_only and grid.inactive is not None and grid.inactive[cell_kji0]:
-         continue
-      if cell_kji0[0] < min_k0 or (max_k0 is not None and cell_kji0[0] > max_k0):
-         continue
-      if depth_limit is not None and grid.centre_point(cell_kji0) > depth_limit:
-         continue
-      cp = grid.corner_points(cell_kji0)
-      if combined:
-         composite_cp[cell_p] = cp
-         cell_p += 1
-      else:
-         cs = rqs.Surface(blocked_well.model)
-         cs.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
-         surface_list.append(cs)
+    cell_p = 0
+    for cell in range(cell_count):
+        grid = grid_list[cell]
+        cell_kji0 = cells_kji0[cell]
+        if active_only and grid.inactive is not None and grid.inactive[cell_kji0]:
+            continue
+        if cell_kji0[0] < min_k0 or (max_k0 is not None and cell_kji0[0] > max_k0):
+            continue
+        if depth_limit is not None and grid.centre_point(cell_kji0) > depth_limit:
+            continue
+        cp = grid.corner_points(cell_kji0)
+        if combined:
+            composite_cp[cell_p] = cp
+            cell_p += 1
+        else:
+            cs = rqs.Surface(blocked_well.model)
+            cs.set_to_single_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
+            surface_list.append(cs)
 
-   if cell_p == 0 and len(surface_list) == 0:
-      return None
+    if cell_p == 0 and len(surface_list) == 0:
+        return None
 
-   if combined:
-      cs = rqs.Surface(blocked_well.model)
-      cs.set_to_multi_cell_faces_from_corner_points(composite_cp[:cell_p])
-      return cs
+    if combined:
+        cs = rqs.Surface(blocked_well.model)
+        cs.set_to_multi_cell_faces_from_corner_points(composite_cp[:cell_p])
+        return cs
 
-   return surface_list
+    return surface_list
 
 
 def trajectory_grid_overlap(trajectory, grid, lazy = False):
-   """Returns True if there is some overlap of the xyz boxes for the trajectory and grid, False otherwise.
+    """Returns True if there is some overlap of the xyz boxes for the trajectory and grid, False otherwise.
 
    notes:
       overlap of the xyz boxes does not guarantee that the trajectory intersects the grid;
       a return value of False guarantees that the trajectory does not intersect the grid
    """
 
-   traj_box = np.empty((2, 3))
-   traj_box[0] = np.amin(trajectory.control_points, axis = 0)
-   traj_box[1] = np.amax(trajectory.control_points, axis = 0)
-   grid_box = grid.xyz_box(lazy = lazy, local = True)
-   if not bu.matching_uuids(trajectory.crs_uuid, grid.crs_uuid):
-      t_crs = rqc.Crs(trajectory.model, uuid = trajectory.crs_uuid)
-      g_crs = rqc.Crs(grid.model, uuid = grid.crs_uuid)
-      t_crs.convert_array_to(g_crs, traj_box)
-   return bx.boxes_overlap(traj_box, grid_box)
+    traj_box = np.empty((2, 3))
+    traj_box[0] = np.amin(trajectory.control_points, axis = 0)
+    traj_box[1] = np.amax(trajectory.control_points, axis = 0)
+    grid_box = grid.xyz_box(lazy = lazy, local = True)
+    if not bu.matching_uuids(trajectory.crs_uuid, grid.crs_uuid):
+        t_crs = rqc.Crs(trajectory.model, uuid = trajectory.crs_uuid)
+        g_crs = rqc.Crs(grid.model, uuid = grid.crs_uuid)
+        t_crs.convert_array_to(g_crs, traj_box)
+    return bx.boxes_overlap(traj_box, grid_box)
 
 
 def populate_blocked_well_from_trajectory(blocked_well,
@@ -1214,7 +1220,7 @@ def populate_blocked_well_from_trajectory(blocked_well,
                                           lazy = False,
                                           use_single_layer_tactics = True,
                                           check_for_reentry = True):
-   """Populate an empty blocked well object based on the intersection of its trajectory with a grid.
+    """Populate an empty blocked well object based on the intersection of its trajectory with a grid.
 
    arguments:
       blocked_well (resqpy.well.BlockedWell object): a largely empty blocked well object to be populated by this
@@ -1248,361 +1254,327 @@ def populate_blocked_well_from_trajectory(blocked_well,
       being introduced as an artefact between the exit point of one cell and the entry point into the abutted cell
    """
 
-   def find_next_cell(grid,
-                      previous_kji0,
-                      axis,
-                      polarity,
-                      trajectory,
-                      segment,
-                      seg_fraction,
-                      xyz,
-                      treat_skin_as_fault = False,
-                      lazy = False,
-                      use_single_layer_tactics = True):
-      # returns for next cell entry: (shared transit point bool, kji0, axis, polarity, segment, seg_fraction, xyz)
-      # or single None if no next cell identified (end of trajectory beyond edge of grid)
-      # take care of: edges of model; pinchouts; faults, (k gaps), exact edge or corner crossings
-      # note: identified cell may be active or inactive: calling code to handle that
-      # note: for convenience, previous_kji0 may lie just outside the extent of the grid
-      # note: polarity is relative to previous cell, so its complement applies to the next cell
-      #      log.debug('finding next cell with previous kji0: ' + str(previous_kji0) + '; exit: ' + 'kji'[axis] + '-+'[polarity])
-      kji0 = np.array(previous_kji0, dtype = int)
-      polarity_sign = 2 * polarity - 1
-      kji0[axis] += polarity_sign
-      # if gone beyond external skin of model, return None
-      if np.any(kji0 < 0) or np.any(kji0 >= grid.extent_kji) or (grid.k_gaps and axis == 0 and (
-         (polarity == 1 and previous_kji0[0] >= 0 and grid.k_gap_after_array[previous_kji0[0]]) or
-         (polarity == 0 and kji0[0] < grid.nk - 1 and grid.k_gap_after_array[kji0[0]]))):
-         if check_for_reentry and not lazy:
+    def find_next_cell(grid,
+                       previous_kji0,
+                       axis,
+                       polarity,
+                       trajectory,
+                       segment,
+                       seg_fraction,
+                       xyz,
+                       treat_skin_as_fault = False,
+                       lazy = False,
+                       use_single_layer_tactics = True):
+        # returns for next cell entry: (shared transit point bool, kji0, axis, polarity, segment, seg_fraction, xyz)
+        # or single None if no next cell identified (end of trajectory beyond edge of grid)
+        # take care of: edges of model; pinchouts; faults, (k gaps), exact edge or corner crossings
+        # note: identified cell may be active or inactive: calling code to handle that
+        # note: for convenience, previous_kji0 may lie just outside the extent of the grid
+        # note: polarity is relative to previous cell, so its complement applies to the next cell
+        #      log.debug('finding next cell with previous kji0: ' + str(previous_kji0) + '; exit: ' + 'kji'[axis] + '-+'[polarity])
+        kji0 = np.array(previous_kji0, dtype = int)
+        polarity_sign = 2 * polarity - 1
+        kji0[axis] += polarity_sign
+        # if gone beyond external skin of model, return None
+        if np.any(kji0 < 0) or np.any(kji0 >= grid.extent_kji) or (grid.k_gaps and axis == 0 and (
+            (polarity == 1 and previous_kji0[0] >= 0 and grid.k_gap_after_array[previous_kji0[0]]) or
+            (polarity == 0 and kji0[0] < grid.nk - 1 and grid.k_gap_after_array[kji0[0]]))):
+            if check_for_reentry and not lazy:
+                skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
+                # nudge in following will be problematic if gap has zero (or tiny) thickness at this location
+                xyz_r, cell_kji0, axis, polarity, segment = skin.find_first_intersection_of_trajectory(trajectory,
+                                                                                                       start = segment,
+                                                                                                       start_xyz = xyz,
+                                                                                                       nudge = +0.05)
+                if xyz_r is None:
+                    log.debug('no skin re-entry found after exit through skin')
+                    return None
+                log.debug(f"skin re-entry after skin exit: kji0: {cell_kji0}; face: {'KJI'[axis]}{'-+'[polarity]}")
+                seg_fraction = segment_fraction(trajectory.control_points, segment, xyz_r)
+                return (False, cell_kji0, axis, polarity, segment, seg_fraction, xyz_r)
+            else:
+                return None
+        # pre-assess split pillar (fault) situation
+        faulted = False
+        if grid.has_split_coordinate_lines and axis != 0:
+            faulted = grid.is_split_column_face(kji0[1], kji0[2], axis, 1 - polarity)
+        if not faulted and treat_skin_as_fault and axis != 0:
+            faulted = (kji0[axis] == 0 and polarity == 1) or (kji0[axis] == grid.extent_kji[axis] - 1 and polarity == 0)
+        # handle the simplest case of a well behaved k neighbour or unsplit j or i neighbour
+        if not grid.pinched_out(cell_kji0 = kji0, cache_pinchout_array = True) and not faulted:
+            return (True, kji0, axis, 1 - polarity, segment, seg_fraction, xyz)
+        if faulted:
+            # look for intersections with column face
+            xyz_f, k0 = find_intersection_of_trajectory_interval_with_column_face(trajectory,
+                                                                                  grid,
+                                                                                  segment,
+                                                                                  kji0[1:],
+                                                                                  axis,
+                                                                                  1 - polarity,
+                                                                                  start_xyz = xyz,
+                                                                                  nudge = -0.1,
+                                                                                  quad_triangles = True)
+            if xyz_f is not None and k0 is not None:
+                kji0[0] = k0
+                seg_fraction = segment_fraction(trajectory.control_points, segment, xyz_f)
+                return (vec.isclose(xyz, xyz_f,
+                                    tolerance = 0.001), kji0, axis, 1 - polarity, segment, seg_fraction, xyz_f)
+            log.debug('failed to find entry point in column face after crossing fault; checking entire cross section')
+            x_sect_surf = generate_torn_surface_for_x_section(grid,
+                                                              'KJI'[axis],
+                                                              ref_slice0 = kji0[axis],
+                                                              plus_face = (polarity == 0),
+                                                              quad_triangles = True,
+                                                              as_single_layer = False)
+            xyz_f, segment_f, tri_index_f = find_first_intersection_of_trajectory_with_surface(trajectory,
+                                                                                               x_sect_surf,
+                                                                                               start = segment,
+                                                                                               start_xyz = xyz,
+                                                                                               nudge = -0.1)
+            if xyz_f is not None:
+                # back out cell info from triangle index; note 'column_from...' is actually x_section cell face
+                k0, j_or_i0 = x_sect_surf.column_from_triangle_index(tri_index_f)
+                kji0[0] = k0
+                kji0[3 - axis] = j_or_i0
+                seg_fraction = segment_fraction(trajectory.control_points, segment_f, xyz_f)
+                return (vec.isclose(xyz, xyz_f,
+                                    tolerance = 0.001), kji0, axis, 1 - polarity, segment_f, seg_fraction, xyz_f)
+            log.debug(
+                f"failed to find entry point in cross section after crossing fault{'' if lazy else '; checking for skin re-entry'}"
+            )
+            if lazy:
+                return None
             skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
-            # nudge in following will be problematic if gap has zero (or tiny) thickness at this location
-            xyz_r, cell_kji0, axis, polarity, segment = skin.find_first_intersection_of_trajectory(trajectory,
-                                                                                                   start = segment,
-                                                                                                   start_xyz = xyz,
-                                                                                                   nudge = +0.05)
+            # following is problematic due to skewed fault planes
+            xyz_r, cell_kji0, axis, polarity, segment = skin.find_first_intersection_of_trajectory(
+                trajectory, start = segment, start_xyz = xyz, nudge = -0.1, exclude_kji0 = previous_kji0)
             if xyz_r is None:
-               log.debug('no skin re-entry found after exit through skin')
-               return None
-            log.debug(f"skin re-entry after skin exit: kji0: {cell_kji0}; face: {'KJI'[axis]}{'-+'[polarity]}")
+                log.warning('no skin re-entry found after exit through fault face')
+                return None
+            log.debug(f"skin re-entry after fault face exit: kji0: {cell_kji0}; face: {'KJI'[axis]}{'-+'[polarity]}")
             seg_fraction = segment_fraction(trajectory.control_points, segment, xyz_r)
             return (False, cell_kji0, axis, polarity, segment, seg_fraction, xyz_r)
-         else:
+        else:
+            # skip pinched out cells
+            pinchout_skip_sign = -1 if axis == 0 and polarity == 0 else 1
+            while True:
+                if not grid.pinched_out(cell_kji0 = kji0, cache_pinchout_array = True):
+                    break
+                kji0[0] += pinchout_skip_sign
+                if not (np.all(kji0 >= 0) and np.all(kji0 < grid.extent_kji)) or (grid.k_gaps and axis == 0 and (
+                    (polarity == 0 and grid.k_gap_after_array[kji0[0]]) or
+                    (polarity == 1 and grid.k_gap_after_array[kji0[0] - 1]))):
+                    log.debug(
+                        f"trajectory reached edge of model {'or k gap ' if grid.k_gaps and axis == 0 else ''}at exit from cell kji0: {previous_kji0}"
+                    )
+                    if lazy:
+                        return None
+                    skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
+                    # nudge in following will be problematic if gap has zero (or tiny) thickness at this location
+                    xyz_r, cell_kji0, axis, polarity, segment = skin.find_first_intersection_of_trajectory(
+                        trajectory, start = segment, start_xyz = xyz, nudge = +0.01)
+                    if xyz_r is None:
+                        return None  # no re-entry found after exit through skin
+                    seg_fraction = segment_fraction(trajectory.control_points, segment, xyz_r)
+                    return (False, cell_kji0, axis, polarity, segment, seg_fraction, xyz_r)
+            return (True, kji0, axis, 1 - polarity, segment, seg_fraction, xyz)
+
+    def segment_fraction(trajectory_xyz, segment, xyz):
+        # returns fraction of way along segment that point xyz lies
+        segment_vector = trajectory_xyz[segment + 1] - trajectory_xyz[segment]
+        segment_length = vec.naive_length(
+            segment_vector)  # note this is length in straight line, rather than diff in mds
+        return vec.naive_length(xyz - trajectory_xyz[segment]) / segment_length
+
+    def back_calculated_md(trajectory, segment, fraction):
+        base_md = trajectory.measured_depths[segment]
+        return base_md + fraction * (trajectory.measured_depths[segment + 1] - base_md)
+
+    assert isinstance(blocked_well, rqw.BlockedWell)
+    assert isinstance(blocked_well.trajectory, rqw.Trajectory)
+    assert grid is not None
+
+    log.debug(f'blocking well {rqw.well_name(blocked_well)} from trajectory and grid')
+
+    if grid.k_gaps:
+        use_single_layer_tactics = False
+        log.debug('skin single layer tactics disabled')
+
+    grid_crs = rqc.Crs(grid.model, uuid = grid.crs_uuid)
+    if bu.matching_uuids(rqet.uuid_for_part_root(blocked_well.trajectory.crs_root), grid.crs_uuid):
+        trajectory = blocked_well.trajectory
+    else:
+        # create a temporary orphanage model (in memory only) to host a copy of the trajectory for crs alignment
+        # NB. temporary objects, relationships left in a mess
+        model = rq.Model(create_basics = True)
+        trajectory = rqw.Trajectory(model,
+                                    blocked_well.trajectory.root_node,
+                                    hdf5_source_model = blocked_well.trajectory.model)
+        assert trajectory is not None
+        traj_crs = rqc.Crs(blocked_well.model, uuid = rqet.uuid_for_part_root(blocked_well.trajectory.crs_root))
+        traj_crs.convert_array_to(grid_crs, trajectory.control_points)  # trajectory xyz converted in situ to grid's crs
+        trajectory.crs_root = model.duplicate_node(grid.crs_root)
+        # note: any represented interpretation object will not be present in the temporary model
+    traj_xyz = trajectory.control_points
+
+    if not trajectory_grid_overlap(trajectory, grid):
+        log.error('no overlap of trajectory with grid for trajectory uuid: ' + str(trajectory.uuid))
+        return None
+    grid_box = grid.xyz_box(lazy = False)
+    if grid_crs.z_inc_down:
+        z_sign = 1.0
+        grid_top_z = grid_box[0, 2]
+    else:
+        z_sign = -1.0
+        grid_top_z = -grid_box[1, 2]  # maximum is least negative, ie. shallowest
+
+    assert z_sign * traj_xyz[0, 2] < grid_top_z, 'trajectory does not start above top of grid'  # min z
+    if z_sign * traj_xyz[-1, 2] < grid_top_z:
+        log.warning('end of trajectory (TD) is above top of grid')
+
+    # scan down wellbore till top of grid reached
+    knot = 0
+    while knot < trajectory.knot_count - 1 and z_sign * traj_xyz[knot + 1, 2] < grid_top_z:
+        knot += 1
+    log.debug('skipped trajectory to knot: ' + str(knot))
+    if knot == trajectory.knot_count - 1:
+        return None  # entire well is above grid
+
+    if lazy:
+
+        skin = None
+        # search for intersection with top of grid: will fail if well comes in from the side (or from below!) or penetrates through fault
+        xyz, entry_knot, col_ji0 = find_first_intersection_of_trajectory_with_layer_interface(
+            trajectory,
+            grid,
+            k0 = 0,
+            ref_k_faces = 'top',
+            start = knot,
+            heal_faults = False,
+            quad_triangles = quad_triangles)
+        log.debug('top intersection x,y,z: ' + str(xyz) + '; knot: ' + str(entry_knot) + '; col j0,i0: ' +
+                  str(col_ji0[0]) + ', ' + str(col_ji0[1]))
+        if xyz is None:
+            log.error('failed to find intersection of trajectory with top surface of grid')
             return None
-      # pre-assess split pillar (fault) situation
-      faulted = False
-      if grid.has_split_coordinate_lines and axis != 0:
-         faulted = grid.is_split_column_face(kji0[1], kji0[2], axis, 1 - polarity)
-      if not faulted and treat_skin_as_fault and axis != 0:
-         faulted = (kji0[axis] == 0 and polarity == 1) or (kji0[axis] == grid.extent_kji[axis] - 1 and polarity == 0)
-      # handle the simplest case of a well behaved k neighbour or unsplit j or i neighbour
-      if not grid.pinched_out(cell_kji0 = kji0, cache_pinchout_array = True) and not faulted:
-         return (True, kji0, axis, 1 - polarity, segment, seg_fraction, xyz)
-      if faulted:
-         # look for intersections with column face
-         xyz_f, k0 = find_intersection_of_trajectory_interval_with_column_face(trajectory,
-                                                                               grid,
-                                                                               segment,
-                                                                               kji0[1:],
-                                                                               axis,
-                                                                               1 - polarity,
-                                                                               start_xyz = xyz,
-                                                                               nudge = -0.1,
-                                                                               quad_triangles = True)
-         if xyz_f is not None and k0 is not None:
-            kji0[0] = k0
-            seg_fraction = segment_fraction(trajectory.control_points, segment, xyz_f)
-            return (vec.isclose(xyz, xyz_f, tolerance = 0.001), kji0, axis, 1 - polarity, segment, seg_fraction, xyz_f)
-         log.debug('failed to find entry point in column face after crossing fault; checking entire cross section')
-         x_sect_surf = generate_torn_surface_for_x_section(grid,
-                                                           'KJI'[axis],
-                                                           ref_slice0 = kji0[axis],
-                                                           plus_face = (polarity == 0),
-                                                           quad_triangles = True,
-                                                           as_single_layer = False)
-         xyz_f, segment_f, tri_index_f = find_first_intersection_of_trajectory_with_surface(trajectory,
-                                                                                            x_sect_surf,
-                                                                                            start = segment,
-                                                                                            start_xyz = xyz,
-                                                                                            nudge = -0.1)
-         if xyz_f is not None:
-            # back out cell info from triangle index; note 'column_from...' is actually x_section cell face
-            k0, j_or_i0 = x_sect_surf.column_from_triangle_index(tri_index_f)
-            kji0[0] = k0
-            kji0[3 - axis] = j_or_i0
-            seg_fraction = segment_fraction(trajectory.control_points, segment_f, xyz_f)
-            return (vec.isclose(xyz, xyz_f,
-                                tolerance = 0.001), kji0, axis, 1 - polarity, segment_f, seg_fraction, xyz_f)
-         log.debug(
-            f"failed to find entry point in cross section after crossing fault{'' if lazy else '; checking for skin re-entry'}"
-         )
-         if lazy:
+        cell_kji0 = np.array((0, col_ji0[0], col_ji0[1]), dtype = int)
+        axis = 0
+        polarity = 0
+
+    else:  # not lazy
+
+        # note: xyz and entry_fraction might be slightly off when penetrating a skewed fault plane – deemed immaterial for real cases
+        skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
+        xyz, cell_kji0, axis, polarity, entry_knot = skin.find_first_intersection_of_trajectory(trajectory)
+        if xyz is None:
+            log.error('failed to find intersection of trajectory with outer skin of grid')
             return None
-         skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
-         # following is problematic due to skewed fault planes
-         xyz_r, cell_kji0, axis, polarity, segment = skin.find_first_intersection_of_trajectory(
-            trajectory, start = segment, start_xyz = xyz, nudge = -0.1, exclude_kji0 = previous_kji0)
-         if xyz_r is None:
-            log.warning('no skin re-entry found after exit through fault face')
-            return None
-         log.debug(f"skin re-entry after fault face exit: kji0: {cell_kji0}; face: {'KJI'[axis]}{'-+'[polarity]}")
-         seg_fraction = segment_fraction(trajectory.control_points, segment, xyz_r)
-         return (False, cell_kji0, axis, polarity, segment, seg_fraction, xyz_r)
-      else:
-         # skip pinched out cells
-         pinchout_skip_sign = -1 if axis == 0 and polarity == 0 else 1
-         while True:
-            if not grid.pinched_out(cell_kji0 = kji0, cache_pinchout_array = True):
-               break
-            kji0[0] += pinchout_skip_sign
-            if not (np.all(kji0 >= 0) and np.all(kji0 < grid.extent_kji)) or (grid.k_gaps and axis == 0 and (
-               (polarity == 0 and grid.k_gap_after_array[kji0[0]]) or
-               (polarity == 1 and grid.k_gap_after_array[kji0[0] - 1]))):
-               log.debug(
-                  f"trajectory reached edge of model {'or k gap ' if grid.k_gaps and axis == 0 else ''}at exit from cell kji0: {previous_kji0}"
-               )
-               if lazy:
-                  return None
-               skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
-               # nudge in following will be problematic if gap has zero (or tiny) thickness at this location
-               xyz_r, cell_kji0, axis, polarity, segment = skin.find_first_intersection_of_trajectory(trajectory,
-                                                                                                      start = segment,
-                                                                                                      start_xyz = xyz,
-                                                                                                      nudge = +0.01)
-               if xyz_r is None:
-                  return None  # no re-entry found after exit through skin
-               seg_fraction = segment_fraction(trajectory.control_points, segment, xyz_r)
-               return (False, cell_kji0, axis, polarity, segment, seg_fraction, xyz_r)
-         return (True, kji0, axis, 1 - polarity, segment, seg_fraction, xyz)
+        else:
+            log.debug('skin intersection x,y,z: ' + str(xyz) + '; knot: ' + str(entry_knot) + '; cell kji0: ' +
+                      str(cell_kji0) + '; face: ' + 'KJI'[axis] + '-+'[polarity])
+            cell_kji0 = np.array(cell_kji0, dtype = int)
 
-   def segment_fraction(trajectory_xyz, segment, xyz):
-      # returns fraction of way along segment that point xyz lies
-      segment_vector = trajectory_xyz[segment + 1] - trajectory_xyz[segment]
-      segment_length = vec.naive_length(segment_vector)  # note this is length in straight line, rather than diff in mds
-      return vec.naive_length(xyz - trajectory_xyz[segment]) / segment_length
+    previous_kji0 = cell_kji0.copy()
+    shift = polarity * 2 - 1
+    previous_kji0[axis] += shift  # note: previous may legitimately be 'beyond' edge of grid
+    entry_fraction = segment_fraction(traj_xyz, entry_knot, xyz)
+    log.debug(f'initial previous kji0: {previous_kji0}')
+    next_cell_info = find_next_cell(grid,
+                                    previous_kji0,
+                                    axis,
+                                    1 - polarity,
+                                    trajectory,
+                                    entry_knot,
+                                    entry_fraction,
+                                    xyz,
+                                    treat_skin_as_fault = use_single_layer_tactics,
+                                    lazy = lazy,
+                                    use_single_layer_tactics = use_single_layer_tactics)
+    log.debug(f'initial next cell info: {next_cell_info}')
+    node_mds_list = [back_calculated_md(trajectory, entry_knot, entry_fraction)]
+    node_count = 1
+    grid_indices_list = []
+    cell_count = 0
+    cell_indices_list = []
+    face_pairs_list = []
+    kissed = np.zeros(grid.extent_kji, dtype = bool)
+    sample_test = np.zeros(grid.extent_kji, dtype = bool)
 
-   def back_calculated_md(trajectory, segment, fraction):
-      base_md = trajectory.measured_depths[segment]
-      return base_md + fraction * (trajectory.measured_depths[segment + 1] - base_md)
+    while next_cell_info is not None:
 
-   assert isinstance(blocked_well, rqw.BlockedWell)
-   assert isinstance(blocked_well.trajectory, rqw.Trajectory)
-   assert grid is not None
+        (entry_shared, kji0, entry_axis, entry_polarity, entry_knot, entry_fraction, entry_xyz) = next_cell_info
 
-   log.debug(f'blocking well {rqw.well_name(blocked_well)} from trajectory and grid')
+        log.debug('next cell entry x,y,z: ' + str(entry_xyz) + '; knot: ' + str(entry_knot) + '; cell kji0: ' +
+                  str(kji0) + '; face: ' + 'KJI'[entry_axis] + '-+'[entry_polarity])
 
-   if grid.k_gaps:
-      use_single_layer_tactics = False
-      log.debug('skin single layer tactics disabled')
-
-   grid_crs = rqc.Crs(grid.model, uuid = grid.crs_uuid)
-   if bu.matching_uuids(rqet.uuid_for_part_root(blocked_well.trajectory.crs_root), grid.crs_uuid):
-      trajectory = blocked_well.trajectory
-   else:
-      # create a temporary orphanage model (in memory only) to host a copy of the trajectory for crs alignment
-      # NB. temporary objects, relationships left in a mess
-      model = rq.Model(create_basics = True)
-      trajectory = rqw.Trajectory(model,
-                                  blocked_well.trajectory.root_node,
-                                  hdf5_source_model = blocked_well.trajectory.model)
-      assert trajectory is not None
-      traj_crs = rqc.Crs(blocked_well.model, uuid = rqet.uuid_for_part_root(blocked_well.trajectory.crs_root))
-      traj_crs.convert_array_to(grid_crs, trajectory.control_points)  # trajectory xyz converted in situ to grid's crs
-      trajectory.crs_root = model.duplicate_node(grid.crs_root)
-      # note: any represented interpretation object will not be present in the temporary model
-   traj_xyz = trajectory.control_points
-
-   if not trajectory_grid_overlap(trajectory, grid):
-      log.error('no overlap of trajectory with grid for trajectory uuid: ' + str(trajectory.uuid))
-      return None
-   grid_box = grid.xyz_box(lazy = False)
-   if grid_crs.z_inc_down:
-      z_sign = 1.0
-      grid_top_z = grid_box[0, 2]
-   else:
-      z_sign = -1.0
-      grid_top_z = -grid_box[1, 2]  # maximum is least negative, ie. shallowest
-
-   assert z_sign * traj_xyz[0, 2] < grid_top_z, 'trajectory does not start above top of grid'  # min z
-   if z_sign * traj_xyz[-1, 2] < grid_top_z:
-      log.warning('end of trajectory (TD) is above top of grid')
-
-   # scan down wellbore till top of grid reached
-   knot = 0
-   while knot < trajectory.knot_count - 1 and z_sign * traj_xyz[knot + 1, 2] < grid_top_z:
-      knot += 1
-   log.debug('skipped trajectory to knot: ' + str(knot))
-   if knot == trajectory.knot_count - 1:
-      return None  # entire well is above grid
-
-   if lazy:
-
-      skin = None
-      # search for intersection with top of grid: will fail if well comes in from the side (or from below!) or penetrates through fault
-      xyz, entry_knot, col_ji0 = find_first_intersection_of_trajectory_with_layer_interface(
-         trajectory,
-         grid,
-         k0 = 0,
-         ref_k_faces = 'top',
-         start = knot,
-         heal_faults = False,
-         quad_triangles = quad_triangles)
-      log.debug('top intersection x,y,z: ' + str(xyz) + '; knot: ' + str(entry_knot) + '; col j0,i0: ' +
-                str(col_ji0[0]) + ', ' + str(col_ji0[1]))
-      if xyz is None:
-         log.error('failed to find intersection of trajectory with top surface of grid')
-         return None
-      cell_kji0 = np.array((0, col_ji0[0], col_ji0[1]), dtype = int)
-      axis = 0
-      polarity = 0
-
-   else:  # not lazy
-
-      # note: xyz and entry_fraction might be slightly off when penetrating a skewed fault plane – deemed immaterial for real cases
-      skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
-      xyz, cell_kji0, axis, polarity, entry_knot = skin.find_first_intersection_of_trajectory(trajectory)
-      if xyz is None:
-         log.error('failed to find intersection of trajectory with outer skin of grid')
-         return None
-      else:
-         log.debug('skin intersection x,y,z: ' + str(xyz) + '; knot: ' + str(entry_knot) + '; cell kji0: ' +
-                   str(cell_kji0) + '; face: ' + 'KJI'[axis] + '-+'[polarity])
-         cell_kji0 = np.array(cell_kji0, dtype = int)
-
-   previous_kji0 = cell_kji0.copy()
-   shift = polarity * 2 - 1
-   previous_kji0[axis] += shift  # note: previous may legitimately be 'beyond' edge of grid
-   entry_fraction = segment_fraction(traj_xyz, entry_knot, xyz)
-   log.debug(f'initial previous kji0: {previous_kji0}')
-   next_cell_info = find_next_cell(grid,
-                                   previous_kji0,
-                                   axis,
-                                   1 - polarity,
-                                   trajectory,
-                                   entry_knot,
-                                   entry_fraction,
-                                   xyz,
-                                   treat_skin_as_fault = use_single_layer_tactics,
-                                   lazy = lazy,
-                                   use_single_layer_tactics = use_single_layer_tactics)
-   log.debug(f'initial next cell info: {next_cell_info}')
-   node_mds_list = [back_calculated_md(trajectory, entry_knot, entry_fraction)]
-   node_count = 1
-   grid_indices_list = []
-   cell_count = 0
-   cell_indices_list = []
-   face_pairs_list = []
-   kissed = np.zeros(grid.extent_kji, dtype = bool)
-   sample_test = np.zeros(grid.extent_kji, dtype = bool)
-
-   while next_cell_info is not None:
-
-      (entry_shared, kji0, entry_axis, entry_polarity, entry_knot, entry_fraction, entry_xyz) = next_cell_info
-
-      log.debug('next cell entry x,y,z: ' + str(entry_xyz) + '; knot: ' + str(entry_knot) + '; cell kji0: ' +
-                str(kji0) + '; face: ' + 'KJI'[entry_axis] + '-+'[entry_polarity])
-
-      if not entry_shared:
-         log.debug('adding unblocked interval')
-         node_mds_list.append(back_calculated_md(trajectory, entry_knot, entry_fraction))
-         node_count += 1
-         grid_indices_list.append(-1)
-         kissed[:] = False
-         sample_test[:] = False
-
-      exit_xyz, exit_knot, exit_axis, exit_polarity = find_first_intersection_of_trajectory_with_cell_surface(
-         trajectory, grid, kji0, entry_knot, start_xyz = entry_xyz, nudge = 0.01, quad_triangles = True)
-
-      if exit_xyz is None:
-         log.debug('no exit')
-      else:
-         log.debug('cell exit x,y,z: ' + str(exit_xyz) + '; knot: ' + str(exit_knot) + '; face: ' + 'KJI'[exit_axis] +
-                   '-+'[exit_polarity])
-
-      if exit_xyz is None:
-
-         if point_is_within_cell(traj_xyz[-1], grid, kji0):
-            # well terminates within cell: add termination blocked interval (or unblocked if inactive cell)
-            log.debug(f'adding termination interval for cell {kji0}')
-            # todo: check for inactive cell and make an unblocked interval instead, if required
-            node_mds_list.append(trajectory.measured_depths[-1])
+        if not entry_shared:
+            log.debug('adding unblocked interval')
+            node_mds_list.append(back_calculated_md(trajectory, entry_knot, entry_fraction))
             node_count += 1
-            grid_indices_list.append(0)
-            cell_indices_list.append(grid.natural_cell_index(kji0))
-            cell_count += 1
-            face_pairs_list.append(((entry_axis, entry_polarity), (-1, -1)))
-            break
+            grid_indices_list.append(-1)
+            kissed[:] = False
+            sample_test[:] = False
 
-         else:
-            next_cell_info = None
-            # trajectory has kissed corner or edge of cell and nudge has gone outside cell
-            # nudge forward and look for point inclusion in possible neighbours
-            log.debug(f'kiss detected at cell kji0 {kji0} ' + 'KJI'[entry_axis] + '-+'[entry_polarity])
-            kissed[tuple(kji0)] = True
-            if np.all(np.array(previous_kji0, dtype = int) >= 0) and np.all(
-                  np.array(previous_kji0, dtype = int) < grid.extent_kji):
-               kissed[tuple(previous_kji0)] = True  # stops immediate revisit for kiss and tell tactics
-            # setup kji offsets of neighbouring cells likely to contain sample point (could check for split column faces)
-            axis_a = (entry_axis + 1) % 3
-            axis_b = (entry_axis + 2) % 3
-            offsets_kji = np.zeros((18, 3), dtype = int)
-            offsets_kji[0, axis_a] = -1
-            offsets_kji[1, axis_a] = 1
-            offsets_kji[2, axis_b] = -1
-            offsets_kji[3, axis_b] = 1
-            offsets_kji[4, axis_a] = offsets_kji[4, axis_b] = -1
-            offsets_kji[5, axis_a] = -1
-            offsets_kji[5, axis_b] = 1
-            offsets_kji[6, axis_a] = 1
-            offsets_kji[6, axis_b] = -1
-            offsets_kji[7, axis_a] = offsets_kji[7, axis_b] = 1
-            offsets_kji[8:16] = offsets_kji[:8]
-            offsets_kji[8:16, axis] = previous_kji0[axis] - kji0[axis]
-            pinchout_skip_sign = -1 if entry_axis == 0 and entry_polarity == 1 else 1
-            offsets_kji[16, axis] = pinchout_skip_sign
-            log.debug(f'kiss pinchout skip sign: {pinchout_skip_sign}')
-            for try_index in range(len(offsets_kji)):
-               try_kji0 = kji0 + offsets_kji[try_index]
-               while np.all(try_kji0 >= 0) and np.all(try_kji0 < grid.extent_kji) and grid.pinched_out(
-                     cell_kji0 = try_kji0):
-                  try_kji0[0] += pinchout_skip_sign
-               if np.any(try_kji0 < 0) or np.any(try_kji0 >= grid.extent_kji) or kissed[tuple(try_kji0)]:
-                  continue
-               # use tiny negative nudge to look for entry into try cell with current segment; check that entry point is close
-               try_entry_xyz, try_entry_knot, try_entry_axis, try_entry_polarity = find_first_intersection_of_trajectory_with_cell_surface(
-                  trajectory, grid, try_kji0, entry_knot, start_xyz = entry_xyz, nudge = -0.01, quad_triangles = True)
-               if try_entry_xyz is not None and vec.isclose(try_entry_xyz, entry_xyz, tolerance = 0.02):
-                  log.debug(f'try accepted for cell: {try_kji0}')
-                  try_entry_fraction = segment_fraction(traj_xyz, try_entry_knot, try_entry_xyz)
-                  # replace the next cell entry info
-                  next_cell_info = (True, try_kji0, try_entry_axis, try_entry_polarity, try_entry_knot,
-                                    try_entry_fraction, try_entry_xyz)
-                  break
-            if next_cell_info is None:
-               log.debug('kiss and tell failed to find next cell entry; switching to point in cell tactics')
-               # take a sample point a little ahead on the trajectory
-               remaining = traj_xyz[entry_knot + 1] - entry_xyz
-               remaining_length = vec.naive_length(remaining)
-               if remaining_length < 0.025:
-                  log.debug(f'not much remaining of segnemt: {remaining_length}')
-               nudge = 0.025
-               if remaining_length <= nudge:
-                  sample_point = entry_xyz + 0.9 * remaining
-               else:
-                  sample_point = entry_xyz + nudge * vec.unit_vector(remaining)
-               sample_test[:] = False
-               log.debug(f'sample point is {sample_point}')
-               for try_index in range(len(offsets_kji)):
-                  try_kji0 = np.array(kji0, dtype = int) + offsets_kji[try_index]
-                  while np.all(try_kji0 >= 0) and np.all(try_kji0 < grid.extent_kji) and grid.pinched_out(
-                        cell_kji0 = try_kji0):
-                     try_kji0[0] += pinchout_skip_sign
-                  if np.any(try_kji0 < 0) or np.any(try_kji0 >= grid.extent_kji):
-                     continue
-                  #                 log.debug(f'tentatively trying: {try_kji0}')
-                  sample_test[tuple(try_kji0)] = True
-                  if point_is_within_cell(sample_point, grid, try_kji0):
-                     log.debug(f'sample point is in cell {try_kji0}')
-                     try_entry_xyz, try_entry_knot, try_entry_axis, try_entry_polarity = find_first_intersection_of_trajectory_with_cell_surface(
+        exit_xyz, exit_knot, exit_axis, exit_polarity = find_first_intersection_of_trajectory_with_cell_surface(
+            trajectory, grid, kji0, entry_knot, start_xyz = entry_xyz, nudge = 0.01, quad_triangles = True)
+
+        if exit_xyz is None:
+            log.debug('no exit')
+        else:
+            log.debug('cell exit x,y,z: ' + str(exit_xyz) + '; knot: ' + str(exit_knot) + '; face: ' +
+                      'KJI'[exit_axis] + '-+'[exit_polarity])
+
+        if exit_xyz is None:
+
+            if point_is_within_cell(traj_xyz[-1], grid, kji0):
+                # well terminates within cell: add termination blocked interval (or unblocked if inactive cell)
+                log.debug(f'adding termination interval for cell {kji0}')
+                # todo: check for inactive cell and make an unblocked interval instead, if required
+                node_mds_list.append(trajectory.measured_depths[-1])
+                node_count += 1
+                grid_indices_list.append(0)
+                cell_indices_list.append(grid.natural_cell_index(kji0))
+                cell_count += 1
+                face_pairs_list.append(((entry_axis, entry_polarity), (-1, -1)))
+                break
+
+            else:
+                next_cell_info = None
+                # trajectory has kissed corner or edge of cell and nudge has gone outside cell
+                # nudge forward and look for point inclusion in possible neighbours
+                log.debug(f'kiss detected at cell kji0 {kji0} ' + 'KJI'[entry_axis] + '-+'[entry_polarity])
+                kissed[tuple(kji0)] = True
+                if np.all(np.array(previous_kji0, dtype = int) >= 0) and np.all(
+                        np.array(previous_kji0, dtype = int) < grid.extent_kji):
+                    kissed[tuple(previous_kji0)] = True  # stops immediate revisit for kiss and tell tactics
+                # setup kji offsets of neighbouring cells likely to contain sample point (could check for split column faces)
+                axis_a = (entry_axis + 1) % 3
+                axis_b = (entry_axis + 2) % 3
+                offsets_kji = np.zeros((18, 3), dtype = int)
+                offsets_kji[0, axis_a] = -1
+                offsets_kji[1, axis_a] = 1
+                offsets_kji[2, axis_b] = -1
+                offsets_kji[3, axis_b] = 1
+                offsets_kji[4, axis_a] = offsets_kji[4, axis_b] = -1
+                offsets_kji[5, axis_a] = -1
+                offsets_kji[5, axis_b] = 1
+                offsets_kji[6, axis_a] = 1
+                offsets_kji[6, axis_b] = -1
+                offsets_kji[7, axis_a] = offsets_kji[7, axis_b] = 1
+                offsets_kji[8:16] = offsets_kji[:8]
+                offsets_kji[8:16, axis] = previous_kji0[axis] - kji0[axis]
+                pinchout_skip_sign = -1 if entry_axis == 0 and entry_polarity == 1 else 1
+                offsets_kji[16, axis] = pinchout_skip_sign
+                log.debug(f'kiss pinchout skip sign: {pinchout_skip_sign}')
+                for try_index in range(len(offsets_kji)):
+                    try_kji0 = kji0 + offsets_kji[try_index]
+                    while np.all(try_kji0 >= 0) and np.all(try_kji0 < grid.extent_kji) and grid.pinched_out(
+                            cell_kji0 = try_kji0):
+                        try_kji0[0] += pinchout_skip_sign
+                    if np.any(try_kji0 < 0) or np.any(try_kji0 >= grid.extent_kji) or kissed[tuple(try_kji0)]:
+                        continue
+                    # use tiny negative nudge to look for entry into try cell with current segment; check that entry point is close
+                    try_entry_xyz, try_entry_knot, try_entry_axis, try_entry_polarity = find_first_intersection_of_trajectory_with_cell_surface(
                         trajectory,
                         grid,
                         try_kji0,
@@ -1610,124 +1582,167 @@ def populate_blocked_well_from_trajectory(blocked_well,
                         start_xyz = entry_xyz,
                         nudge = -0.01,
                         quad_triangles = True)
-                     if try_entry_xyz is None or try_entry_knot is None:
-                        log.warning(f'failed to find entry to favoured cell {try_kji0}')
-                     else:
-                        if np.all(try_kji0 == kji0):
-                           log.debug(f'staying in cell {kji0} after kiss')
-                           # TODO: sort things out to discard kiss completely
+                    if try_entry_xyz is not None and vec.isclose(try_entry_xyz, entry_xyz, tolerance = 0.02):
+                        log.debug(f'try accepted for cell: {try_kji0}')
                         try_entry_fraction = segment_fraction(traj_xyz, try_entry_knot, try_entry_xyz)
-                        next_cell_info = (vec.isclose(try_entry_xyz, entry_xyz,
-                                                      tolerance = 0.01), try_kji0, try_entry_axis, try_entry_polarity,
-                                          try_entry_knot, try_entry_fraction, try_entry_xyz)
-                     break
-               if next_cell_info is None:
-                  log.debug('sample point not found in immediate neighbours, switching to full column search')
-                  k_offset = 0
-                  found = False
-                  while not found and k_offset <= max(kji0[0], grid.nk - kji0[0] - 1):
-                     for k_plus_minus in [1, -1]:
-                        for j_offset in [0, -1, 1]:
-                           for i_offset in [0, -1, 1]:
-                              try_kji0 = kji0 + np.array((k_offset * k_plus_minus, j_offset, i_offset))
-                              if np.any(try_kji0 < 0) or np.any(
-                                    try_kji0 >= grid.extent_kji) or sample_test[tuple(try_kji0)]:
-                                 continue
-                              sample_test[tuple(try_kji0)] = True
-                              if point_is_within_cell(sample_point, grid, try_kji0):
-                                 found = True
-                                 log.debug(f'sample point is in cell {try_kji0}')
-                                 try_entry_xyz, try_entry_knot, try_entry_axis, try_entry_polarity =  \
-                                    find_first_intersection_of_trajectory_with_cell_surface(
-                                       trajectory, grid, try_kji0, entry_knot, start_xyz = entry_xyz, nudge = -0.01, quad_triangles = True)
-                                 if try_entry_xyz is None or try_entry_knot is None:
-                                    log.warning(f'failed to find entry to column sampled cell {try_kji0}')
-                                 else:
-                                    try_entry_fraction = segment_fraction(traj_xyz, try_entry_knot, try_entry_xyz)
-                                    next_cell_info = (vec.isclose(try_entry_xyz, entry_xyz, tolerance = 0.01), try_kji0,
-                                                      try_entry_axis, try_entry_polarity, try_entry_knot,
-                                                      try_entry_fraction, try_entry_xyz)
-                                 break
-                           if found:
-                              break
-                        if found:
-                           break
-                     k_offset += 1
-               if next_cell_info is None:
-                  log.debug('no success during full column search')
-                  if np.any(previous_kji0 == 0) or np.any(previous_kji0 == grid.extent_kji - 1):
-                     log.debug('looking for skin re-entry after possible kissing exit')
-                     skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
-                     try_entry_xyz, try_kji0, try_entry_axis, try_entry_polarity, try_entry_knot =  \
-                        skin.find_first_intersection_of_trajectory(trajectory, start = entry_knot, start_xyz = entry_xyz, nudge = +0.1)
-                     if try_entry_xyz is not None:
-                        log.debug('skin re-entry found')
-                        try_entry_fraction = segment_fraction(traj_xyz, try_entry_knot, try_entry_xyz)
-                        next_cell_info = (vec.isclose(try_entry_xyz, entry_xyz,
-                                                      tolerance = 0.01), try_kji0, try_entry_axis, try_entry_polarity,
-                                          try_entry_knot, try_entry_fraction, try_entry_xyz)
+                        # replace the next cell entry info
+                        next_cell_info = (True, try_kji0, try_entry_axis, try_entry_polarity, try_entry_knot,
+                                          try_entry_fraction, try_entry_xyz)
+                        break
+                if next_cell_info is None:
+                    log.debug('kiss and tell failed to find next cell entry; switching to point in cell tactics')
+                    # take a sample point a little ahead on the trajectory
+                    remaining = traj_xyz[entry_knot + 1] - entry_xyz
+                    remaining_length = vec.naive_length(remaining)
+                    if remaining_length < 0.025:
+                        log.debug(f'not much remaining of segnemt: {remaining_length}')
+                    nudge = 0.025
+                    if remaining_length <= nudge:
+                        sample_point = entry_xyz + 0.9 * remaining
+                    else:
+                        sample_point = entry_xyz + nudge * vec.unit_vector(remaining)
+                    sample_test[:] = False
+                    log.debug(f'sample point is {sample_point}')
+                    for try_index in range(len(offsets_kji)):
+                        try_kji0 = np.array(kji0, dtype = int) + offsets_kji[try_index]
+                        while np.all(try_kji0 >= 0) and np.all(try_kji0 < grid.extent_kji) and grid.pinched_out(
+                                cell_kji0 = try_kji0):
+                            try_kji0[0] += pinchout_skip_sign
+                        if np.any(try_kji0 < 0) or np.any(try_kji0 >= grid.extent_kji):
+                            continue
+                        #                 log.debug(f'tentatively trying: {try_kji0}')
+                        sample_test[tuple(try_kji0)] = True
+                        if point_is_within_cell(sample_point, grid, try_kji0):
+                            log.debug(f'sample point is in cell {try_kji0}')
+                            try_entry_xyz, try_entry_knot, try_entry_axis, try_entry_polarity = find_first_intersection_of_trajectory_with_cell_surface(
+                                trajectory,
+                                grid,
+                                try_kji0,
+                                entry_knot,
+                                start_xyz = entry_xyz,
+                                nudge = -0.01,
+                                quad_triangles = True)
+                            if try_entry_xyz is None or try_entry_knot is None:
+                                log.warning(f'failed to find entry to favoured cell {try_kji0}')
+                            else:
+                                if np.all(try_kji0 == kji0):
+                                    log.debug(f'staying in cell {kji0} after kiss')
+                                    # TODO: sort things out to discard kiss completely
+                                try_entry_fraction = segment_fraction(traj_xyz, try_entry_knot, try_entry_xyz)
+                                next_cell_info = (vec.isclose(try_entry_xyz, entry_xyz,
+                                                              tolerance = 0.01), try_kji0, try_entry_axis,
+                                                  try_entry_polarity, try_entry_knot, try_entry_fraction, try_entry_xyz)
+                            break
+                    if next_cell_info is None:
+                        log.debug('sample point not found in immediate neighbours, switching to full column search')
+                        k_offset = 0
+                        found = False
+                        while not found and k_offset <= max(kji0[0], grid.nk - kji0[0] - 1):
+                            for k_plus_minus in [1, -1]:
+                                for j_offset in [0, -1, 1]:
+                                    for i_offset in [0, -1, 1]:
+                                        try_kji0 = kji0 + np.array((k_offset * k_plus_minus, j_offset, i_offset))
+                                        if np.any(try_kji0 < 0) or np.any(
+                                                try_kji0 >= grid.extent_kji) or sample_test[tuple(try_kji0)]:
+                                            continue
+                                        sample_test[tuple(try_kji0)] = True
+                                        if point_is_within_cell(sample_point, grid, try_kji0):
+                                            found = True
+                                            log.debug(f'sample point is in cell {try_kji0}')
+                                            try_entry_xyz, try_entry_knot, try_entry_axis, try_entry_polarity =  \
+                                               find_first_intersection_of_trajectory_with_cell_surface(
+                                                  trajectory, grid, try_kji0, entry_knot, start_xyz = entry_xyz, nudge = -0.01, quad_triangles = True)
+                                            if try_entry_xyz is None or try_entry_knot is None:
+                                                log.warning(f'failed to find entry to column sampled cell {try_kji0}')
+                                            else:
+                                                try_entry_fraction = segment_fraction(
+                                                    traj_xyz, try_entry_knot, try_entry_xyz)
+                                                next_cell_info = (vec.isclose(try_entry_xyz,
+                                                                              entry_xyz,
+                                                                              tolerance = 0.01), try_kji0,
+                                                                  try_entry_axis, try_entry_polarity, try_entry_knot,
+                                                                  try_entry_fraction, try_entry_xyz)
+                                            break
+                                    if found:
+                                        break
+                                if found:
+                                    break
+                            k_offset += 1
+                    if next_cell_info is None:
+                        log.debug('no success during full column search')
+                        if np.any(previous_kji0 == 0) or np.any(previous_kji0 == grid.extent_kji - 1):
+                            log.debug('looking for skin re-entry after possible kissing exit')
+                            skin = grid.skin(use_single_layer_tactics = use_single_layer_tactics)
+                            try_entry_xyz, try_kji0, try_entry_axis, try_entry_polarity, try_entry_knot =  \
+                               skin.find_first_intersection_of_trajectory(trajectory, start = entry_knot, start_xyz = entry_xyz, nudge = +0.1)
+                            if try_entry_xyz is not None:
+                                log.debug('skin re-entry found')
+                                try_entry_fraction = segment_fraction(traj_xyz, try_entry_knot, try_entry_xyz)
+                                next_cell_info = (vec.isclose(try_entry_xyz, entry_xyz,
+                                                              tolerance = 0.01), try_kji0, try_entry_axis,
+                                                  try_entry_polarity, try_entry_knot, try_entry_fraction, try_entry_xyz)
 
-         if next_cell_info is None:
-            log.warning('well blocking got stuck – cells probably omitted at tail of well')
+            if next_cell_info is None:
+                log.warning('well blocking got stuck – cells probably omitted at tail of well')
 
 
 #      if exit_xyz is not None:  # usual well-behaved case or non-standard due to kiss
-      else:
+        else:
 
-         exit_fraction = segment_fraction(traj_xyz, exit_knot, exit_xyz)
+            exit_fraction = segment_fraction(traj_xyz, exit_knot, exit_xyz)
 
-         log.debug('adding blocked interval for cell kji0: ' + str(kji0))
-         # todo: check for inactive cell and make an unblocked interval instead, if required
-         node_mds_list.append(back_calculated_md(trajectory, exit_knot, exit_fraction))
-         node_count += 1
-         grid_indices_list.append(0)
-         cell_indices_list.append(grid.natural_cell_index(kji0))
-         cell_count += 1
-         face_pairs_list.append(((entry_axis, entry_polarity), (exit_axis, exit_polarity)))
+            log.debug('adding blocked interval for cell kji0: ' + str(kji0))
+            # todo: check for inactive cell and make an unblocked interval instead, if required
+            node_mds_list.append(back_calculated_md(trajectory, exit_knot, exit_fraction))
+            node_count += 1
+            grid_indices_list.append(0)
+            cell_indices_list.append(grid.natural_cell_index(kji0))
+            cell_count += 1
+            face_pairs_list.append(((entry_axis, entry_polarity), (exit_axis, exit_polarity)))
 
-         previous_kji0 = kji0
-         log.debug(f'previous kji0 set to {previous_kji0}')
-         next_cell_info = find_next_cell(grid,
-                                         kji0,
-                                         exit_axis,
-                                         exit_polarity,
-                                         trajectory,
-                                         exit_knot,
-                                         exit_fraction,
-                                         exit_xyz,
-                                         treat_skin_as_fault = use_single_layer_tactics,
-                                         lazy = lazy,
-                                         use_single_layer_tactics = use_single_layer_tactics)
-         kissed[:] = False
-         sample_test[:] = False
+            previous_kji0 = kji0
+            log.debug(f'previous kji0 set to {previous_kji0}')
+            next_cell_info = find_next_cell(grid,
+                                            kji0,
+                                            exit_axis,
+                                            exit_polarity,
+                                            trajectory,
+                                            exit_knot,
+                                            exit_fraction,
+                                            exit_xyz,
+                                            treat_skin_as_fault = use_single_layer_tactics,
+                                            lazy = lazy,
+                                            use_single_layer_tactics = use_single_layer_tactics)
+            kissed[:] = False
+            sample_test[:] = False
 
-   if node_count < 2:
-      log.warning('no nodes found during attempt to block well')
-      return None
+    if node_count < 2:
+        log.warning('no nodes found during attempt to block well')
+        return None
 
-   assert node_count > 1
-   assert len(node_mds_list) == node_count
-   assert len(grid_indices_list) == node_count - 1
-   assert cell_count < node_count
-   assert len(cell_indices_list) == cell_count
-   assert len(face_pairs_list) == cell_count
+    assert node_count > 1
+    assert len(node_mds_list) == node_count
+    assert len(grid_indices_list) == node_count - 1
+    assert cell_count < node_count
+    assert len(cell_indices_list) == cell_count
+    assert len(face_pairs_list) == cell_count
 
-   blocked_well.node_mds = np.array(node_mds_list)
-   blocked_well.node_count = node_count
-   blocked_well.grid_indices = np.array(grid_indices_list, dtype = int)
-   blocked_well.cell_indices = np.array(cell_indices_list, dtype = int)
-   blocked_well.face_pair_indices = np.array(face_pairs_list, dtype = int)
-   blocked_well.cell_count = cell_count
-   blocked_well.grid_list = [grid]
+    blocked_well.node_mds = np.array(node_mds_list)
+    blocked_well.node_count = node_count
+    blocked_well.grid_indices = np.array(grid_indices_list, dtype = int)
+    blocked_well.cell_indices = np.array(cell_indices_list, dtype = int)
+    blocked_well.face_pair_indices = np.array(face_pairs_list, dtype = int)
+    blocked_well.cell_count = cell_count
+    blocked_well.grid_list = [grid]
 
-   assert cell_count == (node_count - np.count_nonzero(blocked_well.grid_indices == -1) - 1)
+    assert cell_count == (node_count - np.count_nonzero(blocked_well.grid_indices == -1) - 1)
 
-   log.info(str(cell_count) + ' cell' + _pl(cell_count) + ' blocked for well trajectory uuid: ' + str(trajectory.uuid))
+    log.info(str(cell_count) + ' cell' + _pl(cell_count) + ' blocked for well trajectory uuid: ' + str(trajectory.uuid))
 
-   return blocked_well
+    return blocked_well
 
 
 def _pl(n, use_es = False):
-   if n == 1:
-      return ''
-   return 'es' if use_es else 's'
+    if n == 1:
+        return ''
+    return 'es' if use_es else 's'

--- a/resqpy/lines.py
+++ b/resqpy/lines.py
@@ -25,79 +25,81 @@ import os
 
 
 class _BasePolyline(BaseResqpy):
-   """Base class to implement shared methods for other classes in this module"""
+    """Base class to implement shared methods for other classes in this module"""
 
-   def create_interpretation_and_feature(self,
-                                         kind = 'horizon',
-                                         name = None,
-                                         interp_title_suffix = None,
-                                         is_normal = True):
-      """Creates xml and objects for a represented interpretaion and interpreted feature, if not already present."""
+    def create_interpretation_and_feature(self,
+                                          kind = 'horizon',
+                                          name = None,
+                                          interp_title_suffix = None,
+                                          is_normal = True):
+        """Creates xml and objects for a represented interpretaion and interpreted feature, if not already present."""
 
-      assert kind in ['horizon', 'fault', 'fracture', 'geobody boundary']
-      assert name or self.title, 'title missing'
-      if not name:
-         name = self.title
+        assert kind in ['horizon', 'fault', 'fracture', 'geobody boundary']
+        assert name or self.title, 'title missing'
+        if not name:
+            name = self.title
 
-      if self.rep_int_root is not None:
-         log.debug(f'represented interpretation already exisrs for surface {self.title}')
-         return
-      if kind in ['horizon', 'geobody boundary']:
-         feature = rqo.GeneticBoundaryFeature(self.model, kind = kind, feature_name = name)
-         feature.create_xml()
-         if kind == 'horizon':
-            interp = rqo.HorizonInterpretation(self.model, genetic_boundary_feature = feature, domain = 'depth')
-         else:
-            interp = rqo.GeobodyBoundaryInterpretation(self.model, genetic_boundary_feature = feature, domain = 'depth')
-      elif kind in ['fault', 'fracture']:
-         feature = rqo.TectonicBoundaryFeature(self.model, kind = kind, feature_name = name)
-         feature.create_xml()
-         interp = rqo.FaultInterpretation(self.model,
-                                          is_normal = is_normal,
-                                          tectonic_boundary_feature = feature,
-                                          domain = 'depth')  # might need more arguments
-      else:
-         log.critical('code failure')
-      interp_root = interp.create_xml(title_suffix = interp_title_suffix)
-      self.rep_int_root = interp_root
+        if self.rep_int_root is not None:
+            log.debug(f'represented interpretation already exisrs for surface {self.title}')
+            return
+        if kind in ['horizon', 'geobody boundary']:
+            feature = rqo.GeneticBoundaryFeature(self.model, kind = kind, feature_name = name)
+            feature.create_xml()
+            if kind == 'horizon':
+                interp = rqo.HorizonInterpretation(self.model, genetic_boundary_feature = feature, domain = 'depth')
+            else:
+                interp = rqo.GeobodyBoundaryInterpretation(self.model,
+                                                           genetic_boundary_feature = feature,
+                                                           domain = 'depth')
+        elif kind in ['fault', 'fracture']:
+            feature = rqo.TectonicBoundaryFeature(self.model, kind = kind, feature_name = name)
+            feature.create_xml()
+            interp = rqo.FaultInterpretation(self.model,
+                                             is_normal = is_normal,
+                                             tectonic_boundary_feature = feature,
+                                             domain = 'depth')  # might need more arguments
+        else:
+            log.critical('code failure')
+        interp_root = interp.create_xml(title_suffix = interp_title_suffix)
+        self.rep_int_root = interp_root
 
 
 def load_hdf5_array(object, node, array_attribute, tag = 'Values'):
-   """Loads the property array data as an attribute of object, from the hdf5 referenced in xml node.
+    """Loads the property array data as an attribute of object, from the hdf5 referenced in xml node.
 
    :meta private:
    """
 
-   assert (rqet.node_type(node) in ['DoubleHdf5Array', 'IntegerHdf5Array', 'Point3dHdf5Array'])
-   # ignore null value
-   h5_key_pair = object.model.h5_uuid_and_path_for_node(node, tag = tag)
-   if h5_key_pair is None:
-      return None
-   return object.model.h5_array_element(h5_key_pair,
-                                        index = None,
-                                        cache_array = True,
-                                        object = object,
-                                        array_attribute = array_attribute)
+    assert (rqet.node_type(node) in ['DoubleHdf5Array', 'IntegerHdf5Array', 'Point3dHdf5Array'])
+    # ignore null value
+    h5_key_pair = object.model.h5_uuid_and_path_for_node(node, tag = tag)
+    if h5_key_pair is None:
+        return None
+    return object.model.h5_array_element(h5_key_pair,
+                                         index = None,
+                                         cache_array = True,
+                                         object = object,
+                                         array_attribute = array_attribute)
 
 
 class Polyline(_BasePolyline):
-   """Class for RESQML polyline representation."""
+    """Class for RESQML polyline representation."""
 
-   resqml_type = 'PolylineRepresentation'
+    resqml_type = 'PolylineRepresentation'
 
-   def __init__(self,
-                parent_model,
-                poly_root = None,
-                uuid = None,
-                set_bool = None,
-                set_coord = None,
-                set_crs = None,
-                set_crsroot = None,
-                title = None,
-                rep_int_root = None,
-                originator = None,
-                extra_metadata = None):
-      """Initialises a new PolylineRepresentation object.
+    def __init__(self,
+                 parent_model,
+                 poly_root = None,
+                 uuid = None,
+                 set_bool = None,
+                 set_coord = None,
+                 set_crs = None,
+                 set_crsroot = None,
+                 title = None,
+                 rep_int_root = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Initialises a new PolylineRepresentation object.
 
         arguments:
             parent_model (model.Model object): the model which the new PolylineRepresentation belongs to
@@ -128,80 +130,80 @@ class Polyline(_BasePolyline):
         :meta common:
         """
 
-      self.model = parent_model
-      self.isclosed = set_bool
-      self.nodepatch = None
-      self.crs_uuid = set_crs
-      self.coordinates = None
-      self.centre = None
-      self.rep_int_root = rep_int_root  # Optional represented interpretation xml root node
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       root_node = poly_root,
-                       extra_metadata = extra_metadata)
+        self.model = parent_model
+        self.isclosed = set_bool
+        self.nodepatch = None
+        self.crs_uuid = set_crs
+        self.coordinates = None
+        self.centre = None
+        self.rep_int_root = rep_int_root  # Optional represented interpretation xml root node
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         root_node = poly_root,
+                         extra_metadata = extra_metadata)
 
-      if self.root is None and all(i is not None for i in [set_bool, set_coord, set_crs, title]):
-         # Using data from a polyline set
-         assert set_coord.ndim > 1 and 2 <= set_coord.shape[-1] <= 3
-         # allow for x,y or x,y,z incoming coordinates but use x,y,z internally
-         coord_shape = list(set_coord.shape)
-         coord_shape[-1] = 3
-         self.coordinates = np.zeros(tuple(coord_shape))
-         self.coordinates[..., :set_coord.shape[-1]] = set_coord
-         if set_coord.ndim > 2:
-            self.coordinates = self.coordinates.reshape((-1, 3))
-         self.nodepatch = (0, len(self.coordinates))
-         assert not any(map(lambda x: x is None, self.nodepatch))  # Required fields - assert neither are None
+        if self.root is None and all(i is not None for i in [set_bool, set_coord, set_crs, title]):
+            # Using data from a polyline set
+            assert set_coord.ndim > 1 and 2 <= set_coord.shape[-1] <= 3
+            # allow for x,y or x,y,z incoming coordinates but use x,y,z internally
+            coord_shape = list(set_coord.shape)
+            coord_shape[-1] = 3
+            self.coordinates = np.zeros(tuple(coord_shape))
+            self.coordinates[..., :set_coord.shape[-1]] = set_coord
+            if set_coord.ndim > 2:
+                self.coordinates = self.coordinates.reshape((-1, 3))
+            self.nodepatch = (0, len(self.coordinates))
+            assert not any(map(lambda x: x is None, self.nodepatch))  # Required fields - assert neither are None
 
-      # TODO: Add SeismicCoordinates later - optional field
-      # TODO: Add LineRole later - optional field
+        # TODO: Add SeismicCoordinates later - optional field
+        # TODO: Add LineRole later - optional field
 
-   def _load_from_xml(self):
+    def _load_from_xml(self):
 
-      assert self.root is not None  # polyline xml node is specified
-      poly_root = self.root
+        assert self.root is not None  # polyline xml node is specified
+        poly_root = self.root
 
-      self.title = rqet.citation_title_for_node(poly_root)
+        self.title = rqet.citation_title_for_node(poly_root)
 
-      self.extra_metadata = rqet.load_metadata_from_xml(self.root)
+        self.extra_metadata = rqet.load_metadata_from_xml(self.root)
 
-      self.isclosed = rqet.bool_from_text(rqet.node_text(rqet.find_tag(poly_root, 'IsClosed')))
-      assert self.isclosed is not None  # Required field
+        self.isclosed = rqet.bool_from_text(rqet.node_text(rqet.find_tag(poly_root, 'IsClosed')))
+        assert self.isclosed is not None  # Required field
 
-      patch_node = rqet.find_tag(poly_root, 'NodePatch')
-      assert patch_node is not None  # Required field
+        patch_node = rqet.find_tag(poly_root, 'NodePatch')
+        assert patch_node is not None  # Required field
 
-      geometry_node = rqet.find_tag(patch_node, 'Geometry')
-      assert geometry_node is not None  # Required field
+        geometry_node = rqet.find_tag(patch_node, 'Geometry')
+        assert geometry_node is not None  # Required field
 
-      self.crs_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(geometry_node, ['LocalCrs', 'UUID']))
-      assert self.crs_uuid is not None  # Required field
+        self.crs_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(geometry_node, ['LocalCrs', 'UUID']))
+        assert self.crs_uuid is not None  # Required field
 
-      points_node = rqet.find_tag(geometry_node, 'Points')
-      assert points_node is not None  # Required field
-      load_hdf5_array(self, points_node, 'coordinates', tag = 'Coordinates')
+        points_node = rqet.find_tag(geometry_node, 'Points')
+        assert points_node is not None  # Required field
+        load_hdf5_array(self, points_node, 'coordinates', tag = 'Coordinates')
 
-      self.nodepatch = (rqet.find_tag_int(patch_node, 'PatchIndex'), rqet.find_tag_int(patch_node, 'Count'))
-      assert not any(map(lambda x: x is None, self.nodepatch))  # Required fields - assert neither are None
+        self.nodepatch = (rqet.find_tag_int(patch_node, 'PatchIndex'), rqet.find_tag_int(patch_node, 'Count'))
+        assert not any(map(lambda x: x is None, self.nodepatch))  # Required fields - assert neither are None
 
-      self.rep_int_root = self.model.referenced_node(rqet.find_tag(poly_root, 'RepresentedInterpretation'))
+        self.rep_int_root = self.model.referenced_node(rqet.find_tag(poly_root, 'RepresentedInterpretation'))
 
-   @property
-   def crs_root(self):
-      """XML node corresponding to self.crs_uuid"""
+    @property
+    def crs_root(self):
+        """XML node corresponding to self.crs_uuid"""
 
-      return self.model.root_for_uuid(self.crs_uuid)
+        return self.model.root_for_uuid(self.crs_uuid)
 
-   @property
-   def rep_int_uuid(self):
-      # TODO: Track uuid only, not root
-      return rqet.uuid_for_part_root(self.rep_int_root)
+    @property
+    def rep_int_uuid(self):
+        # TODO: Track uuid only, not root
+        return rqet.uuid_for_part_root(self.rep_int_root)
 
-   @classmethod
-   def from_scaled_polyline(cls, original, scaling, title = None, originator = None, extra_metadata = None):
-      """Returns a scaled version of the original polyline.
+    @classmethod
+    def from_scaled_polyline(cls, original, scaling, title = None, originator = None, extra_metadata = None):
+        """Returns a scaled version of the original polyline.
 
       arguments:
          original (Polyline): the polyline from which the new polyline will be sporned
@@ -222,213 +224,213 @@ class Polyline(_BasePolyline):
          if extra_metadata is not None, no extra metadata is inherited from original
       """
 
-      if extra_metadata is None:
-         extra_metadata = original.extra_metadata
+        if extra_metadata is None:
+            extra_metadata = original.extra_metadata
 
-      polyline = cls(original.model,
-                     set_crs = original.crs_uuid,
-                     set_bool = original.isclosed,
-                     title = title if title else original.title,
-                     originator = originator if originator else original.originator,
-                     extra_metadata = extra_metadata)
+        polyline = cls(original.model,
+                       set_crs = original.crs_uuid,
+                       set_bool = original.isclosed,
+                       title = title if title else original.title,
+                       originator = originator if originator else original.originator,
+                       extra_metadata = extra_metadata)
 
-      o_centre = original.balanced_centre()
-      polyline.coordinates = scaling * (original.coordinates - o_centre) + o_centre
-      polyline.nodepatch = (0, len(polyline.coordinates))
+        o_centre = original.balanced_centre()
+        polyline.coordinates = scaling * (original.coordinates - o_centre) + o_centre
+        polyline.nodepatch = (0, len(polyline.coordinates))
 
-      return polyline
+        return polyline
 
-   def is_convex(self, trust_metadata = True):
-      """Returns True if the polyline is closed and convex in the xy plane, otherwise False."""
+    def is_convex(self, trust_metadata = True):
+        """Returns True if the polyline is closed and convex in the xy plane, otherwise False."""
 
-      if not self.isclosed:
-         return False
-      if trust_metadata and self.extra_metadata is not None and 'is_convex' in self.extra_metadata.keys():
-         return self.extra_metadata['is_convex'].lower() == 'true'
-      nodes = len(self.coordinates)
-      extras = {}
-      if nodes < 3:
-         result = False
-      else:
-         cw_bool = None
-         result = True
-         for node in range(nodes):
-            cw = vu.clockwise(self.coordinates[node - 2], self.coordinates[node - 1], self.coordinates[node])
-            if cw == 0.0:
-               continue  # striaght line section
+        if not self.isclosed:
+            return False
+        if trust_metadata and self.extra_metadata is not None and 'is_convex' in self.extra_metadata.keys():
+            return self.extra_metadata['is_convex'].lower() == 'true'
+        nodes = len(self.coordinates)
+        extras = {}
+        if nodes < 3:
+            result = False
+        else:
+            cw_bool = None
+            result = True
+            for node in range(nodes):
+                cw = vu.clockwise(self.coordinates[node - 2], self.coordinates[node - 1], self.coordinates[node])
+                if cw == 0.0:
+                    continue  # striaght line section
+                if cw_bool is None:
+                    cw_bool = (cw > 0.0)
+                elif cw_bool != (cw > 0.0):
+                    result = False
+                    break
             if cw_bool is None:
-               cw_bool = (cw > 0.0)
-            elif cw_bool != (cw > 0.0):
-               result = False
-               break
-         if cw_bool is None:
-            result = False  # whole polyline lies in a straight line
-         if result:
-            extras['is_clockwise'] = str(cw_bool).lower()
-      extras['is_convex'] = str(result).lower()
-      self.append_extra_metadata(extras)
-      return result
+                result = False  # whole polyline lies in a straight line
+            if result:
+                extras['is_clockwise'] = str(cw_bool).lower()
+        extras['is_convex'] = str(result).lower()
+        self.append_extra_metadata(extras)
+        return result
 
-   def is_clockwise(self, trust_metadata = True):
-      """Returns True if first non-straight triplet of nodes is clockwise in the xy plane; False if anti-clockwise.
+    def is_clockwise(self, trust_metadata = True):
+        """Returns True if first non-straight triplet of nodes is clockwise in the xy plane; False if anti-clockwise.
 
       note:
          this method currently assumes that the xy axes are left-handed
       """
 
-      if trust_metadata and self.extra_metadata is not None and 'is_clockwise' in self.extra_metadata.keys():
-         return str(self.extra_metadata['is_clockwise']).lower() == 'true'
-      result = None
-      for node in range(3, len(self.coordinates)):
-         cw = vu.clockwise(self.coordinates[node - 2], self.coordinates[node - 1], self.coordinates[node])
-         if cw == 0.0:
-            continue  # striaght line section
-         result = (cw > 0.0)
-         break
-      if result is not None:
-         self.append_extra_metadata({'is_clockwise': str(result).lower()})
-      return result
+        if trust_metadata and self.extra_metadata is not None and 'is_clockwise' in self.extra_metadata.keys():
+            return str(self.extra_metadata['is_clockwise']).lower() == 'true'
+        result = None
+        for node in range(3, len(self.coordinates)):
+            cw = vu.clockwise(self.coordinates[node - 2], self.coordinates[node - 1], self.coordinates[node])
+            if cw == 0.0:
+                continue  # striaght line section
+            result = (cw > 0.0)
+            break
+        if result is not None:
+            self.append_extra_metadata({'is_clockwise': str(result).lower()})
+        return result
 
-   def point_is_inside_xy(self, p, mode = 'crossing'):
-      """Returns True if point p is inside closed polygon, in xy plane, otherwise False.
-
-        :meta common:
-        """
-
-      assert mode in ['crossing', 'winding'], 'unrecognised point inclusion mode: ' + str(mode)
-      assert self.isclosed, 'point inclusion is not applicable to unclosed polylines'
-
-      if mode == 'crossing':
-         return pip.pip_cn(p, self.coordinates)
-      return pip.pip_wn(p, self.coordinates)
-
-   def segment_length(self, segment_index, in_xy = False):
-      """Returns the naive length (ie. assuming x,y & z units are the same) of an individual segment of the polyline."""
-
-      successor = self._successor(segment_index)
-      d = 2 if in_xy else 3
-      return vu.naive_length(self.coordinates[successor, :d] - self.coordinates[segment_index, :d])
-
-   def segment_midpoint(self, segment_index):
-      """Returns the midpoint of an individual segment of the polyline."""
-
-      successor = self._successor(segment_index)
-      return 0.5 * (self.coordinates[segment_index] + self.coordinates[successor])
-
-   def segment_normal(self, segment_index):
-      """For a closed polyline returns a unit vector giving the 2D (xy) direction of an outward facing normal to a segment."""
-
-      successor = self._successor(segment_index)
-      segment_vector = self.coordinates[successor, :2] - self.coordinates[segment_index, :2]
-      segment_vector = vu.unit_vector(segment_vector)
-      normal_vector = np.zeros(3)
-      normal_vector[0] = -segment_vector[1]
-      normal_vector[1] = segment_vector[0]
-      cw = self.is_clockwise()
-      assert cw is not None, 'polyline is straight'
-      if not cw:
-         normal_vector = -normal_vector
-      return normal_vector
-
-   def full_length(self, in_xy = False):
-      """Returns the naive length of the entire polyline.
+    def point_is_inside_xy(self, p, mode = 'crossing'):
+        """Returns True if point p is inside closed polygon, in xy plane, otherwise False.
 
         :meta common:
         """
 
-      length = 0.0
-      end_index = len(self.coordinates) - 1
-      if self.isclosed:
-         end_index += 1
-      for i in range(end_index):
-         length += self.segment_length(i, in_xy = in_xy)
-      return length
+        assert mode in ['crossing', 'winding'], 'unrecognised point inclusion mode: ' + str(mode)
+        assert self.isclosed, 'point inclusion is not applicable to unclosed polylines'
 
-   def interpolated_point(self, fraction, in_xy = False):
-      """Returns x,y,z point on the polyline at fractional distance along entire polyline.
+        if mode == 'crossing':
+            return pip.pip_cn(p, self.coordinates)
+        return pip.pip_wn(p, self.coordinates)
+
+    def segment_length(self, segment_index, in_xy = False):
+        """Returns the naive length (ie. assuming x,y & z units are the same) of an individual segment of the polyline."""
+
+        successor = self._successor(segment_index)
+        d = 2 if in_xy else 3
+        return vu.naive_length(self.coordinates[successor, :d] - self.coordinates[segment_index, :d])
+
+    def segment_midpoint(self, segment_index):
+        """Returns the midpoint of an individual segment of the polyline."""
+
+        successor = self._successor(segment_index)
+        return 0.5 * (self.coordinates[segment_index] + self.coordinates[successor])
+
+    def segment_normal(self, segment_index):
+        """For a closed polyline returns a unit vector giving the 2D (xy) direction of an outward facing normal to a segment."""
+
+        successor = self._successor(segment_index)
+        segment_vector = self.coordinates[successor, :2] - self.coordinates[segment_index, :2]
+        segment_vector = vu.unit_vector(segment_vector)
+        normal_vector = np.zeros(3)
+        normal_vector[0] = -segment_vector[1]
+        normal_vector[1] = segment_vector[0]
+        cw = self.is_clockwise()
+        assert cw is not None, 'polyline is straight'
+        if not cw:
+            normal_vector = -normal_vector
+        return normal_vector
+
+    def full_length(self, in_xy = False):
+        """Returns the naive length of the entire polyline.
 
         :meta common:
         """
 
-      assert 0.0 <= fraction <= 1.0
-      target = fraction * self.full_length(in_xy = in_xy)
-      seg_index = 0
-      while True:
-         next_seg_length = self.segment_length(seg_index, in_xy = in_xy)
-         if target > next_seg_length or next_seg_length == 0.0:
-            target -= next_seg_length
-            seg_index += 1
-            continue
-         seg_fraction = target / next_seg_length
-         successor = (seg_index + 1) % len(self.coordinates)
-         return seg_fraction * self.coordinates[successor] + (1.0 - seg_fraction) * self.coordinates[seg_index]
+        length = 0.0
+        end_index = len(self.coordinates) - 1
+        if self.isclosed:
+            end_index += 1
+        for i in range(end_index):
+            length += self.segment_length(i, in_xy = in_xy)
+        return length
 
-   def equidistant_points(self, n, in_xy = False):
-      """Returns array of shape (n, 3) being points equally distributed along entire polyline."""
+    def interpolated_point(self, fraction, in_xy = False):
+        """Returns x,y,z point on the polyline at fractional distance along entire polyline.
 
-      assert n > 1
-      sample_points = np.empty((n, 3))
-      if self.isclosed:
-         step_fraction = 1.0 / float(n)
-      else:
-         step_fraction = 1.0 / float(n - 1)
-      f = 0.0
-      for step in range(n):
-         sample_points[step] = self.interpolated_point(f, in_xy = in_xy)
-         f += step_fraction
-         if f > 1.0:
-            f = 1.0  # to avoid possible assertion error due to rounding
-      return sample_points
+        :meta common:
+        """
 
-   def balanced_centre(self, mode = 'weighted', n = 20, cache = True, in_xy = False):
-      """Returns a mean x,y,z based on sampling polyline at regular intervals."""
-
-      if cache and self.centre is not None:
-         return self.centre
-      assert mode in ['weighted', 'sampled']
-      if mode == 'sampled':  # this mode is deprecated as it simply approximates the weighted mode
-         sample_points = self.equidistant_points(n, in_xy = in_xy)
-         centre = np.mean(sample_points, axis = 0)
-      else:  # 'weighted'
-         sum = np.zeros(3)
-         seg_count = len(self.coordinates) - 1
-         if self.isclosed:
-            seg_count += 1
-         d = 2 if in_xy else 3
-         for seg_index in range(seg_count):
+        assert 0.0 <= fraction <= 1.0
+        target = fraction * self.full_length(in_xy = in_xy)
+        seg_index = 0
+        while True:
+            next_seg_length = self.segment_length(seg_index, in_xy = in_xy)
+            if target > next_seg_length or next_seg_length == 0.0:
+                target -= next_seg_length
+                seg_index += 1
+                continue
+            seg_fraction = target / next_seg_length
             successor = (seg_index + 1) % len(self.coordinates)
-            p1, p2 = self.coordinates[seg_index, :d], self.coordinates[successor, :d]
-            sum += (p1 + p2) * vu.naive_length(p2 - p1)
-         centre = sum / (2.0 * self.full_length(in_xy = in_xy))
-      if cache:
-         self.centre = centre
-      return centre
+            return seg_fraction * self.coordinates[successor] + (1.0 - seg_fraction) * self.coordinates[seg_index]
 
-   def first_line_intersection(self, x1, y1, x2, y2, half_segment = False):
-      """Returns segment number & x, y of first intersection of (half) bounded line x,y 1 to 2 with polyline, or None, None, None."""
+    def equidistant_points(self, n, in_xy = False):
+        """Returns array of shape (n, 3) being points equally distributed along entire polyline."""
 
-      seg_count = len(self.coordinates) - 1
-      if self.isclosed:
-         seg_count += 1
+        assert n > 1
+        sample_points = np.empty((n, 3))
+        if self.isclosed:
+            step_fraction = 1.0 / float(n)
+        else:
+            step_fraction = 1.0 / float(n - 1)
+        f = 0.0
+        for step in range(n):
+            sample_points[step] = self.interpolated_point(f, in_xy = in_xy)
+            f += step_fraction
+            if f > 1.0:
+                f = 1.0  # to avoid possible assertion error due to rounding
+        return sample_points
 
-      for segment in range(seg_count):
-         successor = (segment + 1) % len(self.coordinates)
-         x, y = meet.line_line_intersect(x1,
-                                         y1,
-                                         x2,
-                                         y2,
-                                         self.coordinates[segment][0],
-                                         self.coordinates[segment][1],
-                                         self.coordinates[successor][0],
-                                         self.coordinates[successor][1],
-                                         line_segment = True,
-                                         half_segment = half_segment)
-         if x is not None:
-            return segment, x, y
-      return None, None, None
+    def balanced_centre(self, mode = 'weighted', n = 20, cache = True, in_xy = False):
+        """Returns a mean x,y,z based on sampling polyline at regular intervals."""
 
-   def normalised_xy(self, x, y, mode = 'square'):
-      """Returns a normalised x',y' pair (in range 0..1) being point x,y under mapping from convex polygon.
+        if cache and self.centre is not None:
+            return self.centre
+        assert mode in ['weighted', 'sampled']
+        if mode == 'sampled':  # this mode is deprecated as it simply approximates the weighted mode
+            sample_points = self.equidistant_points(n, in_xy = in_xy)
+            centre = np.mean(sample_points, axis = 0)
+        else:  # 'weighted'
+            sum = np.zeros(3)
+            seg_count = len(self.coordinates) - 1
+            if self.isclosed:
+                seg_count += 1
+            d = 2 if in_xy else 3
+            for seg_index in range(seg_count):
+                successor = (seg_index + 1) % len(self.coordinates)
+                p1, p2 = self.coordinates[seg_index, :d], self.coordinates[successor, :d]
+                sum += (p1 + p2) * vu.naive_length(p2 - p1)
+            centre = sum / (2.0 * self.full_length(in_xy = in_xy))
+        if cache:
+            self.centre = centre
+        return centre
+
+    def first_line_intersection(self, x1, y1, x2, y2, half_segment = False):
+        """Returns segment number & x, y of first intersection of (half) bounded line x,y 1 to 2 with polyline, or None, None, None."""
+
+        seg_count = len(self.coordinates) - 1
+        if self.isclosed:
+            seg_count += 1
+
+        for segment in range(seg_count):
+            successor = (segment + 1) % len(self.coordinates)
+            x, y = meet.line_line_intersect(x1,
+                                            y1,
+                                            x2,
+                                            y2,
+                                            self.coordinates[segment][0],
+                                            self.coordinates[segment][1],
+                                            self.coordinates[successor][0],
+                                            self.coordinates[successor][1],
+                                            line_segment = True,
+                                            half_segment = half_segment)
+            if x is not None:
+                return segment, x, y
+        return None, None, None
+
+    def normalised_xy(self, x, y, mode = 'square'):
+        """Returns a normalised x',y' pair (in range 0..1) being point x,y under mapping from convex polygon.
 
         arguments:
             x, y (floats): location of a point inside the polyline, which must be closed and project to a
@@ -443,63 +445,63 @@ class Polyline(_BasePolyline):
             for more details of the mapping used by the 3 modes, see documentation for denormalised_xy()
         """
 
-      assert mode in ['square', 'perimeter', 'circle']
-      assert self.is_convex(), 'attempt to find normalised x,y within a polyline that is not a closed convex polygon'
-      centre_xy = self.balanced_centre()[:2]
-      if tuple(centre_xy) == (x, y):
-         if mode == 'square':
-            return 0.5, 0.5
-         return 0.0, 0.0
-      segment, px, py = self.first_line_intersection(centre_xy[0], centre_xy[1], x, y, half_segment = True)
-      assert px is not None
-      norm_x, norm_y = None, None
-      if mode == 'square':
-         if px == centre_xy[0]:
-            norm_x = 0.5
-         else:
-            norm_x = 0.5 + 0.5 * (x - centre_xy[0]) / abs(px - centre_xy[0])
-         if py == centre_xy[1]:
-            norm_y = 0.5
-         else:
-            norm_y = 0.5 + 0.5 * (y - centre_xy[1]) / abs(py - centre_xy[1])
-      elif mode == 'circle':
-         d_xy = np.array((x, y)) - centre_xy
-         dp_xy = np.array((px, py)) - centre_xy
-         if abs(dp_xy[0]) > abs(dp_xy[1]):
-            rf = d_xy[0] / dp_xy[0]
-            theta = maths.atan(d_xy[1] / d_xy[0])
-            if d_xy[0] < 0.0:
-               theta += maths.pi
-         else:
-            rf = d_xy[1] / dp_xy[1]
-            theta = maths.pi / 2.0 - maths.atan(d_xy[0] / d_xy[1])
-            if d_xy[1] < 0.0:
-               theta += maths.pi
-         norm_x = rf * rf
-         theta /= 2.0 * maths.pi
-         if theta < 0.0:
-            theta += 1.0
-         elif theta > 1.0:
-            theta -= 1.0
-         norm_y = theta
-      elif mode == 'perimeter':
-         d_xy = np.array((x, y)) - centre_xy
-         dp_xy = np.array((px, py)) - centre_xy
-         if abs(dp_xy[0]) > abs(dp_xy[1]):
-            rf = d_xy[0] / dp_xy[0]
-         else:
-            rf = d_xy[1] / dp_xy[1]
-         norm_x = rf * rf
-         seg_xy = np.array((px, py)) - self.coordinates[segment, :2]
-         length = 0.0
-         for seg in range(segment):
-            length += self.segment_length(seg, in_xy = True)
-         length += vu.naive_length(seg_xy)
-         norm_y = length / self.full_length(in_xy = True)
-      return norm_x, norm_y
+        assert mode in ['square', 'perimeter', 'circle']
+        assert self.is_convex(), 'attempt to find normalised x,y within a polyline that is not a closed convex polygon'
+        centre_xy = self.balanced_centre()[:2]
+        if tuple(centre_xy) == (x, y):
+            if mode == 'square':
+                return 0.5, 0.5
+            return 0.0, 0.0
+        segment, px, py = self.first_line_intersection(centre_xy[0], centre_xy[1], x, y, half_segment = True)
+        assert px is not None
+        norm_x, norm_y = None, None
+        if mode == 'square':
+            if px == centre_xy[0]:
+                norm_x = 0.5
+            else:
+                norm_x = 0.5 + 0.5 * (x - centre_xy[0]) / abs(px - centre_xy[0])
+            if py == centre_xy[1]:
+                norm_y = 0.5
+            else:
+                norm_y = 0.5 + 0.5 * (y - centre_xy[1]) / abs(py - centre_xy[1])
+        elif mode == 'circle':
+            d_xy = np.array((x, y)) - centre_xy
+            dp_xy = np.array((px, py)) - centre_xy
+            if abs(dp_xy[0]) > abs(dp_xy[1]):
+                rf = d_xy[0] / dp_xy[0]
+                theta = maths.atan(d_xy[1] / d_xy[0])
+                if d_xy[0] < 0.0:
+                    theta += maths.pi
+            else:
+                rf = d_xy[1] / dp_xy[1]
+                theta = maths.pi / 2.0 - maths.atan(d_xy[0] / d_xy[1])
+                if d_xy[1] < 0.0:
+                    theta += maths.pi
+            norm_x = rf * rf
+            theta /= 2.0 * maths.pi
+            if theta < 0.0:
+                theta += 1.0
+            elif theta > 1.0:
+                theta -= 1.0
+            norm_y = theta
+        elif mode == 'perimeter':
+            d_xy = np.array((x, y)) - centre_xy
+            dp_xy = np.array((px, py)) - centre_xy
+            if abs(dp_xy[0]) > abs(dp_xy[1]):
+                rf = d_xy[0] / dp_xy[0]
+            else:
+                rf = d_xy[1] / dp_xy[1]
+            norm_x = rf * rf
+            seg_xy = np.array((px, py)) - self.coordinates[segment, :2]
+            length = 0.0
+            for seg in range(segment):
+                length += self.segment_length(seg, in_xy = True)
+            length += vu.naive_length(seg_xy)
+            norm_y = length / self.full_length(in_xy = True)
+        return norm_x, norm_y
 
-   def denormalised_xy(self, norm_x, norm_y, mode = 'perimeter'):
-      """Returns a denormalised x,y pair being point norm_x,norm_y (in range 0..1) under mapping onto convex polygon.
+    def denormalised_xy(self, norm_x, norm_y, mode = 'perimeter'):
+        """Returns a denormalised x,y pair being point norm_x,norm_y (in range 0..1) under mapping onto convex polygon.
 
         arguments:
             norm_x, norm_y (floats): normalised values, each in range 0..1, identifying a location in a unit shape
@@ -525,102 +527,103 @@ class Polyline(_BasePolyline):
             an even density of denormalised locations
         """
 
-      assert mode in ['square', 'perimeter', 'circle']
-      assert 0.0 <= norm_x <= 1.0 and 0.0 <= norm_y <= 1.0
-      assert self.is_convex(), 'attempt to find denormalised x,y within a polyline that is not a closed convex polygon'
-      centre_xy = self.balanced_centre()[:2]
-      x, y = None, None
-      if mode == 'square':
-         if (norm_x, norm_y) == (0.5, 0.5):
-            return tuple(centre_xy)
-         n_x = (norm_x - 0.5) + centre_xy[0]
-         n_y = (norm_y - 0.5) + centre_xy[1]
-         _, px, py = self.first_line_intersection(centre_xy[0], centre_xy[1], n_x, n_y, half_segment = True)
-         assert px is not None
-         fx = abs(norm_x - 0.5)
-         fy = abs(norm_y - 0.5)
-         f = 2.0 * max(fx, fy)
-         log.debug(f'intersect x,y: {px}, {py}')
-         if px == centre_xy[0]:
-            x = centre_xy[0]
-         else:
-            x = centre_xy[0] + f * (px - centre_xy[0])
-         if py == centre_xy[1]:
-            y = centre_xy[1]
-         else:
-            y = centre_xy[1] + f * (py - centre_xy[1])
-         log.debug(f'denormal x,y: {x}, {y}')
-      elif mode == 'perimeter':
-         if norm_y == 1.0:
-            norm_y = 0.0
-         p_xy = np.empty(2)
-         p_xy[:] = self.interpolated_point(norm_y)[:2]
-         f = maths.sqrt(norm_x)
-         x, y = centre_xy + f * (p_xy - centre_xy)
-      elif mode == 'circle':
-         theta = 2 * maths.pi * norm_y
-         n_x = centre_xy[0] + maths.cos(theta)
-         n_y = centre_xy[1] + maths.sin(theta)
-         p_xy = np.empty(2)
-         p_xy[:] = self.first_line_intersection(centre_xy[0], centre_xy[1], n_x, n_y, half_segment = True)[1:]
-         f = maths.sqrt(norm_x)
-         x, y = centre_xy + f * (p_xy - centre_xy)
-      return x, y
+        assert mode in ['square', 'perimeter', 'circle']
+        assert 0.0 <= norm_x <= 1.0 and 0.0 <= norm_y <= 1.0
+        assert self.is_convex(
+        ), 'attempt to find denormalised x,y within a polyline that is not a closed convex polygon'
+        centre_xy = self.balanced_centre()[:2]
+        x, y = None, None
+        if mode == 'square':
+            if (norm_x, norm_y) == (0.5, 0.5):
+                return tuple(centre_xy)
+            n_x = (norm_x - 0.5) + centre_xy[0]
+            n_y = (norm_y - 0.5) + centre_xy[1]
+            _, px, py = self.first_line_intersection(centre_xy[0], centre_xy[1], n_x, n_y, half_segment = True)
+            assert px is not None
+            fx = abs(norm_x - 0.5)
+            fy = abs(norm_y - 0.5)
+            f = 2.0 * max(fx, fy)
+            log.debug(f'intersect x,y: {px}, {py}')
+            if px == centre_xy[0]:
+                x = centre_xy[0]
+            else:
+                x = centre_xy[0] + f * (px - centre_xy[0])
+            if py == centre_xy[1]:
+                y = centre_xy[1]
+            else:
+                y = centre_xy[1] + f * (py - centre_xy[1])
+            log.debug(f'denormal x,y: {x}, {y}')
+        elif mode == 'perimeter':
+            if norm_y == 1.0:
+                norm_y = 0.0
+            p_xy = np.empty(2)
+            p_xy[:] = self.interpolated_point(norm_y)[:2]
+            f = maths.sqrt(norm_x)
+            x, y = centre_xy + f * (p_xy - centre_xy)
+        elif mode == 'circle':
+            theta = 2 * maths.pi * norm_y
+            n_x = centre_xy[0] + maths.cos(theta)
+            n_y = centre_xy[1] + maths.sin(theta)
+            p_xy = np.empty(2)
+            p_xy[:] = self.first_line_intersection(centre_xy[0], centre_xy[1], n_x, n_y, half_segment = True)[1:]
+            f = maths.sqrt(norm_x)
+            x, y = centre_xy + f * (p_xy - centre_xy)
+        return x, y
 
-   def tangent_vectors(self):
-      """Returns a numpy array of unit length tangent vectors, one for each coordinate in the line."""
+    def tangent_vectors(self):
+        """Returns a numpy array of unit length tangent vectors, one for each coordinate in the line."""
 
-      return tangents(self.coordinates)
+        return tangents(self.coordinates)
 
-   def splined(self,
-               tangent_weight = 'square',
-               min_subdivisions = 1,
-               max_segment_length = None,
-               max_degrees_per_knot = 5.0,
-               title = None,
-               rep_int_root = None):
-      """Retrurns a new Polyline being a cubic spline of this polyline.
+    def splined(self,
+                tangent_weight = 'square',
+                min_subdivisions = 1,
+                max_segment_length = None,
+                max_degrees_per_knot = 5.0,
+                title = None,
+                rep_int_root = None):
+        """Retrurns a new Polyline being a cubic spline of this polyline.
 
         :meta common:
         """
 
-      spline_coords = spline(self.coordinates,
-                             tangent_weight = tangent_weight,
-                             min_subdivisions = min_subdivisions,
-                             max_segment_length = max_segment_length,
-                             max_degrees_per_knot = max_degrees_per_knot,
-                             closed = self.isclosed)
+        spline_coords = spline(self.coordinates,
+                               tangent_weight = tangent_weight,
+                               min_subdivisions = min_subdivisions,
+                               max_segment_length = max_segment_length,
+                               max_degrees_per_knot = max_degrees_per_knot,
+                               closed = self.isclosed)
 
-      if not title:
-         title = self.title
-      if rep_int_root is None:
-         rep_int_root = self.rep_int_root  # todo: check whether it is legal to have 2 representations for 1 interpretation
+        if not title:
+            title = self.title
+        if rep_int_root is None:
+            rep_int_root = self.rep_int_root  # todo: check whether it is legal to have 2 representations for 1 interpretation
 
-      return Polyline(self.model,
-                      set_bool = self.isclosed,
-                      set_coord = spline_coords,
-                      set_crs = self.crs_uuid,
-                      title = title,
-                      rep_int_root = rep_int_root)
+        return Polyline(self.model,
+                        set_bool = self.isclosed,
+                        set_coord = spline_coords,
+                        set_crs = self.crs_uuid,
+                        title = title,
+                        rep_int_root = rep_int_root)
 
-   def area(self):
-      """Returns the area in the xy plane of a closed convex polygon."""
-      assert self.isclosed
-      assert self.is_convex()
-      centre = np.mean(self.coordinates, axis = 0)
-      a = 0.0
-      for node in range(len(self.coordinates)):
-         a += vu.area_of_triangle(centre, self.coordinates[node - 1], self.coordinates[node])
-      return a
+    def area(self):
+        """Returns the area in the xy plane of a closed convex polygon."""
+        assert self.isclosed
+        assert self.is_convex()
+        centre = np.mean(self.coordinates, axis = 0)
+        a = 0.0
+        for node in range(len(self.coordinates)):
+            a += vu.area_of_triangle(centre, self.coordinates[node - 1], self.coordinates[node])
+        return a
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  root = None,
-                  title = None,
-                  originator = None):
-      """Create xml from polyline.
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   root = None,
+                   title = None,
+                   originator = None):
+        """Create xml from polyline.
 
         args:
             ext_uuid: the uuid of the hdf5 external part
@@ -628,118 +631,118 @@ class Polyline(_BasePolyline):
         :meta common:
         """
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      if title is not None:
-         self.title = title
-      if self.title is None:
-         self.title = 'polyline'
+        if title is not None:
+            self.title = title
+        if self.title is None:
+            self.title = 'polyline'
 
-      polyline = super().create_xml(add_as_part = False, originator = originator)
+        polyline = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.rep_int_root is not None:
-         rep_int = self.rep_int_root
-         if "FaultInterpretation" in str(rqet.content_type(rep_int)):
-            content_type = 'obj_FaultInterpretation'
-         else:
-            content_type = 'obj_HorizonInterpretation'
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.citation_title_for_node(rep_int),
-                                    rep_int.attrib['uuid'],
-                                    content_type = content_type,
-                                    root = polyline)
+        if self.rep_int_root is not None:
+            rep_int = self.rep_int_root
+            if "FaultInterpretation" in str(rqet.content_type(rep_int)):
+                content_type = 'obj_FaultInterpretation'
+            else:
+                content_type = 'obj_HorizonInterpretation'
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.citation_title_for_node(rep_int),
+                                       rep_int.attrib['uuid'],
+                                       content_type = content_type,
+                                       root = polyline)
 
-      isclosed = rqet.SubElement(polyline, ns['resqml2'] + 'IsClosed')
-      isclosed.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-      isclosed.text = str(self.isclosed).lower()
+        isclosed = rqet.SubElement(polyline, ns['resqml2'] + 'IsClosed')
+        isclosed.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+        isclosed.text = str(self.isclosed).lower()
 
-      nodepatch = rqet.SubElement(polyline, ns['resqml2'] + 'NodePatch')
-      nodepatch.set(ns['xsi'] + 'type', ns['resqml2'] + 'NodePatch')
-      nodepatch.text = '\n'
+        nodepatch = rqet.SubElement(polyline, ns['resqml2'] + 'NodePatch')
+        nodepatch.set(ns['xsi'] + 'type', ns['resqml2'] + 'NodePatch')
+        nodepatch.text = '\n'
 
-      patchindex = rqet.SubElement(nodepatch, ns['resqml2'] + 'PatchIndex')
-      patchindex.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-      patchindex.text = str(self.nodepatch[0])
+        patchindex = rqet.SubElement(nodepatch, ns['resqml2'] + 'PatchIndex')
+        patchindex.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+        patchindex.text = str(self.nodepatch[0])
 
-      count = rqet.SubElement(nodepatch, ns['resqml2'] + 'Count')
-      count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      count.text = str(self.nodepatch[1])
+        count = rqet.SubElement(nodepatch, ns['resqml2'] + 'Count')
+        count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        count.text = str(self.nodepatch[1])
 
-      geom = rqet.SubElement(nodepatch, ns['resqml2'] + 'Geometry')
-      geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
-      geom.text = '\n'
+        geom = rqet.SubElement(nodepatch, ns['resqml2'] + 'Geometry')
+        geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
+        geom.text = '\n'
 
-      self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+        self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
-      points = rqet.SubElement(geom, ns['resqml2'] + 'Points')
-      points.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-      points.text = '\n'
+        points = rqet.SubElement(geom, ns['resqml2'] + 'Points')
+        points.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+        points.text = '\n'
 
-      coords = rqet.SubElement(points, ns['resqml2'] + 'Coordinates')
-      coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      coords.text = rqet.null_xml_text
+        coords = rqet.SubElement(points, ns['resqml2'] + 'Coordinates')
+        coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        coords.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points_patch0', root = coords)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points_patch0', root = coords)
 
-      if root is not None:
-         root.append(polyline)
-      if add_as_part:
-         self.model.add_part('obj_PolylineRepresentation', self.uuid, polyline)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(polyline, 'destinationObject', self.crs_root, 'sourceObject')
-            if self.rep_int_root is not None:  # Optional
-               self.model.create_reciprocal_relationship(polyline, 'destinationObject', self.rep_int_root,
-                                                         'sourceObject')
+        if root is not None:
+            root.append(polyline)
+        if add_as_part:
+            self.model.add_part('obj_PolylineRepresentation', self.uuid, polyline)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(polyline, 'destinationObject', self.crs_root, 'sourceObject')
+                if self.rep_int_root is not None:  # Optional
+                    self.model.create_reciprocal_relationship(polyline, 'destinationObject', self.rep_int_root,
+                                                              'sourceObject')
 
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(polyline, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(polyline, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
 
-      return polyline
+        return polyline
 
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Create or append the coordinates hdf5 array to hdf5 file.
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Create or append the coordinates hdf5 array to hdf5 file.
 
         :meta common:
         """
 
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
-      h5_reg = rwh5.H5Register(self.model)
-      h5_reg.register_dataset(self.uuid, 'points_patch0', self.coordinates)
-      h5_reg.write(file_name, mode = mode)
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
+        h5_reg = rwh5.H5Register(self.model)
+        h5_reg.register_dataset(self.uuid, 'points_patch0', self.coordinates)
+        h5_reg.write(file_name, mode = mode)
 
-   def _successor(self, segment_index):
-      """Returns segment_index + 1; or zero if segment_index is the last segment in a closed polyline."""
+    def _successor(self, segment_index):
+        """Returns segment_index + 1; or zero if segment_index is the last segment in a closed polyline."""
 
-      successor = segment_index + 1
-      if self.isclosed:
-         assert 0 <= segment_index < len(self.coordinates)
-         if segment_index == len(self.coordinates) - 1:
-            successor = 0
-      else:
-         assert 0 <= segment_index < len(self.coordinates) - 1
-      return successor
+        successor = segment_index + 1
+        if self.isclosed:
+            assert 0 <= segment_index < len(self.coordinates)
+            if segment_index == len(self.coordinates) - 1:
+                successor = 0
+        else:
+            assert 0 <= segment_index < len(self.coordinates) - 1
+        return successor
 
 
 class PolylineSet(_BasePolyline):
-   """Class for RESQML polyline set representation."""
+    """Class for RESQML polyline set representation."""
 
-   resqml_type = 'PolylineSetRepresentation'
+    resqml_type = 'PolylineSetRepresentation'
 
-   def __init__(self,
-                parent_model,
-                set_root = None,
-                uuid = None,
-                polylines = None,
-                irap_file = None,
-                charisma_file = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Initialises a new PolylineSet object.
+    def __init__(self,
+                 parent_model,
+                 set_root = None,
+                 uuid = None,
+                 polylines = None,
+                 irap_file = None,
+                 charisma_file = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Initialises a new PolylineSet object.
 
         arguments:
             parent_model (model.Model object): the model which the new PolylineSetRepresentation belongs to
@@ -765,173 +768,174 @@ class PolylineSet(_BasePolyline):
         :meta common:
         """
 
-      self.model = parent_model
-      self.coordinates = None
-      self.count_perpol = None
-      self.polys = []
-      self.rep_int_root = None
-      self.save_polys = False
-      self.boolnotconstant = None
-      self.boolvalue = None
-      self.crs_uuid = None
+        self.model = parent_model
+        self.coordinates = None
+        self.count_perpol = None
+        self.polys = []
+        self.rep_int_root = None
+        self.save_polys = False
+        self.boolnotconstant = None
+        self.boolvalue = None
+        self.crs_uuid = None
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       root_node = set_root,
-                       extra_metadata = extra_metadata)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         root_node = set_root,
+                         extra_metadata = extra_metadata)
 
-      if self.root is not None:
-         return
+        if self.root is not None:
+            return
 
-      if polylines is not None:  # Create from list of polylines
-         crs_list = []
-         for poly in polylines:
-            crs_list.append(poly.crs_uuid)
-         crs_set = set(crs_list)
-         assert len(crs_set) == 1, 'More than one CRS found in input polylines for polyline set'
-         for crs_uuid in crs_set:
-            self.crs_uuid = crs_uuid
-            if self.crs_root is not None:
-               break
-         self.polys = polylines
-         # Setting the title of the first polyline given as the PolylineSet title
-         if len(polylines) > 1:
-            self.title = f"{polylines[0].title} + {len(polylines)-1} polylines"
-         else:
-            self.title = polylines[0].title
-
-      elif irap_file is not None:  # Create from an input IRAP file
-         inpoints = rsl.read_lines(irap_file)
-         self.count_perpol = []
-         closed_array = []
-         self.title = os.path.basename(irap_file).split(".")[0]
-         for i, poly in enumerate(inpoints):
-            if len(poly) > 1:  # Polylines must have at least 2 points
-               self.count_perpol.append(len(poly))
-               if vu.isclose(poly[0], poly[-1]):
-                  closed_array.append(True)
-               else:
-                  closed_array.append(False)
-               if i == 0:
-                  self.coordinates = poly
-               else:
-                  self.coordinates = np.concatenate((self.coordinates, poly))
-         self.count_perpol = np.array(self.count_perpol)
-         if self.crs_root is None:  # If no crs_uuid is provided, assume the main model crs is valid
-            self.crs_uuid = self.model.crs_uuid
-         self.polys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates, self.crs_uuid,
-                                                self.crs_root, self.rep_int_root)
-
-      elif charisma_file is not None:
-         with open(charisma_file) as f:
-            inpoints = f.readlines()
-         self.count_perpol = []
-         closed_array = []
-         self.title = os.path.basename(charisma_file).split(".")[0]
-         for i, line in enumerate(inpoints):
-            line = line.split()
-            if i == 0:
-               self.coordinates = (np.array([[float(line[3]), float(line[4]), float(line[5])]]))
-               stick = line[7]
-               count = 1
+        if polylines is not None:  # Create from list of polylines
+            crs_list = []
+            for poly in polylines:
+                crs_list.append(poly.crs_uuid)
+            crs_set = set(crs_list)
+            assert len(crs_set) == 1, 'More than one CRS found in input polylines for polyline set'
+            for crs_uuid in crs_set:
+                self.crs_uuid = crs_uuid
+                if self.crs_root is not None:
+                    break
+            self.polys = polylines
+            # Setting the title of the first polyline given as the PolylineSet title
+            if len(polylines) > 1:
+                self.title = f"{polylines[0].title} + {len(polylines)-1} polylines"
             else:
-               self.coordinates = np.concatenate(
-                  (self.coordinates, np.array(([[float(line[3]), float(line[4]),
-                                                 float(line[5])]]))))
-               count += 1
-               if stick != line[7] or i == len(inpoints) - 1:
-                  if count <= 2:  # Line has fewer than 2 points
-                     log.info(f"Polylines must contain at least 2 points - ignoring point {self.coordinates[-2]}")
-                     self.coordinates = np.delete(self.coordinates, -2, 0)  # Remove the second to last entry
-                  else:
-                     self.count_perpol.append(count - 1)
-                     closed_array.append(False)
-                  count = 1
-                  stick = line[7]
-         self.count_perpol = np.array(self.count_perpol)
-         if self.crs_root is None:  # If no crs_uuid is provided, assume the main model crs is valid
-            self.crs_uuid = self.model.crs_uuid
-         self.polys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates, self.crs_uuid,
-                                                self.crs_root, self.rep_int_root)
+                self.title = polylines[0].title
 
-   def _load_from_xml(self):
+        elif irap_file is not None:  # Create from an input IRAP file
+            inpoints = rsl.read_lines(irap_file)
+            self.count_perpol = []
+            closed_array = []
+            self.title = os.path.basename(irap_file).split(".")[0]
+            for i, poly in enumerate(inpoints):
+                if len(poly) > 1:  # Polylines must have at least 2 points
+                    self.count_perpol.append(len(poly))
+                    if vu.isclose(poly[0], poly[-1]):
+                        closed_array.append(True)
+                    else:
+                        closed_array.append(False)
+                    if i == 0:
+                        self.coordinates = poly
+                    else:
+                        self.coordinates = np.concatenate((self.coordinates, poly))
+            self.count_perpol = np.array(self.count_perpol)
+            if self.crs_root is None:  # If no crs_uuid is provided, assume the main model crs is valid
+                self.crs_uuid = self.model.crs_uuid
+            self.polys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates, self.crs_uuid,
+                                                   self.crs_root, self.rep_int_root)
 
-      assert self.root is not None  # polyline set xml node specified
-      root = self.root
+        elif charisma_file is not None:
+            with open(charisma_file) as f:
+                inpoints = f.readlines()
+            self.count_perpol = []
+            closed_array = []
+            self.title = os.path.basename(charisma_file).split(".")[0]
+            for i, line in enumerate(inpoints):
+                line = line.split()
+                if i == 0:
+                    self.coordinates = (np.array([[float(line[3]), float(line[4]), float(line[5])]]))
+                    stick = line[7]
+                    count = 1
+                else:
+                    self.coordinates = np.concatenate(
+                        (self.coordinates, np.array(([[float(line[3]), float(line[4]),
+                                                       float(line[5])]]))))
+                    count += 1
+                    if stick != line[7] or i == len(inpoints) - 1:
+                        if count <= 2:  # Line has fewer than 2 points
+                            log.info(
+                                f"Polylines must contain at least 2 points - ignoring point {self.coordinates[-2]}")
+                            self.coordinates = np.delete(self.coordinates, -2, 0)  # Remove the second to last entry
+                        else:
+                            self.count_perpol.append(count - 1)
+                            closed_array.append(False)
+                        count = 1
+                        stick = line[7]
+            self.count_perpol = np.array(self.count_perpol)
+            if self.crs_root is None:  # If no crs_uuid is provided, assume the main model crs is valid
+                self.crs_uuid = self.model.crs_uuid
+            self.polys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates, self.crs_uuid,
+                                                   self.crs_root, self.rep_int_root)
 
-      self.rep_int_root = self.model.referenced_node(rqet.find_tag(root, 'RepresentedInterpretation'))
+    def _load_from_xml(self):
 
-      for patch_node in rqet.list_of_tag(root, 'LinePatch'):  # Loop over all LinePatches - likely just the one
-         assert patch_node is not None  # Required field
+        assert self.root is not None  # polyline set xml node specified
+        root = self.root
 
-         geometry_node = rqet.find_tag(patch_node, 'Geometry')
-         assert geometry_node is not None  # Required field
+        self.rep_int_root = self.model.referenced_node(rqet.find_tag(root, 'RepresentedInterpretation'))
 
-         crs_root = self.model.referenced_node(rqet.find_tag(geometry_node, 'LocalCrs'))
-         assert crs_root is not None  # Required field
-         self.crs_uuid = rqet.uuid_for_part_root(crs_root)
-         assert self.crs_uuid is not None  # Required field
+        for patch_node in rqet.list_of_tag(root, 'LinePatch'):  # Loop over all LinePatches - likely just the one
+            assert patch_node is not None  # Required field
 
-         closed_node = rqet.find_tag(patch_node, 'ClosedPolylines')
-         assert closed_node is not None  # Required field
-         # The ClosedPolylines could be a BooleanConstantArray, or a BooleanArrayFromIndexArray
-         closed_array = self.get_bool_array(closed_node)
+            geometry_node = rqet.find_tag(patch_node, 'Geometry')
+            assert geometry_node is not None  # Required field
 
-         count_node = rqet.find_tag(patch_node, 'NodeCountPerPolyline')
-         load_hdf5_array(self, count_node, 'count_perpol', tag = 'Values')
+            crs_root = self.model.referenced_node(rqet.find_tag(geometry_node, 'LocalCrs'))
+            assert crs_root is not None  # Required field
+            self.crs_uuid = rqet.uuid_for_part_root(crs_root)
+            assert self.crs_uuid is not None  # Required field
 
-         points_node = rqet.find_tag(geometry_node, 'Points')
-         assert points_node is not None  # Required field
-         load_hdf5_array(self, points_node, 'coordinates', tag = 'Coordinates')
+            closed_node = rqet.find_tag(patch_node, 'ClosedPolylines')
+            assert closed_node is not None  # Required field
+            # The ClosedPolylines could be a BooleanConstantArray, or a BooleanArrayFromIndexArray
+            closed_array = self.get_bool_array(closed_node)
 
-         # Check that the number of bools aligns with the number of count_perpoly
-         # Check that the total of the count_perpoly aligns with the number of coordinates
-         assert len(self.count_perpol) == len(closed_array)
-         assert np.sum(self.count_perpol) == len(self.coordinates)
+            count_node = rqet.find_tag(patch_node, 'NodeCountPerPolyline')
+            load_hdf5_array(self, count_node, 'count_perpol', tag = 'Values')
 
-         subpolys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates, self.crs_uuid,
-                                              self.crs_root, self.rep_int_root)
-         # Check we have the right number of polygons
-         assert len(subpolys) == len(self.count_perpol)
+            points_node = rqet.find_tag(geometry_node, 'Points')
+            assert points_node is not None  # Required field
+            load_hdf5_array(self, points_node, 'coordinates', tag = 'Coordinates')
 
-         # Remove duplicate coordinates and count arrays (exist in polylines now)
-         # delattr(self,'coordinates')
-         # delattr(self,'count_perpol')
+            # Check that the number of bools aligns with the number of count_perpoly
+            # Check that the total of the count_perpoly aligns with the number of coordinates
+            assert len(self.count_perpol) == len(closed_array)
+            assert np.sum(self.count_perpol) == len(self.coordinates)
 
-         self.polys.extend(subpolys)
+            subpolys = self.convert_to_polylines(closed_array, self.count_perpol, self.coordinates, self.crs_uuid,
+                                                 self.crs_root, self.rep_int_root)
+            # Check we have the right number of polygons
+            assert len(subpolys) == len(self.count_perpol)
 
-   @property
-   def crs_root(self):
-      """XML node corresponding to self.crs_uuid"""
+            # Remove duplicate coordinates and count arrays (exist in polylines now)
+            # delattr(self,'coordinates')
+            # delattr(self,'count_perpol')
 
-      return self.model.root_for_uuid(self.crs_uuid)
+            self.polys.extend(subpolys)
 
-   def poly_index_containing_point_in_xy(self, p, mode = 'crossing'):
-      """Returns the index of the first (closed) polyline containing point p in the xy plane, or None.
+    @property
+    def crs_root(self):
+        """XML node corresponding to self.crs_uuid"""
+
+        return self.model.root_for_uuid(self.crs_uuid)
+
+    def poly_index_containing_point_in_xy(self, p, mode = 'crossing'):
+        """Returns the index of the first (closed) polyline containing point p in the xy plane, or None.
 
         :meta common:
         """
 
-      assert mode in ['crossing', 'winding'], 'unrecognised mode when looking for polygon containing point'
+        assert mode in ['crossing', 'winding'], 'unrecognised mode when looking for polygon containing point'
 
-      for i, poly in enumerate(self.polys):
-         if not poly.isclosed:
-            continue
-         if poly.point_is_inside_xy(p, mode = mode):
-            return i
-      return None
+        for i, poly in enumerate(self.polys):
+            if not poly.isclosed:
+                continue
+            if poly.point_is_inside_xy(p, mode = mode):
+                return i
+        return None
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  root = None,
-                  title = None,
-                  originator = None,
-                  save_polylines = False):
-      """Create xml from polylineset
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   root = None,
+                   title = None,
+                   originator = None,
+                   save_polylines = False):
+        """Create xml from polylineset
 
         args:
             save_polylines: If true, polylines are also saved individually
@@ -939,177 +943,177 @@ class PolylineSet(_BasePolyline):
         :meta common:
         """
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      self.save_polys = save_polylines
+        self.save_polys = save_polylines
 
-      if title:
-         self.title = title
-      if not self.title:
-         self.title = 'polyline set'
+        if title:
+            self.title = title
+        if not self.title:
+            self.title = 'polyline set'
 
-      if self.save_polys:
-         for poly in self.polys:
-            poly.create_xml(ext_uuid, add_relationships = add_relationships, originator = originator)
+        if self.save_polys:
+            for poly in self.polys:
+                poly.create_xml(ext_uuid, add_relationships = add_relationships, originator = originator)
 
-      polyset = super().create_xml(add_as_part = False, originator = originator)
+        polyset = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.rep_int_root is not None:
-         rep_int = self.rep_int_root
-         if "FaultInterpretation" in str(rqet.content_type(rep_int)):
-            content_type = 'obj_FaultInterpretation'
-         else:
-            content_type = 'obj_HorizonInterpretation'
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.citation_title_for_node(rep_int),
-                                    rep_int.attrib['uuid'],
-                                    content_type = content_type,
-                                    root = polyset)
+        if self.rep_int_root is not None:
+            rep_int = self.rep_int_root
+            if "FaultInterpretation" in str(rqet.content_type(rep_int)):
+                content_type = 'obj_FaultInterpretation'
+            else:
+                content_type = 'obj_HorizonInterpretation'
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.citation_title_for_node(rep_int),
+                                       rep_int.attrib['uuid'],
+                                       content_type = content_type,
+                                       root = polyset)
 
-      # We convert all Polylines to the CRS of the first Polyline in the set, so set this as crs_uuid
+        # We convert all Polylines to the CRS of the first Polyline in the set, so set this as crs_uuid
 
-      patch = rqet.SubElement(polyset, ns['resqml2'] + 'LinePatch')
-      patch.set(ns['xsi'] + 'type', ns['resqml2'] + 'PolylineSetPatch')
-      patch.text = '\n'
+        patch = rqet.SubElement(polyset, ns['resqml2'] + 'LinePatch')
+        patch.set(ns['xsi'] + 'type', ns['resqml2'] + 'PolylineSetPatch')
+        patch.text = '\n'
 
-      pindex = rqet.SubElement(patch, ns['resqml2'] + 'PatchIndex')
-      pindex.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-      pindex.text = '0'
+        pindex = rqet.SubElement(patch, ns['resqml2'] + 'PatchIndex')
+        pindex.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+        pindex.text = '0'
 
-      if self.boolnotconstant:
-         # We have mixed data - use a BooleanArrayFromIndexArray
-         closed = rqet.SubElement(patch, ns['resqml2'] + 'ClosedPolylines')
-         closed.set(ns['xsi'] + 'type', ns['xsd'] + 'BooleanArrayFromIndexArray')
-         closed.text = '\n'
+        if self.boolnotconstant:
+            # We have mixed data - use a BooleanArrayFromIndexArray
+            closed = rqet.SubElement(patch, ns['resqml2'] + 'ClosedPolylines')
+            closed.set(ns['xsi'] + 'type', ns['xsd'] + 'BooleanArrayFromIndexArray')
+            closed.text = '\n'
 
-         bool_val = rqet.SubElement(closed, ns['resqml2'] + 'Value')
-         bool_val.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-         bool_val.text = str(self.boolvalue).lower()
+            bool_val = rqet.SubElement(closed, ns['resqml2'] + 'Value')
+            bool_val.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+            bool_val.text = str(self.boolvalue).lower()
 
-         ind_val = rqet.SubElement(closed, ns['resqml2'] + 'Indices')
-         ind_val.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         ind_val.text = '\n'
+            ind_val = rqet.SubElement(closed, ns['resqml2'] + 'Indices')
+            ind_val.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            ind_val.text = '\n'
 
-         count = rqet.SubElement(closed, ns['resqml2'] + 'Count')
-         count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         count.text = str(len(self.count_perpol))
+            count = rqet.SubElement(closed, ns['resqml2'] + 'Count')
+            count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            count.text = str(len(self.count_perpol))
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'indices_patch0', root = ind_val)
-      else:
-         # All bools are the same - use a BooleanConstantArray
-         closed = rqet.SubElement(patch, ns['resqml2'] + 'ClosedPolylines')
-         closed.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanConstantArray')
-         closed.text = '\n'
-         bool_val = rqet.SubElement(closed, ns['resqml2'] + 'Value')
-         bool_val.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-         bool_val.text = str(self.boolvalue).lower()
-         count = rqet.SubElement(closed, ns['resqml2'] + 'Count')
-         count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         count.text = str(len(self.count_perpol))
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'indices_patch0', root = ind_val)
+        else:
+            # All bools are the same - use a BooleanConstantArray
+            closed = rqet.SubElement(patch, ns['resqml2'] + 'ClosedPolylines')
+            closed.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanConstantArray')
+            closed.text = '\n'
+            bool_val = rqet.SubElement(closed, ns['resqml2'] + 'Value')
+            bool_val.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+            bool_val.text = str(self.boolvalue).lower()
+            count = rqet.SubElement(closed, ns['resqml2'] + 'Count')
+            count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            count.text = str(len(self.count_perpol))
 
-      count_pp = rqet.SubElement(patch, ns['resqml2'] + 'NodeCountPerPolyline')
-      count_pp.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      count_pp.text = '\n'
+        count_pp = rqet.SubElement(patch, ns['resqml2'] + 'NodeCountPerPolyline')
+        count_pp.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        count_pp.text = '\n'
 
-      null = rqet.SubElement(count_pp, ns['resqml2'] + 'NullValue')
-      null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      null.text = '0'
+        null = rqet.SubElement(count_pp, ns['resqml2'] + 'NullValue')
+        null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        null.text = '0'
 
-      count_val = rqet.SubElement(count_pp, ns['resqml2'] + 'Values')
-      count_val.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      count_val.text = '\n'
+        count_val = rqet.SubElement(count_pp, ns['resqml2'] + 'Values')
+        count_val.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        count_val.text = '\n'
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'NodeCountPerPolyline_patch0', root = count_val)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'NodeCountPerPolyline_patch0', root = count_val)
 
-      geom = rqet.SubElement(patch, ns['resqml2'] + 'Geometry')
-      geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
-      geom.text = '\n'
+        geom = rqet.SubElement(patch, ns['resqml2'] + 'Geometry')
+        geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
+        geom.text = '\n'
 
-      self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+        self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
-      points = rqet.SubElement(geom, ns['resqml2'] + 'Points')
-      points.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-      points.text = '\n'
+        points = rqet.SubElement(geom, ns['resqml2'] + 'Points')
+        points.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+        points.text = '\n'
 
-      coords = rqet.SubElement(points, ns['resqml2'] + 'Coordinates')
-      coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      coords.text = '\n'
+        coords = rqet.SubElement(points, ns['resqml2'] + 'Coordinates')
+        coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        coords.text = '\n'
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points_patch0', root = coords)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points_patch0', root = coords)
 
-      if root is not None:
-         root.append(polyset)
-      if add_as_part:
-         self.model.add_part('obj_PolylineSetRepresentation', self.uuid, polyset)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(polyset, 'destinationObject', self.crs_root, 'sourceObject')
-            if self.rep_int_root is not None:  # Optional
-               self.model.create_reciprocal_relationship(polyset, 'destinationObject', self.rep_int_root,
-                                                         'sourceObject')
-            if self.save_polys:
-               for poly in self.polys:
-                  self.model.create_reciprocal_relationship(polyset, 'destinationObject', poly.root_node,
-                                                            'sourceObject')
+        if root is not None:
+            root.append(polyset)
+        if add_as_part:
+            self.model.add_part('obj_PolylineSetRepresentation', self.uuid, polyset)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(polyset, 'destinationObject', self.crs_root, 'sourceObject')
+                if self.rep_int_root is not None:  # Optional
+                    self.model.create_reciprocal_relationship(polyset, 'destinationObject', self.rep_int_root,
+                                                              'sourceObject')
+                if self.save_polys:
+                    for poly in self.polys:
+                        self.model.create_reciprocal_relationship(polyset, 'destinationObject', poly.root_node,
+                                                                  'sourceObject')
 
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(polyset, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(polyset, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
 
-      return polyset
+        return polyset
 
-   def write_hdf5(self, file_name = None, mode = 'a', save_polylines = False):
-      """Create or append the coordinates, counts and indices hdf5 arrays to hdf5 file.
+    def write_hdf5(self, file_name = None, mode = 'a', save_polylines = False):
+        """Create or append the coordinates, counts and indices hdf5 arrays to hdf5 file.
 
         :meta common:
         """
 
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
-      self.combine_polylines(self.polys)
-      self.bool_array_format(self.closed_array)
-      self.save_polys = save_polylines
-      if self.save_polys:
-         for poly in self.polys:
-            poly.write_hdf5(file_name)
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
+        self.combine_polylines(self.polys)
+        self.bool_array_format(self.closed_array)
+        self.save_polys = save_polylines
+        if self.save_polys:
+            for poly in self.polys:
+                poly.write_hdf5(file_name)
 
-      h5_reg = rwh5.H5Register(self.model)
-      h5_reg.register_dataset(self.uuid, 'points_patch0', self.coordinates)
-      h5_reg.register_dataset(self.uuid, 'NodeCountPerPolyline_patch0', self.count_perpol.astype(np.int32))
-      if self.boolnotconstant:
-         h5_reg.register_dataset(self.uuid, 'indices_patch0', self.indices)
-      h5_reg.write(file_name, mode = mode)
+        h5_reg = rwh5.H5Register(self.model)
+        h5_reg.register_dataset(self.uuid, 'points_patch0', self.coordinates)
+        h5_reg.register_dataset(self.uuid, 'NodeCountPerPolyline_patch0', self.count_perpol.astype(np.int32))
+        if self.boolnotconstant:
+            h5_reg.register_dataset(self.uuid, 'indices_patch0', self.indices)
+        h5_reg.write(file_name, mode = mode)
 
-   def get_bool_array(self, closed_node):
-      # TODO: Check if also defined boolean arrays
-      """ Returns a boolean array using details in the node location.
+    def get_bool_array(self, closed_node):
+        # TODO: Check if also defined boolean arrays
+        """ Returns a boolean array using details in the node location.
 
         If type of boolean array is BooleanConstantArray, uses the array value and count to generate the array. If type of boolean array is BooleanArrayFromIndexArray, find the "other" value bool and indices of the "other" values, and insert these into an array opposite to the main bool.
 
         args:
             closed_node: the node under which the boolean array information sits"""
-      if rqet.node_type(closed_node) == 'BooleanConstantArray':
-         count = rqet.find_tag_int(closed_node, 'Count')
-         value = rqet.bool_from_text(rqet.node_text(rqet.find_tag(closed_node, 'Value')))
-         return np.full((count), value)
-      elif rqet.node_type(closed_node) == 'BooleanArrayFromIndexArray':
-         count = rqet.find_tag_int(closed_node, 'Count')
-         indices_arr = load_hdf5_array(self, closed_node, 'indices_arr', tag = 'Indices')
-         istrue = rqet.bool_from_text(rqet.node_text(rqet.find_tag(closed_node, 'IndexIsTrue')))
-         out = np.full((count), not istrue)
-         out[indices_arr] = istrue
-         return out
+        if rqet.node_type(closed_node) == 'BooleanConstantArray':
+            count = rqet.find_tag_int(closed_node, 'Count')
+            value = rqet.bool_from_text(rqet.node_text(rqet.find_tag(closed_node, 'Value')))
+            return np.full((count), value)
+        elif rqet.node_type(closed_node) == 'BooleanArrayFromIndexArray':
+            count = rqet.find_tag_int(closed_node, 'Count')
+            indices_arr = load_hdf5_array(self, closed_node, 'indices_arr', tag = 'Indices')
+            istrue = rqet.bool_from_text(rqet.node_text(rqet.find_tag(closed_node, 'IndexIsTrue')))
+            out = np.full((count), not istrue)
+            out[indices_arr] = istrue
+            return out
 
-   def convert_to_polylines(
-         self,
-         closed_array = None,
-         count_perpol = None,
-         coordinates = None,
-         crs_uuid = None,
-         crs_root = None,  # deprecated
-         rep_int_root = None):
-      """Returns a list of Polylines objects from a PolylineSet
+    def convert_to_polylines(
+            self,
+            closed_array = None,
+            count_perpol = None,
+            coordinates = None,
+            crs_uuid = None,
+            crs_root = None,  # deprecated
+            rep_int_root = None):
+        """Returns a list of Polylines objects from a PolylineSet
 
         note:
             all arguments are optional and by default the data will be taken from self
@@ -1128,136 +1132,118 @@ class PolylineSet(_BasePolyline):
         :meta common:
         """
 
-      if count_perpol is None:
-         count_perpol = self.count_perpol
-      if closed_array is None:
-         closed_array = np.zeros(count_perpol, dtype = bool)
-         closed_node = rqet.find_nested_tag(self.root, ['LinePatch', 'ClosedPolylines'])
-         if closed_node is not None:
-            closed_array[:] = self.get_bool_array(closed_node)
-      if coordinates is None:
-         coordinates = self.coordinates
-      if crs_uuid is None:
-         crs_uuid = self.crs_uuid
-      if rep_int_root is None:
-         rep_int_root = self.rep_int_root
-      polys = []
-      count = 0
-      for i in range(len(count_perpol)):
-         if i != len(count_perpol) - 1:
-            subset = coordinates[count:int(count_perpol[i]) + count].copy()
-         else:
-            subset = coordinates[count:int(count_perpol[i]) + count + 1].copy()
-         if vu.isclose(subset[0], subset[-1]):
-            isclosed = True
-         else:
-            isclosed = closed_array[i]
-         count += int(count_perpol[i])
-         subtitle = f"{self.title} {i+1}"
-         polys.append(
-            Polyline(self.model,
-                     poly_root = None,
-                     set_bool = isclosed,
-                     set_coord = subset,
-                     set_crs = crs_uuid,
-                     title = subtitle,
-                     rep_int_root = rep_int_root))
+        if count_perpol is None:
+            count_perpol = self.count_perpol
+        if closed_array is None:
+            closed_array = np.zeros(count_perpol, dtype = bool)
+            closed_node = rqet.find_nested_tag(self.root, ['LinePatch', 'ClosedPolylines'])
+            if closed_node is not None:
+                closed_array[:] = self.get_bool_array(closed_node)
+        if coordinates is None:
+            coordinates = self.coordinates
+        if crs_uuid is None:
+            crs_uuid = self.crs_uuid
+        if rep_int_root is None:
+            rep_int_root = self.rep_int_root
+        polys = []
+        count = 0
+        for i in range(len(count_perpol)):
+            if i != len(count_perpol) - 1:
+                subset = coordinates[count:int(count_perpol[i]) + count].copy()
+            else:
+                subset = coordinates[count:int(count_perpol[i]) + count + 1].copy()
+            if vu.isclose(subset[0], subset[-1]):
+                isclosed = True
+            else:
+                isclosed = closed_array[i]
+            count += int(count_perpol[i])
+            subtitle = f"{self.title} {i+1}"
+            polys.append(
+                Polyline(self.model,
+                         poly_root = None,
+                         set_bool = isclosed,
+                         set_coord = subset,
+                         set_crs = crs_uuid,
+                         title = subtitle,
+                         rep_int_root = rep_int_root))
 
-      return polys
+        return polys
 
-   def combine_polylines(self, polylines):
-      """Combines the isclosed boolean array, coordinates and count data for a list of polyline objects
+    def combine_polylines(self, polylines):
+        """Combines the isclosed boolean array, coordinates and count data for a list of polyline objects
 
         args:
             polylines: list of polyline objects
         """
 
-      self.count_perpol = []
-      self.closed_array = []
+        self.count_perpol = []
+        self.closed_array = []
 
-      for poly in polylines:
-         if poly == polylines[0]:
-            master_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
-            self.crs_uuid = poly.crs_uuid
-            self.coordinates = poly.coordinates.copy()
-         else:
-            curr_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
-            if not curr_crs.is_equivalent(master_crs):
-               shifted = curr_crs.convert_array_to(master_crs, poly.coordinates)
-               self.coordinates = np.concatenate((self.coordinates, shifted))
+        for poly in polylines:
+            if poly == polylines[0]:
+                master_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
+                self.crs_uuid = poly.crs_uuid
+                self.coordinates = poly.coordinates.copy()
             else:
-               self.coordinates = np.concatenate((self.coordinates, poly.coordinates))
+                curr_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
+                if not curr_crs.is_equivalent(master_crs):
+                    shifted = curr_crs.convert_array_to(master_crs, poly.coordinates)
+                    self.coordinates = np.concatenate((self.coordinates, shifted))
+                else:
+                    self.coordinates = np.concatenate((self.coordinates, poly.coordinates))
 
-         self.closed_array.append(poly.isclosed)
-         self.count_perpol.append(int(len(poly.coordinates)))
+            self.closed_array.append(poly.isclosed)
+            self.count_perpol.append(int(len(poly.coordinates)))
 
-      self.count_perpol = np.array(self.count_perpol)
+        self.count_perpol = np.array(self.count_perpol)
 
-      assert len(self.closed_array) == len(self.count_perpol)
-      assert np.sum(self.count_perpol) == len(self.coordinates)
+        assert len(self.closed_array) == len(self.count_perpol)
+        assert np.sum(self.count_perpol) == len(self.coordinates)
 
-   def bool_array_format(self, closed_array):
-      """Determines an appropriate output boolean array format from an input array of bools
+    def bool_array_format(self, closed_array):
+        """Determines an appropriate output boolean array format from an input array of bools
 
         self.boolnotconstant - set to True if all are not open or all closed
         self.boolvalue - value of isclosed for all polylines, or for the majority of polylines if mixed
         self.indices - array of indices where the values are not self.boolvalue, if the polylines are mixed
         """
 
-      self.indices = []
-      self.boolnotconstant = False
-      if all(closed_array):
-         self.boolvalue = True
-      elif not all(closed_array) and not any(closed_array):
-         self.boolvalue = False
-      else:
-         if np.count_nonzero(closed_array) > (len(closed_array) / 2):
+        self.indices = []
+        self.boolnotconstant = False
+        if all(closed_array):
             self.boolvalue = True
-            for i, val in enumerate(closed_array):
-               if not val:
-                  self.indices.append(i)
-         else:
+        elif not all(closed_array) and not any(closed_array):
             self.boolvalue = False
-            for i, val in enumerate(closed_array):
-               if val:
-                  self.indices.append(i)
-      if len(self.indices) > 0:
-         self.boolnotconstant = True
+        else:
+            if np.count_nonzero(closed_array) > (len(closed_array) / 2):
+                self.boolvalue = True
+                for i, val in enumerate(closed_array):
+                    if not val:
+                        self.indices.append(i)
+            else:
+                self.boolvalue = False
+                for i, val in enumerate(closed_array):
+                    if val:
+                        self.indices.append(i)
+        if len(self.indices) > 0:
+            self.boolnotconstant = True
 
-   def set_interpretation_root(self, rep_int_root, recursive = True):
-      """Updates the rep_int_root for the polylineset
+    def set_interpretation_root(self, rep_int_root, recursive = True):
+        """Updates the rep_int_root for the polylineset
 
         args:
             rep_int_root: new rep_int_root
             recursive: boolean, if true will update individual polys with same root
         """
 
-      self.rep_int_root = rep_int_root
+        self.rep_int_root = rep_int_root
 
-      if recursive:
-         for poly in self.polys:
-            poly.rep_int_root = rep_int_root
+        if recursive:
+            for poly in self.polys:
+                poly.rep_int_root = rep_int_root
 
-   def convert_to_irap(self, file_name):
-      """Output an irap file from a polyline set.
-
-        If file_name exists, it will be overwritten.
-
-        args:
-            file_name: output file name for polyline set representation
-        """
-
-      end_of_line = np.array([[999.0, 999.0, 999.0]])
-      for poly in self.polys:
-         if poly == self.polys[0]:
-            out_coords = poly.coordinates
-         else:
-            out_coords = np.concatenate((out_coords, poly.coordinates))
-         out_coords = np.concatenate((out_coords, end_of_line))
-      np.savetxt(file_name, out_coords, delimiter = ' ')
-
-   def convert_to_charisma(self, file_name):
-      """Output to Charisma fault sticks from a polyline set.
+    def convert_to_irap(self, file_name):
+        """Output an irap file from a polyline set.
 
         If file_name exists, it will be overwritten.
 
@@ -1265,48 +1251,66 @@ class PolylineSet(_BasePolyline):
             file_name: output file name for polyline set representation
         """
 
-      faultname = self.title.replace(" ", "_")
-      lines = []
-      for i, poly in enumerate(self.polys):
-         for point in poly.coordinates:
-            lines.append(f"INLINE-\t0\t0\t{point[0]}\t{point[1]}\t{point[2]}\t{faultname}\t{i+1}\n")
-      with open(file_name, 'w') as f:
-         for item in lines:
-            f.write(item)
+        end_of_line = np.array([[999.0, 999.0, 999.0]])
+        for poly in self.polys:
+            if poly == self.polys[0]:
+                out_coords = poly.coordinates
+            else:
+                out_coords = np.concatenate((out_coords, poly.coordinates))
+            out_coords = np.concatenate((out_coords, end_of_line))
+        np.savetxt(file_name, out_coords, delimiter = ' ')
+
+    def convert_to_charisma(self, file_name):
+        """Output to Charisma fault sticks from a polyline set.
+
+        If file_name exists, it will be overwritten.
+
+        args:
+            file_name: output file name for polyline set representation
+        """
+
+        faultname = self.title.replace(" ", "_")
+        lines = []
+        for i, poly in enumerate(self.polys):
+            for point in poly.coordinates:
+                lines.append(f"INLINE-\t0\t0\t{point[0]}\t{point[1]}\t{point[2]}\t{faultname}\t{i+1}\n")
+        with open(file_name, 'w') as f:
+            for item in lines:
+                f.write(item)
 
 
 def shift_polyline(parent_model, poly_root, xyz_shift = (0, 0, 0), title = ''):
-   """Returns a new polyline object, shifted by given coordinates."""
+    """Returns a new polyline object, shifted by given coordinates."""
 
-   poly = Polyline(parent_model = parent_model, poly_root = poly_root)
-   if title != '':
-      poly.title = title
-   else:
-      poly.title = poly.title + f" shifted by xyz({xyz_shift})"
-   poly.uuid = bu.new_uuid()
-   poly.coordinates = np.array(xyz_shift) + poly.coordinates
-   return poly
+    poly = Polyline(parent_model = parent_model, poly_root = poly_root)
+    if title != '':
+        poly.title = title
+    else:
+        poly.title = poly.title + f" shifted by xyz({xyz_shift})"
+    poly.uuid = bu.new_uuid()
+    poly.coordinates = np.array(xyz_shift) + poly.coordinates
+    return poly
 
 
 def flatten_polyline(parent_model, poly_root, axis = "z", value = 0.0, title = ''):
-   """Returns a new polyline object, flattened (projected) on a chosen axis to a given value."""
+    """Returns a new polyline object, flattened (projected) on a chosen axis to a given value."""
 
-   axis = axis.lower()
-   value = float(value)
-   assert axis in ["x", "y", "z"], 'Axis must be x, y or z'
-   poly = Polyline(parent_model = parent_model, poly_root = poly_root)
-   if title != '':
-      poly.title = title
-   else:
-      poly.title = poly.title + f" flattened in {axis} to value {value:.3f}"
-   poly.uuid = bu.new_uuid()
-   index = "xyz".index(axis)
-   poly.coordinates[..., index] = value
-   return poly
+    axis = axis.lower()
+    value = float(value)
+    assert axis in ["x", "y", "z"], 'Axis must be x, y or z'
+    poly = Polyline(parent_model = parent_model, poly_root = poly_root)
+    if title != '':
+        poly.title = title
+    else:
+        poly.title = poly.title + f" flattened in {axis} to value {value:.3f}"
+    poly.uuid = bu.new_uuid()
+    index = "xyz".index(axis)
+    poly.coordinates[..., index] = value
+    return poly
 
 
 def tangents(points, weight = 'linear', closed = False):
-   """Returns a numpy array of tangent unit vectors for an ordered list of points.
+    """Returns a numpy array of tangent unit vectors for an ordered list of points.
 
     arguments:
         points (numpy float array of shape (N, 3)): points defining a line
@@ -1323,36 +1327,36 @@ def tangents(points, weight = 'linear', closed = False):
         if two neighbouring points are identical, a divide by zero will occur
     """
 
-   def one_tangent(points, k1, k2, k3, weight):
-      v1 = points[k2] - points[k1]
-      v2 = points[k3] - points[k2]
-      l1 = vu.naive_length(v1)
-      l2 = vu.naive_length(v2)
-      if weight == 'square':
-         return vu.unit_vector(v1 / (l1 * l1) + v2 / (l2 * l2))
-      elif weight == 'cube':
-         return vu.unit_vector(v1 / (l1 * l1 * l1) + v2 / (l2 * l2 * l2))
-      else:  # linear weight mode
-         return vu.unit_vector(v1 / l1 + v2 / l2)
+    def one_tangent(points, k1, k2, k3, weight):
+        v1 = points[k2] - points[k1]
+        v2 = points[k3] - points[k2]
+        l1 = vu.naive_length(v1)
+        l2 = vu.naive_length(v2)
+        if weight == 'square':
+            return vu.unit_vector(v1 / (l1 * l1) + v2 / (l2 * l2))
+        elif weight == 'cube':
+            return vu.unit_vector(v1 / (l1 * l1 * l1) + v2 / (l2 * l2 * l2))
+        else:  # linear weight mode
+            return vu.unit_vector(v1 / l1 + v2 / l2)
 
-   assert points.ndim == 2 and points.shape[1] == 3
-   assert weight in ['linear', 'square', 'cube']
+    assert points.ndim == 2 and points.shape[1] == 3
+    assert weight in ['linear', 'square', 'cube']
 
-   knot_count = len(points)
-   assert knot_count > 1
-   tangent_vectors = np.empty((knot_count, 3))
+    knot_count = len(points)
+    assert knot_count > 1
+    tangent_vectors = np.empty((knot_count, 3))
 
-   for knot in range(1, knot_count - 1):
-      tangent_vectors[knot] = one_tangent(points, knot - 1, knot, knot + 1, weight)
-   if closed:
-      assert knot_count > 2, 'closed poly line must contain at least 3 knots for tangent generation'
-      tangent_vectors[0] = one_tangent(points, -1, 0, 1, weight)
-      tangent_vectors[-1] = one_tangent(points, -2, -1, 0, weight)
-   else:
-      tangent_vectors[0] = vu.unit_vector(points[1] - points[0])
-      tangent_vectors[-1] = vu.unit_vector(points[-1] - points[-2])
+    for knot in range(1, knot_count - 1):
+        tangent_vectors[knot] = one_tangent(points, knot - 1, knot, knot + 1, weight)
+    if closed:
+        assert knot_count > 2, 'closed poly line must contain at least 3 knots for tangent generation'
+        tangent_vectors[0] = one_tangent(points, -1, 0, 1, weight)
+        tangent_vectors[-1] = one_tangent(points, -2, -1, 0, weight)
+    else:
+        tangent_vectors[0] = vu.unit_vector(points[1] - points[0])
+        tangent_vectors[-1] = vu.unit_vector(points[-1] - points[-2])
 
-   return tangent_vectors
+    return tangent_vectors
 
 
 def spline(points,
@@ -1362,7 +1366,7 @@ def spline(points,
            max_segment_length = None,
            max_degrees_per_knot = 5.0,
            closed = False):
-   """Returns a numpy array containing resampled cubic spline of line defined by points.
+    """Returns a numpy array containing resampled cubic spline of line defined by points.
 
     arguments:
         points (numpy float array of shape (N, 3)): points defining a line
@@ -1396,64 +1400,64 @@ def spline(points,
         exceed the argument value
     """
 
-   assert points.ndim == 2 and points.shape[1] == 3
-   knot_count = len(points)
-   assert knot_count > (2 if closed else 1)
-   if tangent_vectors is None:
-      assert tangent_weight in ['linear', 'square', 'cube']
-      tangent_vectors = tangents(points, weight = tangent_weight, closed = closed)
-   assert tangent_vectors.shape == points.shape
-   assert min_subdivisions >= 1
-   assert max_segment_length is None or max_segment_length > 0.0
-   assert max_degrees_per_knot is None or max_degrees_per_knot > 0.0
+    assert points.ndim == 2 and points.shape[1] == 3
+    knot_count = len(points)
+    assert knot_count > (2 if closed else 1)
+    if tangent_vectors is None:
+        assert tangent_weight in ['linear', 'square', 'cube']
+        tangent_vectors = tangents(points, weight = tangent_weight, closed = closed)
+    assert tangent_vectors.shape == points.shape
+    assert min_subdivisions >= 1
+    assert max_segment_length is None or max_segment_length > 0.0
+    assert max_degrees_per_knot is None or max_degrees_per_knot > 0.0
 
-   seg_count = knot_count if closed else knot_count - 1
-   seg_lengths = np.empty(seg_count)
-   for seg in range(knot_count - 1):
-      seg_lengths[seg] = vu.naive_length(points[seg + 1] - points[seg])
-   if closed:
-      seg_lengths[-1] = vu.naive_length(points[0] - points[-1])
+    seg_count = knot_count if closed else knot_count - 1
+    seg_lengths = np.empty(seg_count)
+    for seg in range(knot_count - 1):
+        seg_lengths[seg] = vu.naive_length(points[seg + 1] - points[seg])
+    if closed:
+        seg_lengths[-1] = vu.naive_length(points[0] - points[-1])
 
-   knot_insertions = np.full(seg_count, min_subdivisions - 1, dtype = int)
-   if max_segment_length is not None:
-      for seg in range(seg_count):
-         sub_count = maths.ceil(seg_lengths[seg] / max_segment_length)
-         if sub_count > knot_insertions[seg] + 1:
-            knot_insertions[seg] = sub_count - 1
-   if max_degrees_per_knot is not None:
-      for seg in range(seg_count):
-         next = seg + 1 if seg < knot_count - 1 else 0
-         segment = points[next] - points[seg]
-         turn = (vu.degrees_difference(tangent_vectors[seg], segment) +
-                 vu.degrees_difference(segment, tangent_vectors[next]))
-         log.debug(f'spline segment {seg}; turn: {turn:4.2f}')
-         sub_count = maths.ceil(turn / max_degrees_per_knot)
-         if sub_count > knot_insertions[seg] + 1:
-            knot_insertions[seg] = sub_count - 1
-   insertion_count = np.sum(knot_insertions)
-   log.debug(f'{insertion_count} knot insertions for spline')
-   spline_knot_count = knot_count + insertion_count
+    knot_insertions = np.full(seg_count, min_subdivisions - 1, dtype = int)
+    if max_segment_length is not None:
+        for seg in range(seg_count):
+            sub_count = maths.ceil(seg_lengths[seg] / max_segment_length)
+            if sub_count > knot_insertions[seg] + 1:
+                knot_insertions[seg] = sub_count - 1
+    if max_degrees_per_knot is not None:
+        for seg in range(seg_count):
+            next = seg + 1 if seg < knot_count - 1 else 0
+            segment = points[next] - points[seg]
+            turn = (vu.degrees_difference(tangent_vectors[seg], segment) +
+                    vu.degrees_difference(segment, tangent_vectors[next]))
+            log.debug(f'spline segment {seg}; turn: {turn:4.2f}')
+            sub_count = maths.ceil(turn / max_degrees_per_knot)
+            if sub_count > knot_insertions[seg] + 1:
+                knot_insertions[seg] = sub_count - 1
+    insertion_count = np.sum(knot_insertions)
+    log.debug(f'{insertion_count} knot insertions for spline')
+    spline_knot_count = knot_count + insertion_count
 
-   spline_points = np.empty((spline_knot_count, 3))
-   sk = 0
-   for knot in range(seg_count):
-      next = knot + 1 if knot < knot_count - 1 else 0
-      spline_points[sk] = points[knot]
-      sk += 1
-      for i in range(knot_insertions[knot]):
-         t = float(i + 1) / float(knot_insertions[knot] + 1)
-         t2 = t * t
-         t3 = t * t2
-         p = np.zeros(3)
-         p += (2.0 * t3 - 3.0 * t2 + 1.0) * points[knot]
-         p += (t3 - 2.0 * t2 + t) * tangent_vectors[knot] * seg_lengths[knot]
-         p += (-2.0 * t3 + 3.0 * t2) * points[next]
-         p += (t3 - t2) * tangent_vectors[next] * seg_lengths[knot]
-         spline_points[sk] = p
-         sk += 1
-   if not closed:
-      spline_points[sk] = points[-1]
-      sk += 1
-   assert sk == spline_knot_count
+    spline_points = np.empty((spline_knot_count, 3))
+    sk = 0
+    for knot in range(seg_count):
+        next = knot + 1 if knot < knot_count - 1 else 0
+        spline_points[sk] = points[knot]
+        sk += 1
+        for i in range(knot_insertions[knot]):
+            t = float(i + 1) / float(knot_insertions[knot] + 1)
+            t2 = t * t
+            t3 = t * t2
+            p = np.zeros(3)
+            p += (2.0 * t3 - 3.0 * t2 + 1.0) * points[knot]
+            p += (t3 - 2.0 * t2 + t) * tangent_vectors[knot] * seg_lengths[knot]
+            p += (-2.0 * t3 + 3.0 * t2) * points[next]
+            p += (t3 - t2) * tangent_vectors[next] * seg_lengths[knot]
+            spline_points[sk] = p
+            sk += 1
+    if not closed:
+        spline_points[sk] = points[-1]
+        sk += 1
+    assert sk == spline_knot_count
 
-   return spline_points
+    return spline_points

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -37,11 +37,11 @@ use_version_string = False
 
 
 def _pl(i, e = False):
-   return '' if i == 1 else 'es' if e else 's'
+    return '' if i == 1 else 'es' if e else 's'
 
 
 class Model():
-   """Class for RESQML (v2) based models.
+    """Class for RESQML (v2) based models.
    
    Examples:
 
@@ -59,15 +59,15 @@ class Model():
    
    """
 
-   def __init__(self,
-                epc_file: Optional[str] = None,
-                full_load: bool = True,
-                epc_subdir: Optional[Union[str, Iterable]] = None,
-                new_epc: bool = False,
-                create_basics: Optional[bool] = None,
-                create_hdf5_ext: Optional[bool] = None,
-                copy_from: Optional[str] = None):
-      """Create an empty model; load it from epc_file if given.
+    def __init__(self,
+                 epc_file: Optional[str] = None,
+                 full_load: bool = True,
+                 epc_subdir: Optional[Union[str, Iterable]] = None,
+                 new_epc: bool = False,
+                 create_basics: Optional[bool] = None,
+                 create_hdf5_ext: Optional[bool] = None,
+                 copy_from: Optional[str] = None):
+        """Create an empty model; load it from epc_file if given.
 
       Note:
 
@@ -109,90 +109,91 @@ class Model():
       :meta common:
       """
 
-      if epc_file and not epc_file.endswith('.epc'):
-         epc_file += '.epc'
-      if copy_from and not copy_from.endswith('.epc'):
-         copy_from += '.epc'
-      if copy_from == epc_file:
-         copy_from = None
-      if create_basics is None:
-         create_basics = new_epc and not copy_from
-      if create_hdf5_ext is None:
-         create_hdf5_ext = new_epc and not copy_from
-      self.initialize()
-      if epc_file and (copy_from or not new_epc):
-         self.load_epc(epc_file, full_load = full_load, epc_subdir = epc_subdir, copy_from = copy_from)
-      else:
-         if epc_file and new_epc:
-            try:
-               h5_file = epc_file[:-4] + '.h5'
-               os.remove(h5_file)
-               log.info('old hdf5 file deleted: ' + str(h5_file))
-            except Exception:
-               pass
-            try:
-               os.remove(epc_file)
-               log.info('old epc file deleted: ' + str(epc_file))
-            except Exception:
-               pass
-         if epc_file:
-            self.set_epc_file_and_directory(epc_file)
-         if create_basics:
-            self.create_root()
-            self.create_rels_part()
-            self.create_doc_props()
-            if epc_file and create_hdf5_ext:
-               assert epc_file.endswith('.epc')
-               h5_file = epc_file[:-4] + '.h5'
-               self.create_hdf5_ext(add_as_part = True, file_name = h5_file)
-               with h5py.File(h5_file, 'w') as _:
-                  pass
+        if epc_file and not epc_file.endswith('.epc'):
+            epc_file += '.epc'
+        if copy_from and not copy_from.endswith('.epc'):
+            copy_from += '.epc'
+        if copy_from == epc_file:
+            copy_from = None
+        if create_basics is None:
+            create_basics = new_epc and not copy_from
+        if create_hdf5_ext is None:
+            create_hdf5_ext = new_epc and not copy_from
+        self.initialize()
+        if epc_file and (copy_from or not new_epc):
+            self.load_epc(epc_file, full_load = full_load, epc_subdir = epc_subdir, copy_from = copy_from)
+        else:
+            if epc_file and new_epc:
+                try:
+                    h5_file = epc_file[:-4] + '.h5'
+                    os.remove(h5_file)
+                    log.info('old hdf5 file deleted: ' + str(h5_file))
+                except Exception:
+                    pass
+                try:
+                    os.remove(epc_file)
+                    log.info('old epc file deleted: ' + str(epc_file))
+                except Exception:
+                    pass
+            if epc_file:
+                self.set_epc_file_and_directory(epc_file)
+            if create_basics:
+                self.create_root()
+                self.create_rels_part()
+                self.create_doc_props()
+                if epc_file and create_hdf5_ext:
+                    assert epc_file.endswith('.epc')
+                    h5_file = epc_file[:-4] + '.h5'
+                    self.create_hdf5_ext(add_as_part = True, file_name = h5_file)
+                    with h5py.File(h5_file, 'w') as _:
+                        pass
 
-   def initialize(self):
-      """Set model contents to empty.
+    def initialize(self):
+        """Set model contents to empty.
 
       note:
          not usually called directly (semi-private)
       """
 
-      self.epc_file = None
-      self.epc_directory = None
-      # hdf5 stuff
-      self.h5_dict = {}  # dictionary keyed on hdf5 uuid.bytes; mapping to hdf5 file name (full path)
-      self.h5_currently_open_path = None
-      self.h5_currently_open_root = None  # h5 file handle for open hdf5 file
-      self.h5_currently_open_mode = None
-      self.main_h5_uuid = None  # uuid of main hdf5 file
-      # xml stuff
-      self.main_tree = None
-      self.main_root = None
-      self.crs_uuid = None  # primary coordinate reference system for model
-      self.grid_root = None  # extracted from tree as speed optimization (useful for single grid models), for 'main' grid
-      self.time_series = None  # extracted as speed optimization (single time series only for now)
-      self.parts_forest = {}  # dictionary keyed on part_name; mapping to (content_type, uuid, xml_tree)
-      self.uuid_part_dict = {}  # dictionary keyed on uuid.int; mapping to part_name
-      self.rels_present = False
-      self.rels_forest = {}  # dictionary keyed on part_name; mapping to (uuid, xml_tree)
-      self.other_forest = {}  # dictionary keyed on part_name; mapping to (content_type, xml_tree); used for docProps
-      # grid(s): single grid models only for now
-      self.grid_list = []  # list of grid.Grid objects
-      self.main_grid = None  # grid.Grid object for the 'main' grid
-      self.reservoir_dict = []  # todo: mapping from reservoir name (citation title) to list of grids for that reservoir
-      self.consolidation = None  # Consolidation object for mapping equivalent uuids
-      self.modified = False
+        self.epc_file = None
+        self.epc_directory = None
+        # hdf5 stuff
+        self.h5_dict = {}  # dictionary keyed on hdf5 uuid.bytes; mapping to hdf5 file name (full path)
+        self.h5_currently_open_path = None
+        self.h5_currently_open_root = None  # h5 file handle for open hdf5 file
+        self.h5_currently_open_mode = None
+        self.main_h5_uuid = None  # uuid of main hdf5 file
+        # xml stuff
+        self.main_tree = None
+        self.main_root = None
+        self.crs_uuid = None  # primary coordinate reference system for model
+        self.grid_root = None  # extracted from tree as speed optimization (useful for single grid models), for 'main' grid
+        self.time_series = None  # extracted as speed optimization (single time series only for now)
+        self.parts_forest = {}  # dictionary keyed on part_name; mapping to (content_type, uuid, xml_tree)
+        self.uuid_part_dict = {}  # dictionary keyed on uuid.int; mapping to part_name
+        self.rels_present = False
+        self.rels_forest = {}  # dictionary keyed on part_name; mapping to (uuid, xml_tree)
+        self.other_forest = {}  # dictionary keyed on part_name; mapping to (content_type, xml_tree); used for docProps
+        # grid(s): single grid models only for now
+        self.grid_list = []  # list of grid.Grid objects
+        self.main_grid = None  # grid.Grid object for the 'main' grid
+        self.reservoir_dict = [
+        ]  # todo: mapping from reservoir name (citation title) to list of grids for that reservoir
+        self.consolidation = None  # Consolidation object for mapping equivalent uuids
+        self.modified = False
 
-   def parts(self,
-             parts_list = None,
-             obj_type = None,
-             uuid = None,
-             title = None,
-             title_mode = 'is',
-             title_case_sensitive = False,
-             extra = {},
-             related_uuid = None,
-             epc_subdir = None,
-             sort_by = None):
-      """Returns a list of parts matching all of the arguments passed.
+    def parts(self,
+              parts_list = None,
+              obj_type = None,
+              uuid = None,
+              title = None,
+              title_mode = 'is',
+              title_case_sensitive = False,
+              extra = {},
+              related_uuid = None,
+              epc_subdir = None,
+              sort_by = None):
+        """Returns a list of parts matching all of the arguments passed.
 
       Arguments:
          parts_list (list of strings, optional): if present, an 'input' list of parts to be filtered;
@@ -237,128 +238,128 @@ class Model():
       :meta common:
       """
 
-      if not parts_list:
-         parts_list = self.list_of_parts()
-      if uuid is not None:
-         part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
-         if part_name is None or part_name not in parts_list:
-            return []
-         parts_list = [part_name]
-      if epc_subdir:
-         if epc_subdir.startswith('/'):
-            epc_subdir = epc_subdir[1:]
-         if epc_subdir:
-            if not epc_subdir.endswith('/'):
-               epc_subdir += '/'
+        if not parts_list:
+            parts_list = self.list_of_parts()
+        if uuid is not None:
+            part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
+            if part_name is None or part_name not in parts_list:
+                return []
+            parts_list = [part_name]
+        if epc_subdir:
+            if epc_subdir.startswith('/'):
+                epc_subdir = epc_subdir[1:]
+            if epc_subdir:
+                if not epc_subdir.endswith('/'):
+                    epc_subdir += '/'
+                filtered_list = []
+                for part in parts_list:
+                    if part.startswith[epc_subdir]:
+                        filtered_list.append(part)
+                if len(filtered_list) == 0:
+                    return []
+                parts_list = filtered_list
+        if obj_type:
+            if obj_type[0].isupper():
+                obj_type = 'obj_' + obj_type
             filtered_list = []
             for part in parts_list:
-               if part.startswith[epc_subdir]:
-                  filtered_list.append(part)
+                if self.parts_forest[part][0] == obj_type:
+                    filtered_list.append(part)
             if len(filtered_list) == 0:
-               return []
+                return []
             parts_list = filtered_list
-      if obj_type:
-         if obj_type[0].isupper():
-            obj_type = 'obj_' + obj_type
-         filtered_list = []
-         for part in parts_list:
-            if self.parts_forest[part][0] == obj_type:
-               filtered_list.append(part)
-         if len(filtered_list) == 0:
-            return []
-         parts_list = filtered_list
-      if title:
-         assert title_mode in [
-            'is', 'starts', 'ends', 'contains', 'is not', 'does not start', 'does not end', 'does not contain'
-         ]
-         if not title_case_sensitive:
-            title = title.upper()
-         filtered_list = []
-         for part in parts_list:
-            part_title = self.citation_title_for_part(part)
+        if title:
+            assert title_mode in [
+                'is', 'starts', 'ends', 'contains', 'is not', 'does not start', 'does not end', 'does not contain'
+            ]
             if not title_case_sensitive:
-               part_title = part_title.upper()
-            if title_mode == 'is':
-               if part_title == title:
-                  filtered_list.append(part)
-            elif title_mode == 'starts':
-               if part_title.startswith(title):
-                  filtered_list.append(part)
-            elif title_mode == 'ends':
-               if part_title.endswith(title):
-                  filtered_list.append(part)
-            elif title_mode == 'contains':
-               if title in part_title:
-                  filtered_list.append(part)
-            if title_mode == 'is not':
-               if part_title != title:
-                  filtered_list.append(part)
-            elif title_mode == 'does not start':
-               if not part_title.startswith(title):
-                  filtered_list.append(part)
-            elif title_mode == 'does not end':
-               if not part_title.endswith(title):
-                  filtered_list.append(part)
-            elif title_mode == 'does not contain':
-               if title not in part_title:
-                  filtered_list.append(part)
-         if len(filtered_list) == 0:
+                title = title.upper()
+            filtered_list = []
+            for part in parts_list:
+                part_title = self.citation_title_for_part(part)
+                if not title_case_sensitive:
+                    part_title = part_title.upper()
+                if title_mode == 'is':
+                    if part_title == title:
+                        filtered_list.append(part)
+                elif title_mode == 'starts':
+                    if part_title.startswith(title):
+                        filtered_list.append(part)
+                elif title_mode == 'ends':
+                    if part_title.endswith(title):
+                        filtered_list.append(part)
+                elif title_mode == 'contains':
+                    if title in part_title:
+                        filtered_list.append(part)
+                if title_mode == 'is not':
+                    if part_title != title:
+                        filtered_list.append(part)
+                elif title_mode == 'does not start':
+                    if not part_title.startswith(title):
+                        filtered_list.append(part)
+                elif title_mode == 'does not end':
+                    if not part_title.endswith(title):
+                        filtered_list.append(part)
+                elif title_mode == 'does not contain':
+                    if title not in part_title:
+                        filtered_list.append(part)
+            if len(filtered_list) == 0:
+                return []
+            parts_list = filtered_list
+        if extra:
+            filtered_list = []
+            for part in parts_list:
+                part_extra = rqet.load_metadata_from_xml(self.root_for_part(part))
+                if not part_extra:
+                    continue
+                match = True
+                for key, value in extra.items():
+                    if key not in part_extra or part_extra[key] != value:
+                        match = False
+                        break
+                if match:
+                    filtered_list.append(part)
+            if len(filtered_list) == 0:
+                return []
+            parts_list = filtered_list
+        if related_uuid is not None:
+            parts_list = self.parts_list_filtered_by_related_uuid(parts_list, related_uuid)
+        if len(parts_list) == 0:
             return []
-         parts_list = filtered_list
-      if extra:
-         filtered_list = []
-         for part in parts_list:
-            part_extra = rqet.load_metadata_from_xml(self.root_for_part(part))
-            if not part_extra:
-               continue
-            match = True
-            for key, value in extra.items():
-               if key not in part_extra or part_extra[key] != value:
-                  match = False
-                  break
-            if match:
-               filtered_list.append(part)
-         if len(filtered_list) == 0:
-            return []
-         parts_list = filtered_list
-      if related_uuid is not None:
-         parts_list = self.parts_list_filtered_by_related_uuid(parts_list, related_uuid)
-      if len(parts_list) == 0:
-         return []
-      if sort_by:
-         if sort_by == 'type':
-            parts_list.sort()
-         elif sort_by in ['newest', 'oldest']:
-            parts_list = self.sort_parts_list_by_timestamp(parts_list)
-            if sort_by == 'oldest':
-               parts_list.reverse()
-         elif sort_by in ['uuid', 'title']:
-            sort_list = []
-            for index, part in enumerate(parts_list):
-               if sort_by == 'uuid':
-                  key = str(self.uuid_for_part(part))
-               else:
-                  key = self.citation_title_for_part(part)
-               sort_list.append((key, index))
-            sort_list.sort()
-            sorted_list = []
-            for _, index in sort_list:
-               sorted_list.append(parts_list[index])
-            parts_list = sorted_list
-      return parts_list
+        if sort_by:
+            if sort_by == 'type':
+                parts_list.sort()
+            elif sort_by in ['newest', 'oldest']:
+                parts_list = self.sort_parts_list_by_timestamp(parts_list)
+                if sort_by == 'oldest':
+                    parts_list.reverse()
+            elif sort_by in ['uuid', 'title']:
+                sort_list = []
+                for index, part in enumerate(parts_list):
+                    if sort_by == 'uuid':
+                        key = str(self.uuid_for_part(part))
+                    else:
+                        key = self.citation_title_for_part(part)
+                    sort_list.append((key, index))
+                sort_list.sort()
+                sorted_list = []
+                for _, index in sort_list:
+                    sorted_list.append(parts_list[index])
+                parts_list = sorted_list
+        return parts_list
 
-   def part(self,
-            parts_list = None,
-            obj_type = None,
-            uuid = None,
-            title = None,
-            title_mode = 'is',
-            title_case_sensitive = False,
-            extra = {},
-            related_uuid = None,
-            epc_subdir = None,
-            multiple_handling = 'exception'):
-      """Returns the name of a part matching all of the arguments passed.
+    def part(self,
+             parts_list = None,
+             obj_type = None,
+             uuid = None,
+             title = None,
+             title_mode = 'is',
+             title_case_sensitive = False,
+             extra = {},
+             related_uuid = None,
+             epc_subdir = None,
+             multiple_handling = 'exception'):
+        """Returns the name of a part matching all of the arguments passed.
 
       arguments:
          (as for parts() except no sort_by argument)
@@ -377,183 +378,30 @@ class Model():
       :meta common:
       """
 
-      pl = self.parts(parts_list = parts_list,
-                      obj_type = obj_type,
-                      uuid = uuid,
-                      title = title,
-                      title_mode = title_mode,
-                      title_case_sensitive = title_case_sensitive,
-                      extra = extra,
-                      related_uuid = related_uuid,
-                      epc_subdir = epc_subdir)
-      if len(pl) == 0:
-         return None
-      if len(pl) == 1 or multiple_handling == 'first':
-         return pl[0]
-      if multiple_handling == 'none':
-         return None
-      elif multiple_handling in ['newest', 'oldest']:
-         sorted_list = self.sort_parts_list_by_timestamp(pl)
-         if multiple_handling == 'newest':
-            return sorted_list[0]
-         return sorted_list[-1]
-      else:
-         raise ValueError('more than one part matches criteria')
+        pl = self.parts(parts_list = parts_list,
+                        obj_type = obj_type,
+                        uuid = uuid,
+                        title = title,
+                        title_mode = title_mode,
+                        title_case_sensitive = title_case_sensitive,
+                        extra = extra,
+                        related_uuid = related_uuid,
+                        epc_subdir = epc_subdir)
+        if len(pl) == 0:
+            return None
+        if len(pl) == 1 or multiple_handling == 'first':
+            return pl[0]
+        if multiple_handling == 'none':
+            return None
+        elif multiple_handling in ['newest', 'oldest']:
+            sorted_list = self.sort_parts_list_by_timestamp(pl)
+            if multiple_handling == 'newest':
+                return sorted_list[0]
+            return sorted_list[-1]
+        else:
+            raise ValueError('more than one part matches criteria')
 
-   def uuids(self,
-             parts_list = None,
-             obj_type = None,
-             uuid = None,
-             title = None,
-             title_mode = 'is',
-             title_case_sensitive = False,
-             extra = {},
-             related_uuid = None,
-             epc_subdir = None,
-             sort_by = None):
-      """Returns a list of uuids of parts matching all of the arguments passed.
-
-      arguments:
-         (as for parts() method)
-
-      returns:
-         list of uuids
-
-      :meta common:
-      """
-
-      sort_by_uuid = (sort_by == 'uuid')
-      if sort_by_uuid:
-         sort_by = None
-      pl = self.parts(parts_list = parts_list,
-                      obj_type = obj_type,
-                      uuid = uuid,
-                      title = title,
-                      title_mode = title_mode,
-                      title_case_sensitive = title_case_sensitive,
-                      extra = extra,
-                      related_uuid = related_uuid,
-                      epc_subdir = epc_subdir,
-                      sort_by = sort_by)
-      if len(pl) == 0:
-         return []
-      uuid_list = []
-      for part in pl:
-         uuid_list.append(self.uuid_for_part(part))
-      if sort_by_uuid:
-         uuid_list.sort()
-      return uuid_list
-
-   def uuid(self,
-            parts_list = None,
-            obj_type = None,
-            uuid = None,
-            title = None,
-            title_mode = 'is',
-            title_case_sensitive = False,
-            extra = {},
-            related_uuid = None,
-            epc_subdir = None,
-            multiple_handling = 'exception'):
-      """Returns the uuid of a part matching all of the arguments passed.
-
-      arguments:
-         (as for part())
-
-      returns:
-         uuid of the single part matching all of the criteria, or None
-
-      :meta common:
-      """
-
-      part = self.part(parts_list = parts_list,
-                       obj_type = obj_type,
-                       uuid = uuid,
-                       title = title,
-                       title_mode = title_mode,
-                       title_case_sensitive = title_case_sensitive,
-                       extra = extra,
-                       related_uuid = related_uuid,
-                       epc_subdir = epc_subdir,
-                       multiple_handling = multiple_handling)
-      if part is None:
-         return None
-      return rqet.uuid_in_part_name(part)
-
-   def roots(self,
-             parts_list = None,
-             obj_type = None,
-             uuid = None,
-             title = None,
-             title_mode = 'is',
-             title_case_sensitive = False,
-             extra = {},
-             related_uuid = None,
-             epc_subdir = None,
-             sort_by = None):
-      """Returns a list of xml root nodes of parts matching all of the arguments passed.
-
-      arguments:
-         (as for parts() method)
-
-      returns:
-         list of lxml.etree.Element objects
-
-      :meta common:
-      """
-
-      pl = self.parts(parts_list = parts_list,
-                      obj_type = obj_type,
-                      uuid = uuid,
-                      title = title,
-                      title_mode = title_mode,
-                      title_case_sensitive = title_case_sensitive,
-                      extra = extra,
-                      related_uuid = related_uuid,
-                      epc_subdir = epc_subdir,
-                      sort_by = sort_by)
-      root_list = []
-      for part in pl:
-         root_list.append(self.root_for_part(part))
-      return root_list
-
-   def root(self,
-            parts_list = None,
-            obj_type = None,
-            uuid = None,
-            title = None,
-            title_mode = 'is',
-            title_case_sensitive = False,
-            extra = {},
-            related_uuid = None,
-            epc_subdir = None,
-            multiple_handling = 'exception'):
-      """Returns the xml root node of a part matching all of the arguments passed.
-
-      arguments:
-         (as for part())
-
-      returns:
-         lxml.etree.Element object being the root node of the xml for the single part matching all of the criteria, or None
-
-      :meta common:
-      """
-
-      part = self.part(parts_list = parts_list,
-                       obj_type = obj_type,
-                       uuid = uuid,
-                       title = title,
-                       title_mode = title_mode,
-                       title_case_sensitive = title_case_sensitive,
-                       extra = extra,
-                       related_uuid = related_uuid,
-                       epc_subdir = epc_subdir,
-                       multiple_handling = multiple_handling)
-      if part is None:
-         return None
-      return self.root_for_part(part)
-
-   def titles(self,
+    def uuids(self,
               parts_list = None,
               obj_type = None,
               uuid = None,
@@ -564,33 +412,40 @@ class Model():
               related_uuid = None,
               epc_subdir = None,
               sort_by = None):
-      """Returns a list of citation titles of parts matching all of the arguments passed.
+        """Returns a list of uuids of parts matching all of the arguments passed.
 
       arguments:
          (as for parts() method)
 
       returns:
-         list of strings being the citation titles of matching parts
+         list of uuids
 
       :meta common:
       """
 
-      pl = self.parts(parts_list = parts_list,
-                      obj_type = obj_type,
-                      uuid = uuid,
-                      title = title,
-                      title_mode = title_mode,
-                      title_case_sensitive = title_case_sensitive,
-                      extra = extra,
-                      related_uuid = related_uuid,
-                      epc_subdir = epc_subdir,
-                      sort_by = sort_by)
-      title_list = []
-      for part in pl:
-         title_list.append(self.citation_title_for_part(part))
-      return title_list
+        sort_by_uuid = (sort_by == 'uuid')
+        if sort_by_uuid:
+            sort_by = None
+        pl = self.parts(parts_list = parts_list,
+                        obj_type = obj_type,
+                        uuid = uuid,
+                        title = title,
+                        title_mode = title_mode,
+                        title_case_sensitive = title_case_sensitive,
+                        extra = extra,
+                        related_uuid = related_uuid,
+                        epc_subdir = epc_subdir,
+                        sort_by = sort_by)
+        if len(pl) == 0:
+            return []
+        uuid_list = []
+        for part in pl:
+            uuid_list.append(self.uuid_for_part(part))
+        if sort_by_uuid:
+            uuid_list.sort()
+        return uuid_list
 
-   def title(self,
+    def uuid(self,
              parts_list = None,
              obj_type = None,
              uuid = None,
@@ -601,7 +456,153 @@ class Model():
              related_uuid = None,
              epc_subdir = None,
              multiple_handling = 'exception'):
-      """Returns the citation title of a part matching all of the arguments passed.
+        """Returns the uuid of a part matching all of the arguments passed.
+
+      arguments:
+         (as for part())
+
+      returns:
+         uuid of the single part matching all of the criteria, or None
+
+      :meta common:
+      """
+
+        part = self.part(parts_list = parts_list,
+                         obj_type = obj_type,
+                         uuid = uuid,
+                         title = title,
+                         title_mode = title_mode,
+                         title_case_sensitive = title_case_sensitive,
+                         extra = extra,
+                         related_uuid = related_uuid,
+                         epc_subdir = epc_subdir,
+                         multiple_handling = multiple_handling)
+        if part is None:
+            return None
+        return rqet.uuid_in_part_name(part)
+
+    def roots(self,
+              parts_list = None,
+              obj_type = None,
+              uuid = None,
+              title = None,
+              title_mode = 'is',
+              title_case_sensitive = False,
+              extra = {},
+              related_uuid = None,
+              epc_subdir = None,
+              sort_by = None):
+        """Returns a list of xml root nodes of parts matching all of the arguments passed.
+
+      arguments:
+         (as for parts() method)
+
+      returns:
+         list of lxml.etree.Element objects
+
+      :meta common:
+      """
+
+        pl = self.parts(parts_list = parts_list,
+                        obj_type = obj_type,
+                        uuid = uuid,
+                        title = title,
+                        title_mode = title_mode,
+                        title_case_sensitive = title_case_sensitive,
+                        extra = extra,
+                        related_uuid = related_uuid,
+                        epc_subdir = epc_subdir,
+                        sort_by = sort_by)
+        root_list = []
+        for part in pl:
+            root_list.append(self.root_for_part(part))
+        return root_list
+
+    def root(self,
+             parts_list = None,
+             obj_type = None,
+             uuid = None,
+             title = None,
+             title_mode = 'is',
+             title_case_sensitive = False,
+             extra = {},
+             related_uuid = None,
+             epc_subdir = None,
+             multiple_handling = 'exception'):
+        """Returns the xml root node of a part matching all of the arguments passed.
+
+      arguments:
+         (as for part())
+
+      returns:
+         lxml.etree.Element object being the root node of the xml for the single part matching all of the criteria, or None
+
+      :meta common:
+      """
+
+        part = self.part(parts_list = parts_list,
+                         obj_type = obj_type,
+                         uuid = uuid,
+                         title = title,
+                         title_mode = title_mode,
+                         title_case_sensitive = title_case_sensitive,
+                         extra = extra,
+                         related_uuid = related_uuid,
+                         epc_subdir = epc_subdir,
+                         multiple_handling = multiple_handling)
+        if part is None:
+            return None
+        return self.root_for_part(part)
+
+    def titles(self,
+               parts_list = None,
+               obj_type = None,
+               uuid = None,
+               title = None,
+               title_mode = 'is',
+               title_case_sensitive = False,
+               extra = {},
+               related_uuid = None,
+               epc_subdir = None,
+               sort_by = None):
+        """Returns a list of citation titles of parts matching all of the arguments passed.
+
+      arguments:
+         (as for parts() method)
+
+      returns:
+         list of strings being the citation titles of matching parts
+
+      :meta common:
+      """
+
+        pl = self.parts(parts_list = parts_list,
+                        obj_type = obj_type,
+                        uuid = uuid,
+                        title = title,
+                        title_mode = title_mode,
+                        title_case_sensitive = title_case_sensitive,
+                        extra = extra,
+                        related_uuid = related_uuid,
+                        epc_subdir = epc_subdir,
+                        sort_by = sort_by)
+        title_list = []
+        for part in pl:
+            title_list.append(self.citation_title_for_part(part))
+        return title_list
+
+    def title(self,
+              parts_list = None,
+              obj_type = None,
+              uuid = None,
+              title = None,
+              title_mode = 'is',
+              title_case_sensitive = False,
+              extra = {},
+              related_uuid = None,
+              epc_subdir = None,
+              multiple_handling = 'exception'):
+        """Returns the citation title of a part matching all of the arguments passed.
 
       arguments:
          (as for part())
@@ -612,45 +613,45 @@ class Model():
       :meta common:
       """
 
-      part = self.part(parts_list = parts_list,
-                       obj_type = obj_type,
-                       uuid = uuid,
-                       title = title,
-                       title_mode = title_mode,
-                       title_case_sensitive = title_case_sensitive,
-                       extra = extra,
-                       related_uuid = related_uuid,
-                       epc_subdir = epc_subdir,
-                       multiple_handling = multiple_handling)
-      if part is None:
-         return None
-      return self.citation_title_for_part(part)
+        part = self.part(parts_list = parts_list,
+                         obj_type = obj_type,
+                         uuid = uuid,
+                         title = title,
+                         title_mode = title_mode,
+                         title_case_sensitive = title_case_sensitive,
+                         extra = extra,
+                         related_uuid = related_uuid,
+                         epc_subdir = epc_subdir,
+                         multiple_handling = multiple_handling)
+        if part is None:
+            return None
+        return self.citation_title_for_part(part)
 
-   def set_modified(self):
-      """Marks the model as having been modified and assigns a new uuid.
+    def set_modified(self):
+        """Marks the model as having been modified and assigns a new uuid.
 
       note:
          this modification tracking functionality is not part of the resqml standard and is only loosely
          applied by the library code; not usually called directly
       """
 
-      self.modified = True
+        self.modified = True
 
-   @property
-   def crs_root(self):
-      """XML node corresponding to self.crs_uuid"""
+    @property
+    def crs_root(self):
+        """XML node corresponding to self.crs_uuid"""
 
-      return self.root_for_uuid(self.crs_uuid)
+        return self.root_for_uuid(self.crs_uuid)
 
-   def create_tree_if_none(self):
-      """Checks that model has an xml tree; if not, an empty tree is created; not usually called directly."""
+    def create_tree_if_none(self):
+        """Checks that model has an xml tree; if not, an empty tree is created; not usually called directly."""
 
-      if self.main_tree is None:
-         self.main_tree = rqet.ElementTree()
-         self.modified = True
+        if self.main_tree is None:
+            self.main_tree = rqet.ElementTree()
+            self.modified = True
 
-   def load_part(self, epc, part_name, is_rels = None):
-      """Load and parse xml tree for given part name, storing info in parts forest (or rels forest).
+    def load_part(self, epc, part_name, is_rels = None):
+        """Load and parse xml tree for given part name, storing info in parts forest (or rels forest).
 
       arguments:
          epc: an open ZipFile handle for the epc file
@@ -667,56 +668,56 @@ class Model():
          not usually called directly
       """
 
-      # note: epc is 'open' ZipFile handle
-      if part_name.startswith('/'):
-         part_name = part_name[1:]
+        # note: epc is 'open' ZipFile handle
+        if part_name.startswith('/'):
+            part_name = part_name[1:]
 
-      try:
+        try:
 
-         #        log.debug('loading part ' + part_name)
-         if is_rels is None:
-            is_rels = part_name.endswith('.rels')
-         is_other = not is_rels and part_name.startswith('docProps')
+            #        log.debug('loading part ' + part_name)
+            if is_rels is None:
+                is_rels = part_name.endswith('.rels')
+            is_other = not is_rels and part_name.startswith('docProps')
 
-         part_type = None
-         part_uuid = None
+            part_type = None
+            part_uuid = None
 
-         if is_rels:
-            if part_name in self.rels_forest:
-               (part_uuid, _) = self.rels_forest[part_name]
-            if part_uuid is None:
-               part_uuid = rqet.uuid_in_part_name(part_name)
-         elif is_other:
-            (part_type, _) = self.other_forest[part_name]
-         else:
-            (part_type, part_uuid, _) = self.parts_forest[part_name]  # part_type must already have been established
-
-         with epc.open(part_name) as part_xml:
-            part_tree = rqet.parse(part_xml)
             if is_rels:
-               self.rels_forest[part_name] = (part_uuid, part_tree)
+                if part_name in self.rels_forest:
+                    (part_uuid, _) = self.rels_forest[part_name]
+                if part_uuid is None:
+                    part_uuid = rqet.uuid_in_part_name(part_name)
             elif is_other:
-               self.other_forest[part_name] = (part_type, part_tree)
+                (part_type, _) = self.other_forest[part_name]
             else:
-               uuid_from_tree = rqet.uuid_for_part_root(part_tree.getroot())
-               if part_uuid is None:
-                  part_uuid = uuid_from_tree
-               elif uuid_from_tree is not None:
-                  assert bu.matching_uuids(part_uuid, uuid_from_tree)
-               self.parts_forest[part_name] = (part_type, part_uuid, part_tree)
-               self._set_uuid_to_part(part_name)
-               if self.crs_uuid is None and part_type == 'obj_LocalDepth3dCrs':  # randomly assign first crs as primary crs for model
-                  self.crs_uuid = part_uuid
+                (part_type, part_uuid, _) = self.parts_forest[part_name]  # part_type must already have been established
 
-         return True
+            with epc.open(part_name) as part_xml:
+                part_tree = rqet.parse(part_xml)
+                if is_rels:
+                    self.rels_forest[part_name] = (part_uuid, part_tree)
+                elif is_other:
+                    self.other_forest[part_name] = (part_type, part_tree)
+                else:
+                    uuid_from_tree = rqet.uuid_for_part_root(part_tree.getroot())
+                    if part_uuid is None:
+                        part_uuid = uuid_from_tree
+                    elif uuid_from_tree is not None:
+                        assert bu.matching_uuids(part_uuid, uuid_from_tree)
+                    self.parts_forest[part_name] = (part_type, part_uuid, part_tree)
+                    self._set_uuid_to_part(part_name)
+                    if self.crs_uuid is None and part_type == 'obj_LocalDepth3dCrs':  # randomly assign first crs as primary crs for model
+                        self.crs_uuid = part_uuid
 
-      except Exception:
+            return True
 
-         log.exception('(okay to continue?) failed to load part: ' + part_name)
-         return False
+        except Exception:
 
-   def set_epc_file_and_directory(self, epc_file):
-      """Sets the full path and directory of the epc_file.
+            log.exception('(okay to continue?) failed to load part: ' + part_name)
+            return False
+
+    def set_epc_file_and_directory(self, epc_file):
+        """Sets the full path and directory of the epc_file.
 
       arguments:
          epc_file (string): the path of the epc file
@@ -725,13 +726,13 @@ class Model():
          not usually needed to be called directly, except perhaps when creating a new dataset
       """
 
-      self.epc_file = epc_file  # full path, if provided as such
-      (self.epc_directory, _) = os.path.split(epc_file)
-      if self.epc_directory is None or len(self.epc_directory) == 0:
-         self.epc_directory = '.'
+        self.epc_file = epc_file  # full path, if provided as such
+        (self.epc_directory, _) = os.path.split(epc_file)
+        if self.epc_directory is None or len(self.epc_directory) == 0:
+            self.epc_directory = '.'
 
-   def fell_part(self, part_name):
-      """Removes the named part from the in-memory parts forest.
+    def fell_part(self, part_name):
+        """Removes the named part from the in-memory parts forest.
 
       arguments:
          part_name (string): the name of the part to be removed
@@ -741,83 +742,83 @@ class Model():
          not usually called directly
       """
 
-      try:
-         self._del_uuid_to_part(part_name)
-      except Exception:
-         pass
-      try:
-         del self.parts_forest[part_name]
-      except Exception:
-         pass
-      try:
-         del self.rels_forest[part_name]
-      except Exception:
-         pass
-      try:
-         del self.other_forest[part_name]
-      except Exception:
-         pass
+        try:
+            self._del_uuid_to_part(part_name)
+        except Exception:
+            pass
+        try:
+            del self.parts_forest[part_name]
+        except Exception:
+            pass
+        try:
+            del self.rels_forest[part_name]
+        except Exception:
+            pass
+        try:
+            del self.other_forest[part_name]
+        except Exception:
+            pass
 
-   def remove_part_from_main_tree(self, part):
-      """Removes the named part from the main (Content_Types) tree.
-
-      note:
-         not usually called directly
-      """
-
-      for child in self.main_root:
-         if rqet.stripped_of_prefix(child.tag) == 'Override':
-            part_name = child.attrib['PartName']
-            if part_name[0] == '/':
-               part_name = part_name[1:]
-            if part_name == part:
-               log.debug('removing part from main xml tree: ' + part)
-               self.main_root.remove(child)
-               break
-
-   def tidy_up_forests(self, tidy_main_tree = True, tidy_others = False, remove_extended_core = True):
-      """Removes any parts that do not have any related data in dictionaries.
+    def remove_part_from_main_tree(self, part):
+        """Removes the named part from the main (Content_Types) tree.
 
       note:
          not usually called directly
       """
 
-      deletion_list = []
-      for part, info in self.parts_forest.items():
-         if info == (None, None, None):
-            deletion_list.append(part)
-      for part in deletion_list:
-         log.debug('removing part due to lack of xml tree etc.: ' + str(part))
-         if tidy_main_tree:
-            self.remove_part_from_main_tree(part)
-         self._del_uuid_to_part(part)
-         del self.parts_forest[part]
-      deletion_list = []
-      for part, info in self.rels_forest.items():
-         if info == (None, None):
-            deletion_list.append(part)
-      for part in deletion_list:
-         log.debug('removing rels part due to lack of xml tree etc.: ' + str(part))
-         if tidy_main_tree:
-            self.remove_part_from_main_tree(part)
-         del self.rels_forest[part]
-      if tidy_others:
-         for part, info in self.other_forest.items():
-            if info == (None, None):
-               deletion_list.append(part)
-         for part in deletion_list:
-            log.debug('removing docProps part due to lack of xml tree etc.: ' + str(part))
+        for child in self.main_root:
+            if rqet.stripped_of_prefix(child.tag) == 'Override':
+                part_name = child.attrib['PartName']
+                if part_name[0] == '/':
+                    part_name = part_name[1:]
+                if part_name == part:
+                    log.debug('removing part from main xml tree: ' + part)
+                    self.main_root.remove(child)
+                    break
+
+    def tidy_up_forests(self, tidy_main_tree = True, tidy_others = False, remove_extended_core = True):
+        """Removes any parts that do not have any related data in dictionaries.
+
+      note:
+         not usually called directly
+      """
+
+        deletion_list = []
+        for part, info in self.parts_forest.items():
+            if info == (None, None, None):
+                deletion_list.append(part)
+        for part in deletion_list:
+            log.debug('removing part due to lack of xml tree etc.: ' + str(part))
             if tidy_main_tree:
-               self.remove_part_from_main_tree(part)
+                self.remove_part_from_main_tree(part)
+            self._del_uuid_to_part(part)
+            del self.parts_forest[part]
+        deletion_list = []
+        for part, info in self.rels_forest.items():
+            if info == (None, None):
+                deletion_list.append(part)
+        for part in deletion_list:
+            log.debug('removing rels part due to lack of xml tree etc.: ' + str(part))
+            if tidy_main_tree:
+                self.remove_part_from_main_tree(part)
+            del self.rels_forest[part]
+        if tidy_others:
+            for part, info in self.other_forest.items():
+                if info == (None, None):
+                    deletion_list.append(part)
+            for part in deletion_list:
+                log.debug('removing docProps part due to lack of xml tree etc.: ' + str(part))
+                if tidy_main_tree:
+                    self.remove_part_from_main_tree(part)
+                del self.other_forest[part]
+        if remove_extended_core and 'docProps/extendedCore.xml' in self.other_forest:  # more trouble than it's worth
+            part = 'docProps/extendedCore.xml'
+            if tidy_main_tree:
+                self.remove_part_from_main_tree(part)
             del self.other_forest[part]
-      if remove_extended_core and 'docProps/extendedCore.xml' in self.other_forest:  # more trouble than it's worth
-         part = 'docProps/extendedCore.xml'
-         if tidy_main_tree:
-            self.remove_part_from_main_tree(part)
-         del self.other_forest[part]
 
-   def load_epc(self, epc_file, full_load = True, epc_subdir = None, copy_from = None):
-      """Load xml parts of model from epc file (HDF5 arrays are not loaded).
+    def load_epc(self, epc_file, full_load = True, epc_subdir = None, copy_from = None):
+        """Load xml parts of model from epc file (HDF5 arrays are not loaded).
 
       Arguments:
          epc_file (string): the path of the epc file
@@ -838,107 +839,108 @@ class Model():
          regardless of the epc_subdir setting which only affects the subsequent load into memory
       """
 
-      def exclude(name, epc_subdir):
-         if epc_subdir is None:
-            return False
-         if '/' not in name:
-            return False
-         if name.startswith('docProps') or name.startswith('_rels'):
-            return False
-         if isinstance(epc_subdir, str):
-            epc_subdir = [epc_subdir]
-         for subdir in epc_subdir:
-            if subdir.endswith('/'):
-               head = subdir
-            else:
-               head = subdir + '/'
-            if name.startswith(head):
-               return False
-         return True
+        def exclude(name, epc_subdir):
+            if epc_subdir is None:
+                return False
+            if '/' not in name:
+                return False
+            if name.startswith('docProps') or name.startswith('_rels'):
+                return False
+            if isinstance(epc_subdir, str):
+                epc_subdir = [epc_subdir]
+            for subdir in epc_subdir:
+                if subdir.endswith('/'):
+                    head = subdir
+                else:
+                    head = subdir + '/'
+                if name.startswith(head):
+                    return False
+            return True
 
-      if not epc_file.endswith('.epc'):
-         epc_file += '.epc'
+        if not epc_file.endswith('.epc'):
+            epc_file += '.epc'
 
-      if copy_from:
-         if not copy_from.endswith('.epc'):
-            copy_from += '.epc'
-         log.info('copying ' + copy_from + ' to ' + epc_file + ' along with paired .h5 files')
-         shutil.copy(copy_from, epc_file)
-         shutil.copy(copy_from[:-4] + '.h5', epc_file[:-4] + '.h5')
+        if copy_from:
+            if not copy_from.endswith('.epc'):
+                copy_from += '.epc'
+            log.info('copying ' + copy_from + ' to ' + epc_file + ' along with paired .h5 files')
+            shutil.copy(copy_from, epc_file)
+            shutil.copy(copy_from[:-4] + '.h5', epc_file[:-4] + '.h5')
 
-      log.info('loading resqml model from epc file ' + epc_file)
+        log.info('loading resqml model from epc file ' + epc_file)
 
-      if self.modified:
-         log.warning('loading model from epc, discarding previous in-memory modifications')
-         self.initialize()
+        if self.modified:
+            log.warning('loading model from epc, discarding previous in-memory modifications')
+            self.initialize()
 
-      self.set_epc_file_and_directory(epc_file)
+        self.set_epc_file_and_directory(epc_file)
 
-      with zf.ZipFile(epc_file) as epc:
-         names = epc.namelist()
-         for name in names:
-            if exclude(name, epc_subdir):
-               continue
-            if name != '[Content_Types].xml':
-               if name.startswith('docProps'):
-                  self.other_forest[name] = (None, None)  # used for non-uuid parts, ie. docProps
-               else:
-                  part_uuid = rqet.uuid_in_part_name(name)
-                  if '_rels' in name:
-                     self.rels_forest[name] = (part_uuid, None)
-                  else:
-                     self.parts_forest[name] = (None, part_uuid, None)
-                     self._set_uuid_to_part(name)
-         with epc.open('[Content_Types].xml') as main_xml:
-            self.main_tree = rqet.parse(main_xml)
-            self.main_root = self.main_tree.getroot()
-            for child in self.main_root:
-               if rqet.stripped_of_prefix(child.tag) == 'Override':
-                  attrib_dict = child.attrib
-                  part_name = attrib_dict['PartName']
-                  if part_name[0] == '/':
-                     part_name = part_name[1:]
-                  part_type = rqet.content_type(attrib_dict['ContentType'])
-                  if part_name.startswith('docProps'):
-                     if part_name not in self.other_forest:
-                        log.warning('docProps entry in Content_Types does not exist as part in epc: ' + part_name)
-                        continue
-                     self.other_forest[part_name] = (part_type, None)
-                  else:
-                     if part_name not in self.parts_forest:
-                        if epc_subdir is None:
-                           log.warning('entry in Content_Types does not exist as part in epc: ' + part_name)
-                        continue
-                     part_uuid = self.parts_forest[part_name][1]
-                     self.parts_forest[part_name] = (part_type, part_uuid, None)
-                  if full_load:
-                     load_success = self.load_part(epc, part_name)
-                     if not load_success:
-                        self.fell_part(part_name)
-               elif rqet.stripped_of_prefix(child.tag) == 'Default':
-                  if 'Extension' in child.attrib.keys() and child.attrib['Extension'] == 'rels':
-                     assert not self.rels_present
-                     self.rels_present = True
-               else:
-                  # todo: check standard for other valid tags
-                  pass
-         if self.rels_present and full_load:
+        with zf.ZipFile(epc_file) as epc:
+            names = epc.namelist()
             for name in names:
-               if exclude(name, epc_subdir):
-                  continue
-               if name.startswith('_rels/'):
-                  load_success = self.load_part(epc, name, is_rels = True)
-                  if not load_success:
-                     self.fell_part(part_name)
-            if copy_from:
-               self.change_filename_in_hdf5_rels(os.path.split(epc_file)[1][:-4] + '.h5')
-         elif not self.rels_present:
-            assert len(self.rels_forest) == 0
-         if full_load:
-            self.tidy_up_forests()
+                if exclude(name, epc_subdir):
+                    continue
+                if name != '[Content_Types].xml':
+                    if name.startswith('docProps'):
+                        self.other_forest[name] = (None, None)  # used for non-uuid parts, ie. docProps
+                    else:
+                        part_uuid = rqet.uuid_in_part_name(name)
+                        if '_rels' in name:
+                            self.rels_forest[name] = (part_uuid, None)
+                        else:
+                            self.parts_forest[name] = (None, part_uuid, None)
+                            self._set_uuid_to_part(name)
+            with epc.open('[Content_Types].xml') as main_xml:
+                self.main_tree = rqet.parse(main_xml)
+                self.main_root = self.main_tree.getroot()
+                for child in self.main_root:
+                    if rqet.stripped_of_prefix(child.tag) == 'Override':
+                        attrib_dict = child.attrib
+                        part_name = attrib_dict['PartName']
+                        if part_name[0] == '/':
+                            part_name = part_name[1:]
+                        part_type = rqet.content_type(attrib_dict['ContentType'])
+                        if part_name.startswith('docProps'):
+                            if part_name not in self.other_forest:
+                                log.warning('docProps entry in Content_Types does not exist as part in epc: ' +
+                                            part_name)
+                                continue
+                            self.other_forest[part_name] = (part_type, None)
+                        else:
+                            if part_name not in self.parts_forest:
+                                if epc_subdir is None:
+                                    log.warning('entry in Content_Types does not exist as part in epc: ' + part_name)
+                                continue
+                            part_uuid = self.parts_forest[part_name][1]
+                            self.parts_forest[part_name] = (part_type, part_uuid, None)
+                        if full_load:
+                            load_success = self.load_part(epc, part_name)
+                            if not load_success:
+                                self.fell_part(part_name)
+                    elif rqet.stripped_of_prefix(child.tag) == 'Default':
+                        if 'Extension' in child.attrib.keys() and child.attrib['Extension'] == 'rels':
+                            assert not self.rels_present
+                            self.rels_present = True
+                    else:
+                        # todo: check standard for other valid tags
+                        pass
+            if self.rels_present and full_load:
+                for name in names:
+                    if exclude(name, epc_subdir):
+                        continue
+                    if name.startswith('_rels/'):
+                        load_success = self.load_part(epc, name, is_rels = True)
+                        if not load_success:
+                            self.fell_part(part_name)
+                if copy_from:
+                    self.change_filename_in_hdf5_rels(os.path.split(epc_file)[1][:-4] + '.h5')
+            elif not self.rels_present:
+                assert len(self.rels_forest) == 0
+            if full_load:
+                self.tidy_up_forests()
 
-   def store_epc(self, epc_file = None, main_xml_name = '[Content_Types].xml', only_if_modified = False):
-      """Write xml parts of model to epc file (HDF5 arrays are not written here).
+    def store_epc(self, epc_file = None, main_xml_name = '[Content_Types].xml', only_if_modified = False):
+        """Write xml parts of model to epc file (HDF5 arrays are not written here).
 
       Arguments:
          epc_file (string): the name of the output epc file to be written (any existing file will be
@@ -959,55 +961,55 @@ class Model():
       :meta common:
       """
 
-      #      for prefix, uri in ns.items():
-      #         et.register_namespace(prefix, uri)
+        #      for prefix, uri in ns.items():
+        #         et.register_namespace(prefix, uri)
 
-      if not epc_file:
-         epc_file = self.epc_file
-      assert epc_file, 'no file name given or known when attempting to store epc'
+        if not epc_file:
+            epc_file = self.epc_file
+        assert epc_file, 'no file name given or known when attempting to store epc'
 
-      if only_if_modified and not self.modified:
-         return
+        if only_if_modified and not self.modified:
+            return
 
-      log.info('storing resqml model to epc file ' + epc_file)
+        log.info('storing resqml model to epc file ' + epc_file)
 
-      assert self.main_tree is not None
-      if self.main_root is None:
-         self.main_root = self.main_tree.getroot()
+        assert self.main_tree is not None
+        if self.main_root is None:
+            self.main_root = self.main_tree.getroot()
 
-      with zf.ZipFile(epc_file, mode = 'w') as epc:
-         with epc.open(main_xml_name, mode = 'w') as main_xml:
-            log.debug('Writing main xml: ' + main_xml_name)
-            rqet.write_xml(main_xml, self.main_tree, standalone = 'yes')
-         for part_name, (_, _, part_tree) in self.parts_forest.items():
-            if part_tree is None:
-               log.warning('No xml tree present to write for part: ' + part_name)
-               continue
-            if part_name[0] == '/':
-               part_name = part_name[1:]
-            with epc.open(part_name, mode = 'w') as part_xml:
-               rqet.write_xml(part_xml, part_tree, standalone = None)
-         for part_name, (_, part_tree) in self.other_forest.items():
-            if part_tree is None:
-               log.warning('No xml tree present to write for other part: ' + part_name)
-               continue
-            if part_name[0] == '/':
-               part_name = part_name[1:]
-            with epc.open(part_name, mode = 'w') as part_xml:
-               rqet.write_xml(part_xml, part_tree, standalone = 'yes')
-         if self.rels_present:
-            for part_name, (_, part_tree) in self.rels_forest.items():
-               if part_tree is None:
-                  log.warning('No xml tree present to write for rels part: ' + part_name)
-                  continue
-               with epc.open(part_name, mode = 'w') as part_xml:
-                  rqet.write_xml(part_xml, part_tree, standalone = 'yes')
-         # todo: other parts (documentation etc.)
-      self.set_epc_file_and_directory(epc_file)
-      self.modified = False
+        with zf.ZipFile(epc_file, mode = 'w') as epc:
+            with epc.open(main_xml_name, mode = 'w') as main_xml:
+                log.debug('Writing main xml: ' + main_xml_name)
+                rqet.write_xml(main_xml, self.main_tree, standalone = 'yes')
+            for part_name, (_, _, part_tree) in self.parts_forest.items():
+                if part_tree is None:
+                    log.warning('No xml tree present to write for part: ' + part_name)
+                    continue
+                if part_name[0] == '/':
+                    part_name = part_name[1:]
+                with epc.open(part_name, mode = 'w') as part_xml:
+                    rqet.write_xml(part_xml, part_tree, standalone = None)
+            for part_name, (_, part_tree) in self.other_forest.items():
+                if part_tree is None:
+                    log.warning('No xml tree present to write for other part: ' + part_name)
+                    continue
+                if part_name[0] == '/':
+                    part_name = part_name[1:]
+                with epc.open(part_name, mode = 'w') as part_xml:
+                    rqet.write_xml(part_xml, part_tree, standalone = 'yes')
+            if self.rels_present:
+                for part_name, (_, part_tree) in self.rels_forest.items():
+                    if part_tree is None:
+                        log.warning('No xml tree present to write for rels part: ' + part_name)
+                        continue
+                    with epc.open(part_name, mode = 'w') as part_xml:
+                        rqet.write_xml(part_xml, part_tree, standalone = 'yes')
+            # todo: other parts (documentation etc.)
+        self.set_epc_file_and_directory(epc_file)
+        self.modified = False
 
-   def parts_list_of_type(self, type_of_interest = None, uuid = None):
-      """Returns a list of part names for parts of type of interest, optionally matching a uuid.
+    def parts_list_of_type(self, type_of_interest = None, uuid = None):
+        """Returns a list of part names for parts of type of interest, optionally matching a uuid.
 
          arguments:
             type_of_interest (string): the resqml object class of interest, in string form, eg. 'obj_IjkGridRepresentation'
@@ -1022,43 +1024,43 @@ class Model():
             it is equivalent to: self.parts(obj_type = type_of_interest, uuid = uuid)
       """
 
-      if type_of_interest and type_of_interest[0].isupper():
-         type_of_interest = 'obj_' + type_of_interest
+        if type_of_interest and type_of_interest[0].isupper():
+            type_of_interest = 'obj_' + type_of_interest
 
-      if uuid is not None:
-         part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
-         if part_name is None or (type_of_interest is not None and
-                                  (self.parts_forest[part_name][0] != type_of_interest)):
-            return []
-         return [part_name]
+        if uuid is not None:
+            part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
+            if part_name is None or (type_of_interest is not None and
+                                     (self.parts_forest[part_name][0] != type_of_interest)):
+                return []
+            return [part_name]
 
-      parts_list = []
-      for part_name in self.parts_forest:
-         if type_of_interest is None or self.parts_forest[part_name][0] == type_of_interest:
-            parts_list.append(part_name)
-      return parts_list
+        parts_list = []
+        for part_name in self.parts_forest:
+            if type_of_interest is None or self.parts_forest[part_name][0] == type_of_interest:
+                parts_list.append(part_name)
+        return parts_list
 
-   def list_of_parts(self, only_objects = True):
-      """Return a complete list of parts."""
+    def list_of_parts(self, only_objects = True):
+        """Return a complete list of parts."""
 
-      pl = list(self.parts_forest.keys())
-      if not only_objects:
-         return pl
-      obj_list = []
-      for part in pl:
-         dir_place = part.rfind('/')
-         dir_free_part = part[dir_place + 1:]
-         if dir_free_part.startswith('obj_') and not dir_free_part.startswith('obj_Epc'):
-            obj_list.append(part)
-      return obj_list
+        pl = list(self.parts_forest.keys())
+        if not only_objects:
+            return pl
+        obj_list = []
+        for part in pl:
+            dir_place = part.rfind('/')
+            dir_free_part = part[dir_place + 1:]
+            if dir_free_part.startswith('obj_') and not dir_free_part.startswith('obj_Epc'):
+                obj_list.append(part)
+        return obj_list
 
-   def number_of_parts(self):
-      """Retuns the number of parts in the model, including external parts such as the link to an hdf5 file."""
+    def number_of_parts(self):
+        """Retuns the number of parts in the model, including external parts such as the link to an hdf5 file."""
 
-      return len(self.parts_forest)
+        return len(self.parts_forest)
 
-   def part_for_uuid(self, uuid):
-      """Returns the part name which has the given uuid.
+    def part_for_uuid(self, uuid):
+        """Returns the part name which has the given uuid.
 
       arguments:
          uuid (uuid.UUID object or string): the uuid of the part of interest
@@ -1069,10 +1071,10 @@ class Model():
       :meta common:
       """
 
-      return self.uuid_part_dict.get(bu.uuid_as_int(uuid))
+        return self.uuid_part_dict.get(bu.uuid_as_int(uuid))
 
-   def root_for_uuid(self, uuid):
-      """Returns the xml root for the part which has the given uuid.
+    def root_for_uuid(self, uuid):
+        """Returns the xml root for the part which has the given uuid.
 
       arguments:
          uuid (uuid.UUID object or string): the uuid of the part of interest
@@ -1083,10 +1085,10 @@ class Model():
       :meta common:
       """
 
-      return self.root_for_part(self.part_for_uuid(uuid))
+        return self.root_for_part(self.part_for_uuid(uuid))
 
-   def parts_count_by_type(self, type_of_interest = None):
-      """Returns a sorted list of (type, count) for parts.
+    def parts_count_by_type(self, type_of_interest = None):
+        """Returns a sorted list of (type, count) for parts.
 
       arguments:
          type_of_interest (string, optional): if not None, the returned list only contains one pair, with
@@ -1097,35 +1099,35 @@ class Model():
          and count
       """
 
-      # note: resqml classes start with 'obj_' whilst witsml classes don't!
-      if type_of_interest and type_of_interest.startswith('obj_'):
-         type_of_interest = type_of_interest[4:]
+        # note: resqml classes start with 'obj_' whilst witsml classes don't!
+        if type_of_interest and type_of_interest.startswith('obj_'):
+            type_of_interest = type_of_interest[4:]
 
-      type_list = []
-      for part_name in self.parts_forest:
-         part_type = self.parts_forest[part_name][0]
-         if part_type is None:
-            continue
-         if part_type.startswith('obj_'):
-            part_type = part_type[4:]
-         if type_of_interest is None or part_type == type_of_interest:
-            type_list.append(part_type)
-      type_list.sort()
-      type_list.append('END')  # simplifies termination of scan below
-      result_list = []
-      count = 0
-      current_type = ''
-      for index in range(len(type_list)):
-         if type_list[index] != current_type:
-            if count:
-               result_list.append((current_type, count))
-            current_type = type_list[index]
-            count = 0
-         count += 1
-      return result_list
+        type_list = []
+        for part_name in self.parts_forest:
+            part_type = self.parts_forest[part_name][0]
+            if part_type is None:
+                continue
+            if part_type.startswith('obj_'):
+                part_type = part_type[4:]
+            if type_of_interest is None or part_type == type_of_interest:
+                type_list.append(part_type)
+        type_list.sort()
+        type_list.append('END')  # simplifies termination of scan below
+        result_list = []
+        count = 0
+        current_type = ''
+        for index in range(len(type_list)):
+            if type_list[index] != current_type:
+                if count:
+                    result_list.append((current_type, count))
+                current_type = type_list[index]
+                count = 0
+            count += 1
+        return result_list
 
-   def parts_list_filtered_by_related_uuid(self, parts_list, uuid, uuid_is_source = None):
-      """From a list of parts, returns a list of those parts which have a relationship with the given uuid.
+    def parts_list_filtered_by_related_uuid(self, parts_list, uuid, uuid_is_source = None):
+        """From a list of parts, returns a list of those parts which have a relationship with the given uuid.
 
       arguments:
          parts_list (list of strings): input list of parts from which a selection is made
@@ -1143,63 +1145,63 @@ class Model():
          this method scans the relationship info for every present part, looking for uuid in rels
       """
 
-      if not self.rels_present or parts_list is None or uuid is None:
-         return None
-      filtered_list = []
-      this_part = self.part_for_uuid(uuid)
+        if not self.rels_present or parts_list is None or uuid is None:
+            return None
+        filtered_list = []
+        this_part = self.part_for_uuid(uuid)
 
-      if this_part is not None:
-         rels_part_root = self.root_for_part(rqet.rels_part_name_for_part(this_part), is_rels = True)
-         if rels_part_root is not None:
+        if this_part is not None:
+            rels_part_root = self.root_for_part(rqet.rels_part_name_for_part(this_part), is_rels = True)
+            if rels_part_root is not None:
+                for relation_node in rels_part_root:
+                    if rqet.stripped_of_prefix(relation_node.tag) != 'Relationship':
+                        continue
+                    target_part = relation_node.attrib['Target']
+                    if target_part not in parts_list:
+                        continue
+                    if uuid_is_source is not None:
+                        source_dest = relation_node.attrib['Type']
+                        if uuid_is_source:
+                            if 'source' not in source_dest:
+                                continue
+                        else:
+                            if 'source' in source_dest:
+                                continue
+                    filtered_list.append(target_part)
+
+        for part in parts_list:
+            if part in filtered_list:
+                continue
+            rels_part_root = self.root_for_part(rqet.rels_part_name_for_part(part), is_rels = True)
+            if rels_part_root is None:
+                continue
             for relation_node in rels_part_root:
-               if rqet.stripped_of_prefix(relation_node.tag) != 'Relationship':
-                  continue
-               target_part = relation_node.attrib['Target']
-               if target_part not in parts_list:
-                  continue
-               if uuid_is_source is not None:
-                  source_dest = relation_node.attrib['Type']
-                  if uuid_is_source:
-                     if 'source' not in source_dest:
-                        continue
-                  else:
-                     if 'source' in source_dest:
-                        continue
-               filtered_list.append(target_part)
+                if rqet.stripped_of_prefix(relation_node.tag) != 'Relationship':
+                    continue
+                target_part = relation_node.attrib['Target']
+                relation_uuid = rqet.uuid_in_part_name(target_part)
+                if bu.matching_uuids(uuid, relation_uuid):
+                    if uuid_is_source is not None:
+                        source_dest = relation_node.attrib['Type']
+                        if uuid_is_source:
+                            if 'source' in source_dest:
+                                continue  # relation is source, so uuid is not
+                        else:
+                            if 'source' not in source_dest:
+                                continue  # relation is not source, so uuid is
+                    filtered_list.append(part)
+                    break
 
-      for part in parts_list:
-         if part in filtered_list:
-            continue
-         rels_part_root = self.root_for_part(rqet.rels_part_name_for_part(part), is_rels = True)
-         if rels_part_root is None:
-            continue
-         for relation_node in rels_part_root:
-            if rqet.stripped_of_prefix(relation_node.tag) != 'Relationship':
-               continue
-            target_part = relation_node.attrib['Target']
-            relation_uuid = rqet.uuid_in_part_name(target_part)
-            if bu.matching_uuids(uuid, relation_uuid):
-               if uuid_is_source is not None:
-                  source_dest = relation_node.attrib['Type']
-                  if uuid_is_source:
-                     if 'source' in source_dest:
-                        continue  # relation is source, so uuid is not
-                  else:
-                     if 'source' not in source_dest:
-                        continue  # relation is not source, so uuid is
-               filtered_list.append(part)
-               break
+        return filtered_list
 
-      return filtered_list
+    def supporting_representation_for_part(self, part):
+        """Returns the uuid of the supporting representation for the part, if found, otherwise None."""
 
-   def supporting_representation_for_part(self, part):
-      """Returns the uuid of the supporting representation for the part, if found, otherwise None."""
+        return bu.uuid_from_string(
+            rqet.find_nested_tags_text(self.root_for_part(part), ['SupportingRepresentation', 'UUID']))
 
-      return bu.uuid_from_string(
-         rqet.find_nested_tags_text(self.root_for_part(part), ['SupportingRepresentation', 'UUID']))
-
-   def parts_list_filtered_by_supporting_uuid(self, parts_list, uuid):
-      """From a list of parts, returns a list of those parts which have the given uuid as supporting representation.
+    def parts_list_filtered_by_supporting_uuid(self, parts_list, uuid):
+        """From a list of parts, returns a list of those parts which have the given uuid as supporting representation.
 
       arguments:
          parts_list (list of strings): input list of parts from which a selection is made
@@ -1213,19 +1215,19 @@ class Model():
          the part to which the given uuid applies might or might not be in the input parts list
       """
 
-      if parts_list is None or uuid is None:
-         return None
-      filtered_list = []
-      for part in parts_list:
-         support_ref_uuid = self.supporting_representation_for_part(part)
-         if support_ref_uuid is None:
-            continue
-         if bu.matching_uuids(support_ref_uuid, uuid):
-            filtered_list.append(part)
-      return filtered_list
+        if parts_list is None or uuid is None:
+            return None
+        filtered_list = []
+        for part in parts_list:
+            support_ref_uuid = self.supporting_representation_for_part(part)
+            if support_ref_uuid is None:
+                continue
+            if bu.matching_uuids(support_ref_uuid, uuid):
+                filtered_list.append(part)
+        return filtered_list
 
-   def parts_list_related_to_uuid_of_type(self, uuid, type_of_interest = None):
-      """Returns a list of parts of type of interest that relate to part with given uuid.
+    def parts_list_related_to_uuid_of_type(self, uuid, type_of_interest = None):
+        """Returns a list of parts of type of interest that relate to part with given uuid.
 
       arguments:
          uuid (uuid.UUID): the uuid of a part for which related parts are required
@@ -1236,11 +1238,11 @@ class Model():
          list of strings being the part names of the type of interest, related to the uuid
       """
 
-      parts_list = self.parts_list_of_type(type_of_interest = type_of_interest)
-      return self.parts_list_filtered_by_related_uuid(parts_list, uuid)
+        parts_list = self.parts_list_of_type(type_of_interest = type_of_interest)
+        return self.parts_list_filtered_by_related_uuid(parts_list, uuid)
 
-   def external_parts_list(self):
-      """Returns a list of part names for external part references.
+    def external_parts_list(self):
+        """Returns a list of part names for external part references.
 
       Returns:
          list of strings being the part names for external part references
@@ -1252,10 +1254,10 @@ class Model():
          a single hdf5 file for a given epc file
       """
 
-      return self.parts_list_of_type('obj_EpcExternalPartReference')
+        return self.parts_list_of_type('obj_EpcExternalPartReference')
 
-   def uuid_for_part(self, part_name, is_rels = None):
-      """Returns the uuid for the named part.
+    def uuid_for_part(self, part_name, is_rels = None):
+        """Returns the uuid for the named part.
 
       arguments:
          part_name (string): the part name for which the uuid is required
@@ -1272,16 +1274,16 @@ class Model():
       :meta common:
       """
 
-      if part_name is None:
-         return None
-      if is_rels is None:
-         is_rels = part_name.endswith('.rels')
-      if is_rels:
-         return self.rels_forest[part_name][0]
-      return self.parts_forest[part_name][1]
+        if part_name is None:
+            return None
+        if is_rels is None:
+            is_rels = part_name.endswith('.rels')
+        if is_rels:
+            return self.rels_forest[part_name][0]
+        return self.parts_forest[part_name][1]
 
-   def type_of_part(self, part_name, strip_obj = False):
-      """Returns content type for the named part (does not apply to rels parts).
+    def type_of_part(self, part_name, strip_obj = False):
+        """Returns content type for the named part (does not apply to rels parts).
 
       arguments:
          part_name (string): the part for which the type is required
@@ -1294,16 +1296,16 @@ class Model():
       :meta common:
       """
 
-      part_info = self.parts_forest.get(part_name)
-      if part_info is None:
-         return None
-      obj_type = part_info[0]
-      if obj_type is None or not strip_obj or not obj_type.startswith('obj_'):
-         return obj_type
-      return obj_type[4:]
+        part_info = self.parts_forest.get(part_name)
+        if part_info is None:
+            return None
+        obj_type = part_info[0]
+        if obj_type is None or not strip_obj or not obj_type.startswith('obj_'):
+            return obj_type
+        return obj_type[4:]
 
-   def type_of_uuid(self, uuid, strip_obj = False):
-      """Returns content type for the uuid.
+    def type_of_uuid(self, uuid, strip_obj = False):
+        """Returns content type for the uuid.
 
       arguments:
          uuid (uuid.UUID or str): the uuid for which the type is required
@@ -1316,11 +1318,11 @@ class Model():
       :meta common:
       """
 
-      part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
-      return self.type_of_part(part_name, strip_obj = strip_obj)
+        part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
+        return self.type_of_part(part_name, strip_obj = strip_obj)
 
-   def tree_for_part(self, part_name, is_rels = None):
-      """Returns parsed xml tree for the named part.
+    def tree_for_part(self, part_name, is_rels = None):
+        """Returns parsed xml tree for the named part.
 
       arguments:
          part_name (string): the part name for which the xml tree is required
@@ -1331,50 +1333,50 @@ class Model():
          parsed xml tree (defined in lxml or ElementTree package) for the named part
       """
 
-      if not part_name:
-         return None
-      if is_rels is None:
-         is_rels = part_name.endswith('.rels')
-      is_other = not is_rels and part_name.startswith('docProps')
-      if is_rels:
-         if part_name not in self.rels_forest:
+        if not part_name:
             return None
-         (_, tree) = self.rels_forest[part_name]
-         if tree is None:
-            if not self.epc_file:
-               return None
-            with zf.ZipFile(self.epc_file) as epc:
-               load_success = self.load_part(epc, part_name, is_rels = True)
-               if not load_success:
-                  return None
-         return self.rels_forest[part_name][1]
-      elif is_other:
-         if part_name not in self.other_forest:
-            return None
-         (_, tree) = self.other_forest[part_name]
-         if tree is None:
-            if not self.epc_file:
-               return None
-            with zf.ZipFile(self.epc_file) as epc:
-               load_success = self.load_part(epc, part_name, is_rels = False)
-               if not load_success:
-                  return None
-         return self.other_forest[part_name][1]
-      else:
-         if part_name not in self.parts_forest:
-            return None
-         (_, _, tree) = self.parts_forest[part_name]
-         if tree is None:
-            if not self.epc_file:
-               return None
-            with zf.ZipFile(self.epc_file) as epc:
-               load_success = self.load_part(epc, part_name, is_rels = False)
-               if not load_success:
-                  return None
-         return self.parts_forest[part_name][2]
+        if is_rels is None:
+            is_rels = part_name.endswith('.rels')
+        is_other = not is_rels and part_name.startswith('docProps')
+        if is_rels:
+            if part_name not in self.rels_forest:
+                return None
+            (_, tree) = self.rels_forest[part_name]
+            if tree is None:
+                if not self.epc_file:
+                    return None
+                with zf.ZipFile(self.epc_file) as epc:
+                    load_success = self.load_part(epc, part_name, is_rels = True)
+                    if not load_success:
+                        return None
+            return self.rels_forest[part_name][1]
+        elif is_other:
+            if part_name not in self.other_forest:
+                return None
+            (_, tree) = self.other_forest[part_name]
+            if tree is None:
+                if not self.epc_file:
+                    return None
+                with zf.ZipFile(self.epc_file) as epc:
+                    load_success = self.load_part(epc, part_name, is_rels = False)
+                    if not load_success:
+                        return None
+            return self.other_forest[part_name][1]
+        else:
+            if part_name not in self.parts_forest:
+                return None
+            (_, _, tree) = self.parts_forest[part_name]
+            if tree is None:
+                if not self.epc_file:
+                    return None
+                with zf.ZipFile(self.epc_file) as epc:
+                    load_success = self.load_part(epc, part_name, is_rels = False)
+                    if not load_success:
+                        return None
+            return self.parts_forest[part_name][2]
 
-   def root_for_part(self, part_name, is_rels = None):
-      """Returns root of parsed xml tree for the named part.
+    def root_for_part(self, part_name, is_rels = None):
+        """Returns root of parsed xml tree for the named part.
 
       arguments:
          part_name (string): the part name for which the root of the xml tree is required
@@ -1387,15 +1389,15 @@ class Model():
       :meta common:
       """
 
-      if not part_name:
-         return None
-      tree = self.tree_for_part(part_name, is_rels = is_rels)
-      if tree is None:
-         return None
-      return tree.getroot()
+        if not part_name:
+            return None
+        tree = self.tree_for_part(part_name, is_rels = is_rels)
+        if tree is None:
+            return None
+        return tree.getroot()
 
-   def change_hdf5_uuid_in_hdf5_references(self, node, old_uuid, new_uuid):
-      """Scan node for hdf5 references and set the uuid of the hdf5 file itself to new_uuid.
+    def change_hdf5_uuid_in_hdf5_references(self, node, old_uuid, new_uuid):
+        """Scan node for hdf5 references and set the uuid of the hdf5 file itself to new_uuid.
 
       arguments:
          node: the root node of an xml tree within which hdf5 internal paths are to have hdf5 uuids changed
@@ -1410,26 +1412,26 @@ class Model():
          use change_uuid_in_hdf5_references() instead
       """
 
-      count = 0
-      old_uuid_str = str(old_uuid)
-      new_uuid_str = str(new_uuid)
-      for ref_node in node.iter(ns['eml'] + 'HdfProxy'):
-         try:
-            uuid_node = rqet.find_tag(ref_node, 'UUID')
-            if old_uuid is None or uuid_node.text == old_uuid_str:
-               uuid_node.text = new_uuid_str
-               count += 1
-         except Exception:
-            pass
-      if count == 1:
-         log.debug('one hdf5 reference modified')
-      else:
-         log.debug(str(count) + ' hdf5 references modified')
-      if count > 0:
-         self.set_modified()
+        count = 0
+        old_uuid_str = str(old_uuid)
+        new_uuid_str = str(new_uuid)
+        for ref_node in node.iter(ns['eml'] + 'HdfProxy'):
+            try:
+                uuid_node = rqet.find_tag(ref_node, 'UUID')
+                if old_uuid is None or uuid_node.text == old_uuid_str:
+                    uuid_node.text = new_uuid_str
+                    count += 1
+            except Exception:
+                pass
+        if count == 1:
+            log.debug('one hdf5 reference modified')
+        else:
+            log.debug(str(count) + ' hdf5 references modified')
+        if count > 0:
+            self.set_modified()
 
-   def change_uuid_in_hdf5_references(self, node, old_uuid, new_uuid):
-      """Scan node for hdf5 references using the old_uuid and replace with the new_uuid.
+    def change_uuid_in_hdf5_references(self, node, old_uuid, new_uuid):
+        """Scan node for hdf5 references using the old_uuid and replace with the new_uuid.
 
       arguments:
          node: the root node of an xml tree within which hdf5 internal paths are to have uuids changed
@@ -1445,27 +1447,28 @@ class Model():
          internal path names in the hdf5 file itself, if that has already been written
       """
 
-      count = 0
-      old_uuid_str = str(old_uuid)
-      new_uuid_str = str(new_uuid)
-      for ref_node in node.iter(ns['eml'] + 'PathInHdfFile'):
-         try:
-            uuid_place = ref_node.text.index(old_uuid_str)
-            new_path_in_hdf = ref_node.text[:uuid_place] + new_uuid_str + ref_node.text[uuid_place + len(old_uuid_str):]
-            log.debug('path in hdf update from: ' + ref_node.text + ' to: ' + new_path_in_hdf)
-            ref_node.text = new_path_in_hdf
-            count += 1
-         except Exception:
-            pass
-      if count == 1:
-         log.debug('one hdf5 reference modified')
-      else:
-         log.debug(str(count) + ' hdf5 references modified')
-      if count > 0:
-         self.set_modified()
+        count = 0
+        old_uuid_str = str(old_uuid)
+        new_uuid_str = str(new_uuid)
+        for ref_node in node.iter(ns['eml'] + 'PathInHdfFile'):
+            try:
+                uuid_place = ref_node.text.index(old_uuid_str)
+                new_path_in_hdf = ref_node.text[:uuid_place] + new_uuid_str + ref_node.text[uuid_place +
+                                                                                            len(old_uuid_str):]
+                log.debug('path in hdf update from: ' + ref_node.text + ' to: ' + new_path_in_hdf)
+                ref_node.text = new_path_in_hdf
+                count += 1
+            except Exception:
+                pass
+        if count == 1:
+            log.debug('one hdf5 reference modified')
+        else:
+            log.debug(str(count) + ' hdf5 references modified')
+        if count > 0:
+            self.set_modified()
 
-   def change_uuid_in_supporting_representation_reference(self, node, old_uuid, new_uuid, new_title = None):
-      """Look for supporting representation reference using the old_uuid and replace with the new_uuid.
+    def change_uuid_in_supporting_representation_reference(self, node, old_uuid, new_uuid, new_title = None):
+        """Look for supporting representation reference using the old_uuid and replace with the new_uuid.
 
       arguments:
          node: the root node of an xml tree within which the supporting representation uuid is to be changed
@@ -1481,24 +1484,24 @@ class Model():
          representation object when the actual supporting representation is not present in the dataset
       """
 
-      ref_node = rqet.find_tag(node, 'SupportingRepresentation')
-      if ref_node is None:
-         return False
-      uuid_node = rqet.find_tag(ref_node, 'UUID')
-      if uuid_node is None:
-         return False
-      if not bu.matching_uuids(uuid_node.text, old_uuid):
-         return False
-      uuid_node.text = str(new_uuid)
-      if new_title:
-         title_node = rqet.find_tag(ref_node, 'Title')
-         if title_node is not None:
-            title_node.text = str(new_title)
-      self.set_modified()
-      return True
+        ref_node = rqet.find_tag(node, 'SupportingRepresentation')
+        if ref_node is None:
+            return False
+        uuid_node = rqet.find_tag(ref_node, 'UUID')
+        if uuid_node is None:
+            return False
+        if not bu.matching_uuids(uuid_node.text, old_uuid):
+            return False
+        uuid_node.text = str(new_uuid)
+        if new_title:
+            title_node = rqet.find_tag(ref_node, 'Title')
+            if title_node is not None:
+                title_node.text = str(new_title)
+        self.set_modified()
+        return True
 
-   def change_filename_in_hdf5_rels(self, new_hdf5_filename = None):
-      """Scan relationships forest for hdf5 external parts and patch in a new filename.
+    def change_filename_in_hdf5_rels(self, new_hdf5_filename = None):
+        """Scan relationships forest for hdf5 external parts and patch in a new filename.
 
       arguments:
          new_hdf5_filename: the new filename to patch into the xml; if None, the epc filename is used with
@@ -1512,21 +1515,21 @@ class Model():
          all hdf5 file references will be modified
       """
 
-      if not new_hdf5_filename and self.epc_file and self.epc_file.endswith('.epc'):
-         new_hdf5_filename = os.path.split(self.epc_file)[1][:-4] + '.h5'
-      count = 0
-      for rel_name, entry in self.rels_forest.items():
-         rel_root = entry[1].getroot()
-         for child in rel_root:
-            if child.attrib['Id'] == 'Hdf5File' and child.attrib['TargetMode'] == 'External':
-               child.attrib['Target'] = new_hdf5_filename
-               count += 1
-      log.info(str(count) + ' hdf5 filename' + _pl(count) + ' set to: ' + new_hdf5_filename)
-      if count > 0:
-         self.set_modified()
+        if not new_hdf5_filename and self.epc_file and self.epc_file.endswith('.epc'):
+            new_hdf5_filename = os.path.split(self.epc_file)[1][:-4] + '.h5'
+        count = 0
+        for rel_name, entry in self.rels_forest.items():
+            rel_root = entry[1].getroot()
+            for child in rel_root:
+                if child.attrib['Id'] == 'Hdf5File' and child.attrib['TargetMode'] == 'External':
+                    child.attrib['Target'] = new_hdf5_filename
+                    count += 1
+        log.info(str(count) + ' hdf5 filename' + _pl(count) + ' set to: ' + new_hdf5_filename)
+        if count > 0:
+            self.set_modified()
 
-   def copy_part(self, existing_uuid, new_uuid, change_hdf5_refs = False):
-      """Makes a new part as a copy of an existing part with only a new uuid set; the new part can then be modified.
+    def copy_part(self, existing_uuid, new_uuid, change_hdf5_refs = False):
+        """Makes a new part as a copy of an existing part with only a new uuid set; the new part can then be modified.
 
          arguments:
             existing_uuid (uuid.UUID): the uuid of the existing part
@@ -1549,26 +1552,26 @@ class Model():
             it is best to use the higher level derived_model.copy_grid() function
       """
 
-      old_uuid_str = str(existing_uuid)
-      new_uuid_str = str(new_uuid)
-      log.debug('copying xml part from uuid: ' + old_uuid_str + ' to uuid: ' + new_uuid_str)
-      existing_parts_list = self.parts_list_of_type(uuid = existing_uuid)
-      if len(existing_parts_list) == 0:
-         log.warning('failed to find existing part for copying with uuid: ' + old_uuid_str)
-         return None
-      assert len(existing_parts_list) == 1, 'more than one existing part found with uuid: ' + old_uuid_str
-      (part_type, old_uuid, old_tree) = self.parts_forest[existing_parts_list[0]]
-      assert bu.matching_uuids(old_uuid, existing_uuid)
-      new_tree = copy.deepcopy(old_tree)
-      new_root = new_tree.getroot()
-      part_name = rqet.patch_uuid_in_part_root(new_root, new_uuid)
-      if change_hdf5_refs:
-         self.change_uuid_in_hdf5_references(new_root, old_uuid_str, new_uuid_str)
-      self.add_part(part_type, new_uuid, new_root, add_relationship_part = False)
-      return part_name
+        old_uuid_str = str(existing_uuid)
+        new_uuid_str = str(new_uuid)
+        log.debug('copying xml part from uuid: ' + old_uuid_str + ' to uuid: ' + new_uuid_str)
+        existing_parts_list = self.parts_list_of_type(uuid = existing_uuid)
+        if len(existing_parts_list) == 0:
+            log.warning('failed to find existing part for copying with uuid: ' + old_uuid_str)
+            return None
+        assert len(existing_parts_list) == 1, 'more than one existing part found with uuid: ' + old_uuid_str
+        (part_type, old_uuid, old_tree) = self.parts_forest[existing_parts_list[0]]
+        assert bu.matching_uuids(old_uuid, existing_uuid)
+        new_tree = copy.deepcopy(old_tree)
+        new_root = new_tree.getroot()
+        part_name = rqet.patch_uuid_in_part_root(new_root, new_uuid)
+        if change_hdf5_refs:
+            self.change_uuid_in_hdf5_references(new_root, old_uuid_str, new_uuid_str)
+        self.add_part(part_type, new_uuid, new_root, add_relationship_part = False)
+        return part_name
 
-   def root_for_ijk_grid(self, uuid = None, title = None):
-      """Return root for IJK Grid part.
+    def root_for_ijk_grid(self, uuid = None, title = None):
+        """Return root for IJK Grid part.
 
       arguments:
          uuid (uuid.UUID, optional): if present, the uuid of the ijk grid part for which the root is required;
@@ -1587,29 +1590,29 @@ class Model():
          failure to find a matching grid part results in an assertion exception
       """
 
-      if title is not None:
-         title = title.strip().upper()
-      if uuid is None and not title:
-         grid_root = self.root(obj_type = 'IjkGridRepresentation', title = 'ROOT', multiple_handling = 'oldest')
-         if grid_root is None:
-            grid_root = self.root(obj_type = 'IjkGridRepresentation')
-      else:
-         grid_root = self.root(obj_type = 'IjkGridRepresentation', uuid = uuid, title = title)
+        if title is not None:
+            title = title.strip().upper()
+        if uuid is None and not title:
+            grid_root = self.root(obj_type = 'IjkGridRepresentation', title = 'ROOT', multiple_handling = 'oldest')
+            if grid_root is None:
+                grid_root = self.root(obj_type = 'IjkGridRepresentation')
+        else:
+            grid_root = self.root(obj_type = 'IjkGridRepresentation', uuid = uuid, title = title)
 
-      assert grid_root is not None, 'IJK Grid part not found'
+        assert grid_root is not None, 'IJK Grid part not found'
 
-      return grid_root
+        return grid_root
 
-   def citation_title_for_part(self, part):  # duplicate functionality to title_for_part()
-      """Returns the citation title for the specified part.
+    def citation_title_for_part(self, part):  # duplicate functionality to title_for_part()
+        """Returns the citation title for the specified part.
 
       :meta common:
       """
 
-      return rqet.citation_title_for_node(self.root_for_part(part))
+        return rqet.citation_title_for_node(self.root_for_part(part))
 
-   def root_for_time_series(self, uuid = None):
-      """Return root for time series part.
+    def root_for_time_series(self, uuid = None):
+        """Return root for time series part.
 
       argument:
          uuid (uuid.UUID, optional): if present, the uuid of the time series part for which the root is required;
@@ -1623,23 +1626,23 @@ class Model():
          date is returned
       """
 
-      time_series_list = self.parts_list_of_type('obj_TimeSeries', uuid = uuid)
-      if len(time_series_list) == 0:
-         return None
-      if len(time_series_list) == 1:
-         return self.root_for_part(time_series_list[0])
-      log.warning('selecting time series with earliest creation date')
-      oldest_root = oldest_creation = None
-      for ts in time_series_list:
-         node = self.root_for_part(ts)
-         created = rqet.creation_date_for_node(node)
-         if oldest_creation is None or created < oldest_creation:
-            oldest_creation = created
-            oldest_root = node
-      return oldest_root
+        time_series_list = self.parts_list_of_type('obj_TimeSeries', uuid = uuid)
+        if len(time_series_list) == 0:
+            return None
+        if len(time_series_list) == 1:
+            return self.root_for_part(time_series_list[0])
+        log.warning('selecting time series with earliest creation date')
+        oldest_root = oldest_creation = None
+        for ts in time_series_list:
+            node = self.root_for_part(ts)
+            created = rqet.creation_date_for_node(node)
+            if oldest_creation is None or created < oldest_creation:
+                oldest_creation = created
+                oldest_root = node
+        return oldest_root
 
-   def resolve_grid_root(self, grid_root = None, uuid = None):
-      """If grid root argument is None, returns the root for the IJK Grid part instead.
+    def resolve_grid_root(self, grid_root = None, uuid = None):
+        """If grid root argument is None, returns the root for the IJK Grid part instead.
 
       arguments:
          grid_root (optional): if not None, this method simply returns this argument
@@ -1655,17 +1658,17 @@ class Model():
          grid part is present in the model
       """
 
-      if grid_root is not None:
-         if self.grid_root is None:
-            self.grid_root = grid_root
-      else:
-         if self.grid_root is None:
-            self.grid_root = self.root_for_ijk_grid(uuid = uuid)
-         grid_root = self.grid_root
-      return grid_root
+        if grid_root is not None:
+            if self.grid_root is None:
+                self.grid_root = grid_root
+        else:
+            if self.grid_root is None:
+                self.grid_root = self.root_for_ijk_grid(uuid = uuid)
+            grid_root = self.grid_root
+        return grid_root
 
-   def grid(self, title = None, uuid = None, find_properties = True):
-      """Returns a shared Grid (or RegularGrid) object for this model, by default the 'main' grid.
+    def grid(self, title = None, uuid = None, find_properties = True):
+        """Returns a shared Grid (or RegularGrid) object for this model, by default the 'main' grid.
 
       arguments:
          title (string, optional): if present, the citation title of the IjkGridRepresentation
@@ -1686,34 +1689,35 @@ class Model():
       :meta common:
       """
 
-      if uuid is None and (title is None or title.upper() == 'ROOT'):
-         if self.main_grid is not None:
-            if find_properties:
-               self.main_grid.extract_property_collection()
-            return self.main_grid
-         if title is None:
-            grid_root = self.resolve_grid_root()
-         else:
-            grid_root = self.resolve_grid_root(grid_root = self.root(obj_type = 'IjkGridRepresentation', title = title))
-      else:
-         grid_root = self.root(obj_type = 'IjkGridRepresentation', uuid = uuid, title = title)
-      assert grid_root is not None, 'IJK Grid part not found'
-      if uuid is None:
-         uuid = rqet.uuid_for_part_root(grid_root)
-      for grid in self.grid_list:
-         if grid.root is grid_root:
-            if find_properties:
-               grid.extract_property_collection()
-            return grid
-      grid = grr.any_grid(self, uuid = uuid, find_properties = find_properties)
-      assert grid is not None, 'failed to instantiate grid object'
-      if find_properties:
-         grid.extract_property_collection()
-      self.add_grid(grid)
-      return grid
+        if uuid is None and (title is None or title.upper() == 'ROOT'):
+            if self.main_grid is not None:
+                if find_properties:
+                    self.main_grid.extract_property_collection()
+                return self.main_grid
+            if title is None:
+                grid_root = self.resolve_grid_root()
+            else:
+                grid_root = self.resolve_grid_root(
+                    grid_root = self.root(obj_type = 'IjkGridRepresentation', title = title))
+        else:
+            grid_root = self.root(obj_type = 'IjkGridRepresentation', uuid = uuid, title = title)
+        assert grid_root is not None, 'IJK Grid part not found'
+        if uuid is None:
+            uuid = rqet.uuid_for_part_root(grid_root)
+        for grid in self.grid_list:
+            if grid.root is grid_root:
+                if find_properties:
+                    grid.extract_property_collection()
+                return grid
+        grid = grr.any_grid(self, uuid = uuid, find_properties = find_properties)
+        assert grid is not None, 'failed to instantiate grid object'
+        if find_properties:
+            grid.extract_property_collection()
+        self.add_grid(grid)
+        return grid
 
-   def add_grid(self, grid_object, check_for_duplicates = False):
-      """Add grid object to list of shareable grids for this model.
+    def add_grid(self, grid_object, check_for_duplicates = False):
+        """Add grid object to list of shareable grids for this model.
 
       arguments:
          grid_object (grid.Grid object): the ijk grid object to be added to the list
@@ -1725,30 +1729,30 @@ class Model():
          None
       """
 
-      if check_for_duplicates:
-         for g in self.grid_list:
-            if bu.matching_uuids(g.uuid, grid_object.uuid):
-               return
-      self.grid_list.append(grid_object)
+        if check_for_duplicates:
+            for g in self.grid_list:
+                if bu.matching_uuids(g.uuid, grid_object.uuid):
+                    return
+        self.grid_list.append(grid_object)
 
-   def grid_list_uuid_list(self):
-      """Returns list of uuid's for the grid objects in the cached grid list."""
+    def grid_list_uuid_list(self):
+        """Returns list of uuid's for the grid objects in the cached grid list."""
 
-      uuid_list = []
-      for grid in self.grid_list:
-         uuid_list.append(grid.uuid)
-      return uuid_list
+        uuid_list = []
+        for grid in self.grid_list:
+            uuid_list.append(grid.uuid)
+        return uuid_list
 
-   def grid_for_uuid_from_grid_list(self, uuid):
-      """Returns the cached grid object matching the given uuid, if found in the grid list, otherwise None."""
+    def grid_for_uuid_from_grid_list(self, uuid):
+        """Returns the cached grid object matching the given uuid, if found in the grid list, otherwise None."""
 
-      for grid in self.grid_list:
-         if bu.matching_uuids(uuid, grid.uuid):
-            return grid
-      return None
+        for grid in self.grid_list:
+            if bu.matching_uuids(uuid, grid.uuid):
+                return grid
+        return None
 
-   def resolve_time_series_root(self, time_series_root = None):
-      """If time_series_root is None, finds the root for a time series in the model.
+    def resolve_time_series_root(self, time_series_root = None):
+        """If time_series_root is None, finds the root for a time series in the model.
 
       arguments:
          time_series_root (optional): if not None, this method simply returns this argument
@@ -1762,14 +1766,14 @@ class Model():
          is more than one time series part in the model
       """
 
-      if time_series_root is not None:
-         return time_series_root
-      if self.time_series is None:
-         self.time_series = self.root_for_time_series()
-      return self.time_series
+        if time_series_root is not None:
+            return time_series_root
+        if self.time_series is None:
+            self.time_series = self.root_for_time_series()
+        return self.time_series
 
-   def h5_uuid_and_path_for_node(self, node, tag = 'Values'):
-      """Returns a (hdf5_uuid, hdf5_internal_path) pair for an xml array node.
+    def h5_uuid_and_path_for_node(self, node, tag = 'Values'):
+        """Returns a (hdf5_uuid, hdf5_internal_path) pair for an xml array node.
 
       arguments:
          node: xml node for which the array reference is required
@@ -1785,54 +1789,54 @@ class Model():
          the resqml dataset
       """
 
-      child = rqet.find_tag(node, tag)
-      if child is None:
-         return None
-      assert rqet.node_type(child) == 'Hdf5Dataset'
-      h5_path = rqet.find_tag(child, 'PathInHdfFile').text
-      h5_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(child, ['HdfProxy', 'UUID']))
-      return (h5_uuid, h5_path)
+        child = rqet.find_tag(node, tag)
+        if child is None:
+            return None
+        assert rqet.node_type(child) == 'Hdf5Dataset'
+        h5_path = rqet.find_tag(child, 'PathInHdfFile').text
+        h5_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(child, ['HdfProxy', 'UUID']))
+        return (h5_uuid, h5_path)
 
-   def h5_uuid_list(self, node):
-      """Returns a list of all uuids for hdf5 external part(s) referred to in recursive tree."""
+    def h5_uuid_list(self, node):
+        """Returns a list of all uuids for hdf5 external part(s) referred to in recursive tree."""
 
-      def recursive_uuid_set(node):
-         uuid_set = set()
-         for child in node:
-            uuid_set = uuid_set.union(recursive_uuid_set(child))
-         if rqet.node_type(node) == 'Hdf5Dataset':
-            h5_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['HdfProxy', 'UUID']))
-            uuid_set.add(h5_uuid)
-         return uuid_set
+        def recursive_uuid_set(node):
+            uuid_set = set()
+            for child in node:
+                uuid_set = uuid_set.union(recursive_uuid_set(child))
+            if rqet.node_type(node) == 'Hdf5Dataset':
+                h5_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['HdfProxy', 'UUID']))
+                uuid_set.add(h5_uuid)
+            return uuid_set
 
-      return list(recursive_uuid_set(node))
+        return list(recursive_uuid_set(node))
 
-   def h5_uuid(self):
-      """Returns the uuid of the 'main' hdf5 file."""
+    def h5_uuid(self):
+        """Returns the uuid of the 'main' hdf5 file."""
 
-      if self.main_h5_uuid is None:
-         uuid_list = None
-         ext_parts = self.parts_list_of_type('EpcExternalPartReference')
-         if len(ext_parts) == 1:
-            self.main_h5_uuid = self.uuid_for_part(ext_parts[0])
-         else:
-            try:
-               grid_root = self.resolve_grid_root()
-               if grid_root is not None:
-                  uuid_list = self.h5_uuid_list(grid_root)
-            except Exception:
-               uuid_list = None
-            if uuid_list is None or len(uuid_list) == 0:
-               for part, (_, _, tree) in self.parts_forest.items():
-                  uuid_list = self.h5_uuid_list(tree.getroot())
-                  if uuid_list is not None and len(uuid_list) > 0:
-                     break
-            if uuid_list is not None and len(uuid_list) > 0:
-               self.main_h5_uuid = uuid_list[0]  # arbitrary use of first hdf5 uuid
-      return self.main_h5_uuid
+        if self.main_h5_uuid is None:
+            uuid_list = None
+            ext_parts = self.parts_list_of_type('EpcExternalPartReference')
+            if len(ext_parts) == 1:
+                self.main_h5_uuid = self.uuid_for_part(ext_parts[0])
+            else:
+                try:
+                    grid_root = self.resolve_grid_root()
+                    if grid_root is not None:
+                        uuid_list = self.h5_uuid_list(grid_root)
+                except Exception:
+                    uuid_list = None
+                if uuid_list is None or len(uuid_list) == 0:
+                    for part, (_, _, tree) in self.parts_forest.items():
+                        uuid_list = self.h5_uuid_list(tree.getroot())
+                        if uuid_list is not None and len(uuid_list) > 0:
+                            break
+                if uuid_list is not None and len(uuid_list) > 0:
+                    self.main_h5_uuid = uuid_list[0]  # arbitrary use of first hdf5 uuid
+        return self.main_h5_uuid
 
-   def h5_file_name(self, uuid = None, override = True, file_must_exist = True):
-      """Returns full path for hdf5 file with given uuid.
+    def h5_file_name(self, uuid = None, override = True, file_must_exist = True):
+        """Returns full path for hdf5 file with given uuid.
 
       arguments:
          uuid (uuid.UUID, optional): the uuid of the hdf5 external part reference for which the
@@ -1860,41 +1864,41 @@ class Model():
          are in the same directory
       """
 
-      if override and self.epc_file and self.epc_file.endswith('.epc'):
-         h5_full_path = self.epc_file[:-4] + '.h5'
-         if not file_must_exist or os.path.exists(h5_full_path):
-            return h5_full_path
-      if uuid is None:
-         uuid = self.h5_uuid()
-      if uuid.bytes in self.h5_dict:
-         return self.h5_dict[uuid.bytes]
-      for rel_name in self.rels_forest:
-         entry = self.rels_forest[rel_name]
-         if bu.matching_uuids(uuid, entry[0]):
-            rel_root = entry[1].getroot()
-            for child in rel_root:
-               if child.attrib['Id'] == 'Hdf5File' and child.attrib['TargetMode'] == 'External':
-                  h5_full_path = None
-                  target_path = rqet.strip_path(child.attrib['Target'])
-                  if target_path:
-                     if self.epc_directory:
-                        _, target_file = os.path.split(target_path)
-                        h5_full_path = os.path.join(self.epc_directory, target_file)
-                     else:
-                        h5_full_path = target_path
-                     if file_must_exist and not os.path.exists(h5_full_path):
+        if override and self.epc_file and self.epc_file.endswith('.epc'):
+            h5_full_path = self.epc_file[:-4] + '.h5'
+            if not file_must_exist or os.path.exists(h5_full_path):
+                return h5_full_path
+        if uuid is None:
+            uuid = self.h5_uuid()
+        if uuid.bytes in self.h5_dict:
+            return self.h5_dict[uuid.bytes]
+        for rel_name in self.rels_forest:
+            entry = self.rels_forest[rel_name]
+            if bu.matching_uuids(uuid, entry[0]):
+                rel_root = entry[1].getroot()
+                for child in rel_root:
+                    if child.attrib['Id'] == 'Hdf5File' and child.attrib['TargetMode'] == 'External':
                         h5_full_path = None
-                  if h5_full_path is None:
-                     h5_full_path = child.attrib['Target']
-                     if file_must_exist and not os.path.exists(h5_full_path):
-                        h5_full_path = None
-                  if h5_full_path is not None:
-                     self.h5_dict[uuid.bytes] = h5_full_path
-                  return h5_full_path
-      return None
+                        target_path = rqet.strip_path(child.attrib['Target'])
+                        if target_path:
+                            if self.epc_directory:
+                                _, target_file = os.path.split(target_path)
+                                h5_full_path = os.path.join(self.epc_directory, target_file)
+                            else:
+                                h5_full_path = target_path
+                            if file_must_exist and not os.path.exists(h5_full_path):
+                                h5_full_path = None
+                        if h5_full_path is None:
+                            h5_full_path = child.attrib['Target']
+                            if file_must_exist and not os.path.exists(h5_full_path):
+                                h5_full_path = None
+                        if h5_full_path is not None:
+                            self.h5_dict[uuid.bytes] = h5_full_path
+                        return h5_full_path
+        return None
 
-   def h5_access(self, uuid = None, mode = 'r', override = True, file_path = None):
-      """Returns an open h5 file handle for the hdf5 file with the given uuid.
+    def h5_access(self, uuid = None, mode = 'r', override = True, file_path = None):
+        """Returns an open h5 file handle for the hdf5 file with the given uuid.
 
       arguments:
          uuid (uuid.UUID): the uuid of the hdf5 external part reference for which the
@@ -1913,25 +1917,25 @@ class Model():
          piece of code accessing the file might cause a 'resource unavailable' exception
       """
 
-      if self.h5_currently_open_mode is not None and self.h5_currently_open_mode != mode:
-         self.h5_release()
-      if file_path:
-         file_name = file_path
-      else:
-         file_name = self.h5_file_name(uuid = uuid, override = override, file_must_exist = (mode == 'r'))
-      if mode == 'a' and not os.path.exists(file_name):
-         mode = 'w'
-      if self.h5_currently_open_path == file_name:
-         return self.h5_currently_open_root
-      if self.h5_currently_open_root is not None:
-         self.h5_release()
-      self.h5_currently_open_path = file_name
-      self.h5_currently_open_mode = mode
-      self.h5_currently_open_root = h5py.File(file_name, mode)  # could use try to trap file in use errors?
-      return self.h5_currently_open_root
+        if self.h5_currently_open_mode is not None and self.h5_currently_open_mode != mode:
+            self.h5_release()
+        if file_path:
+            file_name = file_path
+        else:
+            file_name = self.h5_file_name(uuid = uuid, override = override, file_must_exist = (mode == 'r'))
+        if mode == 'a' and not os.path.exists(file_name):
+            mode = 'w'
+        if self.h5_currently_open_path == file_name:
+            return self.h5_currently_open_root
+        if self.h5_currently_open_root is not None:
+            self.h5_release()
+        self.h5_currently_open_path = file_name
+        self.h5_currently_open_mode = mode
+        self.h5_currently_open_root = h5py.File(file_name, mode)  # could use try to trap file in use errors?
+        return self.h5_currently_open_root
 
-   def h5_release(self):
-      """Releases (closes) the currently open hdf5 file.
+    def h5_release(self):
+        """Releases (closes) the currently open hdf5 file.
 
       returns:
          None
@@ -1939,14 +1943,14 @@ class Model():
       :meta common:
       """
 
-      if self.h5_currently_open_root is not None:
-         self.h5_currently_open_root.close()
-         self.h5_currently_open_root = None
-      self.h5_currently_open_path = None
-      self.h5_currently_open_mode = None
+        if self.h5_currently_open_root is not None:
+            self.h5_currently_open_root.close()
+            self.h5_currently_open_root = None
+        self.h5_currently_open_path = None
+        self.h5_currently_open_mode = None
 
-   def h5_array_shape_and_type(self, h5_key_pair):
-      """Returns the shape and dtype of the array, as stored in the hdf5 file.
+    def h5_array_shape_and_type(self, h5_key_pair):
+        """Returns the shape and dtype of the array, as stored in the hdf5 file.
 
       arguments:
          h5_key_pair (uuid.UUID, string): the uuid of the hdf5 external part reference and the hdf5 internal path for the array
@@ -1956,22 +1960,22 @@ class Model():
          if the hdf5 file is not found, or the array is not found within it
       """
 
-      h5_root = self.h5_access(h5_key_pair[0])
-      if h5_root is None:
-         return (None, None)
-      shape_tuple = tuple(h5_root[h5_key_pair[1]].shape)
-      dtype = h5_root[h5_key_pair[1]].dtype
-      return (shape_tuple, dtype)
+        h5_root = self.h5_access(h5_key_pair[0])
+        if h5_root is None:
+            return (None, None)
+        shape_tuple = tuple(h5_root[h5_key_pair[1]].shape)
+        dtype = h5_root[h5_key_pair[1]].dtype
+        return (shape_tuple, dtype)
 
-   def h5_array_element(self,
-                        h5_key_pair,
-                        index = None,
-                        cache_array = False,
-                        object = None,
-                        array_attribute = None,
-                        dtype = 'float',
-                        required_shape = None):
-      """Returns one element from an hdf5 array and/or caches the array.
+    def h5_array_element(self,
+                         h5_key_pair,
+                         index = None,
+                         cache_array = False,
+                         object = None,
+                         array_attribute = None,
+                         dtype = 'float',
+                         required_shape = None):
+        """Returns one element from an hdf5 array and/or caches the array.
 
       arguments:
          h5_key_pair (uuid.UUID, string): the uuid of the hdf5 external part reference and the hdf5 internal path for the array
@@ -1998,79 +2002,79 @@ class Model():
          not have any split pillars
       """
 
-      def reshaped_index(index, shape_tuple, required_shape):
-         tail = len(shape_tuple) - len(index)
-         if tail > 0:
-            assert shape_tuple[-tail:] == required_shape[-tail:], 'not enough indices to allow reshaped indexing'
-         natural = 0
-         extent = 1
-         for axis in range(len(shape_tuple) - tail - 1, -1, -1):
-            natural += index[axis] * extent
-            extent *= shape_tuple[axis]
-         r_extent = np.empty(len(required_shape) - tail, dtype = int)
-         r_extent[-1] = required_shape[-(tail + 1)]
-         for axis in range(len(required_shape) - tail - 2, -1, -1):
-            r_extent[axis] = required_shape[axis] * r_extent[axis + 1]
-         r_index = np.empty(len(required_shape) - tail, dtype = int)
-         for axis in range(len(r_index) - 1):
-            r_index[axis], natural = divmod(natural, r_extent[axis + 1])
-         r_index[-1] = natural
-         return r_index
+        def reshaped_index(index, shape_tuple, required_shape):
+            tail = len(shape_tuple) - len(index)
+            if tail > 0:
+                assert shape_tuple[-tail:] == required_shape[-tail:], 'not enough indices to allow reshaped indexing'
+            natural = 0
+            extent = 1
+            for axis in range(len(shape_tuple) - tail - 1, -1, -1):
+                natural += index[axis] * extent
+                extent *= shape_tuple[axis]
+            r_extent = np.empty(len(required_shape) - tail, dtype = int)
+            r_extent[-1] = required_shape[-(tail + 1)]
+            for axis in range(len(required_shape) - tail - 2, -1, -1):
+                r_extent[axis] = required_shape[axis] * r_extent[axis + 1]
+            r_index = np.empty(len(required_shape) - tail, dtype = int)
+            for axis in range(len(r_index) - 1):
+                r_index[axis], natural = divmod(natural, r_extent[axis + 1])
+            r_index[-1] = natural
+            return r_index
 
-      if object is None:
-         object = self
+        if object is None:
+            object = self
 
-      # Check if attribute has already be cached
-      if array_attribute is not None:
-         existing_value = getattr(object, array_attribute, None)
+        # Check if attribute has already be cached
+        if array_attribute is not None:
+            existing_value = getattr(object, array_attribute, None)
 
-         # Watch out for np.array(None): check existing_value has a valid "shape"
-         if existing_value is not None and getattr(existing_value, "shape", False):
-            if index is None:
-               return None  # this option allows caching of array without actually referring to any element
-            return existing_value[tuple(index)]
+            # Watch out for np.array(None): check existing_value has a valid "shape"
+            if existing_value is not None and getattr(existing_value, "shape", False):
+                if index is None:
+                    return None  # this option allows caching of array without actually referring to any element
+                return existing_value[tuple(index)]
 
-      h5_root = self.h5_access(h5_key_pair[0])
-      if h5_root is None:
-         return None
-      if cache_array:
-         shape_tuple = tuple(h5_root[h5_key_pair[1]].shape)
-         if required_shape is None or shape_tuple == required_shape:
-            object.__dict__[array_attribute] = np.zeros(shape_tuple, dtype = dtype)
-            object.__dict__[array_attribute][:] = h5_root[h5_key_pair[1]]
-         else:
-            object.__dict__[array_attribute] = np.zeros(required_shape, dtype = dtype)
-            object.__dict__[array_attribute][:] = np.array(h5_root[h5_key_pair[1]],
-                                                           dtype = dtype).reshape(required_shape)
-         self.h5_release()
-         if index is None:
+        h5_root = self.h5_access(h5_key_pair[0])
+        if h5_root is None:
             return None
-         return object.__dict__[array_attribute][tuple(index)]
-      else:
-         if index is None:
-            return None
-         if required_shape is None:
-            result = h5_root[h5_key_pair[1]][tuple(index)]
-         else:
+        if cache_array:
             shape_tuple = tuple(h5_root[h5_key_pair[1]].shape)
-            if shape_tuple == required_shape:
-               result = h5_root[h5_key_pair[1]][tuple(index)]
+            if required_shape is None or shape_tuple == required_shape:
+                object.__dict__[array_attribute] = np.zeros(shape_tuple, dtype = dtype)
+                object.__dict__[array_attribute][:] = h5_root[h5_key_pair[1]]
             else:
-               index = reshaped_index(index, required_shape, shape_tuple)
-               result = h5_root[h5_key_pair[1]][tuple(index)]
-         if dtype is None:
-            return result
-         if result.size == 1:
-            if dtype is float or (isinstance(dtype, str) and dtype.startswith('float')):
-               return float(result)
-            elif dtype is int or (isinstance(dtype, str) and dtype.startswith('int')):
-               return int(result)
-            elif dtype is bool or (isinstance(dtype, str) and dtype.startswith('bool')):
-               return bool(result)
-         return np.array(result, dtype = dtype)
+                object.__dict__[array_attribute] = np.zeros(required_shape, dtype = dtype)
+                object.__dict__[array_attribute][:] = np.array(h5_root[h5_key_pair[1]],
+                                                               dtype = dtype).reshape(required_shape)
+            self.h5_release()
+            if index is None:
+                return None
+            return object.__dict__[array_attribute][tuple(index)]
+        else:
+            if index is None:
+                return None
+            if required_shape is None:
+                result = h5_root[h5_key_pair[1]][tuple(index)]
+            else:
+                shape_tuple = tuple(h5_root[h5_key_pair[1]].shape)
+                if shape_tuple == required_shape:
+                    result = h5_root[h5_key_pair[1]][tuple(index)]
+                else:
+                    index = reshaped_index(index, required_shape, shape_tuple)
+                    result = h5_root[h5_key_pair[1]][tuple(index)]
+            if dtype is None:
+                return result
+            if result.size == 1:
+                if dtype is float or (isinstance(dtype, str) and dtype.startswith('float')):
+                    return float(result)
+                elif dtype is int or (isinstance(dtype, str) and dtype.startswith('int')):
+                    return int(result)
+                elif dtype is bool or (isinstance(dtype, str) and dtype.startswith('bool')):
+                    return bool(result)
+            return np.array(result, dtype = dtype)
 
-   def h5_array_slice(self, h5_key_pair, slice_tuple):
-      """Loads a slice of an hdf5 array.
+    def h5_array_slice(self, h5_key_pair, slice_tuple):
+        """Loads a slice of an hdf5 array.
 
       arguments:
          h5_key_pair (uuid, string): the uuid of the hdf5 ext part and the hdf5 internal path to the
@@ -2087,11 +2091,11 @@ class Model():
          an axis is 1
       """
 
-      h5_root = self.h5_access(h5_key_pair[0])
-      return h5_root[h5_key_pair[1]][slice_tuple]
+        h5_root = self.h5_access(h5_key_pair[0])
+        return h5_root[h5_key_pair[1]][slice_tuple]
 
-   def h5_overwrite_array_slice(self, h5_key_pair, slice_tuple, array_slice):
-      """Overwrites (updates) a slice of an hdf5 array.
+    def h5_overwrite_array_slice(self, h5_key_pair, slice_tuple, array_slice):
+        """Overwrites (updates) a slice of an hdf5 array.
 
       arguments:
          h5_key_pair (uuid, string): the uuid of the hdf5 ext part and the hdf5 internal path to the
@@ -2105,24 +2109,24 @@ class Model():
          metadata (such as uuid or property min, max values) is not modified in any way by the method
       """
 
-      h5_root = self.h5_access(h5_key_pair[0], mode = 'a')
-      dset = h5_root[h5_key_pair[1]]
-      dset[slice_tuple] = array_slice
+        h5_root = self.h5_access(h5_key_pair[0], mode = 'a')
+        dset = h5_root[h5_key_pair[1]]
+        dset[slice_tuple] = array_slice
 
-   def create_root(self):
-      """Initialises an empty main xml tree for model.
+    def create_root(self):
+        """Initialises an empty main xml tree for model.
 
       note:
          not usually called directly
       """
 
-      assert (self.main_tree is None)
-      assert (self.main_root is None)
-      self.main_root = rqet.Element(ns['content_types'] + 'Types')
-      self.main_tree = rqet.ElementTree(element = self.main_root)
+        assert (self.main_tree is None)
+        assert (self.main_root is None)
+        self.main_root = rqet.Element(ns['content_types'] + 'Types')
+        self.main_tree = rqet.ElementTree(element = self.main_root)
 
-   def add_part(self, content_type, uuid, root, add_relationship_part = True, epc_subdir = None):
-      """Adds a (recently created) node as a new part in the model's parts forest.
+    def add_part(self, content_type, uuid, root, add_relationship_part = True, epc_subdir = None):
+        """Adds a (recently created) node as a new part in the model's parts forest.
 
       arguments:
          content_type (string): the resqml object class of the new part
@@ -2141,80 +2145,80 @@ class Model():
          do not use this function for the main rels extension part: use create_rels_part() instead
       """
 
-      if content_type[0].isupper():
-         content_type = 'obj_' + content_type
-      use_other = (content_type == 'docProps')
-      if use_other:
-         if rqet.pretend_to_be_fesapi or rqet.use_fesapi_quirks:
-            prefix = '/'
-         else:
-            prefix = ''
-         part_name = prefix + 'docProps/core.xml'
-         ct = 'application/vnd.openxmlformats-package.core-properties+xml'
-      else:
-         part_name = rqet.part_name_for_object(content_type, uuid, prefixed = False, epc_subdir = epc_subdir)
-         if 'EpcExternalPartReference' in content_type:
-            ct = 'application/x-eml+xml;version=2.0;type=' + content_type
-         else:
-            ct = 'application/x-resqml+xml;version=2.0;type=' + content_type
+        if content_type[0].isupper():
+            content_type = 'obj_' + content_type
+        use_other = (content_type == 'docProps')
+        if use_other:
+            if rqet.pretend_to_be_fesapi or rqet.use_fesapi_quirks:
+                prefix = '/'
+            else:
+                prefix = ''
+            part_name = prefix + 'docProps/core.xml'
+            ct = 'application/vnd.openxmlformats-package.core-properties+xml'
+        else:
+            part_name = rqet.part_name_for_object(content_type, uuid, prefixed = False, epc_subdir = epc_subdir)
+            if 'EpcExternalPartReference' in content_type:
+                ct = 'application/x-eml+xml;version=2.0;type=' + content_type
+            else:
+                ct = 'application/x-resqml+xml;version=2.0;type=' + content_type
 
-      # log.debug('adding part: ' + part_name)
-      if isinstance(uuid, str):
-         uuid = bu.uuid_from_string(uuid)
-      part_tree = rqet.ElementTree(element = root)
-      if use_other:
-         self.other_forest[part_name] = (content_type, part_tree)
-      else:
-         self.parts_forest[part_name] = (content_type, uuid, part_tree)
-         self._set_uuid_to_part(part_name)
-      main_ref = rqet.SubElement(self.main_root, ns['content_types'] + 'Override')
-      main_ref.set('PartName', part_name)
-      main_ref.set('ContentType', ct)
-      if add_relationship_part and self.rels_present:
-         rels_node = rqet.Element(ns['rels'] + 'Relationships')
-         rels_node.text = '\n'
-         rels_tree = rqet.ElementTree(element = rels_node)
-         if use_other:
-            rels_part_name = '_rels/.rels'
-         else:
-            rels_part_name = rqet.rels_part_name_for_part(part_name)
-         self.rels_forest[rels_part_name] = (uuid, rels_tree)
-      self.set_modified()
+        # log.debug('adding part: ' + part_name)
+        if isinstance(uuid, str):
+            uuid = bu.uuid_from_string(uuid)
+        part_tree = rqet.ElementTree(element = root)
+        if use_other:
+            self.other_forest[part_name] = (content_type, part_tree)
+        else:
+            self.parts_forest[part_name] = (content_type, uuid, part_tree)
+            self._set_uuid_to_part(part_name)
+        main_ref = rqet.SubElement(self.main_root, ns['content_types'] + 'Override')
+        main_ref.set('PartName', part_name)
+        main_ref.set('ContentType', ct)
+        if add_relationship_part and self.rels_present:
+            rels_node = rqet.Element(ns['rels'] + 'Relationships')
+            rels_node.text = '\n'
+            rels_tree = rqet.ElementTree(element = rels_node)
+            if use_other:
+                rels_part_name = '_rels/.rels'
+            else:
+                rels_part_name = rqet.rels_part_name_for_part(part_name)
+            self.rels_forest[rels_part_name] = (uuid, rels_tree)
+        self.set_modified()
 
-   def patch_root_for_part(self, part, root):
-      """Updates the xml tree for the part without changing the uuid."""
+    def patch_root_for_part(self, part, root):
+        """Updates the xml tree for the part without changing the uuid."""
 
-      content_type, uuid, part_tree = self.parts_forest[part]
-      assert bu.matching_uuids(uuid, rqet.uuid_for_part_root(root))
-      part_tree = rqet.ElementTree(element = root)
-      self.parts_forest[part] = (content_type, uuid, part_tree)
+        content_type, uuid, part_tree = self.parts_forest[part]
+        assert bu.matching_uuids(uuid, rqet.uuid_for_part_root(root))
+        part_tree = rqet.ElementTree(element = root)
+        self.parts_forest[part] = (content_type, uuid, part_tree)
 
-   def remove_part(self, part_name, remove_relationship_part = True):
-      """Removes a part from the parts forest; optionally remove corresponding rels part and other relationships."""
+    def remove_part(self, part_name, remove_relationship_part = True):
+        """Removes a part from the parts forest; optionally remove corresponding rels part and other relationships."""
 
-      self._del_uuid_to_part(part_name)
-      self.parts_forest.pop(part_name)
-      if remove_relationship_part:
-         if 'docProps' in part_name:
-            rels_part_name = '_rels/.rels'
-         else:
-            related_parts = self.parts_list_filtered_by_related_uuid(self.list_of_parts(),
-                                                                     rqet.uuid_in_part_name(part_name))
-            for relative in related_parts:
-               (rel_uuid, rel_tree) = self.rels_forest[rqet.rels_part_name_for_part(relative)]
-               rel_root = rel_tree.getroot()
-               for child in rel_root:
-                  if rqet.stripped_of_prefix(child.tag) != 'Relationship':
-                     continue
-                  if child.attrib['Target'] == part_name:
-                     rel_root.remove(child)
-            rels_part_name = rqet.rels_part_name_for_part(part_name)
-         self.rels_forest.pop(rels_part_name)
-      self.remove_part_from_main_tree(part_name)
-      self.set_modified()
+        self._del_uuid_to_part(part_name)
+        self.parts_forest.pop(part_name)
+        if remove_relationship_part:
+            if 'docProps' in part_name:
+                rels_part_name = '_rels/.rels'
+            else:
+                related_parts = self.parts_list_filtered_by_related_uuid(self.list_of_parts(),
+                                                                         rqet.uuid_in_part_name(part_name))
+                for relative in related_parts:
+                    (rel_uuid, rel_tree) = self.rels_forest[rqet.rels_part_name_for_part(relative)]
+                    rel_root = rel_tree.getroot()
+                    for child in rel_root:
+                        if rqet.stripped_of_prefix(child.tag) != 'Relationship':
+                            continue
+                        if child.attrib['Target'] == part_name:
+                            rel_root.remove(child)
+                rels_part_name = rqet.rels_part_name_for_part(part_name)
+            self.rels_forest.pop(rels_part_name)
+        self.remove_part_from_main_tree(part_name)
+        self.set_modified()
 
-   def new_obj_node(self, flavour, name_space = 'resqml2', is_top_lvl_obj = True):
-      """Creates a new main object element and sets attributes (does not add children).
+    def new_obj_node(self, flavour, name_space = 'resqml2', is_top_lvl_obj = True):
+        """Creates a new main object element and sets attributes (does not add children).
 
       arguments:
          flavour (string): the resqml object class (type of part) for which a new xml tree
@@ -2227,50 +2231,50 @@ class Model():
          newly created root node for xml tree for flavour of object, without any children
       """
 
-      if flavour.startswith('obj_'):
-         flavour = flavour[4:]
+        if flavour.startswith('obj_'):
+            flavour = flavour[4:]
 
-      node = rqet.Element(ns[name_space] + flavour)
-      node.set('schemaVersion', '2.0')
-      node.set('uuid', str(bu.new_uuid()))
-      if is_top_lvl_obj:
-         node.set(ns['xsi'] + 'type', ns[name_space] + 'obj_' + flavour)
-      node.text = rqet.null_xml_text
+        node = rqet.Element(ns[name_space] + flavour)
+        node.set('schemaVersion', '2.0')
+        node.set('uuid', str(bu.new_uuid()))
+        if is_top_lvl_obj:
+            node.set(ns['xsi'] + 'type', ns[name_space] + 'obj_' + flavour)
+        node.text = rqet.null_xml_text
 
-      return node
+        return node
 
-   def referenced_node(self, ref_node, consolidate = False):
-      """For a given xml reference node, returns the node for the object referred to, if present."""
+    def referenced_node(self, ref_node, consolidate = False):
+        """For a given xml reference node, returns the node for the object referred to, if present."""
 
-      # note: the RESQML standard allows referenced objects to be missing from the package (model)
+        # note: the RESQML standard allows referenced objects to be missing from the package (model)
 
-      if ref_node is None:
-         return None
-      #      content_type = rqet.find_tag_text(ref_node, 'ContentType')
-      uuid = bu.uuid_from_string(rqet.find_tag_text(ref_node, 'UUID'))
-      if uuid is None:
-         return None
-      #      return self.root_for_part(self.parts_list_of_type(type_of_interest = content_type, uuid = uuid))
-      if consolidate and self.consolidation is not None and uuid in self.consolidation.map:
-         resident_uuid = self.consolidation.map[uuid]
-         if resident_uuid is None:
+        if ref_node is None:
             return None
-         node = self.root_for_part(self.part_for_uuid(resident_uuid))
-         if node is not None:
-            # patch resident uuid and title into ref node!
-            uuid_node = rqet.find_tag(ref_node, 'UUID')
-            uuid_node.text = str(resident_uuid)
-            title_node = rqet.find_tag(ref_node, 'Title')
-            if title_node is not None:
-               title = rqet.citation_title_for_node(node)
-               if title:
-                  title_node.text = str(title)
-      else:
-         node = self.root_for_part(self.part_for_uuid(uuid))
-      return node
+        #      content_type = rqet.find_tag_text(ref_node, 'ContentType')
+        uuid = bu.uuid_from_string(rqet.find_tag_text(ref_node, 'UUID'))
+        if uuid is None:
+            return None
+        #      return self.root_for_part(self.parts_list_of_type(type_of_interest = content_type, uuid = uuid))
+        if consolidate and self.consolidation is not None and uuid in self.consolidation.map:
+            resident_uuid = self.consolidation.map[uuid]
+            if resident_uuid is None:
+                return None
+            node = self.root_for_part(self.part_for_uuid(resident_uuid))
+            if node is not None:
+                # patch resident uuid and title into ref node!
+                uuid_node = rqet.find_tag(ref_node, 'UUID')
+                uuid_node.text = str(resident_uuid)
+                title_node = rqet.find_tag(ref_node, 'Title')
+                if title_node is not None:
+                    title = rqet.citation_title_for_node(node)
+                    if title:
+                        title_node.text = str(title)
+        else:
+            node = self.root_for_part(self.part_for_uuid(uuid))
+        return node
 
-   def create_ref_node(self, flavour, title, uuid, content_type = None, root = None):
-      """Create a reference node, optionally add to root.
+    def create_ref_node(self, flavour, title, uuid, content_type = None, root = None):
+        """Create a reference node, optionally add to root.
 
       arguments:
          flavour (string): the resqml object class (type of part) for which a
@@ -2286,51 +2290,51 @@ class Model():
          newly created reference xml node
       """
 
-      assert uuid is not None
+        assert uuid is not None
 
-      if flavour.startswith('obj_'):
-         flavour = flavour[4:]
+        if flavour.startswith('obj_'):
+            flavour = flavour[4:]
 
-      if not content_type:
-         content_type = 'obj_' + flavour
-      else:
-         if content_type[0].isupper():
-            content_type = 'obj_' + content_type
+        if not content_type:
+            content_type = 'obj_' + flavour
+        else:
+            if content_type[0].isupper():
+                content_type = 'obj_' + content_type
 
-      prefix = ns['eml'] if flavour == 'HdfProxy' else ns['resqml2']
-      ref_node = rqet.Element(prefix + flavour)
-      ref_node.set(ns['xsi'] + 'type', ns['eml'] + 'DataObjectReference')
-      ref_node.text = rqet.null_xml_text
+        prefix = ns['eml'] if flavour == 'HdfProxy' else ns['resqml2']
+        ref_node = rqet.Element(prefix + flavour)
+        ref_node.set(ns['xsi'] + 'type', ns['eml'] + 'DataObjectReference')
+        ref_node.text = rqet.null_xml_text
 
-      ct_node = rqet.SubElement(ref_node, ns['eml'] + 'ContentType')
-      ct_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-      if 'EpcExternalPartReference' in content_type:
-         ct_node.text = 'application/x-eml+xml;version=2.0;type=' + content_type
-      else:
-         ct_node.text = 'application/x-resqml+xml;version=2.0;type=' + content_type
+        ct_node = rqet.SubElement(ref_node, ns['eml'] + 'ContentType')
+        ct_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+        if 'EpcExternalPartReference' in content_type:
+            ct_node.text = 'application/x-eml+xml;version=2.0;type=' + content_type
+        else:
+            ct_node.text = 'application/x-resqml+xml;version=2.0;type=' + content_type
 
-      if not title:
-         title = '(title unavailable)'
-      title_node = rqet.SubElement(ref_node, ns['eml'] + 'Title')
-      title_node.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
-      title_node.text = title
+        if not title:
+            title = '(title unavailable)'
+        title_node = rqet.SubElement(ref_node, ns['eml'] + 'Title')
+        title_node.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
+        title_node.text = title
 
-      uuid_node = rqet.SubElement(ref_node, ns['eml'] + 'UUID')
-      uuid_node.set(ns['xsi'] + 'type', ns['eml'] + 'UuidString')
-      uuid_node.text = str(uuid)
+        uuid_node = rqet.SubElement(ref_node, ns['eml'] + 'UUID')
+        uuid_node.set(ns['xsi'] + 'type', ns['eml'] + 'UuidString')
+        uuid_node.text = str(uuid)
 
-      if use_version_string:
-         version_str = rqet.SubElement(ref_node, ns['eml'] + 'VersionString')  # I'm guessing what this is
-         version_str.set(ns['xsi'] + 'type', ns['eml'] + 'NameString')
-         version_str.text = bu.version_string(uuid)
+        if use_version_string:
+            version_str = rqet.SubElement(ref_node, ns['eml'] + 'VersionString')  # I'm guessing what this is
+            version_str.set(ns['xsi'] + 'type', ns['eml'] + 'NameString')
+            version_str.text = bu.version_string(uuid)
 
-      if root is not None:
-         root.append(ref_node)
+        if root is not None:
+            root.append(ref_node)
 
-      return ref_node
+        return ref_node
 
-   def uom_node(self, root, uom):
-      """Add a generic unit of measure sub element to root.
+    def uom_node(self, root, uom):
+        """Add a generic unit of measure sub element to root.
 
       arguments:
          root: xml node to which unit of measure subelement (child) will be added
@@ -2340,16 +2344,16 @@ class Model():
          newly created unit of measure node (having already been added to root)
       """
 
-      assert root is not None and uom is not None and len(uom)
+        assert root is not None and uom is not None and len(uom)
 
-      uom_node = rqet.SubElement(root, ns['resqml2'] + 'UOM')
-      uom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlUom')
-      uom_node.text = uom
+        uom_node = rqet.SubElement(root, ns['resqml2'] + 'UOM')
+        uom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlUom')
+        uom_node.text = uom
 
-      return uom_node
+        return uom_node
 
-   def create_rels_part(self):
-      """Adds a relationships reference node as a new part in the model's parts forest.
+    def create_rels_part(self):
+        """Adds a relationships reference node as a new part in the model's parts forest.
 
       returns:
          newly created main relationships reference xml node
@@ -2358,16 +2362,16 @@ class Model():
          there can only be one relationships reference part in the model
       """
 
-      rels = rqet.SubElement(self.main_root, ns['content_types'] + 'Default')
-      rels.set('Extension', 'rels')
-      rels.set('ContentType', 'application/vnd.openxmlformats-package.relationships+xml')
-      self.rels_present = True
-      self.set_modified()
+        rels = rqet.SubElement(self.main_root, ns['content_types'] + 'Default')
+        rels.set('Extension', 'rels')
+        rels.set('ContentType', 'application/vnd.openxmlformats-package.relationships+xml')
+        self.rels_present = True
+        self.set_modified()
 
-      return rels
+        return rels
 
-   def create_citation(self, root = None, title = '', originator = None):
-      """Creates a citation xml node and optionally appends as a child of root.
+    def create_citation(self, root = None, title = '', originator = None):
+        """Creates a citation xml node and optionally appends as a child of root.
 
       arguments:
          root (optional): if not None, the newly created citation node is appended as
@@ -2381,46 +2385,46 @@ class Model():
          newly created citation xml node
       """
 
-      if not title:
-         title = '(no title)'
+        if not title:
+            title = '(no title)'
 
-      citation = rqet.Element(ns['eml'] + 'Citation')
-      citation.set(ns['xsi'] + 'type', ns['eml'] + 'Citation')
-      citation.text = rqet.null_xml_text
+        citation = rqet.Element(ns['eml'] + 'Citation')
+        citation.set(ns['xsi'] + 'type', ns['eml'] + 'Citation')
+        citation.text = rqet.null_xml_text
 
-      title_node = rqet.SubElement(citation, ns['eml'] + 'Title')
-      title_node.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
-      title_node.text = title
+        title_node = rqet.SubElement(citation, ns['eml'] + 'Title')
+        title_node.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
+        title_node.text = title
 
-      originator_node = rqet.SubElement(citation, ns['eml'] + 'Originator')
-      if originator is None:
-         try:
-            originator = str(getpass.getuser())
-         except Exception:
-            originator = 'unknown'
-      originator_node.set(ns['xsi'] + 'type', ns['eml'] + 'NameString')
-      originator_node.text = originator
+        originator_node = rqet.SubElement(citation, ns['eml'] + 'Originator')
+        if originator is None:
+            try:
+                originator = str(getpass.getuser())
+            except Exception:
+                originator = 'unknown'
+        originator_node.set(ns['xsi'] + 'type', ns['eml'] + 'NameString')
+        originator_node.text = originator
 
-      creation_node = rqet.SubElement(citation, ns['eml'] + 'Creation')
-      creation_node.set(ns['xsi'] + 'type', ns['xsd'] + 'dateTime')
-      creation_node.text = time.now()
+        creation_node = rqet.SubElement(citation, ns['eml'] + 'Creation')
+        creation_node.set(ns['xsi'] + 'type', ns['xsd'] + 'dateTime')
+        creation_node.text = time.now()
 
-      format_node = rqet.SubElement(citation, ns['eml'] + 'Format')
-      format_node.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
-      if rqet.pretend_to_be_fesapi:
-         format_node.text = '[F2I-CONSULTING:fesapi]'
-      else:
-         format_node.text = citation_format
+        format_node = rqet.SubElement(citation, ns['eml'] + 'Format')
+        format_node.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
+        if rqet.pretend_to_be_fesapi:
+            format_node.text = '[F2I-CONSULTING:fesapi]'
+        else:
+            format_node.text = citation_format
 
-      # todo: add optional description field
+        # todo: add optional description field
 
-      if root is not None:
-         root.append(citation)
+        if root is not None:
+            root.append(citation)
 
-      return citation
+        return citation
 
-   def title_for_root(self, root = None):
-      """Returns the Title text from the Citation within the given root node.
+    def title_for_root(self, root = None):
+        """Returns the Title text from the Citation within the given root node.
 
       arguments:
          root: the xml node for the object for which the citation title is required
@@ -2432,14 +2436,14 @@ class Model():
       :meta common:
       """
 
-      title = rqet.find_tag(rqet.find_tag(root, 'Citation'), 'Title')
-      if title is None:
-         return None
+        title = rqet.find_tag(rqet.find_tag(root, 'Citation'), 'Title')
+        if title is None:
+            return None
 
-      return title.text
+        return title.text
 
-   def title_for_part(self, part_name):  # duplicate functionality to citation_title_for_part()
-      """Returns the Title text from the Citation for the given main part name (not for rels).
+    def title_for_part(self, part_name):  # duplicate functionality to citation_title_for_part()
+        """Returns the Title text from the Citation for the given main part name (not for rels).
 
       arguments:
          part_name (string): the name of the part for which the citation title is required
@@ -2451,10 +2455,10 @@ class Model():
       :meta common:
       """
 
-      return self.title_for_root(self.root_for_part(part_name))
+        return self.title_for_root(self.root_for_part(part_name))
 
-   def create_unknown(self, root = None):
-      """Creates an Unknown node and optionally adds as child of root.
+    def create_unknown(self, root = None):
+        """Creates an Unknown node and optionally adds as child of root.
 
       arguments:
          root (optional): if present, the newly created Unknown node is appended as a child
@@ -2466,15 +2470,15 @@ class Model():
       :meta common:
       """
 
-      unknown = rqet.Element(ns['eml'] + 'Unknown')
-      unknown.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
-      unknown.text = 'Unknown'
-      if root is not None:
-         root.append(unknown)
-      return unknown
+        unknown = rqet.Element(ns['eml'] + 'Unknown')
+        unknown.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
+        unknown.text = 'Unknown'
+        if root is not None:
+            root.append(unknown)
+        return unknown
 
-   def create_doc_props(self, add_as_part = True, root = None, originator = None):
-      """Creates a document properties stub node and optionally adds as child of root and/or to parts forest.
+    def create_doc_props(self, add_as_part = True, root = None, originator = None):
+        """Creates a document properties stub node and optionally adds as child of root and/or to parts forest.
 
       arguments:
          add_as_part (boolean, default True): if True, the newly created node is also added as a part
@@ -2491,49 +2495,49 @@ class Model():
          other stuff that is not covered by the standard; there should be exactly one doc props part
       """
 
-      dp = rqet.Element(ns['cp'] + 'coreProperties')
-      dp.text = rqet.null_xml_text
+        dp = rqet.Element(ns['cp'] + 'coreProperties')
+        dp.text = rqet.null_xml_text
 
-      created = rqet.SubElement(dp, ns['dcterms'] + 'created')
-      created.set(ns['xsi'] + 'type', ns['dcterms'] + 'W3CDTF')  # not sure of namespace here
-      created.text = time.now()
+        created = rqet.SubElement(dp, ns['dcterms'] + 'created')
+        created.set(ns['xsi'] + 'type', ns['dcterms'] + 'W3CDTF')  # not sure of namespace here
+        created.text = time.now()
 
-      if originator is None:
-         try:
-            originator = str(os.getlogin())
-         except Exception:
-            originator = 'unknown'
-      creator = rqet.SubElement(dp, ns['dc'] + 'creator')
-      creator.text = originator
+        if originator is None:
+            try:
+                originator = str(os.getlogin())
+            except Exception:
+                originator = 'unknown'
+        creator = rqet.SubElement(dp, ns['dc'] + 'creator')
+        creator.text = originator
 
-      ver = rqet.SubElement(dp, ns['cp'] + 'version')
-      ver.text = '1.0'
+        ver = rqet.SubElement(dp, ns['cp'] + 'version')
+        ver.text = '1.0'
 
-      if root is not None:
-         root.append(dp)
-      if add_as_part:
-         self.add_part('docProps', None, dp)
-         if self.rels_present:
-            (_, rel_tree) = self.rels_forest['_rels/.rels']
-            core_rel = rqet.SubElement(rel_tree.getroot(), ns['rels'] + 'Relationship')
-            core_rel.set('Id', 'CoreProperties')
-            core_rel.set('Type', ns_url['rels_md'] + 'core-properties')
-            core_rel.set('Target', 'docProps/core.xml')
-      return dp
+        if root is not None:
+            root.append(dp)
+        if add_as_part:
+            self.add_part('docProps', None, dp)
+            if self.rels_present:
+                (_, rel_tree) = self.rels_forest['_rels/.rels']
+                core_rel = rqet.SubElement(rel_tree.getroot(), ns['rels'] + 'Relationship')
+                core_rel.set('Id', 'CoreProperties')
+                core_rel.set('Type', ns_url['rels_md'] + 'core-properties')
+                core_rel.set('Target', 'docProps/core.xml')
+        return dp
 
-   def create_crs(self,
-                  add_as_part = True,
-                  title = 'cell grid local CRS',
-                  epsg_code = None,
-                  originator = None,
-                  x_offset = 0.0,
-                  y_offset = 0.0,
-                  z_offset = 0.0,
-                  areal_rotation_radians = 0.0,
-                  xy_units = 'm',
-                  z_units = 'm',
-                  z_inc_down = True):
-      """DEPRECATED: Creates a Coordinate Reference System node and optionally adds as child of root and/or to parts forest.
+    def create_crs(self,
+                   add_as_part = True,
+                   title = 'cell grid local CRS',
+                   epsg_code = None,
+                   originator = None,
+                   x_offset = 0.0,
+                   y_offset = 0.0,
+                   z_offset = 0.0,
+                   areal_rotation_radians = 0.0,
+                   xy_units = 'm',
+                   z_units = 'm',
+                   z_inc_down = True):
+        """DEPRECATED: Creates a Coordinate Reference System node and optionally adds as child of root and/or to parts forest.
 
       arguments:
          add_as_part (boolean, default True): if True the newly created crs node is added to the model
@@ -2556,26 +2560,26 @@ class Model():
          newly created coordinate reference system xml node
       """
 
-      warnings.warn("model.create_crs is Deprecated, will be removed", DeprecationWarning)
-      crs = rqc.Crs(self,
-                    x_offset = x_offset,
-                    y_offset = y_offset,
-                    z_offset = z_offset,
-                    rotation = areal_rotation_radians,
-                    xy_units = xy_units,
-                    z_units = z_units,
-                    z_inc_down = z_inc_down,
-                    epsg_code = epsg_code)
+        warnings.warn("model.create_crs is Deprecated, will be removed", DeprecationWarning)
+        crs = rqc.Crs(self,
+                      x_offset = x_offset,
+                      y_offset = y_offset,
+                      z_offset = z_offset,
+                      rotation = areal_rotation_radians,
+                      xy_units = xy_units,
+                      z_units = z_units,
+                      z_inc_down = z_inc_down,
+                      epsg_code = epsg_code)
 
-      crs_node = crs.create_xml(add_as_part = add_as_part, title = title, originator = originator)
+        crs_node = crs.create_xml(add_as_part = add_as_part, title = title, originator = originator)
 
-      if self.crs_uuid is None:
-         self.crs_uuid = crs.uuid
+        if self.crs_uuid is None:
+            self.crs_uuid = crs.uuid
 
-      return crs_node
+        return crs_node
 
-   def create_crs_reference(self, crs_root = None, root = None, crs_uuid = None):
-      """Creates a node refering to an existing crs node and optionally adds as child of root.
+    def create_crs_reference(self, crs_root = None, root = None, crs_uuid = None):
+        """Creates a node refering to an existing crs node and optionally adds as child of root.
 
       arguments:
          crs_root: DEPRECATED, use uuid instead; the root xml node for the coordinate reference system being referenced
@@ -2587,21 +2591,21 @@ class Model():
          newly created crs reference xml node
       """
 
-      if crs_uuid is None:
-         warnings.warn('use of crs_root is deprecated in Model.create_crs_reference(); use crs_uuid instead')
-         crs_uuid = rqet.uuid_for_part_root(crs_root)
-      else:
-         crs_root = self.root_for_uuid(crs_uuid)
-      assert crs_root is not None
+        if crs_uuid is None:
+            warnings.warn('use of crs_root is deprecated in Model.create_crs_reference(); use crs_uuid instead')
+            crs_uuid = rqet.uuid_for_part_root(crs_root)
+        else:
+            crs_root = self.root_for_uuid(crs_uuid)
+        assert crs_root is not None
 
-      return self.create_ref_node('LocalCrs',
-                                  rqet.find_nested_tags_text(crs_root, ['Citation', 'Title']),
-                                  crs_uuid,
-                                  content_type = 'obj_LocalDepth3dCrs',
-                                  root = root)
+        return self.create_ref_node('LocalCrs',
+                                    rqet.find_nested_tags_text(crs_root, ['Citation', 'Title']),
+                                    crs_uuid,
+                                    content_type = 'obj_LocalDepth3dCrs',
+                                    root = root)
 
-   def create_md_datum_reference(self, md_datum_root, root = None):
-      """Creates a node refering to an existing measured depth datum and optionally adds as child of root.
+    def create_md_datum_reference(self, md_datum_root, root = None):
+        """Creates a node refering to an existing measured depth datum and optionally adds as child of root.
 
       arguments:
          md_datum_root: the root xml node for the measured depth datum being referenced
@@ -2612,14 +2616,19 @@ class Model():
          newly created measured depth datum reference xml node
       """
 
-      return self.create_ref_node('MdDatum',
-                                  rqet.find_nested_tags_text(md_datum_root, ['Citation', 'Title']),
-                                  bu.uuid_from_string(md_datum_root.attrib['uuid']),
-                                  content_type = 'obj_MdDatum',
-                                  root = root)
+        return self.create_ref_node('MdDatum',
+                                    rqet.find_nested_tags_text(md_datum_root, ['Citation', 'Title']),
+                                    bu.uuid_from_string(md_datum_root.attrib['uuid']),
+                                    content_type = 'obj_MdDatum',
+                                    root = root)
 
-   def create_hdf5_ext(self, add_as_part = True, root = None, title = 'Hdf Proxy', originator = None, file_name = None):
-      """Creates an hdf5 external node and optionally adds as child of root and/or to parts forest.
+    def create_hdf5_ext(self,
+                        add_as_part = True,
+                        root = None,
+                        title = 'Hdf Proxy',
+                        originator = None,
+                        file_name = None):
+        """Creates an hdf5 external node and optionally adds as child of root and/or to parts forest.
 
       arguments:
          add_as_part (boolean, default True): if True the newly created ext node is added to the model
@@ -2635,38 +2644,38 @@ class Model():
          newly created hdf5 external part xml node
       """
 
-      ext = self.new_obj_node('EpcExternalPartReference', name_space = 'eml')
+        ext = self.new_obj_node('EpcExternalPartReference', name_space = 'eml')
 
-      self.create_citation(root = ext, title = title, originator = originator)
+        self.create_citation(root = ext, title = title, originator = originator)
 
-      mime_type = rqet.SubElement(ext, ns['eml'] + 'MimeType')
-      mime_type.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-      mime_type.text = 'application/x-hdf5'
+        mime_type = rqet.SubElement(ext, ns['eml'] + 'MimeType')
+        mime_type.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+        mime_type.text = 'application/x-hdf5'
 
-      if root is not None:
-         root.append(ext)
-      if add_as_part:
-         ext_uuid = bu.uuid_from_string(ext.attrib['uuid'])
-         self.add_part('obj_EpcExternalPartReference', ext_uuid, ext)
-         if not file_name:
-            file_name = self.h5_file_name(file_must_exist = False)
-         assert file_name
-         self.h5_dict[ext_uuid] = file_name
-         if self.main_h5_uuid is None:
-            self.main_h5_uuid = ext_uuid
-         if self.rels_present and file_name:
-            (uuid, rel_tree) = self.rels_forest[rqet.rels_part_name_for_part(
-               rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid))]
-            assert (bu.matching_uuids(uuid, ext_uuid))
-            rel_node = rqet.SubElement(rel_tree.getroot(), ns['rels'] + 'Relationship')
-            rel_node.set('Id', 'Hdf5File')
-            rel_node.set('Type', ns_url['rels_ext'] + 'externalResource')
-            rel_node.set('Target', rqet.strip_path(file_name))
-            rel_node.set('TargetMode', 'External')
-      return ext
+        if root is not None:
+            root.append(ext)
+        if add_as_part:
+            ext_uuid = bu.uuid_from_string(ext.attrib['uuid'])
+            self.add_part('obj_EpcExternalPartReference', ext_uuid, ext)
+            if not file_name:
+                file_name = self.h5_file_name(file_must_exist = False)
+            assert file_name
+            self.h5_dict[ext_uuid] = file_name
+            if self.main_h5_uuid is None:
+                self.main_h5_uuid = ext_uuid
+            if self.rels_present and file_name:
+                (uuid, rel_tree) = self.rels_forest[rqet.rels_part_name_for_part(
+                    rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid))]
+                assert (bu.matching_uuids(uuid, ext_uuid))
+                rel_node = rqet.SubElement(rel_tree.getroot(), ns['rels'] + 'Relationship')
+                rel_node.set('Id', 'Hdf5File')
+                rel_node.set('Type', ns_url['rels_ext'] + 'externalResource')
+                rel_node.set('Target', rqet.strip_path(file_name))
+                rel_node.set('TargetMode', 'External')
+        return ext
 
-   def create_hdf5_dataset_ref(self, hdf5_uuid, object_uuid, group_tail, root, title = 'Hdf Proxy'):
-      """Creates a pair of nodes referencing an hdf5 dataset (array) and adds to root.
+    def create_hdf5_dataset_ref(self, hdf5_uuid, object_uuid, group_tail, root, title = 'Hdf Proxy'):
+        """Creates a pair of nodes referencing an hdf5 dataset (array) and adds to root.
 
       arguments:
          hdf5_uuid (uuid.UUID): the uuid of the hdf5 external part being referenced
@@ -2681,33 +2690,33 @@ class Model():
          the newly created xml node holding the hdf5 internal path
       """
 
-      assert root is not None
-      assert group_tail
+        assert root is not None
+        assert group_tail
 
-      if group_tail[0] == '/':
-         group_tail = group_tail[1:]
-      if group_tail[-1] == '/':
-         group_tail = group_tail[:-1]
-      hdf5_path = '/RESQML/' + str(object_uuid) + '/' + group_tail
+        if group_tail[0] == '/':
+            group_tail = group_tail[1:]
+        if group_tail[-1] == '/':
+            group_tail = group_tail[:-1]
+        hdf5_path = '/RESQML/' + str(object_uuid) + '/' + group_tail
 
-      path_node = rqet.Element(ns['eml'] + 'PathInHdfFile')
-      path_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-      path_node.text = hdf5_path
-      root.append(path_node)
+        path_node = rqet.Element(ns['eml'] + 'PathInHdfFile')
+        path_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+        path_node.text = hdf5_path
+        root.append(path_node)
 
-      self.create_ref_node('HdfProxy', title, hdf5_uuid, content_type = 'obj_EpcExternalPartReference', root = root)
+        self.create_ref_node('HdfProxy', title, hdf5_uuid, content_type = 'obj_EpcExternalPartReference', root = root)
 
-      return path_node
+        return path_node
 
-   # todo: def create_property_kind():
+    # todo: def create_property_kind():
 
-   def create_supporting_representation(self,
-                                        grid_root = None,
-                                        support_uuid = None,
-                                        root = None,
-                                        title = None,
-                                        content_type = 'obj_IjkGridRepresentation'):
-      """Craate a supporting representation reference node refering to an IjkGrid and optionally add to root.
+    def create_supporting_representation(self,
+                                         grid_root = None,
+                                         support_uuid = None,
+                                         root = None,
+                                         title = None,
+                                         content_type = 'obj_IjkGridRepresentation'):
+        """Craate a supporting representation reference node refering to an IjkGrid and optionally add to root.
 
       arguments:
          grid_root: the xml node of the grid object which is the supporting representation being
@@ -2730,29 +2739,29 @@ class Model():
          representation; one of grid_root or support_uuid should be passed when calling this method
       """
 
-      assert grid_root is not None or support_uuid is not None
+        assert grid_root is not None or support_uuid is not None
 
-      # todo: check that grid_root is for an IJK Grid
-      #       (or other content type when handled, eg. blocked wells?)
+        # todo: check that grid_root is for an IJK Grid
+        #       (or other content type when handled, eg. blocked wells?)
 
-      if grid_root is not None:
-         uuid = rqet.uuid_for_part_root(grid_root)
-         if uuid is not None:
-            support_uuid = uuid
-         if title is None:
-            title = rqet.citation_title_for_node(grid_root)
-      elif title is None:
-         title = 'supporting representation'
-      assert support_uuid is not None
+        if grid_root is not None:
+            uuid = rqet.uuid_for_part_root(grid_root)
+            if uuid is not None:
+                support_uuid = uuid
+            if title is None:
+                title = rqet.citation_title_for_node(grid_root)
+        elif title is None:
+            title = 'supporting representation'
+        assert support_uuid is not None
 
-      return self.create_ref_node('SupportingRepresentation',
-                                  title,
-                                  support_uuid,
-                                  content_type = content_type,
-                                  root = root)
+        return self.create_ref_node('SupportingRepresentation',
+                                    title,
+                                    support_uuid,
+                                    content_type = content_type,
+                                    root = root)
 
-   def create_source(self, source, root = None):
-      """Create an extra meta data node holding information on the source of the data, optionally add to root.
+    def create_source(self, source, root = None):
+        """Create an extra meta data node holding information on the source of the data, optionally add to root.
 
       arguments:
          source (string): text describing the source of an object
@@ -2762,34 +2771,34 @@ class Model():
          the newly created extra metadata xml node
       """
 
-      emd_node = rqet.Element(ns['resqml2'] + 'ExtraMetadata')
-      emd_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'NameValuePair')
-      emd_node.text = rqet.null_xml_text
+        emd_node = rqet.Element(ns['resqml2'] + 'ExtraMetadata')
+        emd_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'NameValuePair')
+        emd_node.text = rqet.null_xml_text
 
-      name_node = rqet.SubElement(emd_node, ns['resqml2'] + 'Name')
-      name_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-      name_node.text = 'source'
+        name_node = rqet.SubElement(emd_node, ns['resqml2'] + 'Name')
+        name_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+        name_node.text = 'source'
 
-      value_node = rqet.SubElement(emd_node, ns['resqml2'] + 'Value')
-      value_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-      value_node.text = source
+        value_node = rqet.SubElement(emd_node, ns['resqml2'] + 'Value')
+        value_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+        value_node.text = source
 
-      if root is not None:
-         root.append(emd_node)
-      return emd_node
+        if root is not None:
+            root.append(emd_node)
+        return emd_node
 
-   def create_patch(self,
-                    p_uuid,
-                    ext_uuid = None,
-                    root = None,
-                    patch_index = 0,
-                    hdf5_type = 'DoubleHdf5Array',
-                    xsd_type = 'double',
-                    null_value = None,
-                    const_value = None,
-                    const_count = None,
-                    points = False):
-      """Create a node for a patch of values, including ref to hdf5 data set, optionally add to root.
+    def create_patch(self,
+                     p_uuid,
+                     ext_uuid = None,
+                     root = None,
+                     patch_index = 0,
+                     hdf5_type = 'DoubleHdf5Array',
+                     xsd_type = 'double',
+                     null_value = None,
+                     const_value = None,
+                     const_count = None,
+                     points = False):
+        """Create a node for a patch of values, including ref to hdf5 data set, optionally add to root.
 
       arguments:
          p_uuid (uuid.UUID): the uuid of the object for which this patch is a component
@@ -2822,75 +2831,75 @@ class Model():
          such in the xml and no data is stored in the hdf5
       """
 
-      if const_value is None:
-         assert ext_uuid is not None
-      else:
-         assert const_count is not None and const_count > 0
-         if hdf5_type.endswith('Hdf5Array'):
-            hdf5_type = hdf5_type[:-9] + 'ConstantArray'
+        if const_value is None:
+            assert ext_uuid is not None
+        else:
+            assert const_count is not None and const_count > 0
+            if hdf5_type.endswith('Hdf5Array'):
+                hdf5_type = hdf5_type[:-9] + 'ConstantArray'
 
-      lxt = str(xsd_type).lower()
-      discrete = ('int' in lxt) or ('bool' in lxt)
+        lxt = str(xsd_type).lower()
+        discrete = ('int' in lxt) or ('bool' in lxt)
 
-      if points:
-         assert not discrete
-         patch_node = rqet.Element(ns['resqml2'] + 'PatchOfPoints')
-         patch_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'PatchOfPoints')
-         patch_node.text = rqet.null_xml_text
-         outer_values_tag = 'Points'
-         inner_values_tag = 'Coordinates'
-         hdf_path_tail = 'points_patch'
-      else:
-         patch_node = rqet.Element(ns['resqml2'] + 'PatchOfValues')
-         patch_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'PatchOfValues')
-         patch_node.text = rqet.null_xml_text
-         outer_values_tag = 'Values'
-         inner_values_tag = 'Values'
-         hdf_path_tail = 'values_patch'
+        if points:
+            assert not discrete
+            patch_node = rqet.Element(ns['resqml2'] + 'PatchOfPoints')
+            patch_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'PatchOfPoints')
+            patch_node.text = rqet.null_xml_text
+            outer_values_tag = 'Points'
+            inner_values_tag = 'Coordinates'
+            hdf_path_tail = 'points_patch'
+        else:
+            patch_node = rqet.Element(ns['resqml2'] + 'PatchOfValues')
+            patch_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'PatchOfValues')
+            patch_node.text = rqet.null_xml_text
+            outer_values_tag = 'Values'
+            inner_values_tag = 'Values'
+            hdf_path_tail = 'values_patch'
 
-      rep_patch_index = rqet.SubElement(patch_node, ns['resqml2'] + 'RepresentationPatchIndex')
-      rep_patch_index.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-      rep_patch_index.text = str(patch_index)
+        rep_patch_index = rqet.SubElement(patch_node, ns['resqml2'] + 'RepresentationPatchIndex')
+        rep_patch_index.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+        rep_patch_index.text = str(patch_index)
 
-      outer_values_node = rqet.SubElement(patch_node, ns['resqml2'] + outer_values_tag)
-      outer_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + hdf5_type)  # may also be constant array type
-      outer_values_node.text = rqet.null_xml_text
+        outer_values_node = rqet.SubElement(patch_node, ns['resqml2'] + outer_values_tag)
+        outer_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + hdf5_type)  # may also be constant array type
+        outer_values_node.text = rqet.null_xml_text
 
-      if discrete:
-         if null_value is None:
-            if str(xsd_type).startswith('u'):
-               null_value = 4294967295  # 2^32 - 1, used as default even for 64 bit data!
-            else:
-               null_value = -1
-         null_value_node = rqet.SubElement(outer_values_node, ns['resqml2'] + 'NullValue')
-         null_value_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
-         null_value_node.text = str(null_value)
+        if discrete:
+            if null_value is None:
+                if str(xsd_type).startswith('u'):
+                    null_value = 4294967295  # 2^32 - 1, used as default even for 64 bit data!
+                else:
+                    null_value = -1
+            null_value_node = rqet.SubElement(outer_values_node, ns['resqml2'] + 'NullValue')
+            null_value_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
+            null_value_node.text = str(null_value)
 
-      if const_value is None:
+        if const_value is None:
 
-         inner_values_node = rqet.SubElement(outer_values_node, ns['resqml2'] + inner_values_tag)
-         inner_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         inner_values_node.text = rqet.null_xml_text
+            inner_values_node = rqet.SubElement(outer_values_node, ns['resqml2'] + inner_values_tag)
+            inner_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            inner_values_node.text = rqet.null_xml_text
 
-         self.create_hdf5_dataset_ref(ext_uuid, p_uuid, f'{hdf_path_tail}{patch_index}', root = inner_values_node)
+            self.create_hdf5_dataset_ref(ext_uuid, p_uuid, f'{hdf_path_tail}{patch_index}', root = inner_values_node)
 
-      else:
+        else:
 
-         const_value_node = rqet.SubElement(outer_values_node, ns['resqml2'] + 'Value')
-         const_value_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
-         const_value_node.text = str(const_value)
+            const_value_node = rqet.SubElement(outer_values_node, ns['resqml2'] + 'Value')
+            const_value_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
+            const_value_node.text = str(const_value)
 
-         const_count_node = rqet.SubElement(outer_values_node, ns['resqml2'] + 'Count')
-         const_count_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-         const_count_node.text = str(const_count)
+            const_count_node = rqet.SubElement(outer_values_node, ns['resqml2'] + 'Count')
+            const_count_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+            const_count_node.text = str(const_count)
 
-      if root is not None:
-         root.append(patch_node)
+        if root is not None:
+            root.append(patch_node)
 
-      return patch_node
+        return patch_node
 
-   def create_time_series_ref(self, time_series_uuid, root = None):
-      """Create a reference node to a time series, optionally add to root.
+    def create_time_series_ref(self, time_series_uuid, root = None):
+        """Create a reference node to a time series, optionally add to root.
 
       arguments:
          time_series_uuid (uuid.UUID): the uuid of the time series part being referenced
@@ -2901,10 +2910,10 @@ class Model():
          the newly created time series reference xml node
       """
 
-      return self.create_ref_node('TimeSeries', 'time series', time_series_uuid, root = root)
+        return self.create_ref_node('TimeSeries', 'time series', time_series_uuid, root = root)
 
-   def create_solitary_point3d(self, flavour, root, xyz):
-      """Creates a subelement to root for a solitary point in 3D space.
+    def create_solitary_point3d(self, flavour, root, xyz):
+        """Creates a subelement to root for a solitary point in 3D space.
 
       arguments:
          flavour (string): the object class (type) of the point node to be created
@@ -2916,20 +2925,20 @@ class Model():
          the newly created xml node for the solitary point
       """
 
-      # todo: check namespaces
-      p3d = rqet.SubElement(root, ns['resqml2'] + flavour)
-      p3d.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3d')
-      p3d.text = rqet.null_xml_text
+        # todo: check namespaces
+        p3d = rqet.SubElement(root, ns['resqml2'] + flavour)
+        p3d.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3d')
+        p3d.text = rqet.null_xml_text
 
-      for axis in range(3):
-         coord_node = rqet.SubElement(p3d, ns['resqml2'] + 'Coordinate' + str(axis + 1))
-         coord_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-         coord_node.text = str(xyz[axis])
+        for axis in range(3):
+            coord_node = rqet.SubElement(p3d, ns['resqml2'] + 'Coordinate' + str(axis + 1))
+            coord_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+            coord_node.text = str(xyz[axis])
 
-      return p3d
+        return p3d
 
-   def create_reciprocal_relationship(self, node_a, rel_type_a, node_b, rel_type_b, avoid_duplicates = True):
-      """Adds a node to each of a pair of trees in the rels forest, to represent a two-way relationship.
+    def create_reciprocal_relationship(self, node_a, rel_type_a, node_b, rel_type_b, avoid_duplicates = True):
+        """Adds a node to each of a pair of trees in the rels forest, to represent a two-way relationship.
 
       arguments:
          node_a: one of the two xml nodes to be related
@@ -2945,64 +2954,66 @@ class Model():
          None
       """
 
-      def id_str(uuid):
-         stringy = str(uuid)
-         if not (rqet.pretend_to_be_fesapi or rqet.use_fesapi_quirks) or not stringy[0].isdigit():
-            return stringy
-         return '_' + stringy
+        def id_str(uuid):
+            stringy = str(uuid)
+            if not (rqet.pretend_to_be_fesapi or rqet.use_fesapi_quirks) or not stringy[0].isdigit():
+                return stringy
+            return '_' + stringy
 
-      assert (self.rels_present)
+        assert (self.rels_present)
 
-      if node_a is None or node_b is None:
-         log.error('attempt to create relationship with missing object')
-         return
+        if node_a is None or node_b is None:
+            log.error('attempt to create relationship with missing object')
+            return
 
-      uuid_a = node_a.attrib['uuid']
-      obj_type_a = rqet.stripped_of_prefix(rqet.content_type(node_a.attrib[ns['xsi'] + 'type']))
-      part_name_a = rqet.part_name_for_object(obj_type_a, uuid_a)
-      rel_part_name_a = rqet.rels_part_name_for_part(part_name_a)
-      (rel_uuid_a, rel_tree_a) = self.rels_forest[rel_part_name_a]
-      rel_root_a = rel_tree_a.getroot()
+        uuid_a = node_a.attrib['uuid']
+        obj_type_a = rqet.stripped_of_prefix(rqet.content_type(node_a.attrib[ns['xsi'] + 'type']))
+        part_name_a = rqet.part_name_for_object(obj_type_a, uuid_a)
+        rel_part_name_a = rqet.rels_part_name_for_part(part_name_a)
+        (rel_uuid_a, rel_tree_a) = self.rels_forest[rel_part_name_a]
+        rel_root_a = rel_tree_a.getroot()
 
-      uuid_b = node_b.attrib['uuid']
-      obj_type_b = rqet.stripped_of_prefix(rqet.content_type(node_b.attrib[ns['xsi'] + 'type']))
-      part_name_b = rqet.part_name_for_object(obj_type_b, uuid_b)
-      rel_part_name_b = rqet.rels_part_name_for_part(part_name_b)
-      (rel_uuid_b, rel_tree_b) = self.rels_forest[rel_part_name_b]
-      rel_root_b = rel_tree_b.getroot()
+        uuid_b = node_b.attrib['uuid']
+        obj_type_b = rqet.stripped_of_prefix(rqet.content_type(node_b.attrib[ns['xsi'] + 'type']))
+        part_name_b = rqet.part_name_for_object(obj_type_b, uuid_b)
+        rel_part_name_b = rqet.rels_part_name_for_part(part_name_b)
+        (rel_uuid_b, rel_tree_b) = self.rels_forest[rel_part_name_b]
+        rel_root_b = rel_tree_b.getroot()
 
-      create_a = True
-      if avoid_duplicates:
-         existing_rel_nodes = rqet.list_of_tag(rel_root_a, 'Relationship')
-         for existing in existing_rel_nodes:
-            if (rqet.stripped_of_prefix(existing.attrib['Type']) == rel_type_a and
-                existing.attrib['Target'] == part_name_b):
-               create_a = False
-               break
-      if create_a:
-         rel_a = rqet.SubElement(rel_root_a, ns['rels'] + 'Relationship')
-         rel_a.set(
-            'Id', id_str(uuid_b))  # NB: fesapi prefixes uuid with _ for some rels only (where uuid starts with a digit)
-         rel_a.set('Type', ns_url['rels_ext'] + rel_type_a)
-         rel_a.set('Target', part_name_b)
+        create_a = True
+        if avoid_duplicates:
+            existing_rel_nodes = rqet.list_of_tag(rel_root_a, 'Relationship')
+            for existing in existing_rel_nodes:
+                if (rqet.stripped_of_prefix(existing.attrib['Type']) == rel_type_a and
+                        existing.attrib['Target'] == part_name_b):
+                    create_a = False
+                    break
+        if create_a:
+            rel_a = rqet.SubElement(rel_root_a, ns['rels'] + 'Relationship')
+            rel_a.set(
+                'Id',
+                id_str(uuid_b))  # NB: fesapi prefixes uuid with _ for some rels only (where uuid starts with a digit)
+            rel_a.set('Type', ns_url['rels_ext'] + rel_type_a)
+            rel_a.set('Target', part_name_b)
 
-      create_b = True
-      if avoid_duplicates:
-         existing_rel_nodes = rqet.list_of_tag(rel_root_b, 'Relationship')
-         for existing in existing_rel_nodes:
-            if (rqet.stripped_of_prefix(existing.attrib['Type']) == rel_type_b and
-                existing.attrib['Target'] == part_name_a):
-               create_b = False
-               break
-      if create_b:
-         rel_b = rqet.SubElement(rel_root_b, ns['rels'] + 'Relationship')
-         rel_b.set(
-            'Id', id_str(uuid_a))  # NB: fesapi prefixes uuid with _ for some rels only (where uuid starts with a digit)
-         rel_b.set('Type', ns_url['rels_ext'] + rel_type_b)
-         rel_b.set('Target', part_name_a)
+        create_b = True
+        if avoid_duplicates:
+            existing_rel_nodes = rqet.list_of_tag(rel_root_b, 'Relationship')
+            for existing in existing_rel_nodes:
+                if (rqet.stripped_of_prefix(existing.attrib['Type']) == rel_type_b and
+                        existing.attrib['Target'] == part_name_a):
+                    create_b = False
+                    break
+        if create_b:
+            rel_b = rqet.SubElement(rel_root_b, ns['rels'] + 'Relationship')
+            rel_b.set(
+                'Id',
+                id_str(uuid_a))  # NB: fesapi prefixes uuid with _ for some rels only (where uuid starts with a digit)
+            rel_b.set('Type', ns_url['rels_ext'] + rel_type_b)
+            rel_b.set('Target', part_name_a)
 
-   def duplicate_node(self, existing_node, add_as_part = True):
-      """Creates a deep copy of the xml node (typically from another model) and optionally adds as part.
+    def duplicate_node(self, existing_node, add_as_part = True):
+        """Creates a deep copy of the xml node (typically from another model) and optionally adds as part.
 
       arguments:
          existing_node: the existing xml node, usually in another model, to be duplicated
@@ -3020,34 +3031,34 @@ class Model():
          prior to adding as part
       """
 
-      new_node = copy.deepcopy(existing_node)
-      if add_as_part:
-         uuid = rqet.uuid_for_part_root(new_node)
-         if self.part_for_uuid(uuid) is None:
-            self.add_part(rqet.node_type(new_node), uuid, new_node)
-         else:
-            log.warning('rejected attempt to add a duplicated part with an existing uuid')
-      return new_node
+        new_node = copy.deepcopy(existing_node)
+        if add_as_part:
+            uuid = rqet.uuid_for_part_root(new_node)
+            if self.part_for_uuid(uuid) is None:
+                self.add_part(rqet.node_type(new_node), uuid, new_node)
+            else:
+                log.warning('rejected attempt to add a duplicated part with an existing uuid')
+        return new_node
 
-   def force_consolidation_uuid_equivalence(self, immigrant_uuid, resident_uuid):
-      """Forces object identified by immigrant uuid to be teated as equivalent to that with resident uuid during consolidation."""
+    def force_consolidation_uuid_equivalence(self, immigrant_uuid, resident_uuid):
+        """Forces object identified by immigrant uuid to be teated as equivalent to that with resident uuid during consolidation."""
 
-      if self.consolidation is None:
-         self.consolidation = cons.Consolidation(self)
-      self.consolidation.force_uuid_equivalence(immigrant_uuid, resident_uuid)
+        if self.consolidation is None:
+            self.consolidation = cons.Consolidation(self)
+        self.consolidation.force_uuid_equivalence(immigrant_uuid, resident_uuid)
 
-   def copy_part_from_other_model(self,
-                                  other_model,
-                                  part,
-                                  realization = None,
-                                  consolidate = True,
-                                  force = False,
-                                  cut_refs_to_uuids = None,
-                                  cut_node_types = None,
-                                  self_h5_file_name = None,
-                                  h5_uuid = None,
-                                  other_h5_file_name = None):
-      """Fully copies part in from another model, with referenced parts, hdf5 data and relationships.
+    def copy_part_from_other_model(self,
+                                   other_model,
+                                   part,
+                                   realization = None,
+                                   consolidate = True,
+                                   force = False,
+                                   cut_refs_to_uuids = None,
+                                   cut_node_types = None,
+                                   self_h5_file_name = None,
+                                   h5_uuid = None,
+                                   other_h5_file_name = None):
+        """Fully copies part in from another model, with referenced parts, hdf5 data and relationships.
 
       arguments:
          other model (Model): the source model from which to copy a part
@@ -3074,152 +3085,152 @@ class Model():
          default hdf5 file used in this model and assumed in other_model
       """
 
-      # todo: double check behaviour around equivalent CRSes, especially any default crs in model
+        # todo: double check behaviour around equivalent CRSes, especially any default crs in model
 
-      assert other_model is not None
-      if other_model is self:
-         return
-      assert part is not None
-      if realization is not None:
-         assert isinstance(realization, int) and realization >= 0
-      if force:
-         assert consolidate
-      if not other_h5_file_name:
-         other_h5_file_name = other_model.h5_file_name()
-      if not self_h5_file_name:
-         self_h5_file_name = self.h5_file_name(file_must_exist = False)
+        assert other_model is not None
+        if other_model is self:
+            return
+        assert part is not None
+        if realization is not None:
+            assert isinstance(realization, int) and realization >= 0
+        if force:
+            assert consolidate
+        if not other_h5_file_name:
+            other_h5_file_name = other_model.h5_file_name()
+        if not self_h5_file_name:
+            self_h5_file_name = self.h5_file_name(file_must_exist = False)
 
-      # check whether already existing in this model
-      if part in self.parts_forest.keys():
-         return
+        # check whether already existing in this model
+        if part in self.parts_forest.keys():
+            return
 
-      if other_model.type_of_part(part) == 'obj_EpcExternalPartReference':
-         log.debug('refusing to copy hdf5 ext part from other model')
-         return
+        if other_model.type_of_part(part) == 'obj_EpcExternalPartReference':
+            log.debug('refusing to copy hdf5 ext part from other model')
+            return
 
-      log.debug('copying part: ' + str(part))
+        log.debug('copying part: ' + str(part))
 
-      uuid = rqet.uuid_in_part_name(part)
-      if not force:
-         assert self.part_for_uuid(uuid) is None, 'part copying failure: uuid exists for different part!'
+        uuid = rqet.uuid_in_part_name(part)
+        if not force:
+            assert self.part_for_uuid(uuid) is None, 'part copying failure: uuid exists for different part!'
 
-      # duplicate xml tree and add as a part
-      other_root = other_model.root_for_part(part, is_rels = False)
-      if other_root is None:
-         log.error('failed to copy part (missing in source model?): ' + str(part))
-         return
+        # duplicate xml tree and add as a part
+        other_root = other_model.root_for_part(part, is_rels = False)
+        if other_root is None:
+            log.error('failed to copy part (missing in source model?): ' + str(part))
+            return
 
-      if consolidate and not force:
-         if self.consolidation is None:
-            self.consolidation = cons.Consolidation(self)
-         resident_uuid = self.consolidation.equivalent_uuid_for_part(part, immigrant_model = other_model)
-      else:
-         resident_uuid = None
+        if consolidate and not force:
+            if self.consolidation is None:
+                self.consolidation = cons.Consolidation(self)
+            resident_uuid = self.consolidation.equivalent_uuid_for_part(part, immigrant_model = other_model)
+        else:
+            resident_uuid = None
 
-      if resident_uuid is None:
+        if resident_uuid is None:
 
-         root_node = self.duplicate_node(other_root)  # adds duplicated node as part
-         assert root_node is not None
+            root_node = self.duplicate_node(other_root)  # adds duplicated node as part
+            assert root_node is not None
 
-         if realization is not None and rqet.node_type(root_node).endswith('Property'):
-            ri_node = rqet.find_tag(root_node, 'RealizationIndex')
-            if ri_node is None:
-               ri_node = rqet.SubElement(root_node, ns['resqml2'] + 'RealizationIndex')
-               ri_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-               ri_node.text = str(realization)
-            # NB. this intentionally overwrites any pre-existing realization number
-            ri_node.text = str(realization)
+            if realization is not None and rqet.node_type(root_node).endswith('Property'):
+                ri_node = rqet.find_tag(root_node, 'RealizationIndex')
+                if ri_node is None:
+                    ri_node = rqet.SubElement(root_node, ns['resqml2'] + 'RealizationIndex')
+                    ri_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+                    ri_node.text = str(realization)
+                # NB. this intentionally overwrites any pre-existing realization number
+                ri_node.text = str(realization)
 
-         # copy hdf5 data
-         hdf5_internal_paths = [node.text for node in rqet.list_of_descendant_tag(other_root, 'PathInHdfFile')]
-         hdf5_count = whdf5.copy_h5_path_list(other_h5_file_name, self_h5_file_name, hdf5_internal_paths, mode = 'a')
+            # copy hdf5 data
+            hdf5_internal_paths = [node.text for node in rqet.list_of_descendant_tag(other_root, 'PathInHdfFile')]
+            hdf5_count = whdf5.copy_h5_path_list(other_h5_file_name, self_h5_file_name, hdf5_internal_paths, mode = 'a')
 
-         # create relationship with hdf5 if needed and modify h5 file uuid in xml references
-         if hdf5_count:
-            if h5_uuid is None:
-               h5_uuid = self.h5_uuid()
-            if h5_uuid is None:
-               self.create_hdf5_ext()
-               h5_uuid = self.h5_uuid()
-            self.change_hdf5_uuid_in_hdf5_references(root_node, None, h5_uuid)
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', h5_uuid, prefixed = False)
-            ext_node = self.root_for_part(ext_part)
-            self.create_reciprocal_relationship(root_node,
-                                                'mlToExternalPartProxy',
-                                                ext_node,
-                                                'externalPartProxyToMl',
-                                                avoid_duplicates = False)
+            # create relationship with hdf5 if needed and modify h5 file uuid in xml references
+            if hdf5_count:
+                if h5_uuid is None:
+                    h5_uuid = self.h5_uuid()
+                if h5_uuid is None:
+                    self.create_hdf5_ext()
+                    h5_uuid = self.h5_uuid()
+                self.change_hdf5_uuid_in_hdf5_references(root_node, None, h5_uuid)
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', h5_uuid, prefixed = False)
+                ext_node = self.root_for_part(ext_part)
+                self.create_reciprocal_relationship(root_node,
+                                                    'mlToExternalPartProxy',
+                                                    ext_node,
+                                                    'externalPartProxyToMl',
+                                                    avoid_duplicates = False)
 
-         # cut references to objects to be excluded
-         if cut_refs_to_uuids:
-            rqet.cut_obj_references(root_node, cut_refs_to_uuids)
+            # cut references to objects to be excluded
+            if cut_refs_to_uuids:
+                rqet.cut_obj_references(root_node, cut_refs_to_uuids)
 
-         if cut_node_types:
-            rqet.cut_nodes_of_types(root_node, cut_node_types)
+            if cut_node_types:
+                rqet.cut_nodes_of_types(root_node, cut_node_types)
 
-         # recursively copy in referenced parts where they don't already exist in this model
-         for ref_node in rqet.list_obj_references(root_node):
-            resident_referred_node = None
-            if consolidate:
-               resident_referred_node = self.referenced_node(ref_node, consolidate = True)
-            if force:
-               continue
-            if resident_referred_node is None:
-               referred_node = other_model.referenced_node(ref_node)
-               if referred_node is None:
-                  log.warning(
-                     f'referred node not found in other model for {rqet.find_tag_text(ref_node, "Title")}; uuid: {rqet.find_tag_text(ref_node, "UUID")}'
-                  )
-               else:
-                  referred_part = rqet.part_name_for_part_root(referred_node)
-                  if other_model.type_of_part(referred_part) == 'obj_EpcExternalPartReference':
-                     continue
-                  if referred_part in self.list_of_parts():
-                     continue
-                  self.copy_part_from_other_model(other_model, referred_part, consolidate = consolidate)
+            # recursively copy in referenced parts where they don't already exist in this model
+            for ref_node in rqet.list_obj_references(root_node):
+                resident_referred_node = None
+                if consolidate:
+                    resident_referred_node = self.referenced_node(ref_node, consolidate = True)
+                if force:
+                    continue
+                if resident_referred_node is None:
+                    referred_node = other_model.referenced_node(ref_node)
+                    if referred_node is None:
+                        log.warning(
+                            f'referred node not found in other model for {rqet.find_tag_text(ref_node, "Title")}; uuid: {rqet.find_tag_text(ref_node, "UUID")}'
+                        )
+                    else:
+                        referred_part = rqet.part_name_for_part_root(referred_node)
+                        if other_model.type_of_part(referred_part) == 'obj_EpcExternalPartReference':
+                            continue
+                        if referred_part in self.list_of_parts():
+                            continue
+                        self.copy_part_from_other_model(other_model, referred_part, consolidate = consolidate)
 
-         resident_uuid = uuid
+            resident_uuid = uuid
 
-      else:
+        else:
 
-         root_node = self.root_for_uuid(resident_uuid)
+            root_node = self.root_for_uuid(resident_uuid)
 
-      # copy relationships where target part is present in this model – this part is source, then destination
-      for source_flag in [True, False]:
-         other_related_parts = other_model.parts_list_filtered_by_related_uuid(other_model.list_of_parts(),
-                                                                               resident_uuid,
-                                                                               uuid_is_source = source_flag)
-         for related_part in other_related_parts:
-            # log.debug('considering relationship with: ' + str(related_part))
-            if not force and (related_part in self.parts_forest):
-               resident_related_part = related_part
-            else:
-               # log.warning('skipping relationship between ' + str(part) + ' and ' + str(related_part))
-               if consolidate:
-                  resident_related_uuid = self.consolidation.equivalent_uuid_for_part(related_part,
-                                                                                      immigrant_model = other_model)
-                  if resident_related_uuid is None:
-                     continue
-                  resident_related_part = rqet.part_name_for_object(other_model.type_of_part(related_part),
-                                                                    resident_related_uuid)
-                  if resident_related_part is None:
-                     continue
-               else:
-                  continue
-            if not force and resident_related_part in self.parts_list_filtered_by_related_uuid(
-                  self.list_of_parts(), resident_uuid):
-               continue
-            related_node = self.root_for_part(resident_related_part)
-            assert related_node is not None
+        # copy relationships where target part is present in this model – this part is source, then destination
+        for source_flag in [True, False]:
+            other_related_parts = other_model.parts_list_filtered_by_related_uuid(other_model.list_of_parts(),
+                                                                                  resident_uuid,
+                                                                                  uuid_is_source = source_flag)
+            for related_part in other_related_parts:
+                # log.debug('considering relationship with: ' + str(related_part))
+                if not force and (related_part in self.parts_forest):
+                    resident_related_part = related_part
+                else:
+                    # log.warning('skipping relationship between ' + str(part) + ' and ' + str(related_part))
+                    if consolidate:
+                        resident_related_uuid = self.consolidation.equivalent_uuid_for_part(
+                            related_part, immigrant_model = other_model)
+                        if resident_related_uuid is None:
+                            continue
+                        resident_related_part = rqet.part_name_for_object(other_model.type_of_part(related_part),
+                                                                          resident_related_uuid)
+                        if resident_related_part is None:
+                            continue
+                    else:
+                        continue
+                if not force and resident_related_part in self.parts_list_filtered_by_related_uuid(
+                        self.list_of_parts(), resident_uuid):
+                    continue
+                related_node = self.root_for_part(resident_related_part)
+                assert related_node is not None
 
-            if source_flag:
-               sd_a, sd_b = 'sourceObject', 'destinationObject'
-            else:
-               sd_b, sd_a = 'sourceObject', 'destinationObject'
-            self.create_reciprocal_relationship(root_node, sd_a, related_node, sd_b)
+                if source_flag:
+                    sd_a, sd_b = 'sourceObject', 'destinationObject'
+                else:
+                    sd_b, sd_a = 'sourceObject', 'destinationObject'
+                self.create_reciprocal_relationship(root_node, sd_a, related_node, sd_b)
 
-   def copy_all_parts_from_other_model(self, other_model, realization = None, consolidate = True):
-      """Fully copies parts in from another model, with referenced parts, hdf5 data and relationships.
+    def copy_all_parts_from_other_model(self, other_model, realization = None, consolidate = True):
+        """Fully copies parts in from another model, with referenced parts, hdf5 data and relationships.
 
       arguments:
          other model (Model): the source model from which to copy parts
@@ -3234,33 +3245,33 @@ class Model():
          default hdf5 file used in this model and assumed in other_model
       """
 
-      assert other_model is not None and other_model is not self
+        assert other_model is not None and other_model is not self
 
-      other_parts_list = other_model.parts()
-      if not other_parts_list:
-         log.warning('no parts found in other model for merging')
-         return
+        other_parts_list = other_model.parts()
+        if not other_parts_list:
+            log.warning('no parts found in other model for merging')
+            return
 
-      if consolidate:
-         other_parts_list = cons.sort_parts_list(other_model, other_parts_list)
+        if consolidate:
+            other_parts_list = cons.sort_parts_list(other_model, other_parts_list)
 
-      self_h5_file_name = self.h5_file_name(file_must_exist = False)
-      self_h5_uuid = self.h5_uuid()
-      other_h5_file_name = other_model.h5_file_name()
-      for part in other_parts_list:
-         self.copy_part_from_other_model(other_model,
-                                         part,
-                                         realization = realization,
-                                         consolidate = consolidate,
-                                         self_h5_file_name = self_h5_file_name,
-                                         h5_uuid = self_h5_uuid,
-                                         other_h5_file_name = other_h5_file_name)
+        self_h5_file_name = self.h5_file_name(file_must_exist = False)
+        self_h5_uuid = self.h5_uuid()
+        other_h5_file_name = other_model.h5_file_name()
+        for part in other_parts_list:
+            self.copy_part_from_other_model(other_model,
+                                            part,
+                                            realization = realization,
+                                            consolidate = consolidate,
+                                            self_h5_file_name = self_h5_file_name,
+                                            h5_uuid = self_h5_uuid,
+                                            other_h5_file_name = other_h5_file_name)
 
-      if consolidate and self.consolidation is not None:
-         self.consolidation.check_map_integrity()
+        if consolidate and self.consolidation is not None:
+            self.consolidation.check_map_integrity()
 
-   def iter_objs(self, cls):
-      """Iterate over all available objects of given resqpy class within the model
+    def iter_objs(self, cls):
+        """Iterate over all available objects of given resqpy class within the model
 
       Note:
 
@@ -3281,96 +3292,96 @@ class Model():
       :meta common:
       """
 
-      uuids = self.uuids(obj_type = cls.resqml_type)
-      for uuid in uuids:
-         yield cls(self, uuid = uuid)
+        uuids = self.uuids(obj_type = cls.resqml_type)
+        for uuid in uuids:
+            yield cls(self, uuid = uuid)
 
-   def iter_grid_connection_sets(self):
-      """Yields grid connection set objects, one for each gcs in this model."""
+    def iter_grid_connection_sets(self):
+        """Yields grid connection set objects, one for each gcs in this model."""
 
-      gcs_uuids = self.uuids(obj_type = 'GridConnectionSetRepresentation')
-      for gcs_uuid in gcs_uuids:
-         yield rqf.GridConnectionSet(self, uuid = gcs_uuid)
+        gcs_uuids = self.uuids(obj_type = 'GridConnectionSetRepresentation')
+        for gcs_uuid in gcs_uuids:
+            yield rqf.GridConnectionSet(self, uuid = gcs_uuid)
 
-   def iter_wellbore_interpretations(self):
-      """ Iterable of all WellboreInterpretations associated with the model
+    def iter_wellbore_interpretations(self):
+        """ Iterable of all WellboreInterpretations associated with the model
 
       Yields:
          wellbore: instance of :class:`resqpy.organize.WellboreInterpretation`
 
       :meta common:
       """
-      import resqpy.organize  # Imported here for speed, module is not always needed
+        import resqpy.organize  # Imported here for speed, module is not always needed
 
-      uuids = self.uuids(obj_type = 'WellboreInterpretation')
-      if uuids:
-         for uuid in uuids:
-            yield resqpy.organize.WellboreInterpretation(self, uuid = uuid)
+        uuids = self.uuids(obj_type = 'WellboreInterpretation')
+        if uuids:
+            for uuid in uuids:
+                yield resqpy.organize.WellboreInterpretation(self, uuid = uuid)
 
-   def iter_trajectories(self):
-      """ Iterable of all trajectories associated with the model
+    def iter_trajectories(self):
+        """ Iterable of all trajectories associated with the model
 
       Yields:
          trajectory: instance of :class:`resqpy.well.Trajectory`
 
       :meta common:
       """
-      import resqpy.well  # Imported here for speed, module is not always needed
+        import resqpy.well  # Imported here for speed, module is not always needed
 
-      uuids = self.uuids(obj_type = "WellboreTrajectoryRepresentation")
-      for uuid in uuids:
-         yield resqpy.well.Trajectory(self, uuid = uuid)
+        uuids = self.uuids(obj_type = "WellboreTrajectoryRepresentation")
+        for uuid in uuids:
+            yield resqpy.well.Trajectory(self, uuid = uuid)
 
-   def iter_md_datums(self):
-      """ Iterable of all MdDatum objects associated with the model
+    def iter_md_datums(self):
+        """ Iterable of all MdDatum objects associated with the model
 
       Yields:
          md_datum: instance of :class:`resqpy.well.MdDatum`
 
       :meta common:
       """
-      import resqpy.well  # Imported here to avoid circular imports
+        import resqpy.well  # Imported here to avoid circular imports
 
-      uuids = self.uuids(obj_type = 'MdDatum')
-      if uuids:
-         for uuid in uuids:
-            datum = resqpy.well.MdDatum(self, uuid = uuid)
-            yield datum
+        uuids = self.uuids(obj_type = 'MdDatum')
+        if uuids:
+            for uuid in uuids:
+                datum = resqpy.well.MdDatum(self, uuid = uuid)
+                yield datum
 
-   def iter_crs(self):
-      """Iterable of all CRS objects associated with the model
+    def iter_crs(self):
+        """Iterable of all CRS objects associated with the model
       
       Yields:
          crs: instance of :class:`resqpy.crs.CRS`
 
       :meta common:
       """
-      import resqpy.crs  # Imported here for speed, module is not always needed
+        import resqpy.crs  # Imported here for speed, module is not always needed
 
-      uuids = self.uuids(obj_type = 'LocalDepth3dCrs') + self.uuids(obj_type = 'LocalTime3dCrs')
-      if uuids:
-         for uuid in uuids:
-            yield resqpy.crs.Crs(self, uuid = uuid)
+        uuids = self.uuids(obj_type = 'LocalDepth3dCrs') + self.uuids(obj_type = 'LocalTime3dCrs')
+        if uuids:
+            for uuid in uuids:
+                yield resqpy.crs.Crs(self, uuid = uuid)
 
-   def sort_parts_list_by_timestamp(self, parts_list):
-      """Returns a copy of the parts list sorted by citation block creation date, with the newest first."""
+    def sort_parts_list_by_timestamp(self, parts_list):
+        """Returns a copy of the parts list sorted by citation block creation date, with the newest first."""
 
-      if parts_list is None:
-         return None
-      if len(parts_list) == 0:
-         return []
-      sort_list = []
-      for index, part in enumerate(parts_list):
-         timestamp = rqet.find_nested_tags_text(self.root_for_part(part), ['Citation', 'Creation'])
-         sort_list.append((timestamp, index))
-      sort_list.sort()
-      results = []
-      for timestamp, index in reversed(sort_list):
-         results.append(parts_list[index])
-      return results
+        if parts_list is None:
+            return None
+        if len(parts_list) == 0:
+            return []
+        sort_list = []
+        for index, part in enumerate(parts_list):
+            timestamp = rqet.find_nested_tags_text(self.root_for_part(part), ['Citation', 'Creation'])
+            sort_list.append((timestamp, index))
+        sort_list.sort()
+        results = []
+        for timestamp, index in reversed(sort_list):
+            results.append(parts_list[index])
+        return results
 
-   def as_graph(self, uuids_subset = None):
-      """Return representation of model as nodes and edges, suitable for plotting in a graph
+    def as_graph(self, uuids_subset = None):
+        """Return representation of model as nodes and edges, suitable for plotting in a graph
 
       Note:
          The graph can be most readily visualised with other packages such as
@@ -3412,43 +3423,43 @@ class Model():
 
       :meta common:
       """
-      nodes = {}
-      edges = set()
+        nodes = {}
+        edges = set()
 
-      if uuids_subset is None:
-         uuids_subset = self.uuids()
+        if uuids_subset is None:
+            uuids_subset = self.uuids()
 
-      uuids_subset = set(map(str, uuids_subset))
+        uuids_subset = set(map(str, uuids_subset))
 
-      for uuid in uuids_subset:
-         part = self.part_for_uuid(uuid)
-         nodes[uuid] = dict(
-            resqml_type = self.type_of_part(part, strip_obj = True),
-            title = self.citation_title_for_part(part),
-         )
-         for rel in map(str, self.uuids(related_uuid = uuid)):
-            if rel in uuids_subset:
-               edges.add(frozenset([uuid, rel]))
+        for uuid in uuids_subset:
+            part = self.part_for_uuid(uuid)
+            nodes[uuid] = dict(
+                resqml_type = self.type_of_part(part, strip_obj = True),
+                title = self.citation_title_for_part(part),
+            )
+            for rel in map(str, self.uuids(related_uuid = uuid)):
+                if rel in uuids_subset:
+                    edges.add(frozenset([uuid, rel]))
 
-      return nodes, edges
+        return nodes, edges
 
-   def _set_uuid_to_part(self, part_name):
-      """Adds an entry to the dictionary mapping from uuid to part name."""
+    def _set_uuid_to_part(self, part_name):
+        """Adds an entry to the dictionary mapping from uuid to part name."""
 
-      uuid = rqet.uuid_in_part_name(part_name)
-      self.uuid_part_dict[bu.uuid_as_int(uuid)] = part_name
+        uuid = rqet.uuid_in_part_name(part_name)
+        self.uuid_part_dict[bu.uuid_as_int(uuid)] = part_name
 
-   def _del_uuid_to_part(self, part_name):
-      """Deletes an entry from the dictionary mapping from uuid to part name."""
+    def _del_uuid_to_part(self, part_name):
+        """Deletes an entry from the dictionary mapping from uuid to part name."""
 
-      uuid = rqet.uuid_in_part_name(part_name)
-      try:
-         del self.uuid_part_dict[bu.uuid_as_int(uuid)]
-      except Exception:
-         pass
+        uuid = rqet.uuid_in_part_name(part_name)
+        try:
+            del self.uuid_part_dict[bu.uuid_as_int(uuid)]
+        except Exception:
+            pass
 
 
 def new_model(epc_file):
-   """Returns a new, empty Model object with basics and hdf5 ext part set up."""
+    """Returns a new, empty Model object with basics and hdf5 ext part set up."""
 
-   return Model(epc_file = epc_file, new_epc = True, create_basics = True, create_hdf5_ext = True)
+    return Model(epc_file = epc_file, new_epc = True, create_basics = True, create_hdf5_ext = True)

--- a/resqpy/olio/ab_toolbox.py
+++ b/resqpy/olio/ab_toolbox.py
@@ -16,51 +16,51 @@ ab_dtype_dict = {'.db': np.float64, '.fb': np.float32, '.lb': np.int64, '.ib': n
 
 
 def load_array_from_ab_file(file_name, shape, return_64_bit = False):
-   """Loads a pure binary file into a numpy array, optionally converting to 64 bit."""
+    """Loads a pure binary file into a numpy array, optionally converting to 64 bit."""
 
-   count = 1
-   for axis in range(len(shape)):
-      count *= shape[axis]
-   dtype = ab_dtype_dict[file_name[-3:]]
-   with open(file_name, 'rb') as fp:
-      a = np.fromfile(fp, dtype = dtype, count = count).reshape(tuple(shape))
-   try:  # expected to return null
-      c = fp.read(1)
-      if len(c):
-         log.warning('binary file contains more data than expected: ' + file_name)
-   except Exception:
-      pass
-   return a
+    count = 1
+    for axis in range(len(shape)):
+        count *= shape[axis]
+    dtype = ab_dtype_dict[file_name[-3:]]
+    with open(file_name, 'rb') as fp:
+        a = np.fromfile(fp, dtype = dtype, count = count).reshape(tuple(shape))
+    try:  # expected to return null
+        c = fp.read(1)
+        if len(c):
+            log.warning('binary file contains more data than expected: ' + file_name)
+    except Exception:
+        pass
+    return a
 
 
 def cp_binary_filename(file_name, nexus_ordering = True):
-   """Returns a version of the file name with extension adjusted to indicate reseq order and pure binary."""
+    """Returns a version of the file name with extension adjusted to indicate reseq order and pure binary."""
 
-   if file_name[-9:] == '.reseq.db':
-      root_name = file_name[:-9]
-   elif file_name[-3:] == '.db':
-      root_name = file_name[:-3]
-   else:
-      root_name = file_name
-   if nexus_ordering:
-      return root_name + '.db'
-   else:
-      return root_name + '.reseq.db'
+    if file_name[-9:] == '.reseq.db':
+        root_name = file_name[:-9]
+    elif file_name[-3:] == '.db':
+        root_name = file_name[:-3]
+    else:
+        root_name = file_name
+    if nexus_ordering:
+        return root_name + '.db'
+    else:
+        return root_name + '.reseq.db'
 
 
 def binary_file_extension_and_np_type_for_data_type(data_type):
-   """Returns a file extension suitable for a pure binary array (ab) file of given data type."""
+    """Returns a file extension suitable for a pure binary array (ab) file of given data type."""
 
-   if data_type in ['real', 'float']:
-      ab_type = np.dtype('f8')  # 8 byte floating point (-double in ab_* suite)
-      extension = '.db'
-   elif data_type in ['int', 'integer']:
-      ab_type = np.dtype('i8')  # NB: 8 byte integers not currently supported by ab_* suite
-      extension = '.lb'
-   elif data_type in ['bool', 'boolean']:
-      ab_type = np.dtype('?')  # single byte boolean (-byte in ab_* suite)
-      extension = '.bb'
-   else:
-      log.error('Unknown data_type [%s] passed to load_array_from_file()', data_type)
-      assert (False)
-   return (extension, ab_type)
+    if data_type in ['real', 'float']:
+        ab_type = np.dtype('f8')  # 8 byte floating point (-double in ab_* suite)
+        extension = '.db'
+    elif data_type in ['int', 'integer']:
+        ab_type = np.dtype('i8')  # NB: 8 byte integers not currently supported by ab_* suite
+        extension = '.lb'
+    elif data_type in ['bool', 'boolean']:
+        ab_type = np.dtype('?')  # single byte boolean (-byte in ab_* suite)
+        extension = '.bb'
+    else:
+        log.error('Unknown data_type [%s] passed to load_array_from_file()', data_type)
+        assert (False)
+    return (extension, ab_type)

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseResqpy(metaclass = ABCMeta):
-   """Base class for generic resqpy classes
+    """Base class for generic resqpy classes
     
     Implements generic attributes such as uuid, root, part, title, originator.
 
@@ -26,17 +26,17 @@ class BaseResqpy(metaclass = ABCMeta):
 
     """
 
-   @property
-   @abstractmethod
-   def resqml_type(self):
-      """Definition of which RESQML object the class represents.
+    @property
+    @abstractmethod
+    def resqml_type(self):
+        """Definition of which RESQML object the class represents.
         
         Subclasses must overwrite this abstract attribute.
         """
-      raise NotImplementedError
+        raise NotImplementedError
 
-   def __init__(self, model, uuid = None, title = None, originator = None, root_node = None, extra_metadata = None):
-      """Load an existing resqml object, or create new.
+    def __init__(self, model, uuid = None, title = None, originator = None, root_node = None, extra_metadata = None):
+        """Load an existing resqml object, or create new.
 
         Args:
             model (resqpy.model.Model): Parent model
@@ -44,61 +44,61 @@ class BaseResqpy(metaclass = ABCMeta):
             title (str, optional): Citation title
             originator (str, optional): Creator of object. By default, uses user id.
         """
-      self.model = model
-      self.title = title  #: Citation title
-      self.originator = originator  #: Creator of object. By default, user id.
-      self.extra_metadata = {}
-      if extra_metadata:
-         self.extra_metadata = extra_metadata
-         self._standardise_extra_metadata()  # has side effect of making a copy
+        self.model = model
+        self.title = title  #: Citation title
+        self.originator = originator  #: Creator of object. By default, user id.
+        self.extra_metadata = {}
+        if extra_metadata:
+            self.extra_metadata = extra_metadata
+            self._standardise_extra_metadata()  # has side effect of making a copy
 
-      if root_node is not None:
-         warnings.warn("root_node parameter is deprecated, use uuid instead", DeprecationWarning)
-         uuid = rqet.uuid_for_part_root(root_node)
+        if root_node is not None:
+            warnings.warn("root_node parameter is deprecated, use uuid instead", DeprecationWarning)
+            uuid = rqet.uuid_for_part_root(root_node)
 
-      if uuid is None:
-         self.uuid = bu.new_uuid()  #: Unique identifier
+        if uuid is None:
+            self.uuid = bu.new_uuid()  #: Unique identifier
 
 
 #            logger.debug(f"created new uuid for object {self}")
-      else:
-         self.uuid = uuid
-         #            logger.debug(f"loading existing object {self}")
-         citation_node = rqet.find_tag(self.root, 'Citation')
-         if citation_node is not None:
-            self.title = rqet.find_tag_text(citation_node, 'Title')
-            self.originator = rqet.find_tag_text(citation_node, 'Originator')
-         self.extra_metadata = rqet.load_metadata_from_xml(self.root)
-         self._load_from_xml()
+        else:
+            self.uuid = uuid
+            #            logger.debug(f"loading existing object {self}")
+            citation_node = rqet.find_tag(self.root, 'Citation')
+            if citation_node is not None:
+                self.title = rqet.find_tag_text(citation_node, 'Title')
+                self.originator = rqet.find_tag_text(citation_node, 'Originator')
+            self.extra_metadata = rqet.load_metadata_from_xml(self.root)
+            self._load_from_xml()
 
-   # usually overridden by derived class, unless generic code above handles all attributes
-   def _load_from_xml(self):
-      pass
+    # usually overridden by derived class, unless generic code above handles all attributes
+    def _load_from_xml(self):
+        pass
 
-   # Define attributes self.part and self.root, using uuid as the primary key
+    # Define attributes self.part and self.root, using uuid as the primary key
 
-   @property
-   def part(self):
-      """Standard part name corresponding to self.uuid"""
+    @property
+    def part(self):
+        """Standard part name corresponding to self.uuid"""
 
-      # following caused trouble when resqml_type dynamically determined
-      #       return rqet.part_name_for_object(self.resqml_type, self.uuid)
-      return self.model.part_for_uuid(self.uuid)
+        # following caused trouble when resqml_type dynamically determined
+        #       return rqet.part_name_for_object(self.resqml_type, self.uuid)
+        return self.model.part_for_uuid(self.uuid)
 
-   @property
-   def root(self):
-      """XML node corresponding to self.uuid"""
+    @property
+    def root(self):
+        """XML node corresponding to self.uuid"""
 
-      return self.model.root_for_uuid(self.uuid)
+        return self.model.root_for_uuid(self.uuid)
 
-   @property
-   def citation_title(self):
-      """Citation block title equivalent to self.title"""
+    @property
+    def citation_title(self):
+        """Citation block title equivalent to self.title"""
 
-      return self.title
+        return self.title
 
-   def try_reuse(self):
-      """Look for an equivalent existing RESQML object and modify the uuid of this object if found.
+    def try_reuse(self):
+        """Look for an equivalent existing RESQML object and modify the uuid of this object if found.
 
         returns:
            boolean: True if an equivalent object was found, False if not
@@ -107,27 +107,27 @@ class BaseResqpy(metaclass = ABCMeta):
            by design this method may change this object's uuid as a side effect
         """
 
-      assert self.uuid is not None
-      if self.root is not None:
-         return True
-      uuid_list = self.model.uuids(obj_type = self.resqml_type)
-      for other_uuid in uuid_list:
-         if bu.matching_uuids(self.uuid, other_uuid):
-            logger.debug(f'reusing existing xml for uuid {other_uuid}')
+        assert self.uuid is not None
+        if self.root is not None:
             return True
-         try:
-            other = self.__class__(self.model, uuid = other_uuid)
-         except Exception:
-            return False
-         if self == other:
-            logger.debug(f'reusing equivalent resqml object with uuid {other_uuid}')
-            self.uuid = other_uuid  # NB: change of uuid for this object
-            assert self.root is not None
-            return True
-      return False
+        uuid_list = self.model.uuids(obj_type = self.resqml_type)
+        for other_uuid in uuid_list:
+            if bu.matching_uuids(self.uuid, other_uuid):
+                logger.debug(f'reusing existing xml for uuid {other_uuid}')
+                return True
+            try:
+                other = self.__class__(self.model, uuid = other_uuid)
+            except Exception:
+                return False
+            if self == other:
+                logger.debug(f'reusing equivalent resqml object with uuid {other_uuid}')
+                self.uuid = other_uuid  # NB: change of uuid for this object
+                assert self.root is not None
+                return True
+        return False
 
-   def create_xml(self, title = None, originator = None, extra_metadata = None, add_as_part = False):
-      """Write citation block to XML
+    def create_xml(self, title = None, originator = None, extra_metadata = None, add_as_part = False):
+        """Write citation block to XML
         
         Note:
 
@@ -147,86 +147,86 @@ class BaseResqpy(metaclass = ABCMeta):
             node: the newly created root node
         """
 
-      assert self.uuid is not None
+        assert self.uuid is not None
 
-      # Create the root node
-      node = self.model.new_obj_node(self.resqml_type)
-      node.attrib['uuid'] = str(self.uuid)
+        # Create the root node
+        node = self.model.new_obj_node(self.resqml_type)
+        node.attrib['uuid'] = str(self.uuid)
 
-      # Citation block
-      if title:
-         self.title = title
-      if originator:
-         self.originator = originator
-      self.model.create_citation(root = node, title = self.title, originator = self.originator)
+        # Citation block
+        if title:
+            self.title = title
+        if originator:
+            self.originator = originator
+        self.model.create_citation(root = node, title = self.title, originator = self.originator)
 
-      # Extra metadata
-      if extra_metadata:
-         if not hasattr(self, 'extra_metadata'):
-            self.extra_metadata = {}
-         for key, value in extra_metadata.items():
-            self.extra_metadata[str(key)] = str(value)
-      if hasattr(self, 'extra_metadata') and self.extra_metadata:
-         rqet.create_metadata_xml(node = node, extra_metadata = self.extra_metadata)
+        # Extra metadata
+        if extra_metadata:
+            if not hasattr(self, 'extra_metadata'):
+                self.extra_metadata = {}
+            for key, value in extra_metadata.items():
+                self.extra_metadata[str(key)] = str(value)
+        if hasattr(self, 'extra_metadata') and self.extra_metadata:
+            rqet.create_metadata_xml(node = node, extra_metadata = self.extra_metadata)
 
-      if add_as_part:
-         self.model.add_part(self.resqml_type, self.uuid, node)
-         assert self.root is not None
+        if add_as_part:
+            self.model.add_part(self.resqml_type, self.uuid, node)
+            assert self.root is not None
 
-      return node
+        return node
 
-   def append_extra_metadata(self, meta_dict):
-      """Append a given dictionary of metadata to the existing metadata."""
-      for key in meta_dict:
-         self.extra_metadata[key] = meta_dict[key]
-      self._standardise_extra_metadata()
+    def append_extra_metadata(self, meta_dict):
+        """Append a given dictionary of metadata to the existing metadata."""
+        for key in meta_dict:
+            self.extra_metadata[key] = meta_dict[key]
+        self._standardise_extra_metadata()
 
-   def _standardise_extra_metadata(self):
-      if self.extra_metadata:
-         em = {}
-         for key, value in self.extra_metadata.items():
-            em[str(key)] = str(value)
-         self.extra_metadata = em
+    def _standardise_extra_metadata(self):
+        if self.extra_metadata:
+            em = {}
+            for key, value in self.extra_metadata.items():
+                em[str(key)] = str(value)
+            self.extra_metadata = em
 
-   # Generic magic methods
+    # Generic magic methods
 
-   def __eq__(self, other):
-      """Implements equals operator; uses is_equivalent() otherwise compares class type and uuid"""
-      if hasattr(self, 'is_equivalent'):
-         return self.is_equivalent(other)
-      if not isinstance(other, self.__class__):
-         return False
-      other_uuid = getattr(other, "uuid", None)
-      return bu.matching_uuids(self.uuid, other_uuid)
+    def __eq__(self, other):
+        """Implements equals operator; uses is_equivalent() otherwise compares class type and uuid"""
+        if hasattr(self, 'is_equivalent'):
+            return self.is_equivalent(other)
+        if not isinstance(other, self.__class__):
+            return False
+        other_uuid = getattr(other, "uuid", None)
+        return bu.matching_uuids(self.uuid, other_uuid)
 
-   def __ne__(self, other):
-      """Implements not equal operator"""
-      return not self.__eq__(other)
+    def __ne__(self, other):
+        """Implements not equal operator"""
+        return not self.__eq__(other)
 
-   def __repr__(self):
-      """String representation"""
-      return f"{self.__class__.__name__}(uuid={self.uuid}, title={self.title})"
+    def __repr__(self):
+        """String representation"""
+        return f"{self.__class__.__name__}(uuid={self.uuid}, title={self.title})"
 
-   def _repr_html_(self):
-      """IPython / Jupyter representation"""
+    def _repr_html_(self):
+        """IPython / Jupyter representation"""
 
-      keys_to_display = ('uuid', 'title', 'originator')
-      html = f"<h3>{self.__class__.__name__}</h3>\n"
-      for key in keys_to_display:
-         html += f"<strong>{key}</strong>: {getattr(self, key)}<br>\n"
-      return html
+        keys_to_display = ('uuid', 'title', 'originator')
+        html = f"<h3>{self.__class__.__name__}</h3>\n"
+        for key in keys_to_display:
+            html += f"<strong>{key}</strong>: {getattr(self, key)}<br>\n"
+        return html
 
-   # Include some aliases for root, but raise warnings if they are used
-   # TODO: remove these aliases for self.root
+    # Include some aliases for root, but raise warnings if they are used
+    # TODO: remove these aliases for self.root
 
-   @property
-   def root_node(self):
-      """DEPRECATED. Alias for root"""
-      warnings.warn("Attribute 'root_node' is deprecated. Use 'root'", DeprecationWarning)
-      return self.root
+    @property
+    def root_node(self):
+        """DEPRECATED. Alias for root"""
+        warnings.warn("Attribute 'root_node' is deprecated. Use 'root'", DeprecationWarning)
+        return self.root
 
-   @property
-   def node(self):
-      """DEPRECATED. Alias for root"""
-      warnings.warn("Attribute 'node' is deprecated. Use 'root'", DeprecationWarning)
-      return self.root
+    @property
+    def node(self):
+        """DEPRECATED. Alias for root"""
+        warnings.warn("Attribute 'node' is deprecated. Use 'root'", DeprecationWarning)
+        return self.root

--- a/resqpy/olio/box_utilities.py
+++ b/resqpy/olio/box_utilities.py
@@ -37,7 +37,7 @@ import numpy as np
 
 
 def extent_of_box(box):  # returns 3 element extent of box (box can be kji or ijk, 0 or 1 based)
-   """Returns a 3 integer numpy array holding the size of the box, with the same ordering as the box.
+    """Returns a 3 integer numpy array holding the size of the box, with the same ordering as the box.
 
    input argument (unmodified):
       box: numpy int array of shape (2, 3)
@@ -47,12 +47,12 @@ def extent_of_box(box):  # returns 3 element extent of box (box can be kji or ij
          the extent (shape) of the cuboid defined by box
    """
 
-   assert box.ndim == 2 and box.shape == (2, 3)
-   return box[1] - box[0] + 1  # numpy array operation
+    assert box.ndim == 2 and box.shape == (2, 3)
+    return box[1] - box[0] + 1  # numpy array operation
 
 
 def volume_of_box(box):
-   """Returns the number of cells in the logical 3D cell space defined by box.
+    """Returns the number of cells in the logical 3D cell space defined by box.
 
    input argument (unmodified):
       box: numpy int array of shape (2, 3)
@@ -62,15 +62,15 @@ def volume_of_box(box):
          the total number of cells in box
    """
 
-   return (box[1, 0] - box[0, 0] + 1) * (box[1, 1] - box[0, 1] + 1) * (box[1, 2] - box[0, 2] + 1)
+    return (box[1, 0] - box[0, 0] + 1) * (box[1, 1] - box[0, 1] + 1) * (box[1, 2] - box[0, 2] + 1)
 
 
 def central_cell(box):
-   return box[0] + ((box[1] - box[0]) // 2)
+    return box[0] + ((box[1] - box[0]) // 2)
 
 
 def string_iijjkk1_for_box_kji0(box_kji0):
-   """Returns a string representing the box space in simulator protocol, eg. '[1:5, 3:20, 100:103]'.
+    """Returns a string representing the box space in simulator protocol, eg. '[1:5, 3:20, 100:103]'.
 
    input argument (unmodified):
       box_kji0: numpy int array of shape (2, 3)
@@ -81,13 +81,13 @@ def string_iijjkk1_for_box_kji0(box_kji0):
       human readable representation of box in Fortran/simulator ijk protocol starting 1
    """
 
-   return '[' + str(box_kji0[0, 2] + 1) + ':' + str(box_kji0[1, 2] + 1) + ', ' +  \
-                str(box_kji0[0, 1] + 1) + ':' + str(box_kji0[1, 1] + 1) + ', ' +  \
-                str(box_kji0[0, 0] + 1) + ':' + str(box_kji0[1, 0] + 1) + ']'
+    return '[' + str(box_kji0[0, 2] + 1) + ':' + str(box_kji0[1, 2] + 1) + ', ' +  \
+                 str(box_kji0[0, 1] + 1) + ':' + str(box_kji0[1, 1] + 1) + ', ' +  \
+                 str(box_kji0[0, 0] + 1) + ':' + str(box_kji0[1, 0] + 1) + ']'
 
 
 def spaced_string_iijjkk1_for_box_kji0(box_kji0, colon_separator = ' '):
-   """Returns a string representing the box space in simulator input format, eg. '1 5  3 20  100 103'.
+    """Returns a string representing the box space in simulator input format, eg. '1 5  3 20  100 103'.
 
    input arguments (unmodified):
       box_kji0: numpy int array of shape (2, 3)
@@ -100,13 +100,13 @@ def spaced_string_iijjkk1_for_box_kji0(box_kji0, colon_separator = ' '):
       ascii representation of box in Fortran/simulator ijk protocol starting 1, suitable for use in include files
    """
 
-   return str(box_kji0[0, 2] + 1) + colon_separator + str(box_kji0[1, 2] + 1) + '  ' +  \
-          str(box_kji0[0, 1] + 1) + colon_separator + str(box_kji0[1, 1] + 1) + '  ' +  \
-          str(box_kji0[0, 0] + 1) + colon_separator + str(box_kji0[1, 0] + 1)
+    return str(box_kji0[0, 2] + 1) + colon_separator + str(box_kji0[1, 2] + 1) + '  ' +  \
+           str(box_kji0[0, 1] + 1) + colon_separator + str(box_kji0[1, 1] + 1) + '  ' +  \
+           str(box_kji0[0, 0] + 1) + colon_separator + str(box_kji0[1, 0] + 1)
 
 
 def box_kji0_from_words_iijjkk1(words):
-   """Returns an integer array of extent [2, 3] converted from a list of words representing logical box
+    """Returns an integer array of extent [2, 3] converted from a list of words representing logical box
 
    input argument (unmodified):
       words: a list of strings with at least 6 elements castable to int
@@ -121,21 +121,21 @@ def box_kji0_from_words_iijjkk1(words):
       NB: output indices have been decremented by 1 (for python indexing starting at zero)
    """
 
-   assert len(words) >= 6  # expecting minI maxI minJ maxJ minK maxK value
-   box = np.zeros([2, 3], dtype = 'int')
-   box[0, 0] = int(words[4]) - 1  # k min
-   box[1, 0] = int(words[5]) - 1  # k max
-   box[0, 1] = int(words[2]) - 1  # j min
-   box[1, 1] = int(words[3]) - 1  # j max
-   box[0, 2] = int(words[0]) - 1  # i min
-   box[1, 2] = int(words[1]) - 1  # i max
-   assert box[0, 0] <= box[1, 0] and box[0, 1] <= box[1, 1] and box[0, 2] <= box[1, 2]
+    assert len(words) >= 6  # expecting minI maxI minJ maxJ minK maxK value
+    box = np.zeros([2, 3], dtype = 'int')
+    box[0, 0] = int(words[4]) - 1  # k min
+    box[1, 0] = int(words[5]) - 1  # k max
+    box[0, 1] = int(words[2]) - 1  # j min
+    box[1, 1] = int(words[3]) - 1  # j max
+    box[0, 2] = int(words[0]) - 1  # i min
+    box[1, 2] = int(words[1]) - 1  # i max
+    assert box[0, 0] <= box[1, 0] and box[0, 1] <= box[1, 1] and box[0, 2] <= box[1, 2]
 
-   return box
+    return box
 
 
 def cell_in_box(cell, box):
-   """Returns True if cell is within box, otherwise False.
+    """Returns True if cell is within box, otherwise False.
 
    input arguments (unmodified):
       cell: numpy int array of shape (3)
@@ -148,12 +148,12 @@ def cell_in_box(cell, box):
       True if cell is within box, False otherwise
    """
 
-   return (box[0, 0] <= cell[0] <= box[1, 0]) and (box[0, 1] <= cell[1] <= box[1, 1]) and (box[0, 2] <= cell[2] <=
-                                                                                           box[1, 2])
+    return (box[0, 0] <= cell[0] <= box[1, 0]) and (box[0, 1] <= cell[1] <= box[1, 1]) and (box[0, 2] <= cell[2] <=
+                                                                                            box[1, 2])
 
 
 def valid_box(box, host_extent):
-   """Returns True if the entire box is within a grid of size host_extent.
+    """Returns True if the entire box is within a grid of size host_extent.
 
    input arguments (unmodified):
       box: numpy int array of shape (2, 3)
@@ -166,18 +166,18 @@ def valid_box(box, host_extent):
       True if box is a valid box within a grid of shape host_extent, False otherwise
    """
 
-   if box.ndim != 2 or box.shape != (2, 3) or box.dtype != 'int':
-      return False
-   if len(host_extent) != 3:
-      return False
-   for d in range(3):
-      if box[0, d] < 0 or box[0, d] > box[1, d] or box[1, d] >= host_extent[d]:
-         return False
-   return True
+    if box.ndim != 2 or box.shape != (2, 3) or box.dtype != 'int':
+        return False
+    if len(host_extent) != 3:
+        return False
+    for d in range(3):
+        if box[0, d] < 0 or box[0, d] > box[1, d] or box[1, d] >= host_extent[d]:
+            return False
+    return True
 
 
 def single_cell_box(cell):
-   """Returns a box containing the single given cell; protocol for box matches that of cell.
+    """Returns a box containing the single given cell; protocol for box matches that of cell.
 
    input argument (unmodified):
       cell: numpy int array of shape (3)
@@ -187,15 +187,15 @@ def single_cell_box(cell):
       indices defining a minimal box containing a single cell; protocol is same as that of cell
    """
 
-   assert cell.ndim == 1 and cell.size == 3
-   box = np.zeros((2, 3), dtype = 'int')
-   box[0] = cell  # numpy 1D array op
-   box[1] = cell  # numpy 1D array op
-   return box
+    assert cell.ndim == 1 and cell.size == 3
+    box = np.zeros((2, 3), dtype = 'int')
+    box[0] = cell  # numpy 1D array op
+    box[1] = cell  # numpy 1D array op
+    return box
 
 
 def full_extent_box0(extent):
-   """Returns a box containing all the cells in a grid of the given extent.
+    """Returns a box containing all the cells in a grid of the given extent.
 
    input argument (unmodified):
       extent: numpy int array of shape (3)
@@ -205,30 +205,30 @@ def full_extent_box0(extent):
       indices defining a maximal box containing the entire grid; kji ordering is same as that of extent; zero base
    """
 
-   assert extent.ndim == 1 and extent.size == 3
-   box = np.zeros((2, 3), dtype = 'int')
-   box[1, :] = extent - 1  # numpy 1D array op
-   return box
+    assert extent.ndim == 1 and extent.size == 3
+    box = np.zeros((2, 3), dtype = 'int')
+    box[1, :] = extent - 1  # numpy 1D array op
+    return box
 
 
 def union(box_1, box_2):
-   """Returns the box which contains both box_1 and box_2."""
+    """Returns the box which contains both box_1 and box_2."""
 
-   if box_1 is None and box_2 is None:
-      return None
-   if box_1 is None:
-      return box_2.copy()
-   if box_2 is None:
-      return box_1.copy()
-   result = np.zeros((2, 3), dtype = 'int')
-   for dir in range(3):
-      result[0][dir] = min(box_1[0][dir], box_2[0][dir])
-      result[1][dir] = max(box_1[1][dir], box_2[1][dir])
-   return result
+    if box_1 is None and box_2 is None:
+        return None
+    if box_1 is None:
+        return box_2.copy()
+    if box_2 is None:
+        return box_1.copy()
+    result = np.zeros((2, 3), dtype = 'int')
+    for dir in range(3):
+        result[0][dir] = min(box_1[0][dir], box_2[0][dir])
+        result[1][dir] = max(box_1[1][dir], box_2[1][dir])
+    return result
 
 
 def parent_cell_from_local_box_cell(box, box_cell, based_0_or_1 = 0):
-   """Given a box and a local cell index triplet, converts to the equivalent cell index triplet in the host grid.
+    """Given a box and a local cell index triplet, converts to the equivalent cell index triplet in the host grid.
 
    input arguments (unmodified):
       box: numpy int array of shape (2, 3)
@@ -245,13 +245,13 @@ def parent_cell_from_local_box_cell(box, box_cell, based_0_or_1 = 0):
       ordering of indices is same as that of box and box_cell; base is given by based_0_or_1 argument
    """
 
-   assert box.ndim == 2 and box.shape == (2, 3)
-   assert box_cell.ndim == 1 and box_cell.size == 3
-   return box[0] + box_cell - based_0_or_1  # numpy 1D array op
+    assert box.ndim == 2 and box.shape == (2, 3)
+    assert box_cell.ndim == 1 and box_cell.size == 3
+    return box[0] + box_cell - based_0_or_1  # numpy 1D array op
 
 
 def local_box_cell_from_parent_cell(box, parent_cell, based_0_or_1 = 0):
-   """Given a cell index triplet in the host grid, and a box, returns the equivalent local cell index triplet.
+    """Given a cell index triplet in the host grid, and a box, returns the equivalent local cell index triplet.
 
    input arguments (unmodified):
       box: numpy int array of shape (2, 3)
@@ -268,16 +268,16 @@ def local_box_cell_from_parent_cell(box, parent_cell, based_0_or_1 = 0):
       if parent_cell is not within box, None is returned
    """
 
-   assert box.ndim == 2 and box.shape == (2, 3)
-   assert parent_cell.ndim == 1 and parent_cell.size == 3
-   if np.all(box[0] <= parent_cell) and np.all(parent_cell <= box[1]):  # numpy 1D array ops
-      return parent_cell - box[0] + based_0_or_1  # numpy 1D array op
-   else:
-      return None
+    assert box.ndim == 2 and box.shape == (2, 3)
+    assert parent_cell.ndim == 1 and parent_cell.size == 3
+    if np.all(box[0] <= parent_cell) and np.all(parent_cell <= box[1]):  # numpy 1D array ops
+        return parent_cell - box[0] + based_0_or_1  # numpy 1D array op
+    else:
+        return None
 
 
 def boxes_overlap(box_a, box_b):
-   """Returns True if the two boxes have any overlap in 3D, otherwise False.
+    """Returns True if the two boxes have any overlap in 3D, otherwise False.
 
    Arguments:
       box_a: numpy int or float array of shape (2, 3)
@@ -291,12 +291,12 @@ def boxes_overlap(box_a, box_b):
       True if box_a and box_b overlap, False otherwise
    """
 
-   return not ((box_a[1, 0] < box_b[0, 0]) or (box_a[0, 0] > box_b[1, 0]) or (box_a[1, 1] < box_b[0, 1]) or
-               (box_a[0, 1] > box_b[1, 1]) or (box_a[1, 2] < box_b[0, 2]) or (box_a[0, 2] > box_b[1, 2]))
+    return not ((box_a[1, 0] < box_b[0, 0]) or (box_a[0, 0] > box_b[1, 0]) or (box_a[1, 1] < box_b[0, 1]) or
+                (box_a[0, 1] > box_b[1, 1]) or (box_a[1, 2] < box_b[0, 2]) or (box_a[0, 2] > box_b[1, 2]))
 
 
 def overlapping_boxes(established_box, new_box, trim_box):
-   """Checks for 3D overlap of two boxes; returns True and sets trim_box if there is overlap, otherwise False.
+    """Checks for 3D overlap of two boxes; returns True and sets trim_box if there is overlap, otherwise False.
 
    Arguments:
       established_box: numpy int array of shape (2, 3)
@@ -322,46 +322,46 @@ def overlapping_boxes(established_box, new_box, trim_box):
       True if established_box and new_box overlap (implies trim_box valid), False otherwise (trim_box elements all 0)
    """
 
-   assert established_box.ndim == 2 and established_box.shape == (2, 3) and established_box.dtype == 'int'
-   assert new_box.ndim == 2 and new_box.shape == (2, 3) and new_box.dtype == 'int'
-   assert trim_box.ndim == 2 and trim_box.shape == (2, 3) and trim_box.dtype == 'int'
-   trim_box[:, :] = 0
-   if not boxes_overlap(established_box, new_box):
-      return False
-   # determine trim direction based on minimizing number of cells to be trimmed
-   new_box_area = np.zeros(
-      3, dtype = 'int')  # compute number of cells in a 2D slice of new_box, taken in k, j or i directions
-   # note: '_area' is a cell count, not an area in xyz space
-   new_box_area[0] = (new_box[1, 1] - new_box[0, 1] + 1) * (new_box[1, 2] - new_box[0, 2] + 1)  # k slice
-   new_box_area[1] = (new_box[1, 0] - new_box[0, 0] + 1) * (new_box[1, 2] - new_box[0, 2] + 1)  # j slice
-   new_box_area[2] = (new_box[1, 0] - new_box[0, 0] + 1) * (new_box[1, 1] - new_box[0, 1] + 1)  # i slice
-   # find the actual box of overlap and 'cost' of trimming in each dimension and minimize over k,j,i
-   trim_cost = np.zeros(3, dtype = 'int')
-   trim_direction = -1
-   min_trim_cost = volume_of_box(new_box) + 1  # anything will be better than this
-   overlap_box = np.zeros((2, 3), dtype = 'int')
-   for dir in range(3):
-      overlap_box[0, dir] = max(established_box[0, dir], new_box[0, dir])
-      overlap_box[1, dir] = min(established_box[1, dir], new_box[1, dir])
-      trim_cost[dir] = (overlap_box[1, dir] - overlap_box[0, dir] + 1) * new_box_area[dir]
-      if trim_cost[dir] < min_trim_cost:
-         min_trim_cost = trim_cost[dir]
-         trim_direction = dir
-   # set trim_box for chosen direction
-   assert 0 <= trim_direction <= 2
-   other_dir_a = (trim_direction + 1) % 3
-   other_dir_b = (trim_direction + 2) % 3
-   trim_box[0, trim_direction] = overlap_box[0, trim_direction]
-   trim_box[1, trim_direction] = overlap_box[1, trim_direction]
-   trim_box[0, other_dir_a] = new_box[0, other_dir_a]
-   trim_box[1, other_dir_a] = new_box[1, other_dir_a]
-   trim_box[0, other_dir_b] = new_box[0, other_dir_b]
-   trim_box[1, other_dir_b] = new_box[1, other_dir_b]
-   return True
+    assert established_box.ndim == 2 and established_box.shape == (2, 3) and established_box.dtype == 'int'
+    assert new_box.ndim == 2 and new_box.shape == (2, 3) and new_box.dtype == 'int'
+    assert trim_box.ndim == 2 and trim_box.shape == (2, 3) and trim_box.dtype == 'int'
+    trim_box[:, :] = 0
+    if not boxes_overlap(established_box, new_box):
+        return False
+    # determine trim direction based on minimizing number of cells to be trimmed
+    new_box_area = np.zeros(
+        3, dtype = 'int')  # compute number of cells in a 2D slice of new_box, taken in k, j or i directions
+    # note: '_area' is a cell count, not an area in xyz space
+    new_box_area[0] = (new_box[1, 1] - new_box[0, 1] + 1) * (new_box[1, 2] - new_box[0, 2] + 1)  # k slice
+    new_box_area[1] = (new_box[1, 0] - new_box[0, 0] + 1) * (new_box[1, 2] - new_box[0, 2] + 1)  # j slice
+    new_box_area[2] = (new_box[1, 0] - new_box[0, 0] + 1) * (new_box[1, 1] - new_box[0, 1] + 1)  # i slice
+    # find the actual box of overlap and 'cost' of trimming in each dimension and minimize over k,j,i
+    trim_cost = np.zeros(3, dtype = 'int')
+    trim_direction = -1
+    min_trim_cost = volume_of_box(new_box) + 1  # anything will be better than this
+    overlap_box = np.zeros((2, 3), dtype = 'int')
+    for dir in range(3):
+        overlap_box[0, dir] = max(established_box[0, dir], new_box[0, dir])
+        overlap_box[1, dir] = min(established_box[1, dir], new_box[1, dir])
+        trim_cost[dir] = (overlap_box[1, dir] - overlap_box[0, dir] + 1) * new_box_area[dir]
+        if trim_cost[dir] < min_trim_cost:
+            min_trim_cost = trim_cost[dir]
+            trim_direction = dir
+    # set trim_box for chosen direction
+    assert 0 <= trim_direction <= 2
+    other_dir_a = (trim_direction + 1) % 3
+    other_dir_b = (trim_direction + 2) % 3
+    trim_box[0, trim_direction] = overlap_box[0, trim_direction]
+    trim_box[1, trim_direction] = overlap_box[1, trim_direction]
+    trim_box[0, other_dir_a] = new_box[0, other_dir_a]
+    trim_box[1, other_dir_a] = new_box[1, other_dir_a]
+    trim_box[0, other_dir_b] = new_box[0, other_dir_b]
+    trim_box[1, other_dir_b] = new_box[1, other_dir_b]
+    return True
 
 
 def trim_box_by_box_returning_new_mask(box_to_be_trimmed, trim_box, mask_kji0):
-   """Reduces box_to_be_trimmed by trim_box; trim_box must be a neat subset box at one face of box_to_be_trimmed.
+    """Reduces box_to_be_trimmed by trim_box; trim_box must be a neat subset box at one face of box_to_be_trimmed.
 
    input/output argument (modified):
       box_to_be_trimmed: numpy int array of shape (2, 3)
@@ -383,80 +383,80 @@ def trim_box_by_box_returning_new_mask(box_to_be_trimmed, trim_box, mask_kji0):
       the return array is a version of mask_kji0 that has been trimmed in accordance with the box trimming
    """
 
-   local_box = np.zeros((2, 3), dtype = 'int')
-   local_box[1] = extent_of_box(box_to_be_trimmed) - 1
-   if np.all(trim_box[0] == box_to_be_trimmed[0]):  # shift box_to_be_trimmed [0] (minumum) up (in logical space)
-      if trim_box[1, 0] != box_to_be_trimmed[1, 0]:  # trim in k direction
-         assert (trim_box[1, 1] == box_to_be_trimmed[1, 1]) and (trim_box[1, 2] == box_to_be_trimmed[1, 2])
-         local_box[0, 0] = trim_box[1, 0] - box_to_be_trimmed[0, 0] + 1
-         box_to_be_trimmed[0, 0] = trim_box[1, 0] + 1
-      elif trim_box[1, 1] != box_to_be_trimmed[1, 1]:  # trim in j direction
-         assert (trim_box[1, 2] == box_to_be_trimmed[1, 2])
-         local_box[0, 1] = trim_box[1, 1] - box_to_be_trimmed[0, 1] + 1
-         box_to_be_trimmed[0, 1] = trim_box[1, 1] + 1
-      else:  # trim in i direction
-         assert trim_box[1, 2] != box_to_be_trimmed[1, 2]
-         local_box[0, 2] = trim_box[1, 2] - box_to_be_trimmed[0, 2] + 1
-         box_to_be_trimmed[0, 2] = trim_box[1, 2] + 1
-   elif np.all(trim_box[1] == box_to_be_trimmed[1]):  # shift box_to_be_trimmed [1] (maxumum) down (in logical space)
-      if trim_box[0, 0] != box_to_be_trimmed[0, 0]:  # trim in k direction
-         assert (trim_box[0, 1] == box_to_be_trimmed[0, 1]) and (trim_box[0, 2] == box_to_be_trimmed[0, 2])
-         local_box[1, 0] -= box_to_be_trimmed[1, 0] - trim_box[0, 0] + 1
-         box_to_be_trimmed[1, 0] = trim_box[0, 0] - 1
-      elif trim_box[0, 1] != box_to_be_trimmed[0, 1]:  # trim in j direction
-         assert (trim_box[0, 2] == box_to_be_trimmed[0, 2])
-         local_box[1, 1] -= box_to_be_trimmed[1, 1] - trim_box[0, 1] + 1
-         box_to_be_trimmed[1, 1] = trim_box[0, 1] - 1
-      else:  # trim in i direction
-         assert trim_box[0, 2] != box_to_be_trimmed[0, 2]
-         local_box[1, 2] -= box_to_be_trimmed[1, 2] - trim_box[0, 2] + 1
-         box_to_be_trimmed[1, 2] = trim_box[0, 2] - 1
-   else:  # shouldn't happen
-      log.critical('Trim box code failure: box to be trimmed is %s', string_iijjkk1_for_box_kji0(box_to_be_trimmed))
-      log.critical('Trim box code failure:          trim box is %s', string_iijjkk1_for_box_kji0(trim_box))
-      assert False
-   assert np.all(box_to_be_trimmed[0] <= box_to_be_trimmed[1])
-   return (mask_kji0[local_box[0, 0]:local_box[1, 0] + 1, local_box[0, 1]:local_box[1, 1] + 1,
-                     local_box[0, 2]:local_box[1, 2] + 1]).copy()
+    local_box = np.zeros((2, 3), dtype = 'int')
+    local_box[1] = extent_of_box(box_to_be_trimmed) - 1
+    if np.all(trim_box[0] == box_to_be_trimmed[0]):  # shift box_to_be_trimmed [0] (minumum) up (in logical space)
+        if trim_box[1, 0] != box_to_be_trimmed[1, 0]:  # trim in k direction
+            assert (trim_box[1, 1] == box_to_be_trimmed[1, 1]) and (trim_box[1, 2] == box_to_be_trimmed[1, 2])
+            local_box[0, 0] = trim_box[1, 0] - box_to_be_trimmed[0, 0] + 1
+            box_to_be_trimmed[0, 0] = trim_box[1, 0] + 1
+        elif trim_box[1, 1] != box_to_be_trimmed[1, 1]:  # trim in j direction
+            assert (trim_box[1, 2] == box_to_be_trimmed[1, 2])
+            local_box[0, 1] = trim_box[1, 1] - box_to_be_trimmed[0, 1] + 1
+            box_to_be_trimmed[0, 1] = trim_box[1, 1] + 1
+        else:  # trim in i direction
+            assert trim_box[1, 2] != box_to_be_trimmed[1, 2]
+            local_box[0, 2] = trim_box[1, 2] - box_to_be_trimmed[0, 2] + 1
+            box_to_be_trimmed[0, 2] = trim_box[1, 2] + 1
+    elif np.all(trim_box[1] == box_to_be_trimmed[1]):  # shift box_to_be_trimmed [1] (maxumum) down (in logical space)
+        if trim_box[0, 0] != box_to_be_trimmed[0, 0]:  # trim in k direction
+            assert (trim_box[0, 1] == box_to_be_trimmed[0, 1]) and (trim_box[0, 2] == box_to_be_trimmed[0, 2])
+            local_box[1, 0] -= box_to_be_trimmed[1, 0] - trim_box[0, 0] + 1
+            box_to_be_trimmed[1, 0] = trim_box[0, 0] - 1
+        elif trim_box[0, 1] != box_to_be_trimmed[0, 1]:  # trim in j direction
+            assert (trim_box[0, 2] == box_to_be_trimmed[0, 2])
+            local_box[1, 1] -= box_to_be_trimmed[1, 1] - trim_box[0, 1] + 1
+            box_to_be_trimmed[1, 1] = trim_box[0, 1] - 1
+        else:  # trim in i direction
+            assert trim_box[0, 2] != box_to_be_trimmed[0, 2]
+            local_box[1, 2] -= box_to_be_trimmed[1, 2] - trim_box[0, 2] + 1
+            box_to_be_trimmed[1, 2] = trim_box[0, 2] - 1
+    else:  # shouldn't happen
+        log.critical('Trim box code failure: box to be trimmed is %s', string_iijjkk1_for_box_kji0(box_to_be_trimmed))
+        log.critical('Trim box code failure:          trim box is %s', string_iijjkk1_for_box_kji0(trim_box))
+        assert False
+    assert np.all(box_to_be_trimmed[0] <= box_to_be_trimmed[1])
+    return (mask_kji0[local_box[0, 0]:local_box[1, 0] + 1, local_box[0, 1]:local_box[1, 1] + 1,
+                      local_box[0, 2]:local_box[1, 2] + 1]).copy()
 
 
 def trim_box_to_mask_returning_new_mask(bounding_box_kji0, mask_kji0):
-   """Reduces the coverage of bounding box to the minimum needed to contain True elements of mask; returns trimmed mask.
+    """Reduces the coverage of bounding box to the minimum needed to contain True elements of mask; returns trimmed mask.
    """
 
-   # NB: bounding box is modified by this function
-   assert bounding_box_kji0.ndim == 2 and bounding_box_kji0.shape == (2, 3) and bounding_box_kji0.dtype == 'int'
-   assert (mask_kji0.ndim == 3 and
-           np.all(np.array([mask_kji0.shape], dtype = 'int') == extent_of_box(bounding_box_kji0)) and
-           mask_kji0.dtype == 'bool')
-   assert np.any(mask_kji0)
-   box_extent = extent_of_box(bounding_box_kji0)
-   local_box = np.zeros((2, 3), dtype = 'int')
-   local_box[0] = box_extent.copy()
-   local_box[1] = -1
-   for k in range(box_extent[0]):
-      if np.any(mask_kji0[k, :, :]):
-         local_box[1, 0] = k
-         if local_box[0, 0] == box_extent[0]:
-            local_box[0, 0] = k
-   for j in range(box_extent[1]):
-      if np.any(mask_kji0[:, j, :]):
-         local_box[1, 1] = j
-         if local_box[0, 1] == box_extent[1]:
-            local_box[0, 1] = j
-   for i in range(box_extent[2]):
-      if np.any(mask_kji0[:, :, i]):
-         local_box[1, 2] = i
-         if local_box[0, 2] == box_extent[2]:
-            local_box[0, 2] = i
-   assert np.all(local_box >= 0)
-   assert np.all(local_box[1] >= local_box[0])
-   assert np.all(local_box[1] < box_extent)
-   bounding_box_kji0[0] += local_box[0]
-   bounding_box_kji0[1] -= (box_extent - local_box[1] - 1)
-   assert np.all(bounding_box_kji0[0] <= bounding_box_kji0[1])
-   return (mask_kji0[local_box[0, 0]:local_box[1, 0] + 1, local_box[0, 1]:local_box[1, 1] + 1,
-                     local_box[0, 2]:local_box[1, 2] + 1]).copy()
+    # NB: bounding box is modified by this function
+    assert bounding_box_kji0.ndim == 2 and bounding_box_kji0.shape == (2, 3) and bounding_box_kji0.dtype == 'int'
+    assert (mask_kji0.ndim == 3 and
+            np.all(np.array([mask_kji0.shape], dtype = 'int') == extent_of_box(bounding_box_kji0)) and
+            mask_kji0.dtype == 'bool')
+    assert np.any(mask_kji0)
+    box_extent = extent_of_box(bounding_box_kji0)
+    local_box = np.zeros((2, 3), dtype = 'int')
+    local_box[0] = box_extent.copy()
+    local_box[1] = -1
+    for k in range(box_extent[0]):
+        if np.any(mask_kji0[k, :, :]):
+            local_box[1, 0] = k
+            if local_box[0, 0] == box_extent[0]:
+                local_box[0, 0] = k
+    for j in range(box_extent[1]):
+        if np.any(mask_kji0[:, j, :]):
+            local_box[1, 1] = j
+            if local_box[0, 1] == box_extent[1]:
+                local_box[0, 1] = j
+    for i in range(box_extent[2]):
+        if np.any(mask_kji0[:, :, i]):
+            local_box[1, 2] = i
+            if local_box[0, 2] == box_extent[2]:
+                local_box[0, 2] = i
+    assert np.all(local_box >= 0)
+    assert np.all(local_box[1] >= local_box[0])
+    assert np.all(local_box[1] < box_extent)
+    bounding_box_kji0[0] += local_box[0]
+    bounding_box_kji0[1] -= (box_extent - local_box[1] - 1)
+    assert np.all(bounding_box_kji0[0] <= bounding_box_kji0[1])
+    return (mask_kji0[local_box[0, 0]:local_box[1, 0] + 1, local_box[0, 1]:local_box[1, 1] + 1,
+                      local_box[0, 2]:local_box[1, 2] + 1]).copy()
 
 
 # end of box_utilities module

--- a/resqpy/olio/class_dict.py
+++ b/resqpy/olio/class_dict.py
@@ -3,98 +3,98 @@
 version = '17th December 2020'
 
 class_dict = {
-   'obj_LocalDepth3dCrs': 'Coordinate Reference System (z is length)',
-   'obj_LocalTime3dCrs': 'Coordinate Reference System (z is time)',
-   'obj_IjkGridRepresentation': 'Grid (IJK)',
-   'obj_UnstructuredColumnLayerGridRepresentation': 'Grid (Column Layer)',
-   'obj_UnstructuredGridRepresentation': 'Grid (Unstructured)',
-   'obj_GridConnectionSetRepresentation': 'Grid Connection Set',
-   'obj_TruncatedIjkGridRepresentation': 'Grid (Truncated IJK)',
-   'obj_TruncatedUnstructuredColumnLayerGridRepresentation': 'Grid (Truncated Column Layer)',
-   'obj_GpGridRepresentation': 'Grid (General Purpose)',
-   'obj_LocalGridSet': 'Local Grid Set',
-   'obj_EpcExternalPartReference': 'HDF5 Reference',
-   'obj_PropertyKind': 'Kind of Property',
-   'obj_CategoricalProperty': 'Property (Categorical)',
-   'obj_DiscreteProperty': 'Property (Discrete)',
-   'obj_ContinuousProperty': 'Property (Continuous)',
-   'obj_CategoricalPropertySeries': 'Property Series (Categorical)',
-   'obj_DiscretePropertySeries': 'Property Series (Discrete)',
-   'obj_ContinuousPropertySeries': 'Property Series (Continuous)',
-   'obj_PropertySet': 'Property Set',
-   'obj_TimeSeries': 'Time Series',
-   'obj_WellboreTrajectoryRepresentation': 'Wellbore Trajectory',
-   'obj_BlockedWellboreRepresentation': 'Blocked Wellbore',
-   'obj_WellboreInterpretation': 'Wellbore Interpretation',
-   'obj_WellboreFeature': 'Wellbore Feature',
-   'obj_WellboreFrameRepresentation': 'Wellbore Frame',
-   'obj_WellboreMarkerFrameRepresentation': 'Wellbore Marker Frame',
-   'obj_DeviationSurveyRepresentation': 'Deviation Survey',
-   'obj_MdDatum': 'Measured Depth Datum',
-   # geo classes
-   'obj_TectonicBoundaryFeature': 'Tectonic Boundary Feature (fault or fracture)',
-   'obj_Grid2dRepresentation': 'Mesh (Grid 2D)',
-   'obj_Grid2dSetRepresentation': 'Mesh Set (Grid 2D set)',
-   'obj_SealedSurfaceFrameworkRepresentation': 'Sealed Surface Framework',
-   'obj_SealedVolumeFrameworkRepresentation': 'Sealed Volume Framework',
-   'obj_NonSealedSurfaceFrameworkRepresentation': 'Non-sealed Surface Framework',
-   'obj_SeismicLineSetFeature': 'Seismic Line Set Feature',
-   'obj_SeismicLineFeature': 'Seismic Line Feature',
-   'obj_SeismicLatticeFeature': 'Seismic Lattice Feature',
-   'obj_GeneticBoundaryFeature': 'Genetic Boundary Feature (horizon or geobody)',
-   'obj_FaultInterpretation': 'Fault Interpretation',
-   'obj_HorizonInterpretation': 'Horizon Interpretation',
-   'obj_GenericFeatureInterpretation': 'Generic Feature Interpretation',
-   'obj_EarthModelInterpretation': 'Earth Model Interpretation',
-   'obj_OrganizationFeature': 'Organization Feature',
-   'obj_StructuralOrganizationInterpretation': 'Structural Organization Interpretation',
-   'obj_BoundaryFeature': 'Boundary Feature',
-   'obj_BoundaryFeatureInterpretation': 'Boundary Feature Interpretation',
-   'obj_FluidBoundaryFeature': 'Fluid Boundary Feature',
-   'obj_FrontierFeature': 'Frontier Feature (area of interest boundary)',
-   'obj_GeobodyFeature': 'Geobody Feature',
-   'obj_GeobodyInterpretation': 'Geobody Interpretation',
-   'obj_GeobodyBoundaryInterpretation': 'Geobody Boundary Interpretation',
-   'obj_GeologicUnitFeature': 'Geological Unit Feature',
-   'obj_GeologicUnitInterpretation': 'Geological Unit Interpretation',
-   'obj_RockFluidOrganizationInterpretation': 'Rock Fluid Organization Interpretation',
-   'obj_RockFluidUnitFeature': 'Rock Fluid Unit Feature',
-   'obj_RockFluidUnitInterpretation': 'Rock Fluid Unit Interpretation',
-   # stratigraphy classes
-   'obj_GlobalChronostratigraphicColumn': 'Global Chronostratigraphic Column',
-   'obj_StratigraphicColumn': 'Stratigraphic Column',
-   'obj_StratigraphicColumnRankInterpretation': 'Stratigraphic Column Rank Interpretation',
-   'obj_StratigraphicOccurrenceInterpretation': 'Stratigraphic Occurrence Interpretation',
-   'obj_StratigraphicUnitFeature': 'Stratigraphic Unit Feature',
-   'obj_StratigraphicUnitInterpretation': 'Stratigraphic Unit Interpretation',
-   # low level classes
-   'obj_SubRepresentation': 'Sub Representation',
-   'obj_RepresentationSetRepresentation': 'Representation Set',
-   'obj_StringTableLookup': 'String Lookup Table',
-   'obj_DoubleTableLookup': 'Double (real) Lookup Table',
-   'obj_TriangulatedSetRepresentation': 'Triangulated Set',
-   'obj_PolylineSetRepresentation': 'Poly Line Set',
-   'obj_PolylineRepresentation': 'Poly Line',
-   'obj_PointSetRepresentation': 'Point Set',
-   'obj_PlaneSetRepresentation': 'Plane Set',
-   'obj_PointsProperty': 'Points Property',
-   'obj_RedefinedGeometryRepresentation': 'Redefined Geometry Representation',
-   # doc props bits
-   'application/vnd.openxmlformats-package.core-properties+xml': 'Documentation (core properties)',
-   'application/x-extended-core-properties+xml': 'Documentation (extended properties)',
-   # other
-   'obj_Activity': 'Activity',
-   'obj_ActivityTemplate': 'Activity Template',
-   'obj_CommentProperty': 'Comment Property',
-   'obj_CommentPropertySeries': 'Comment Property Series',
-   'obj_RepresentationIdentitySet': 'Representation Identity Set',
-   'obj_StreamlinesFeature': 'Streamlines Feature',
-   'obj_StreamlinesRepresentation': 'Streamlines'
+    'obj_LocalDepth3dCrs': 'Coordinate Reference System (z is length)',
+    'obj_LocalTime3dCrs': 'Coordinate Reference System (z is time)',
+    'obj_IjkGridRepresentation': 'Grid (IJK)',
+    'obj_UnstructuredColumnLayerGridRepresentation': 'Grid (Column Layer)',
+    'obj_UnstructuredGridRepresentation': 'Grid (Unstructured)',
+    'obj_GridConnectionSetRepresentation': 'Grid Connection Set',
+    'obj_TruncatedIjkGridRepresentation': 'Grid (Truncated IJK)',
+    'obj_TruncatedUnstructuredColumnLayerGridRepresentation': 'Grid (Truncated Column Layer)',
+    'obj_GpGridRepresentation': 'Grid (General Purpose)',
+    'obj_LocalGridSet': 'Local Grid Set',
+    'obj_EpcExternalPartReference': 'HDF5 Reference',
+    'obj_PropertyKind': 'Kind of Property',
+    'obj_CategoricalProperty': 'Property (Categorical)',
+    'obj_DiscreteProperty': 'Property (Discrete)',
+    'obj_ContinuousProperty': 'Property (Continuous)',
+    'obj_CategoricalPropertySeries': 'Property Series (Categorical)',
+    'obj_DiscretePropertySeries': 'Property Series (Discrete)',
+    'obj_ContinuousPropertySeries': 'Property Series (Continuous)',
+    'obj_PropertySet': 'Property Set',
+    'obj_TimeSeries': 'Time Series',
+    'obj_WellboreTrajectoryRepresentation': 'Wellbore Trajectory',
+    'obj_BlockedWellboreRepresentation': 'Blocked Wellbore',
+    'obj_WellboreInterpretation': 'Wellbore Interpretation',
+    'obj_WellboreFeature': 'Wellbore Feature',
+    'obj_WellboreFrameRepresentation': 'Wellbore Frame',
+    'obj_WellboreMarkerFrameRepresentation': 'Wellbore Marker Frame',
+    'obj_DeviationSurveyRepresentation': 'Deviation Survey',
+    'obj_MdDatum': 'Measured Depth Datum',
+    # geo classes
+    'obj_TectonicBoundaryFeature': 'Tectonic Boundary Feature (fault or fracture)',
+    'obj_Grid2dRepresentation': 'Mesh (Grid 2D)',
+    'obj_Grid2dSetRepresentation': 'Mesh Set (Grid 2D set)',
+    'obj_SealedSurfaceFrameworkRepresentation': 'Sealed Surface Framework',
+    'obj_SealedVolumeFrameworkRepresentation': 'Sealed Volume Framework',
+    'obj_NonSealedSurfaceFrameworkRepresentation': 'Non-sealed Surface Framework',
+    'obj_SeismicLineSetFeature': 'Seismic Line Set Feature',
+    'obj_SeismicLineFeature': 'Seismic Line Feature',
+    'obj_SeismicLatticeFeature': 'Seismic Lattice Feature',
+    'obj_GeneticBoundaryFeature': 'Genetic Boundary Feature (horizon or geobody)',
+    'obj_FaultInterpretation': 'Fault Interpretation',
+    'obj_HorizonInterpretation': 'Horizon Interpretation',
+    'obj_GenericFeatureInterpretation': 'Generic Feature Interpretation',
+    'obj_EarthModelInterpretation': 'Earth Model Interpretation',
+    'obj_OrganizationFeature': 'Organization Feature',
+    'obj_StructuralOrganizationInterpretation': 'Structural Organization Interpretation',
+    'obj_BoundaryFeature': 'Boundary Feature',
+    'obj_BoundaryFeatureInterpretation': 'Boundary Feature Interpretation',
+    'obj_FluidBoundaryFeature': 'Fluid Boundary Feature',
+    'obj_FrontierFeature': 'Frontier Feature (area of interest boundary)',
+    'obj_GeobodyFeature': 'Geobody Feature',
+    'obj_GeobodyInterpretation': 'Geobody Interpretation',
+    'obj_GeobodyBoundaryInterpretation': 'Geobody Boundary Interpretation',
+    'obj_GeologicUnitFeature': 'Geological Unit Feature',
+    'obj_GeologicUnitInterpretation': 'Geological Unit Interpretation',
+    'obj_RockFluidOrganizationInterpretation': 'Rock Fluid Organization Interpretation',
+    'obj_RockFluidUnitFeature': 'Rock Fluid Unit Feature',
+    'obj_RockFluidUnitInterpretation': 'Rock Fluid Unit Interpretation',
+    # stratigraphy classes
+    'obj_GlobalChronostratigraphicColumn': 'Global Chronostratigraphic Column',
+    'obj_StratigraphicColumn': 'Stratigraphic Column',
+    'obj_StratigraphicColumnRankInterpretation': 'Stratigraphic Column Rank Interpretation',
+    'obj_StratigraphicOccurrenceInterpretation': 'Stratigraphic Occurrence Interpretation',
+    'obj_StratigraphicUnitFeature': 'Stratigraphic Unit Feature',
+    'obj_StratigraphicUnitInterpretation': 'Stratigraphic Unit Interpretation',
+    # low level classes
+    'obj_SubRepresentation': 'Sub Representation',
+    'obj_RepresentationSetRepresentation': 'Representation Set',
+    'obj_StringTableLookup': 'String Lookup Table',
+    'obj_DoubleTableLookup': 'Double (real) Lookup Table',
+    'obj_TriangulatedSetRepresentation': 'Triangulated Set',
+    'obj_PolylineSetRepresentation': 'Poly Line Set',
+    'obj_PolylineRepresentation': 'Poly Line',
+    'obj_PointSetRepresentation': 'Point Set',
+    'obj_PlaneSetRepresentation': 'Plane Set',
+    'obj_PointsProperty': 'Points Property',
+    'obj_RedefinedGeometryRepresentation': 'Redefined Geometry Representation',
+    # doc props bits
+    'application/vnd.openxmlformats-package.core-properties+xml': 'Documentation (core properties)',
+    'application/x-extended-core-properties+xml': 'Documentation (extended properties)',
+    # other
+    'obj_Activity': 'Activity',
+    'obj_ActivityTemplate': 'Activity Template',
+    'obj_CommentProperty': 'Comment Property',
+    'obj_CommentPropertySeries': 'Comment Property Series',
+    'obj_RepresentationIdentitySet': 'Representation Identity Set',
+    'obj_StreamlinesFeature': 'Streamlines Feature',
+    'obj_StreamlinesRepresentation': 'Streamlines'
 }
 
 
 def readable_class(class_name):
-   """Given a resqml object class name as a string, returns a more human readable string.
+    """Given a resqml object class name as a string, returns a more human readable string.
 
       argument:
          class_name (string): the resqml class name, eg. 'obj_IjkGridRepresentation'
@@ -103,10 +103,10 @@ def readable_class(class_name):
          a human readable version of the class name, eg. 'Grid (IJK)'
    """
 
-   if class_name in class_dict.keys():
-      return class_dict[class_name]
-   if class_name.startswith('obj_'):
-      return class_name[4:]
-   elif 'obj_' + class_name in class_dict.keys():
-      return class_dict['obj_' + class_name]
-   return class_name
+    if class_name in class_dict.keys():
+        return class_dict[class_name]
+    if class_name.startswith('obj_'):
+        return class_name[4:]
+    elif 'obj_' + class_name in class_dict.keys():
+        return class_dict['obj_' + class_name]
+    return class_name

--- a/resqpy/olio/consolidation.py
+++ b/resqpy/olio/consolidation.py
@@ -19,11 +19,11 @@ import resqpy.time_series as rqt
 # it is lightly ordered with earlier classes having no dependence on classes later in the list
 
 consolidatable_list = [
-   'OrganizationFeature', 'GeobodyFeature', 'BoundaryFeature', 'FrontierFeature', 'GeologicUnitFeature',
-   'FluidBoundaryFeature', 'RockFluidUnitFeature', 'TectonicBoundaryFeature', 'GeneticBoundaryFeature',
-   'WellboreFeature', 'FaultInterpretation', 'EarthModelInterpretation', 'HorizonInterpretation',
-   'GeobodyBoundaryInterpretation', 'GeobodyInterpretation', 'WellboreInterpretation', 'LocalDepth3dCrs',
-   'LocalTime3dCrs', 'TimeSeries', 'StringTableLookup', 'PropertyKind'
+    'OrganizationFeature', 'GeobodyFeature', 'BoundaryFeature', 'FrontierFeature', 'GeologicUnitFeature',
+    'FluidBoundaryFeature', 'RockFluidUnitFeature', 'TectonicBoundaryFeature', 'GeneticBoundaryFeature',
+    'WellboreFeature', 'FaultInterpretation', 'EarthModelInterpretation', 'HorizonInterpretation',
+    'GeobodyBoundaryInterpretation', 'GeobodyInterpretation', 'WellboreInterpretation', 'LocalDepth3dCrs',
+    'LocalTime3dCrs', 'TimeSeries', 'StringTableLookup', 'PropertyKind'
 ]
 
 # todo: add to this list as other classes gain an is_equivalent() method
@@ -31,129 +31,129 @@ consolidatable_list = [
 
 class Consolidation:
 
-   def __init__(self, resident_model):
+    def __init__(self, resident_model):
 
-      self.model = resident_model
-      log.debug(f'new consolidation for {self.model.epc_file} with {len(self.model.uuids())} uuids')
-      self.map = {}  # dictionary mapping immigrant uuid to primary uuid
-      self.stale = True
+        self.model = resident_model
+        log.debug(f'new consolidation for {self.model.epc_file} with {len(self.model.uuids())} uuids')
+        self.map = {}  # dictionary mapping immigrant uuid to primary uuid
+        self.stale = True
 
-   def equivalent_uuid_for_part(self, part, immigrant_model = None, ignore_identical_part = False):
-      """Returns uuid of an equivalent part in primary model, or None if no equivalent found."""
+    def equivalent_uuid_for_part(self, part, immigrant_model = None, ignore_identical_part = False):
+        """Returns uuid of an equivalent part in primary model, or None if no equivalent found."""
 
-      #      log.debug('Looking for equivalent uuid for: ' + str(part))
-      if not part:
-         return None
-      if immigrant_model is None:
-         immigrant_model = self.model
-      immigrant_uuid = rqet.uuid_in_part_name(part)
-      #      log.debug('   immigrant uuid: ' + str(immigrant_uuid))
-      if immigrant_uuid in self.map:
-         #         log.debug('   known to be equivalent to: ' + str(self.map[immigrant_uuid]))
-         return self.map[immigrant_uuid]
-      obj_type = immigrant_model.type_of_part(part, strip_obj = True)
-      if obj_type is None or obj_type not in consolidatable_list:
-         return None
-      #      log.debug('   object type is consolidatable')
-      resident_uuids = self.model.uuids(obj_type = obj_type)
-      if resident_uuids is None or len(resident_uuids) == 0:
-         #         log.debug('   no resident parts found of type: ' + str(obj_type))
-         return None
+        #      log.debug('Looking for equivalent uuid for: ' + str(part))
+        if not part:
+            return None
+        if immigrant_model is None:
+            immigrant_model = self.model
+        immigrant_uuid = rqet.uuid_in_part_name(part)
+        #      log.debug('   immigrant uuid: ' + str(immigrant_uuid))
+        if immigrant_uuid in self.map:
+            #         log.debug('   known to be equivalent to: ' + str(self.map[immigrant_uuid]))
+            return self.map[immigrant_uuid]
+        obj_type = immigrant_model.type_of_part(part, strip_obj = True)
+        if obj_type is None or obj_type not in consolidatable_list:
+            return None
+        #      log.debug('   object type is consolidatable')
+        resident_uuids = self.model.uuids(obj_type = obj_type)
+        if resident_uuids is None or len(resident_uuids) == 0:
+            #         log.debug('   no resident parts found of type: ' + str(obj_type))
+            return None
 #      log.debug(f'   {len(resident_uuids)} resident parts of same class')
-      if not ignore_identical_part:
-         for resident_uuid in resident_uuids:
-            if bu.matching_uuids(resident_uuid, immigrant_uuid):
-               #               log.debug('   uuid already resident: ' + str(resident_uuid))
-               return resident_uuid
+        if not ignore_identical_part:
+            for resident_uuid in resident_uuids:
+                if bu.matching_uuids(resident_uuid, immigrant_uuid):
+                    #               log.debug('   uuid already resident: ' + str(resident_uuid))
+                    return resident_uuid
 
 
 #      log.debug('   preparing immigrant object')
-      if obj_type.endswith('Interpretation') or obj_type.endswith('Feature'):
-         immigrant_obj = rqo.__dict__[obj_type](immigrant_model, uuid = immigrant_uuid)
-      elif obj_type.endswith('Crs'):
-         immigrant_obj = rqc.Crs(immigrant_model, uuid = immigrant_uuid)
-      elif obj_type == 'TimeSeries':
-         immigrant_obj = rqt.TimeSeries(immigrant_model, uuid = immigrant_uuid)
-      elif obj_type == 'StringTableLookup':
-         immigrant_obj = rqp.StringLookup(immigrant_model, uuid = immigrant_uuid)
-      elif obj_type == 'PropertyKind':
-         immigrant_obj = rqp.PropertyKind(immigrant_model, uuid = immigrant_uuid)
-      else:
-         raise Exception('code failure')
-      assert immigrant_obj is not None
-      for resident_uuid in resident_uuids:
-         #         log.debug('   considering resident: ' + str(resident_uuid))
-         if ignore_identical_part and bu.matching_uuids(resident_uuid, immigrant_uuid):
-            continue
-         if obj_type.endswith('Interpretation') or obj_type.endswith('Feature'):
-            resident_obj = rqo.__dict__[obj_type](self.model, uuid = resident_uuid)
-         elif obj_type.endswith('Crs'):
-            resident_obj = rqc.Crs(self.model, uuid = resident_uuid)
-         elif obj_type == 'TimeSeries':
-            resident_obj = rqt.TimeSeries(self.model, uuid = resident_uuid)
-         elif obj_type == 'StringTableLookup':
-            resident_obj = rqp.StringLookup(self.model, uuid = resident_uuid)
-         elif obj_type == 'PropertyKind':
-            resident_obj = rqp.PropertyKind(self.model, uuid = resident_uuid)
-         else:
+        if obj_type.endswith('Interpretation') or obj_type.endswith('Feature'):
+            immigrant_obj = rqo.__dict__[obj_type](immigrant_model, uuid = immigrant_uuid)
+        elif obj_type.endswith('Crs'):
+            immigrant_obj = rqc.Crs(immigrant_model, uuid = immigrant_uuid)
+        elif obj_type == 'TimeSeries':
+            immigrant_obj = rqt.TimeSeries(immigrant_model, uuid = immigrant_uuid)
+        elif obj_type == 'StringTableLookup':
+            immigrant_obj = rqp.StringLookup(immigrant_model, uuid = immigrant_uuid)
+        elif obj_type == 'PropertyKind':
+            immigrant_obj = rqp.PropertyKind(immigrant_model, uuid = immigrant_uuid)
+        else:
             raise Exception('code failure')
-         assert resident_obj is not None
-         #         log.debug('   comparing with: ' + str(resident_obj.uuid))
-         if immigrant_obj == resident_obj:  # note: == operator overloaded with equivalence method for these classes
-            while resident_uuid in self.map:
-               #               log.debug('   following equivalence for: ' + str(resident_uuid))
-               resident_uuid = self.map[resident_uuid]
-            self.map[immigrant_uuid] = resident_uuid
-            #            log.debug('   new equivalence found with: ' + str(resident_uuid))
-            return resident_uuid
-      return None
+        assert immigrant_obj is not None
+        for resident_uuid in resident_uuids:
+            #         log.debug('   considering resident: ' + str(resident_uuid))
+            if ignore_identical_part and bu.matching_uuids(resident_uuid, immigrant_uuid):
+                continue
+            if obj_type.endswith('Interpretation') or obj_type.endswith('Feature'):
+                resident_obj = rqo.__dict__[obj_type](self.model, uuid = resident_uuid)
+            elif obj_type.endswith('Crs'):
+                resident_obj = rqc.Crs(self.model, uuid = resident_uuid)
+            elif obj_type == 'TimeSeries':
+                resident_obj = rqt.TimeSeries(self.model, uuid = resident_uuid)
+            elif obj_type == 'StringTableLookup':
+                resident_obj = rqp.StringLookup(self.model, uuid = resident_uuid)
+            elif obj_type == 'PropertyKind':
+                resident_obj = rqp.PropertyKind(self.model, uuid = resident_uuid)
+            else:
+                raise Exception('code failure')
+            assert resident_obj is not None
+            #         log.debug('   comparing with: ' + str(resident_obj.uuid))
+            if immigrant_obj == resident_obj:  # note: == operator overloaded with equivalence method for these classes
+                while resident_uuid in self.map:
+                    #               log.debug('   following equivalence for: ' + str(resident_uuid))
+                    resident_uuid = self.map[resident_uuid]
+                self.map[immigrant_uuid] = resident_uuid
+                #            log.debug('   new equivalence found with: ' + str(resident_uuid))
+                return resident_uuid
+        return None
 
-   def force_uuid_equivalence(self, immigrant_uuid, resident_uuid):
-      """Forces immigrant object to be treated as equivalent to (same as) resident object, identified by uuids."""
+    def force_uuid_equivalence(self, immigrant_uuid, resident_uuid):
+        """Forces immigrant object to be treated as equivalent to (same as) resident object, identified by uuids."""
 
-      assert immigrant_uuid is not None and resident_uuid is not None
-      if isinstance(immigrant_uuid, str):
-         immigrant_uuid = bu.uuid_from_string(immigrant_uuid)
-      if isinstance(resident_uuid, str):
-         resident_uuid = bu.uuid_from_string(resident_uuid)
-      if bu.matching_uuids(immigrant_uuid, resident_uuid):
-         return
-      assert immigrant_uuid not in self.map.values()
+        assert immigrant_uuid is not None and resident_uuid is not None
+        if isinstance(immigrant_uuid, str):
+            immigrant_uuid = bu.uuid_from_string(immigrant_uuid)
+        if isinstance(resident_uuid, str):
+            resident_uuid = bu.uuid_from_string(resident_uuid)
+        if bu.matching_uuids(immigrant_uuid, resident_uuid):
+            return
+        assert immigrant_uuid not in self.map.values()
 
-      self.map[immigrant_uuid] = resident_uuid
+        self.map[immigrant_uuid] = resident_uuid
 
-   def force_part_equivalence(self, immigrant_part, resident_part):
-      """Forces immigrant part to be treated as equivalent to resident part."""
+    def force_part_equivalence(self, immigrant_part, resident_part):
+        """Forces immigrant part to be treated as equivalent to resident part."""
 
-      assert immigrant_part is not None and resident_part is not None
-      if immigrant_part == resident_part:
-         return
-      self.force_uuid_equivalence(rqet.uuid_in_part_name(immigrant_part), rqet.uuid_in_part_name(resident_part))
+        assert immigrant_part is not None and resident_part is not None
+        if immigrant_part == resident_part:
+            return
+        self.force_uuid_equivalence(rqet.uuid_in_part_name(immigrant_part), rqet.uuid_in_part_name(resident_part))
 
-   def check_map_integrity(self):
-      """Raises assertion failure if map contains any potentially circular references."""
+    def check_map_integrity(self):
+        """Raises assertion failure if map contains any potentially circular references."""
 
-      for immigrant in self.map.keys():
-         assert immigrant not in self.map.values()
-      for resident in self.map.values():
-         assert resident not in self.map.keys()
+        for immigrant in self.map.keys():
+            assert immigrant not in self.map.values()
+        for resident in self.map.values():
+            assert resident not in self.map.keys()
 
 
 def sort_parts_list(model, parts_list):
-   """Returns a copy of the parts list sorted into the preferred order for consolidating."""
+    """Returns a copy of the parts list sorted into the preferred order for consolidating."""
 
-   def ordering(obj_type):
-      if obj_type in consolidatable_list:
-         return consolidatable_list.index(obj_type)
-      seq = len(consolidatable_list)
-      if obj_type.endswith('Interpretation'):
-         seq += 1
-      elif obj_type.endswith('Representation'):
-         seq += 2
-      elif obj_type.endswith('Property'):
-         seq += 3
-      return seq
+    def ordering(obj_type):
+        if obj_type in consolidatable_list:
+            return consolidatable_list.index(obj_type)
+        seq = len(consolidatable_list)
+        if obj_type.endswith('Interpretation'):
+            seq += 1
+        elif obj_type.endswith('Representation'):
+            seq += 2
+        elif obj_type.endswith('Property'):
+            seq += 3
+        return seq
 
-   pair_list = [(ordering(model.type_of_part(part, strip_obj = True)), part) for part in parts_list]
-   pair_list.sort()
-   return [part for _, part in pair_list]
+    pair_list = [(ordering(model.type_of_part(part, strip_obj = True)), part) for part in parts_list]
+    pair_list.sort()
+    return [part for _, part in pair_list]

--- a/resqpy/olio/data/build.py
+++ b/resqpy/olio/data/build.py
@@ -15,152 +15,152 @@ import math as maths
 
 def main():
 
-   uom_dict_xml_path = Path(__file__).parent / 'Energistics_Unit_of_Measure_Dictionary_V1.0.xml'
-   properties_xsd_path = Path(__file__).parent / 'Properties.xsd'
-   json_path = Path(__file__).parent / 'properties.json'
+    uom_dict_xml_path = Path(__file__).parent / 'Energistics_Unit_of_Measure_Dictionary_V1.0.xml'
+    properties_xsd_path = Path(__file__).parent / 'Properties.xsd'
+    json_path = Path(__file__).parent / 'properties.json'
 
-   # Load xml
-   assert uom_dict_xml_path.exists()
-   assert properties_xsd_path.exists()
-   uom_dict_root = etree.parse(str(uom_dict_xml_path)).getroot()
-   properties_xsd_root = etree.parse(str(properties_xsd_path)).getroot()
+    # Load xml
+    assert uom_dict_xml_path.exists()
+    assert properties_xsd_path.exists()
+    uom_dict_root = etree.parse(str(uom_dict_xml_path)).getroot()
+    properties_xsd_root = etree.parse(str(properties_xsd_path)).getroot()
 
-   # Parse into memory
-   data = dict(dimensions = parse_dimensions(uom_dict_root),
-               quantities = parse_quantities(uom_dict_root),
-               units = parse_units(uom_dict_root),
-               prefixes = parse_prefixes(uom_dict_root),
-               property_kinds = parse_property_kinds(properties_xsd_root))
+    # Parse into memory
+    data = dict(dimensions = parse_dimensions(uom_dict_root),
+                quantities = parse_quantities(uom_dict_root),
+                units = parse_units(uom_dict_root),
+                prefixes = parse_prefixes(uom_dict_root),
+                property_kinds = parse_property_kinds(properties_xsd_root))
 
-   # Save to JSON
-   with open(json_path, 'w', encoding = 'utf-8') as f:
-      json.dump(data, f, ensure_ascii = False, indent = 2)
+    # Save to JSON
+    with open(json_path, 'w', encoding = 'utf-8') as f:
+        json.dump(data, f, ensure_ascii = False, indent = 2)
 
 
 def parse_dimensions(root):
 
-   dims = {}
-   for node in root.find("{*}unitDimensionSet"):
+    dims = {}
+    for node in root.find("{*}unitDimensionSet"):
 
-      dimension = node.find('{*}dimension').text
-      dims[dimension] = dict(
-         name = node.find('{*}name').text,
-         baseForConversion = node.find('{*}baseForConversion').text,
-         canonicalUnit = node.find('{*}canonicalUnit').text,
-      )
-   return dims
+        dimension = node.find('{*}dimension').text
+        dims[dimension] = dict(
+            name = node.find('{*}name').text,
+            baseForConversion = node.find('{*}baseForConversion').text,
+            canonicalUnit = node.find('{*}canonicalUnit').text,
+        )
+    return dims
 
 
 def parse_quantities(root):
 
-   quantities = {}
-   for node in root.find("{*}quantityClassSet"):
-      name = node.find('{*}name').text
-      quantities[name] = dict(
-         dimension = node.find('{*}dimension').text,
-         baseForConversion = node.find('{*}baseForConversion').text,
-      )
-      alt = node.find('{*}alternativeBase')
-      if alt is not None:
-         quantities[name]['alternativeBase'] = alt.text
+    quantities = {}
+    for node in root.find("{*}quantityClassSet"):
+        name = node.find('{*}name').text
+        quantities[name] = dict(
+            dimension = node.find('{*}dimension').text,
+            baseForConversion = node.find('{*}baseForConversion').text,
+        )
+        alt = node.find('{*}alternativeBase')
+        if alt is not None:
+            quantities[name]['alternativeBase'] = alt.text
 
-      members = []
-      for member in node.findall('{*}memberUnit'):
-         members.append(member.text)
-      if members:
-         quantities[name]["members"] = members
+        members = []
+        for member in node.findall('{*}memberUnit'):
+            members.append(member.text)
+        if members:
+            quantities[name]["members"] = members
 
-   return quantities
+    return quantities
 
 
 def parse_units(root):
 
-   units = {}
-   for node in root.find("{*}unitSet"):
-      symbol = node.find('{*}symbol').text
-      unit_dict = {}
-      for key, typ in [
-         ('name', str),
-         ('dimension', str),
-         ('isSI', as_bool),
-         ('category', str),
-         ('baseUnit', str),
-         ('conversionRef', str),
-         ('isExact', as_bool),
-         ('A', as_numeric),
-         ('B', as_numeric),
-         ('C', as_numeric),
-         ('D', as_numeric),
-         ('conversionRef', str),
-         ('description', str),
-      ]:
-         prop = node.find("{*}" + key)
-         if prop is not None:
-            unit_dict[key] = typ(prop.text)
+    units = {}
+    for node in root.find("{*}unitSet"):
+        symbol = node.find('{*}symbol').text
+        unit_dict = {}
+        for key, typ in [
+            ('name', str),
+            ('dimension', str),
+            ('isSI', as_bool),
+            ('category', str),
+            ('baseUnit', str),
+            ('conversionRef', str),
+            ('isExact', as_bool),
+            ('A', as_numeric),
+            ('B', as_numeric),
+            ('C', as_numeric),
+            ('D', as_numeric),
+            ('conversionRef', str),
+            ('description', str),
+        ]:
+            prop = node.find("{*}" + key)
+            if prop is not None:
+                unit_dict[key] = typ(prop.text)
 
-      units[symbol] = unit_dict
+        units[symbol] = unit_dict
 
-   return units
+    return units
 
 
 def parse_prefixes(root):
-   prefixes = {}
-   for node in root.find("{*}prefixSet"):
-      name = node.find('{*}name').text
-      prefixes[name] = dict(
-         symbol = node.find('{*}symbol').text,
-         multiplier = node.find('{*}multiplier').text,
-      )
-      common_name = node.find('{*}commonName')
-      if common_name is not None:
-         prefixes[name]['common_name'] = common_name.text
+    prefixes = {}
+    for node in root.find("{*}prefixSet"):
+        name = node.find('{*}name').text
+        prefixes[name] = dict(
+            symbol = node.find('{*}symbol').text,
+            multiplier = node.find('{*}multiplier').text,
+        )
+        common_name = node.find('{*}commonName')
+        if common_name is not None:
+            prefixes[name]['common_name'] = common_name.text
 
-   return prefixes
+    return prefixes
 
 
 def parse_property_kinds(root):
-   """ Return dict of valid RESQML property kinds
+    """ Return dict of valid RESQML property kinds
 
    Dict keys are the valid property kinds, e.g. 'angle per time'
    Dict values are the description, which may be None
    """
 
-   kind_list = get_nodes_with_name(root, 'ResqmlPropertyKind')[1]
-   kind_dict = {}
-   for child in kind_list:
-      kind = child.get('value')
-      try:
-         doc = child[0][0].text
-      except IndexError:
-         doc = None
-      kind_dict[kind] = doc
-   return kind_dict
+    kind_list = get_nodes_with_name(root, 'ResqmlPropertyKind')[1]
+    kind_dict = {}
+    for child in kind_list:
+        kind = child.get('value')
+        try:
+            doc = child[0][0].text
+        except IndexError:
+            doc = None
+        kind_dict[kind] = doc
+    return kind_dict
 
 
 def get_nodes_with_name(root, name):
-   """ Find xml child node with given name """
-   for child in root:
-      if child.get('name') == name:
-         return child
-   raise ValueError(f'{name} not found')
+    """ Find xml child node with given name """
+    for child in root:
+        if child.get('name') == name:
+            return child
+    raise ValueError(f'{name} not found')
 
 
 def as_bool(a_string):
-   return a_string.lower() == "true"
+    return a_string.lower() == "true"
 
 
 def as_numeric(a_string):
-   if a_string == 'PI':
-      return maths.pi
-   elif a_string == "2*PI":
-      return 2 * maths.pi
-   elif a_string == "4*PI":
-      return 4 * maths.pi
-   elif a_string.isdigit():
-      return int(a_string)
-   else:
-      return float(a_string)
+    if a_string == 'PI':
+        return maths.pi
+    elif a_string == "2*PI":
+        return 2 * maths.pi
+    elif a_string == "4*PI":
+        return 4 * maths.pi
+    elif a_string.isdigit():
+        return int(a_string)
+    else:
+        return float(a_string)
 
 
 if __name__ == "__main__":
-   main()
+    main()

--- a/resqpy/olio/exceptions.py
+++ b/resqpy/olio/exceptions.py
@@ -2,10 +2,10 @@
 
 
 class InvalidUnitError(Exception):
-   """Raised when a unit cannot be converted into a valid RESQML unit of measure"""
-   pass
+    """Raised when a unit cannot be converted into a valid RESQML unit of measure"""
+    pass
 
 
 class IncompatibleUnitsError(Exception):
-   """Raised when two units do not share compatible base units and dimensions"""
-   pass
+    """Raised when two units do not share compatible base units and dimensions"""
+    pass

--- a/resqpy/olio/factors.py
+++ b/resqpy/olio/factors.py
@@ -5,51 +5,51 @@ version = '24th December 2019'
 
 
 def factorize(n):
-   """Returns list of prime factors of positive integer n."""
-   i = 2
-   factors = []
-   while True:
-      q, r = divmod(n, i)
-      if r:
-         i += 1
-         if i > n:
-            return factors
-      else:
-         factors.append(i)
-         if q < i:
-            return factors
-         n = q
+    """Returns list of prime factors of positive integer n."""
+    i = 2
+    factors = []
+    while True:
+        q, r = divmod(n, i)
+        if r:
+            i += 1
+            if i > n:
+                return factors
+        else:
+            factors.append(i)
+            if q < i:
+                return factors
+            n = q
 
 
 def combinatorial(numbers):
-   """Returns a list of all possible product combinations of numbers from list numbers, with some duplicates."""
-   if len(numbers) == 0:
-      return []
-   head = numbers[0]
-   c = [head]
-   tail = combinatorial(numbers[1:])
-   for o in tail:
-      if o != head:
-         c.append(o)
-      c.append(head * o)
-   return sorted(c)
+    """Returns a list of all possible product combinations of numbers from list numbers, with some duplicates."""
+    if len(numbers) == 0:
+        return []
+    head = numbers[0]
+    c = [head]
+    tail = combinatorial(numbers[1:])
+    for o in tail:
+        if o != head:
+            c.append(o)
+        c.append(head * o)
+    return sorted(c)
 
 
 def all_factors_from_primes(primes):
-   """Returns a sorted list of unique factors from prime factorization."""
-   all = list(set(combinatorial(primes)))
-   all.append(1)
-   return sorted(all)
+    """Returns a sorted list of unique factors from prime factorization."""
+    all = list(set(combinatorial(primes)))
+    all.append(1)
+    return sorted(all)
 
 
 def all_factors(n):
-   """Returns a sorted list of unique factors of n."""
-   primes = factorize(n)
-   return all_factors_from_primes(primes)
+    """Returns a sorted list of unique factors of n."""
+    primes = factorize(n)
+    return all_factors_from_primes(primes)
 
 
 def remove_subset(primary, subset):
-   """Remove all elements of subset from primary list."""
+    """Remove all elements of subset from primary list."""
 
-   for e in subset:
-      primary.remove(e)
+    for e in subset:
+        primary.remove(e)

--- a/resqpy/olio/fine_coarse.py
+++ b/resqpy/olio/fine_coarse.py
@@ -16,10 +16,10 @@ import resqpy.olio.box_utilities as box
 
 
 class FineCoarse:
-   """Class for holding a mapping between fine and coarse grids."""
+    """Class for holding a mapping between fine and coarse grids."""
 
-   def __init__(self, fine_extent_kji, coarse_extent_kji, within_fine_box = None, within_coarse_box = None):
-      """Partial initialisation function, call other methods to assign ratios and proportions.
+    def __init__(self, fine_extent_kji, coarse_extent_kji, within_fine_box = None, within_coarse_box = None):
+        """Partial initialisation function, call other methods to assign ratios and proportions.
 
       arguments:
          fine_extent_kji (triple int): the local extent of the fine grid in k, j, i axes, ie (nk, nj, ni).
@@ -42,333 +42,334 @@ class FineCoarse:
          after intialisation, set_* methods should be called to establish the mapping
       """
 
-      assert len(fine_extent_kji) == 3 and len(coarse_extent_kji) == 3
-      assert within_fine_box is None or within_coarse_box is None
+        assert len(fine_extent_kji) == 3 and len(coarse_extent_kji) == 3
+        assert within_fine_box is None or within_coarse_box is None
 
-      self.fine_extent_kji = tuple(fine_extent_kji)  #: fine extent
-      self.coarse_extent_kji = tuple(coarse_extent_kji)  #: coarse extent
-      self._assert_extents_valid()
-      if within_fine_box is not None:
-         _assert_valid_box(fine_extent_kji, within_fine_box)
-      if within_coarse_box is not None:
-         _assert_valid_box(coarse_extent_kji, within_coarse_box)
-      self.within_fine_box = within_fine_box  #: if not None, a box within an unidentified larger fine grid
-      self.within_coarse_box = within_coarse_box  #: if not None, a box within an unidentified larger coarse grid
+        self.fine_extent_kji = tuple(fine_extent_kji)  #: fine extent
+        self.coarse_extent_kji = tuple(coarse_extent_kji)  #: coarse extent
+        self._assert_extents_valid()
+        if within_fine_box is not None:
+            _assert_valid_box(fine_extent_kji, within_fine_box)
+        if within_coarse_box is not None:
+            _assert_valid_box(coarse_extent_kji, within_coarse_box)
+        self.within_fine_box = within_fine_box  #: if not None, a box within an unidentified larger fine grid
+        self.within_coarse_box = within_coarse_box  #: if not None, a box within an unidentified larger coarse grid
 
-      self.constant_ratios = [None, None, None]  #: list for 3 axes kji, each None or int
-      self.vector_ratios = [None, None, None]  #: list for 3 axes kji, each numpy vector of int or None
-      self.equal_proportions = [True, True, True]  #: list for 3 axes kji, each boolean defaulting to equal proportions
-      self.vector_proportions = [None, None, None
-                                ]  #: list for 3 axes kji, each None or list of numpy vectors of float summing to 1.0
+        self.constant_ratios = [None, None, None]  #: list for 3 axes kji, each None or int
+        self.vector_ratios = [None, None, None]  #: list for 3 axes kji, each numpy vector of int or None
+        self.equal_proportions = [True, True,
+                                  True]  #: list for 3 axes kji, each boolean defaulting to equal proportions
+        self.vector_proportions = [None, None, None
+                                  ]  #: list for 3 axes kji, each None or list of numpy vectors of float summing to 1.0
 
-      self.fine_to_coarse_mapping = None  # derived triplet of int vectors holding coarse cell index for each fine cell index
+        self.fine_to_coarse_mapping = None  # derived triplet of int vectors holding coarse cell index for each fine cell index
 
-   def assert_valid(self):
-      """Checks consistency of everything within the fine coarse mapping; raises assertion error if not valid."""
+    def assert_valid(self):
+        """Checks consistency of everything within the fine coarse mapping; raises assertion error if not valid."""
 
-      self._assert_extents_valid()
+        self._assert_extents_valid()
 
-      assert self.constant_ratios is not None and len(self.constant_ratios) == 3
-      assert self.vector_ratios is not None and len(self.vector_ratios) == 3
-      assert self.equal_proportions is not None and len(self.equal_proportions) == 3
-      assert self.vector_proportions is not None and len(self.vector_proportions) == 3
+        assert self.constant_ratios is not None and len(self.constant_ratios) == 3
+        assert self.vector_ratios is not None and len(self.vector_ratios) == 3
+        assert self.equal_proportions is not None and len(self.equal_proportions) == 3
+        assert self.vector_proportions is not None and len(self.vector_proportions) == 3
 
-      for axis in range(3):
-         assert (self.constant_ratios[axis] is None or
-                 _is_int(self.constant_ratios[axis]) and self.constant_ratios[axis] > 0)
-         if self.constant_ratios[axis] is None:
-            assert (self.vector_ratios[axis] is not None and isinstance(self.vector_ratios[axis], np.ndarray) and
-                    self.vector_ratios[axis].ndim == 1 and str(self.vector_ratios[axis].dtype).startswith('int'))
-            assert len(self.vector_ratios[axis]) == self.coarse_extent_kji[axis]
-            assert np.all(self.vector_ratios[axis] > 0)
-            assert np.sum(self.vector_ratios[axis]) == self.fine_extent_kji[axis]
-         else:
-            assert self.vector_ratios[axis] is None
-            assert self.coarse_extent_kji[axis] * self.constant_ratios[axis] == self.fine_extent_kji[axis]
-         assert isinstance(self.equal_proportions[axis], bool)
-         if self.equal_proportions[axis]:
-            assert self.vector_proportions[axis] is None
-         else:
-            assert (self.vector_proportions[axis] is not None and
-                    isinstance(self.vector_proportions[axis], list) and  # could allow a tuple
-                    len(self.vector_proportions[axis]) == self.coarse_extent_kji[axis])
-            for c0 in range(self.coarse_extent_kji[axis]):
-               assert (isinstance(self.vector_proportions[axis][c0], np.ndarray) and
-                       self.vector_proportions[axis][c0].ndim == 1 and
-                       str(self.vector_proportions[axis][c0].dtype).startswith('float') and
-                       len(self.vector_proportions[axis][c0]) == self.ratio(axis, c0))
-               assert np.min(self.vector_proportions[axis][c0]) > 0.0
-               assert abs(np.sum(self.vector_proportions[axis][c0]) - 1.0) < 1.0e-6
+        for axis in range(3):
+            assert (self.constant_ratios[axis] is None or
+                    _is_int(self.constant_ratios[axis]) and self.constant_ratios[axis] > 0)
+            if self.constant_ratios[axis] is None:
+                assert (self.vector_ratios[axis] is not None and isinstance(self.vector_ratios[axis], np.ndarray) and
+                        self.vector_ratios[axis].ndim == 1 and str(self.vector_ratios[axis].dtype).startswith('int'))
+                assert len(self.vector_ratios[axis]) == self.coarse_extent_kji[axis]
+                assert np.all(self.vector_ratios[axis] > 0)
+                assert np.sum(self.vector_ratios[axis]) == self.fine_extent_kji[axis]
+            else:
+                assert self.vector_ratios[axis] is None
+                assert self.coarse_extent_kji[axis] * self.constant_ratios[axis] == self.fine_extent_kji[axis]
+            assert isinstance(self.equal_proportions[axis], bool)
+            if self.equal_proportions[axis]:
+                assert self.vector_proportions[axis] is None
+            else:
+                assert (self.vector_proportions[axis] is not None and
+                        isinstance(self.vector_proportions[axis], list) and  # could allow a tuple
+                        len(self.vector_proportions[axis]) == self.coarse_extent_kji[axis])
+                for c0 in range(self.coarse_extent_kji[axis]):
+                    assert (isinstance(self.vector_proportions[axis][c0], np.ndarray) and
+                            self.vector_proportions[axis][c0].ndim == 1 and
+                            str(self.vector_proportions[axis][c0].dtype).startswith('float') and
+                            len(self.vector_proportions[axis][c0]) == self.ratio(axis, c0))
+                    assert np.min(self.vector_proportions[axis][c0]) > 0.0
+                    assert abs(np.sum(self.vector_proportions[axis][c0]) - 1.0) < 1.0e-6
 
-   def ratio(self, axis, c0):
-      """Return fine:coarse ratio in given axis and coarse slice."""
+    def ratio(self, axis, c0):
+        """Return fine:coarse ratio in given axis and coarse slice."""
 
-      if self.constant_ratios[axis] is not None:
-         return self.constant_ratios[axis]
-      return self.vector_ratios[axis][c0]
+        if self.constant_ratios[axis] is not None:
+            return self.constant_ratios[axis]
+        return self.vector_ratios[axis][c0]
 
-   def ratios(self, c_kji0):
-      """Return find:coarse ratios triplet for coarse cell."""
+    def ratios(self, c_kji0):
+        """Return find:coarse ratios triplet for coarse cell."""
 
-      return tuple(self.ratio(axis, c_kji0[axis]) for axis in range(3))
+        return tuple(self.ratio(axis, c_kji0[axis]) for axis in range(3))
 
-   def coarse_for_fine(self):
-      """Returns triplet of numpy int vectors being the axial coarse cell indices for the axial fine cell indices."""
+    def coarse_for_fine(self):
+        """Returns triplet of numpy int vectors being the axial coarse cell indices for the axial fine cell indices."""
 
-      if self.fine_to_coarse_mapping is None:
-         self._set_fine_to_coarse_mapping()
-      return self.fine_to_coarse_mapping
+        if self.fine_to_coarse_mapping is None:
+            self._set_fine_to_coarse_mapping()
+        return self.fine_to_coarse_mapping
 
-   def coarse_for_fine_kji0(self, fine_kji0):
-      """Returns the index of the coarse cell which the given fine cell falls within."""
+    def coarse_for_fine_kji0(self, fine_kji0):
+        """Returns the index of the coarse cell which the given fine cell falls within."""
 
-      if self.fine_to_coarse_mapping is None:
-         self._set_fine_to_coarse_mapping()
-      return (self.fine_to_coarse_mapping[0][fine_kji0[0]], self.fine_to_coarse_mapping[1][fine_kji0[1]],
-              self.fine_to_coarse_mapping[2][fine_kji0[2]])
+        if self.fine_to_coarse_mapping is None:
+            self._set_fine_to_coarse_mapping()
+        return (self.fine_to_coarse_mapping[0][fine_kji0[0]], self.fine_to_coarse_mapping[1][fine_kji0[1]],
+                self.fine_to_coarse_mapping[2][fine_kji0[2]])
 
-   def coarse_for_fine_axial(self, axis, f0):
-      """Returns the index, for a single axis, of the coarse cell which the given fine cell falls within."""
+    def coarse_for_fine_axial(self, axis, f0):
+        """Returns the index, for a single axis, of the coarse cell which the given fine cell falls within."""
 
-      if self.fine_to_coarse_mapping is None:
-         self._set_fine_to_coarse_mapping()
-      return self.fine_to_coarse_mapping[axis][f0]
+        if self.fine_to_coarse_mapping is None:
+            self._set_fine_to_coarse_mapping()
+        return self.fine_to_coarse_mapping[axis][f0]
 
-   def coarse_for_fine_axial_vector(self, axis):
-      """Returns a numpy int vector, for a single axis, of the coarse cell index which each fine cell falls within."""
+    def coarse_for_fine_axial_vector(self, axis):
+        """Returns a numpy int vector, for a single axis, of the coarse cell index which each fine cell falls within."""
 
-      if self.fine_to_coarse_mapping is None:
-         self._set_fine_to_coarse_mapping()
-      return self.fine_to_coarse_mapping[axis]
+        if self.fine_to_coarse_mapping is None:
+            self._set_fine_to_coarse_mapping()
+        return self.fine_to_coarse_mapping[axis]
 
-   def fine_base_for_coarse_axial(self, axis, c0):
-      """Returns the index, for a single axis, of the 'first' fine cell within the coarse cell (lowest fine index)."""
+    def fine_base_for_coarse_axial(self, axis, c0):
+        """Returns the index, for a single axis, of the 'first' fine cell within the coarse cell (lowest fine index)."""
 
-      if self.constant_ratios[axis] is not None:
-         return c0 * self.constant_ratios[axis]
-      return np.sum(self.vector_ratios[axis][:c0])  # todo: check this returns zero for c0 == 0
+        if self.constant_ratios[axis] is not None:
+            return c0 * self.constant_ratios[axis]
+        return np.sum(self.vector_ratios[axis][:c0])  # todo: check this returns zero for c0 == 0
 
-   def fine_base_for_coarse(self, c_kji0):
-      """Returns a 3-tuple being the 'first' (min) k, j, i0 in fine grid for given coarse cell."""
+    def fine_base_for_coarse(self, c_kji0):
+        """Returns a 3-tuple being the 'first' (min) k, j, i0 in fine grid for given coarse cell."""
 
-      base = []
-      for axis in range(3):
-         base.append(self.fine_base_for_coarse_axial(axis, c_kji0[axis]))
-      return tuple(base)
+        base = []
+        for axis in range(3):
+            base.append(self.fine_base_for_coarse_axial(axis, c_kji0[axis]))
+        return tuple(base)
 
-   def fine_box_for_coarse(self, c_kji0):
-      """Returns a numpy int array of shape (2, 3) being the min, max for k, j, i0 in fine grid for given coarse cell."""
+    def fine_box_for_coarse(self, c_kji0):
+        """Returns a numpy int array of shape (2, 3) being the min, max for k, j, i0 in fine grid for given coarse cell."""
 
-      box = np.empty((2, 3), dtype = int)
-      box[0] = self.fine_base_for_coarse(c_kji0)
-      box[1] = box[0] + self.ratios(c_kji0) - 1
-      return box
+        box = np.empty((2, 3), dtype = int)
+        box[0] = self.fine_base_for_coarse(c_kji0)
+        box[1] = box[0] + self.ratios(c_kji0) - 1
+        return box
 
-   def proportion(self, axis, c0):
-      """Return a numpy vector of floats (summing to one) being the axial relative proportions of fine within coarse."""
+    def proportion(self, axis, c0):
+        """Return a numpy vector of floats (summing to one) being the axial relative proportions of fine within coarse."""
 
-      if self.equal_proportions[axis]:
-         count = self.ratio(axis, c0)
-         fraction = 1.0 / float(count)
-         return np.full((count,), fraction)
-      return self.vector_proportions[axis][c0]
+        if self.equal_proportions[axis]:
+            count = self.ratio(axis, c0)
+            fraction = 1.0 / float(count)
+            return np.full((count,), fraction)
+        return self.vector_proportions[axis][c0]
 
-   def proportions_for_axis(self, axis):
-      """Return a numpy vector of floats for fine (summing to one for each coarse slice) being the axial relative proportions."""
+    def proportions_for_axis(self, axis):
+        """Return a numpy vector of floats for fine (summing to one for each coarse slice) being the axial relative proportions."""
 
-      if self.equal_proportions[axis]:
-         count = self.constant_ratios[axis]
-         fraction = 1.0 / float(count)
-         return np.full((self.fine_extent_kji[axis],), fraction)
-      return np.concatenate(self.vector_proportions[axis])
+        if self.equal_proportions[axis]:
+            count = self.constant_ratios[axis]
+            fraction = 1.0 / float(count)
+            return np.full((self.fine_extent_kji[axis],), fraction)
+        return np.concatenate(self.vector_proportions[axis])
 
-   def interpolation(self, axis, c0):
-      """Return a numpy vector of floats starting at zero and increasing monotonically to less than one, ready for interpolation."""
+    def interpolation(self, axis, c0):
+        """Return a numpy vector of floats starting at zero and increasing monotonically to less than one, ready for interpolation."""
 
-      count = self.ratio(axis, c0)
-      fractions = np.zeros((count,))
-      proport = self.proportion(axis, c0)
-      for f0 in range(1, count):
-         fractions[f0] = fractions[f0 - 1] + proport[f0 - 1]
-      return fractions
+        count = self.ratio(axis, c0)
+        fractions = np.zeros((count,))
+        proport = self.proportion(axis, c0)
+        for f0 in range(1, count):
+            fractions[f0] = fractions[f0 - 1] + proport[f0 - 1]
+        return fractions
 
-   def proportions(self, c_kji0):
-      """Return triplet of axial proportions for refinement of coarse cell."""
+    def proportions(self, c_kji0):
+        """Return triplet of axial proportions for refinement of coarse cell."""
 
-      return (self.proportion(axis, c_kji0[axis]) for axis in range(3))
+        return (self.proportion(axis, c_kji0[axis]) for axis in range(3))
 
-   def set_constant_ratio(self, axis):
-      """Set the refinement ratio for axis based on the ratio of the fine to coarse extents."""
+    def set_constant_ratio(self, axis):
+        """Set the refinement ratio for axis based on the ratio of the fine to coarse extents."""
 
-      assert 0 <= axis < 3
-      extent_ratio, remainder = divmod(self.fine_extent_kji[axis], self.coarse_extent_kji[axis])
-      assert remainder == 0, 'coarse extent in ' + 'KJI'[axis] + ' is not a multiple of fine extent'
-      self.constant_ratios[axis] = extent_ratio
-      self.vector_ratios[axis] = None
+        assert 0 <= axis < 3
+        extent_ratio, remainder = divmod(self.fine_extent_kji[axis], self.coarse_extent_kji[axis])
+        assert remainder == 0, 'coarse extent in ' + 'KJI'[axis] + ' is not a multiple of fine extent'
+        self.constant_ratios[axis] = extent_ratio
+        self.vector_ratios[axis] = None
 
-   def set_ij_ratios_constant(self):
-      """Set the refinement ratio for I & J axes based on the ratio of the fine to coarse extents."""
+    def set_ij_ratios_constant(self):
+        """Set the refinement ratio for I & J axes based on the ratio of the fine to coarse extents."""
 
-      for axis in (1, 2):
-         self.set_constant_ratio(axis)
+        for axis in (1, 2):
+            self.set_constant_ratio(axis)
 
-   def set_all_ratios_constant(self):
-      """Set all refinement ratios constant based on the ratio of the fine to coarse extents."""
+    def set_all_ratios_constant(self):
+        """Set all refinement ratios constant based on the ratio of the fine to coarse extents."""
 
-      for axis in range(3):
-         self.set_constant_ratio(axis)
+        for axis in range(3):
+            self.set_constant_ratio(axis)
 
-   def set_ratio_vector(self, axis, vector):
-      """Set fine:coarse ratios for axis from numpy int vector of length matching coarse extent."""
+    def set_ratio_vector(self, axis, vector):
+        """Set fine:coarse ratios for axis from numpy int vector of length matching coarse extent."""
 
-      assert 0 <= axis < 3
-      if isinstance(vector, list) or isinstance(vector, tuple):
-         vector = np.array(vector)
-      assert isinstance(vector, np.ndarray) and vector.ndim == 1
-      assert str(vector.dtype).startswith('int')
-      assert len(vector) == self.coarse_extent_kji[axis],  \
-             'length of vector of refinement ratios does not match coarse extent'
-      assert np.sum(vector) == self.fine_extent_kji[axis],  \
-             'sum of refinement ratios in vector does not match fine extent'
-      minimum = np.min(vector)
-      assert minimum > 0
-      if minimum == np.max(vector):
-         self.set_constant_ratio(axis)
-         assert self.constant_ratios[axis] == minimum
-      else:
-         self.vector_ratios[axis] = vector.copy()
-         self.constant_ratios[axis] = None
-
-   def set_equal_proportions(self, axis):
-      """Set proportions equal for axis."""
-
-      assert 0 <= axis < 3
-      self.equal_proportions[axis] = True
-      self.vector_proportions[axis] = None
-
-   def set_all_proprtions_equal(self):
-      """Sets proportions equal in all 3 axes."""
-
-      for axis in range(3):
-         self.set_equal_proportions(axis)
-
-   def set_proportions_list_of_vectors(self, axis, list_of_vectors):
-      """Sets the proportions for given axis, with one vector for each coarse slice in the axis."""
-
-      assert 0 <= axis < 3
-      assert len(list_of_vectors) == self.coarse_extent_kji[axis]
-      if self.vector_proportions is None:
-         self.vector_proportions = [None, None, None]
-      fractions_list_of_vectors = []
-      all_equal = True
-      for c0 in range(self.coarse_extent_kji[axis]):
-         vector = list_of_vectors[c0]
-         count = self.ratio(axis, c0)
-         if isinstance(vector, list) or isinstance(vector, tuple):
+        assert 0 <= axis < 3
+        if isinstance(vector, list) or isinstance(vector, tuple):
             vector = np.array(vector)
-         assert isinstance(vector, np.ndarray) and vector.ndim == 1
-         assert len(vector) == count, 'wrong number of proportions for axis: ' + str(axis) + ' slice(0): ' + c0
-         assert not np.any(np.isnan(vector))
-         assert np.all(vector > 0)
-         total = float(np.sum(vector))
-         fractions = np.empty((count,), dtype = float)
-         fractions[:] = vector
-         fractions /= total
-         fractions_list_of_vectors.append(fractions)
-         if np.max(fractions) - np.min(fractions) > 1.0e-6:
-            all_equal = False
-      if all_equal:
-         self.equal_proportions[axis] = True
-         self.vector_proportions[axis] = None
-      else:
-         self.equal_proportions[axis] = False
-         self.vector_proportions[axis] = fractions_list_of_vectors
+        assert isinstance(vector, np.ndarray) and vector.ndim == 1
+        assert str(vector.dtype).startswith('int')
+        assert len(vector) == self.coarse_extent_kji[axis],  \
+               'length of vector of refinement ratios does not match coarse extent'
+        assert np.sum(vector) == self.fine_extent_kji[axis],  \
+               'sum of refinement ratios in vector does not match fine extent'
+        minimum = np.min(vector)
+        assert minimum > 0
+        if minimum == np.max(vector):
+            self.set_constant_ratio(axis)
+            assert self.constant_ratios[axis] == minimum
+        else:
+            self.vector_ratios[axis] = vector.copy()
+            self.constant_ratios[axis] = None
 
-   def fine_for_coarse_natural_column_index(self, coarse_col):
-      """Returns the fine equivalent natural (first) column index for coarse natural column index."""
+    def set_equal_proportions(self, axis):
+        """Set proportions equal for axis."""
 
-      j, i = divmod(coarse_col, self.coarse_extent_kji[2])
-      ratio_j, ratio_i = self.constant_ratios[1], self.constant_ratios[2]
-      if ratio_j is None:
-         if j:
-            j = np.sum(self.vector_ratios[1][0:j])
-      else:
-         j *= ratio_j
-      if ratio_i is None:
-         if i:
-            i = np.sum(self.vector_ratios[2][0:i])
-      else:
-         i *= ratio_i
-      return j * self.fine_extent_kji[2] + i
+        assert 0 <= axis < 3
+        self.equal_proportions[axis] = True
+        self.vector_proportions[axis] = None
 
-   def fine_for_coarse_natural_pillar_index(self, coarse_p):
-      """Returns the fine equivalent natural (first) pillar index for coarse natural pillar index."""
+    def set_all_proprtions_equal(self):
+        """Sets proportions equal in all 3 axes."""
 
-      p_j, p_i = divmod(coarse_p, self.coarse_extent_kji[2] + 1)
-      ratio_j, ratio_i = self.constant_ratios[1], self.constant_ratios[2]
-      if ratio_j is None:
-         if p_j:
-            p_j = np.sum(self.vector_ratios[1][0:p_j])
-      else:
-         p_j *= ratio_j
-      if ratio_i is None:
-         if p_i:
-            p_i = np.sum(self.vector_ratios[2][0:p_i])
-      else:
-         p_i *= ratio_i
-      return p_j * (self.fine_extent_kji[2] + 1) + p_i
+        for axis in range(3):
+            self.set_equal_proportions(axis)
 
-   def write_cartref(self,
-                     filename,
-                     lgr_name,
-                     mode = 'a',
-                     root_name = None,
-                     preceeding_blank_lines = 0,
-                     trailing_blank_lines = 0):
-      """Write Nexus ascii input format CARTREF; within_coarse_box must have been set."""
+    def set_proportions_list_of_vectors(self, axis, list_of_vectors):
+        """Sets the proportions for given axis, with one vector for each coarse slice in the axis."""
 
-      assert self.within_coarse_box is not None, 'box within larger coarse grid required for cartref'
-      assert filename and lgr_name, 'filename or lgr name missing for cartref'
-      assert ' ' not in lgr_name, 'lgr name may not contain spaces'
-      if len(lgr_name) > 8 or (root_name and len(root_name) > 8):
-         log.warning('Nexus might only differentiate first 8 characters of grid names')
-      with open(filename, mode) as fp:
-         for _ in range(preceeding_blank_lines):
-            fp.write('\n')
-         if root_name:
-            fp.write('LGR ' + str(root_name) + '\n')
-         fp.write('LGR\n')
-         fp.write('CARTREF ' + str(lgr_name) + '\n')
-         fp.write('   ' + box.spaced_string_iijjkk1_for_box_kji0(self.within_coarse_box) + '\n')
-         for axis in range(2, -1, -1):
-            fp.write('  ')
+        assert 0 <= axis < 3
+        assert len(list_of_vectors) == self.coarse_extent_kji[axis]
+        if self.vector_proportions is None:
+            self.vector_proportions = [None, None, None]
+        fractions_list_of_vectors = []
+        all_equal = True
+        for c0 in range(self.coarse_extent_kji[axis]):
+            vector = list_of_vectors[c0]
+            count = self.ratio(axis, c0)
+            if isinstance(vector, list) or isinstance(vector, tuple):
+                vector = np.array(vector)
+            assert isinstance(vector, np.ndarray) and vector.ndim == 1
+            assert len(vector) == count, 'wrong number of proportions for axis: ' + str(axis) + ' slice(0): ' + c0
+            assert not np.any(np.isnan(vector))
+            assert np.all(vector > 0)
+            total = float(np.sum(vector))
+            fractions = np.empty((count,), dtype = float)
+            fractions[:] = vector
+            fractions /= total
+            fractions_list_of_vectors.append(fractions)
+            if np.max(fractions) - np.min(fractions) > 1.0e-6:
+                all_equal = False
+        if all_equal:
+            self.equal_proportions[axis] = True
+            self.vector_proportions[axis] = None
+        else:
+            self.equal_proportions[axis] = False
+            self.vector_proportions[axis] = fractions_list_of_vectors
+
+    def fine_for_coarse_natural_column_index(self, coarse_col):
+        """Returns the fine equivalent natural (first) column index for coarse natural column index."""
+
+        j, i = divmod(coarse_col, self.coarse_extent_kji[2])
+        ratio_j, ratio_i = self.constant_ratios[1], self.constant_ratios[2]
+        if ratio_j is None:
+            if j:
+                j = np.sum(self.vector_ratios[1][0:j])
+        else:
+            j *= ratio_j
+        if ratio_i is None:
+            if i:
+                i = np.sum(self.vector_ratios[2][0:i])
+        else:
+            i *= ratio_i
+        return j * self.fine_extent_kji[2] + i
+
+    def fine_for_coarse_natural_pillar_index(self, coarse_p):
+        """Returns the fine equivalent natural (first) pillar index for coarse natural pillar index."""
+
+        p_j, p_i = divmod(coarse_p, self.coarse_extent_kji[2] + 1)
+        ratio_j, ratio_i = self.constant_ratios[1], self.constant_ratios[2]
+        if ratio_j is None:
+            if p_j:
+                p_j = np.sum(self.vector_ratios[1][0:p_j])
+        else:
+            p_j *= ratio_j
+        if ratio_i is None:
+            if p_i:
+                p_i = np.sum(self.vector_ratios[2][0:p_i])
+        else:
+            p_i *= ratio_i
+        return p_j * (self.fine_extent_kji[2] + 1) + p_i
+
+    def write_cartref(self,
+                      filename,
+                      lgr_name,
+                      mode = 'a',
+                      root_name = None,
+                      preceeding_blank_lines = 0,
+                      trailing_blank_lines = 0):
+        """Write Nexus ascii input format CARTREF; within_coarse_box must have been set."""
+
+        assert self.within_coarse_box is not None, 'box within larger coarse grid required for cartref'
+        assert filename and lgr_name, 'filename or lgr name missing for cartref'
+        assert ' ' not in lgr_name, 'lgr name may not contain spaces'
+        if len(lgr_name) > 8 or (root_name and len(root_name) > 8):
+            log.warning('Nexus might only differentiate first 8 characters of grid names')
+        with open(filename, mode) as fp:
+            for _ in range(preceeding_blank_lines):
+                fp.write('\n')
+            if root_name:
+                fp.write('LGR ' + str(root_name) + '\n')
+            fp.write('LGR\n')
+            fp.write('CARTREF ' + str(lgr_name) + '\n')
+            fp.write('   ' + box.spaced_string_iijjkk1_for_box_kji0(self.within_coarse_box) + '\n')
+            for axis in range(2, -1, -1):
+                fp.write('  ')
+                for c0 in range(self.coarse_extent_kji[axis]):
+                    fp.write(' ' + str(self.ratio(axis, c0)))
+                fp.write('\n')
+                if not self.equal_proportions[axis]:
+                    log.warning('unequal propertions in axis ' + 'KJI'[axis] + ': define Lgr corp separately')
+            fp.write('ENDREF\n')
+            fp.write('ENDLGR\n')
+            for _ in range(trailing_blank_lines):
+                fp.write('\n')
+
+    def _assert_extents_valid(self):
+
+        for axis in range(3):
+            assert _is_int(self.fine_extent_kji[axis]) and _is_int(self.coarse_extent_kji[axis])
+            assert self.fine_extent_kji[axis] > 0
+            assert self.coarse_extent_kji[axis] <= self.fine_extent_kji[axis]
+
+    def _set_fine_to_coarse_mapping(self):
+        self.fine_to_coarse_mapping = [None, None, None]
+        for axis in range(3):
+            self.fine_to_coarse_mapping[axis] = np.empty(self.fine_extent_kji[axis], dtype = int)
+            f0 = 0
             for c0 in range(self.coarse_extent_kji[axis]):
-               fp.write(' ' + str(self.ratio(axis, c0)))
-            fp.write('\n')
-            if not self.equal_proportions[axis]:
-               log.warning('unequal propertions in axis ' + 'KJI'[axis] + ': define Lgr corp separately')
-         fp.write('ENDREF\n')
-         fp.write('ENDLGR\n')
-         for _ in range(trailing_blank_lines):
-            fp.write('\n')
-
-   def _assert_extents_valid(self):
-
-      for axis in range(3):
-         assert _is_int(self.fine_extent_kji[axis]) and _is_int(self.coarse_extent_kji[axis])
-         assert self.fine_extent_kji[axis] > 0
-         assert self.coarse_extent_kji[axis] <= self.fine_extent_kji[axis]
-
-   def _set_fine_to_coarse_mapping(self):
-      self.fine_to_coarse_mapping = [None, None, None]
-      for axis in range(3):
-         self.fine_to_coarse_mapping[axis] = np.empty(self.fine_extent_kji[axis], dtype = int)
-         f0 = 0
-         for c0 in range(self.coarse_extent_kji[axis]):
-            ratio = self.ratio(axis, c0)
-            self.fine_to_coarse_mapping[axis][f0:f0 + ratio] = c0
-            f0 += ratio
-         assert f0 == self.fine_extent_kji[axis]
+                ratio = self.ratio(axis, c0)
+                self.fine_to_coarse_mapping[axis][f0:f0 + ratio] = c0
+                f0 += ratio
+            assert f0 == self.fine_extent_kji[axis]
 
 
 def tartan_refinement(coarse_extent_kji,
@@ -377,7 +378,7 @@ def tartan_refinement(coarse_extent_kji,
                       decay_rates_kji = None,
                       decay_mode = 'exponential',
                       within_coarse_box = None):
-   """Returns a new FineCoarse object set to a tartan grid refinement; fine extent is determined from arguments.
+    """Returns a new FineCoarse object set to a tartan grid refinement; fine extent is determined from arguments.
 
    arguments:
       coarse_extent_kji (triple int): the extent of the coarse grid being refined
@@ -408,99 +409,99 @@ def tartan_refinement(coarse_extent_kji,
       ratio of one at the boundary of the grid
    """
 
-   assert box.valid_box(coarse_fovea_box, coarse_extent_kji)
-   assert decay_mode in ['exponential', 'linear']
-   assert len(fovea_ratios_kji) == 3
+    assert box.valid_box(coarse_fovea_box, coarse_extent_kji)
+    assert decay_mode in ['exponential', 'linear']
+    assert len(fovea_ratios_kji) == 3
 
-   fovea_ratios_kji = np.array(fovea_ratios_kji)
-   assert np.all(fovea_ratios_kji >= 1)
+    fovea_ratios_kji = np.array(fovea_ratios_kji)
+    assert np.all(fovea_ratios_kji >= 1)
 
-   # generate decay rates if not passed in
-   rates = np.zeros((2, 3), dtype = float)  # -/+ side of fovea, in each axis
-   if decay_rates_kji is None:
-      border = np.zeros((2, 3), dtype = float)
-      border[0] = coarse_fovea_box[0].astype(float) + 0.5
-      border[1] = (coarse_extent_kji - coarse_fovea_box[1]).astype(float) - 0.5
-      for side in (0, 1):
-         if decay_mode == 'linear':
-            rates[side] = (fovea_ratios_kji - 1) / border[side]
-         else:  # exponential decay
-            rates[side] = np.power(1.5 / fovea_ratios_kji, 1.0 / border[side])
-   else:
-      assert len(decay_rates_kji) == 3
-      rates[:] = decay_rates_kji
+    # generate decay rates if not passed in
+    rates = np.zeros((2, 3), dtype = float)  # -/+ side of fovea, in each axis
+    if decay_rates_kji is None:
+        border = np.zeros((2, 3), dtype = float)
+        border[0] = coarse_fovea_box[0].astype(float) + 0.5
+        border[1] = (coarse_extent_kji - coarse_fovea_box[1]).astype(float) - 0.5
+        for side in (0, 1):
+            if decay_mode == 'linear':
+                rates[side] = (fovea_ratios_kji - 1) / border[side]
+            else:  # exponential decay
+                rates[side] = np.power(1.5 / fovea_ratios_kji, 1.0 / border[side])
+    else:
+        assert len(decay_rates_kji) == 3
+        rates[:] = decay_rates_kji
 
-   log.debug(f'decay rates: {rates}')
+    log.debug(f'decay rates: {rates}')
 
-   ratios_list = []
-   fine_extent_kji = np.zeros(3, dtype = int)
+    ratios_list = []
+    fine_extent_kji = np.zeros(3, dtype = int)
 
-   for axis in range(3):
-      ratios = np.ones(coarse_extent_kji[axis], dtype = int)
-      slice_a, slice_b = coarse_fovea_box[:, axis]
-      ratios[slice_a:slice_b + 1] = fovea_ratios_kji[axis]
-      floating_ratio = np.ones(2, dtype = float)
-      if decay_mode == 'linear':
-         floating_ratio[:] = fovea_ratios_kji[axis] - rates[:, axis]
-      else:
-         floating_ratio[:] = fovea_ratios_kji[axis] * rates[:, axis]  # exponential decay
-      rounded_ratio = np.around(floating_ratio).astype(int)
-      while np.any(rounded_ratio > 1) and (slice_a > 0 or slice_b < coarse_extent_kji[axis] - 1):
-         slice_a -= 1
-         slice_b += 1
-         if slice_a >= 0:
-            ratios[slice_a] = rounded_ratio[0]
-         if slice_b < coarse_extent_kji[axis]:
-            ratios[slice_b] = rounded_ratio[1]
-         if decay_mode == 'linear':
-            floating_ratio[:] -= rates[:, axis]
-         else:
-            floating_ratio[:] *= rates[:, axis]  # exponential decay
-         rounded_ratio = np.around(floating_ratio).astype(int)
-      ratios_list.append(ratios)
-      fine_extent_kji[axis] = np.sum(ratios)
+    for axis in range(3):
+        ratios = np.ones(coarse_extent_kji[axis], dtype = int)
+        slice_a, slice_b = coarse_fovea_box[:, axis]
+        ratios[slice_a:slice_b + 1] = fovea_ratios_kji[axis]
+        floating_ratio = np.ones(2, dtype = float)
+        if decay_mode == 'linear':
+            floating_ratio[:] = fovea_ratios_kji[axis] - rates[:, axis]
+        else:
+            floating_ratio[:] = fovea_ratios_kji[axis] * rates[:, axis]  # exponential decay
+        rounded_ratio = np.around(floating_ratio).astype(int)
+        while np.any(rounded_ratio > 1) and (slice_a > 0 or slice_b < coarse_extent_kji[axis] - 1):
+            slice_a -= 1
+            slice_b += 1
+            if slice_a >= 0:
+                ratios[slice_a] = rounded_ratio[0]
+            if slice_b < coarse_extent_kji[axis]:
+                ratios[slice_b] = rounded_ratio[1]
+            if decay_mode == 'linear':
+                floating_ratio[:] -= rates[:, axis]
+            else:
+                floating_ratio[:] *= rates[:, axis]  # exponential decay
+            rounded_ratio = np.around(floating_ratio).astype(int)
+        ratios_list.append(ratios)
+        fine_extent_kji[axis] = np.sum(ratios)
 
 
 #      log.debug(f'retio vector [{axis}]: {ratios}')
 
-   fc = FineCoarse(fine_extent_kji, coarse_extent_kji, within_coarse_box = within_coarse_box)
+    fc = FineCoarse(fine_extent_kji, coarse_extent_kji, within_coarse_box = within_coarse_box)
 
-   for axis in range(3):
-      fc.set_ratio_vector(axis, ratios_list[axis])
-      # todo: set proportions ?
+    for axis in range(3):
+        fc.set_ratio_vector(axis, ratios_list[axis])
+        # todo: set proportions ?
 
-   return fc
+    return fc
 
 
 def axis_for_letter(letter):
-   """Returns 0, 1 or 2 for 'K', 'J', or 'I'; as required for axis arguments in FineCoarse methods."""
+    """Returns 0, 1 or 2 for 'K', 'J', or 'I'; as required for axis arguments in FineCoarse methods."""
 
-   assert isinstance(letter, str) and len(letter) == 1
-   u = letter.upper()
-   return 'KJI'.index(u)
+    assert isinstance(letter, str) and len(letter) == 1
+    u = letter.upper()
+    return 'KJI'.index(u)
 
 
 def letter_for_axis(axis):
-   """Returns K, J, or I for axis; axis as required for axis arguments in FineCoarse methods."""
+    """Returns K, J, or I for axis; axis as required for axis arguments in FineCoarse methods."""
 
-   assert isinstance(axis, int) and 0 <= axis < 3
-   return 'KJI'[axis]
+    assert isinstance(axis, int) and 0 <= axis < 3
+    return 'KJI'[axis]
 
 
 def _assert_valid_box(extent_kji, box):
-   assert isinstance(box, np.ndarray) and box.shape == (2, 3) and str(box.dtype).startswith('int')
-   for axis in range(3):
-      assert 0 <= box[0, axis] <= box[1, axis]
-      assert box[1, axis] - box[0, axis] + 1 == extent_kji[axis]
+    assert isinstance(box, np.ndarray) and box.shape == (2, 3) and str(box.dtype).startswith('int')
+    for axis in range(3):
+        assert 0 <= box[0, axis] <= box[1, axis]
+        assert box[1, axis] - box[0, axis] + 1 == extent_kji[axis]
 
 
 def _is_int(v):
-   t = type(v)
-   if t is int:
-      return True
-   if t in [np.int64, np.int32, np.int16, np.int8]:
-      return True
-   s = str(t)
-   if s.startswith('int'):
-      return True
-   return False
+    t = type(v)
+    if t is int:
+        return True
+    if t in [np.int64, np.int32, np.int16, np.int8]:
+        return True
+    s = str(t)
+    if s.startswith('int'):
+        return True
+    return False

--- a/resqpy/olio/grid_functions.py
+++ b/resqpy/olio/grid_functions.py
@@ -57,93 +57,93 @@ def infill_block_geometry(extent,
                           vertical_cell_overlap_tolerance = 0.01,
                           snap_to_top_and_base = True,
                           nudge = True):
-   """Scans logically vertical columns of cells setting depth (& thickness) of inactive cells."""
+    """Scans logically vertical columns of cells setting depth (& thickness) of inactive cells."""
 
-   if k_increase_direction == 'down':
-      k_dir_sign = 1.0
-   elif k_increase_direction == 'up':
-      k_dir_sign = -1.0
-   else:
-      assert (False)
+    if k_increase_direction == 'down':
+        k_dir_sign = 1.0
+    elif k_increase_direction == 'up':
+        k_dir_sign = -1.0
+    else:
+        assert (False)
 
-   for j in range(extent[1]):
-      for i in range(extent[2]):
-         k_top = 0  # NB: 'top' & 'bottom' are misleading if k_increase_direction == 'up'
-         while k_top < extent[0] and abs(depth[k_top, j, i]) <= depth_zero_tolerance:
-            depth[k_top, j, i] = 0.0  # clean up tiny values
-            thickness[k_top, j, i] = 0.0
-            if abs(x[k_top, j, i]) <= x_y_zero_tolerance:
-               x[k_top, j, i] = 0.0
-            if abs(y[k_top, j, i]) <= x_y_zero_tolerance:
-               y[k_top, j, i] = 0.0
-            k_top += 1  # skip topmost inactive batch
-         if k_top >= extent[0]:
-            continue  # whole column is inactive
-         if snap_to_top_and_base:
-            snap_depth = depth[k_top, j, i] - k_dir_sign * thickness[k_top, j, i] / 2.0
-            snap_x = x[k_top, j, i]
-            snap_y = y[k_top, j, i]
-            for k_snap in range(k_top):
-               depth[k_snap, j, i] = snap_depth
-               x[k_snap, j, i] = snap_x
-               y[k_snap, j, i] = snap_y
-         while True:
-            while k_top < extent[0] and abs(depth[k_top, j, i]) > depth_zero_tolerance:  # skip active layers
-               k_top += 1
-            k_base = k_top + 1
-            while k_base < extent[0] and abs(depth[k_base, j, i]) <= depth_zero_tolerance:
-               depth[k_base, j, i] = 0.0  # clean up tiny depth values
-               thickness[k_base, j, i] = 0.0
-               if abs(x[k_base, j, i]) <= x_y_zero_tolerance:
-                  x[k_base, j, i] = 0.0
-               if abs(y[k_base, j, i]) <= x_y_zero_tolerance:
-                  y[k_base, j, i] = 0.0
-               k_base += 1  # look for deeper active layer
-            if k_base >= extent[0]:  # no deeper active cells found
-               if snap_to_top_and_base:
-                  snap_depth = depth[k_top - 1, j, i] + k_dir_sign * thickness[k_top - 1, j, i] / 2.0
-                  snap_x = x[k_top - 1, j, i]
-                  snap_y = y[k_top - 1, j, i]
-                  for k_snap in range(extent[0] - k_top):
-                     depth[k_top + k_snap, j, i] = snap_depth
-                     x[k_top + k_snap, j, i] = snap_x
-                     y[k_top + k_snap, j, i] = snap_y
-               break
-            void_cell_count = k_base - k_top
-            assert (void_cell_count > 0)
-            void_top_depth = depth[k_top - 1, j, i] + (thickness[k_top - 1, j, i] / 2.0) * k_dir_sign
-            void_bottom_depth = depth[k_base, j, i] - (thickness[k_base, j, i] / 2.0) * k_dir_sign
-            void_top_x = x[k_top - 1, j, i]
-            void_top_y = y[k_top - 1, j, i]
-            void_interval = k_dir_sign * (void_bottom_depth - void_top_depth)
-            void_x_interval = x[k_base, j, i] - void_top_x
-            void_y_interval = y[k_base, j, i] - void_top_y
-            infill_cell_thickness = void_interval / void_cell_count
-            if void_interval < 0.0:  # overlapping cells
-               if -void_interval < vertical_cell_overlap_tolerance:
-                  if nudge:
-                     nudge_count = 0  # debug
-                     for k_nudge in range(extent[0] - k_base):
-                        if depth[k_base + k_nudge, j, i] > depth_zero_tolerance:
-                           depth[k_base + k_nudge, j, i] += -void_interval * k_dir_sign
-                           nudge_count += 1  # debug
-                     log.debug('%1d cells nudged in [ i j ] column [%1d, %1d]', nudge_count, i + 1, j + 1)
-                     void_bottom_depth += -void_interval
-                  void_interval = 0.0
-                  infill_cell_thickness = 0.0
-               else:
-                  log.warn('Cells [%1d, %1d, %1d] and [%1d, %1d, %1d] overlap ...', i + 1, j + 1, k_top, i + 1, j + 1,
-                           k_base + 1)
-                  log.warn('   check k_increase_direction and tolerances')
-                  log.warn('Skipping rest of i,j column')  # todo: could abort here
-                  break
-            assert (infill_cell_thickness >= 0.0)
-            for void_k in range(void_cell_count):
-               depth[k_top + void_k, j, i] = void_top_depth + (0.5 + void_k) * infill_cell_thickness * k_dir_sign
-               thickness[k_top + void_k, j, i] = infill_cell_thickness
-               x[k_top + void_k, j, i] = void_top_x + (0.5 + void_k) * void_x_interval / void_cell_count
-               y[k_top + void_k, j, i] = void_top_y + (0.5 + void_k) * void_y_interval / void_cell_count
-            k_top = k_base
+    for j in range(extent[1]):
+        for i in range(extent[2]):
+            k_top = 0  # NB: 'top' & 'bottom' are misleading if k_increase_direction == 'up'
+            while k_top < extent[0] and abs(depth[k_top, j, i]) <= depth_zero_tolerance:
+                depth[k_top, j, i] = 0.0  # clean up tiny values
+                thickness[k_top, j, i] = 0.0
+                if abs(x[k_top, j, i]) <= x_y_zero_tolerance:
+                    x[k_top, j, i] = 0.0
+                if abs(y[k_top, j, i]) <= x_y_zero_tolerance:
+                    y[k_top, j, i] = 0.0
+                k_top += 1  # skip topmost inactive batch
+            if k_top >= extent[0]:
+                continue  # whole column is inactive
+            if snap_to_top_and_base:
+                snap_depth = depth[k_top, j, i] - k_dir_sign * thickness[k_top, j, i] / 2.0
+                snap_x = x[k_top, j, i]
+                snap_y = y[k_top, j, i]
+                for k_snap in range(k_top):
+                    depth[k_snap, j, i] = snap_depth
+                    x[k_snap, j, i] = snap_x
+                    y[k_snap, j, i] = snap_y
+            while True:
+                while k_top < extent[0] and abs(depth[k_top, j, i]) > depth_zero_tolerance:  # skip active layers
+                    k_top += 1
+                k_base = k_top + 1
+                while k_base < extent[0] and abs(depth[k_base, j, i]) <= depth_zero_tolerance:
+                    depth[k_base, j, i] = 0.0  # clean up tiny depth values
+                    thickness[k_base, j, i] = 0.0
+                    if abs(x[k_base, j, i]) <= x_y_zero_tolerance:
+                        x[k_base, j, i] = 0.0
+                    if abs(y[k_base, j, i]) <= x_y_zero_tolerance:
+                        y[k_base, j, i] = 0.0
+                    k_base += 1  # look for deeper active layer
+                if k_base >= extent[0]:  # no deeper active cells found
+                    if snap_to_top_and_base:
+                        snap_depth = depth[k_top - 1, j, i] + k_dir_sign * thickness[k_top - 1, j, i] / 2.0
+                        snap_x = x[k_top - 1, j, i]
+                        snap_y = y[k_top - 1, j, i]
+                        for k_snap in range(extent[0] - k_top):
+                            depth[k_top + k_snap, j, i] = snap_depth
+                            x[k_top + k_snap, j, i] = snap_x
+                            y[k_top + k_snap, j, i] = snap_y
+                    break
+                void_cell_count = k_base - k_top
+                assert (void_cell_count > 0)
+                void_top_depth = depth[k_top - 1, j, i] + (thickness[k_top - 1, j, i] / 2.0) * k_dir_sign
+                void_bottom_depth = depth[k_base, j, i] - (thickness[k_base, j, i] / 2.0) * k_dir_sign
+                void_top_x = x[k_top - 1, j, i]
+                void_top_y = y[k_top - 1, j, i]
+                void_interval = k_dir_sign * (void_bottom_depth - void_top_depth)
+                void_x_interval = x[k_base, j, i] - void_top_x
+                void_y_interval = y[k_base, j, i] - void_top_y
+                infill_cell_thickness = void_interval / void_cell_count
+                if void_interval < 0.0:  # overlapping cells
+                    if -void_interval < vertical_cell_overlap_tolerance:
+                        if nudge:
+                            nudge_count = 0  # debug
+                            for k_nudge in range(extent[0] - k_base):
+                                if depth[k_base + k_nudge, j, i] > depth_zero_tolerance:
+                                    depth[k_base + k_nudge, j, i] += -void_interval * k_dir_sign
+                                    nudge_count += 1  # debug
+                            log.debug('%1d cells nudged in [ i j ] column [%1d, %1d]', nudge_count, i + 1, j + 1)
+                            void_bottom_depth += -void_interval
+                        void_interval = 0.0
+                        infill_cell_thickness = 0.0
+                    else:
+                        log.warn('Cells [%1d, %1d, %1d] and [%1d, %1d, %1d] overlap ...', i + 1, j + 1, k_top, i + 1,
+                                 j + 1, k_base + 1)
+                        log.warn('   check k_increase_direction and tolerances')
+                        log.warn('Skipping rest of i,j column')  # todo: could abort here
+                        break
+                assert (infill_cell_thickness >= 0.0)
+                for void_k in range(void_cell_count):
+                    depth[k_top + void_k, j, i] = void_top_depth + (0.5 + void_k) * infill_cell_thickness * k_dir_sign
+                    thickness[k_top + void_k, j, i] = infill_cell_thickness
+                    x[k_top + void_k, j, i] = void_top_x + (0.5 + void_k) * void_x_interval / void_cell_count
+                    y[k_top + void_k, j, i] = void_top_y + (0.5 + void_k) * void_y_interval / void_cell_count
+                k_top = k_base
 
 
 # end of def infill_block_geometry()
@@ -154,36 +154,36 @@ def infill_block_geometry(extent,
 
 
 def resequence_nexus_corp(corner_points, eight_mode = False, undo = False):
-   """Reorders corner point data in situ, to handle bizarre nexus orderings"""
+    """Reorders corner point data in situ, to handle bizarre nexus orderings"""
 
-   # undo False for corp to internal; undo True for internal to corp; only relevant in eight_mode
-   assert (corner_points.ndim == 7)
-   extent = np.array(corner_points.shape, dtype = 'int')
-   if eight_mode:
-      for k in range(extent[0]):
-         for j in range(extent[1]):
-            for i in range(extent[2]):
-               if undo:
-                  xyz = np.zeros((3, 8))
-                  c = 0
-                  for kp in range(2):
-                     for jp in range(2):
-                        for ip in range(2):
-                           xyz[:, c] = corner_points[k, j, i, kp, jp, ip, :]
-                           c += 1
-                  corner_points[k, j, i] = xyz.reshape((2, 2, 2, 3))
-               else:
-                  xyz = corner_points[k, j, i].reshape((3, 8)).copy()
-                  c = 0
-                  for kp in range(2):
-                     for jp in range(2):
-                        for ip in range(2):
-                           corner_points[k, j, i, kp, jp, ip, :] = xyz[:, c]
-                           c += 1
-   else:  # reversible, so not dependent on undo argument
-      jp_slice = corner_points[:, :, :, :, 1, 0, :].copy()
-      corner_points[:, :, :, :, 1, 0, :] = corner_points[:, :, :, :, 1, 1, :]
-      corner_points[:, :, :, :, 1, 1, :] = jp_slice
+    # undo False for corp to internal; undo True for internal to corp; only relevant in eight_mode
+    assert (corner_points.ndim == 7)
+    extent = np.array(corner_points.shape, dtype = 'int')
+    if eight_mode:
+        for k in range(extent[0]):
+            for j in range(extent[1]):
+                for i in range(extent[2]):
+                    if undo:
+                        xyz = np.zeros((3, 8))
+                        c = 0
+                        for kp in range(2):
+                            for jp in range(2):
+                                for ip in range(2):
+                                    xyz[:, c] = corner_points[k, j, i, kp, jp, ip, :]
+                                    c += 1
+                        corner_points[k, j, i] = xyz.reshape((2, 2, 2, 3))
+                    else:
+                        xyz = corner_points[k, j, i].reshape((3, 8)).copy()
+                        c = 0
+                        for kp in range(2):
+                            for jp in range(2):
+                                for ip in range(2):
+                                    corner_points[k, j, i, kp, jp, ip, :] = xyz[:, c]
+                                    c += 1
+    else:  # reversible, so not dependent on undo argument
+        jp_slice = corner_points[:, :, :, :, 1, 0, :].copy()
+        corner_points[:, :, :, :, 1, 0, :] = corner_points[:, :, :, :, 1, 1, :]
+        corner_points[:, :, :, :, 1, 1, :] = jp_slice
 
 
 # end of def resequence_nexus_corp()
@@ -194,43 +194,43 @@ def resequence_nexus_corp(corner_points, eight_mode = False, undo = False):
 
 
 def random_cell(corner_points, border = 0.25, max_tries = 20, tolerance = 0.003):
-   """Returns a random cell's (k,j,i) tuple for a cell with non-zero lengths on all 3 primary edges."""
+    """Returns a random cell's (k,j,i) tuple for a cell with non-zero lengths on all 3 primary edges."""
 
-   assert (corner_points.ndim == 7)
-   assert (border >= 0.0 and border < 0.5)
-   assert (max_tries > 0)
+    assert (corner_points.ndim == 7)
+    assert (border >= 0.0 and border < 0.5)
+    assert (max_tries > 0)
 
-   extent = np.array(corner_points.shape, dtype = 'int')
-   kji_extent = extent[:3]
-   kji_border = np.zeros(3, dtype = 'int')
-   kji_upper = np.zeros(3, dtype = 'int')
-   for axis in range(3):
-      kji_border[axis] = int(float(kji_extent[axis]) * border)
-      kji_upper[axis] = kji_extent[axis] - kji_border[axis] - 1
-      if kji_upper[axis] < kji_border[axis]:
-         kji_upper[axis] = kji_border[axis]
+    extent = np.array(corner_points.shape, dtype = 'int')
+    kji_extent = extent[:3]
+    kji_border = np.zeros(3, dtype = 'int')
+    kji_upper = np.zeros(3, dtype = 'int')
+    for axis in range(3):
+        kji_border[axis] = int(float(kji_extent[axis]) * border)
+        kji_upper[axis] = kji_extent[axis] - kji_border[axis] - 1
+        if kji_upper[axis] < kji_border[axis]:
+            kji_upper[axis] = kji_border[axis]
 
-   kji_cell = np.empty(3, dtype = 'int')
-   attempt = 0
-   while attempt < max_tries:
-      attempt += 1
-      for axis in range(3):
-         if kji_extent[axis] == 1:
-            kji_cell[axis] = 0
-         else:
-            kji_cell[axis] = random.randint(kji_border[axis], kji_upper[axis])
-      cell_cp = corner_points[tuple(kji_cell)]
-      assert (cell_cp.shape == (2, 2, 2, 3))
-      if vec.manhatten_distance(cell_cp[0, 0, 0], cell_cp[1, 0, 0]) < tolerance:
-         continue
-      if vec.manhatten_distance(cell_cp[0, 0, 0], cell_cp[0, 1, 0]) < tolerance:
-         continue
-      if vec.manhatten_distance(cell_cp[0, 0, 0], cell_cp[0, 0, 1]) < tolerance:
-         continue
-      return tuple(kji_cell)
+    kji_cell = np.empty(3, dtype = 'int')
+    attempt = 0
+    while attempt < max_tries:
+        attempt += 1
+        for axis in range(3):
+            if kji_extent[axis] == 1:
+                kji_cell[axis] = 0
+            else:
+                kji_cell[axis] = random.randint(kji_border[axis], kji_upper[axis])
+        cell_cp = corner_points[tuple(kji_cell)]
+        assert (cell_cp.shape == (2, 2, 2, 3))
+        if vec.manhatten_distance(cell_cp[0, 0, 0], cell_cp[1, 0, 0]) < tolerance:
+            continue
+        if vec.manhatten_distance(cell_cp[0, 0, 0], cell_cp[0, 1, 0]) < tolerance:
+            continue
+        if vec.manhatten_distance(cell_cp[0, 0, 0], cell_cp[0, 0, 1]) < tolerance:
+            continue
+        return tuple(kji_cell)
 
-   log.warning('failed to find random voluminous cell')
-   return None
+    log.warning('failed to find random voluminous cell')
+    return None
 
 
 # end of def random_cell()
@@ -241,26 +241,26 @@ def random_cell(corner_points, border = 0.25, max_tries = 20, tolerance = 0.003)
 
 
 def determine_corp_ijk_handedness(corner_points, xyz_is_left_handed = True):
-   """Determine true ijk handedness from corner point data in pagoda style 7D array; returns 'right' or 'left'."""
+    """Determine true ijk handedness from corner point data in pagoda style 7D array; returns 'right' or 'left'."""
 
-   assert (corner_points.ndim == 7)
-   cell_kji = random_cell(corner_points)
-   assert (cell_kji is not None)
-   log.debug('using cell ijk0 [{}, {}, {}] to determine ijk handedness'.format(cell_kji[2], cell_kji[1], cell_kji[0]))
-   cell_cp = corner_points[cell_kji]
-   origin = cell_cp[0, 0, 0]
-   det = vec.determinant(cell_cp[0, 0, 1] - origin, cell_cp[0, 1, 0] - origin,
-                         cell_cp[1, 0, 0] - origin)  # NB. IJK ordering
-   if det == 0.0:
-      log.warning('indeterminate handedness in cell ijk0 [{}, {}, {}]'.format(cell_kji[2], cell_kji[1], cell_kji[0]))
-      return None
-   if det > 0.0:
-      ijk_is_left_handed = xyz_is_left_handed
-   else:
-      ijk_is_left_handed = not xyz_is_left_handed
-   if ijk_is_left_handed:
-      return 'left'
-   return 'right'
+    assert (corner_points.ndim == 7)
+    cell_kji = random_cell(corner_points)
+    assert (cell_kji is not None)
+    log.debug('using cell ijk0 [{}, {}, {}] to determine ijk handedness'.format(cell_kji[2], cell_kji[1], cell_kji[0]))
+    cell_cp = corner_points[cell_kji]
+    origin = cell_cp[0, 0, 0]
+    det = vec.determinant(cell_cp[0, 0, 1] - origin, cell_cp[0, 1, 0] - origin,
+                          cell_cp[1, 0, 0] - origin)  # NB. IJK ordering
+    if det == 0.0:
+        log.warning('indeterminate handedness in cell ijk0 [{}, {}, {}]'.format(cell_kji[2], cell_kji[1], cell_kji[0]))
+        return None
+    if det > 0.0:
+        ijk_is_left_handed = xyz_is_left_handed
+    else:
+        ijk_is_left_handed = not xyz_is_left_handed
+    if ijk_is_left_handed:
+        return 'left'
+    return 'right'
 
 
 # end of def determine_corp_ijk_handedness()
@@ -271,101 +271,101 @@ def determine_corp_ijk_handedness(corner_points, xyz_is_left_handed = True):
 
 
 def determine_corp_extent(corner_points, tolerance = 0.003):
-   """Returns extent of grid derived from 7D corner points with all cells temporarily in I."""
+    """Returns extent of grid derived from 7D corner points with all cells temporarily in I."""
 
-   def neighbours(corner_points, sextuple_cell_a_p1, sextuple_cell_a_p2, sextuple_cell_b_p1, sextuple_cell_b_p2,
-                  tolerance):
-      # allows for reversal of points (or not) in neighbouring cell
-      if (
-         (vec.manhatten_distance(corner_points[sextuple_cell_a_p1], corner_points[sextuple_cell_b_p1]) <= tolerance) and
-         (vec.manhatten_distance(corner_points[sextuple_cell_a_p2], corner_points[sextuple_cell_b_p2]) <= tolerance)):
-         return True
-      if (
-         (vec.manhatten_distance(corner_points[sextuple_cell_a_p1], corner_points[sextuple_cell_b_p2]) <= tolerance) and
-         (vec.manhatten_distance(corner_points[sextuple_cell_a_p2], corner_points[sextuple_cell_b_p1]) <= tolerance)):
-         return True
-      return False
+    def neighbours(corner_points, sextuple_cell_a_p1, sextuple_cell_a_p2, sextuple_cell_b_p1, sextuple_cell_b_p2,
+                   tolerance):
+        # allows for reversal of points (or not) in neighbouring cell
+        if ((vec.manhatten_distance(corner_points[sextuple_cell_a_p1], corner_points[sextuple_cell_b_p1]) <= tolerance)
+                and (vec.manhatten_distance(corner_points[sextuple_cell_a_p2], corner_points[sextuple_cell_b_p2]) <=
+                     tolerance)):
+            return True
+        if ((vec.manhatten_distance(corner_points[sextuple_cell_a_p1], corner_points[sextuple_cell_b_p2]) <= tolerance)
+                and (vec.manhatten_distance(corner_points[sextuple_cell_a_p2], corner_points[sextuple_cell_b_p1]) <=
+                     tolerance)):
+            return True
+        return False
 
-   assert (corner_points.ndim == 7 and corner_points.shape[:2] == (1, 1))
+    assert (corner_points.ndim == 7 and corner_points.shape[:2] == (1, 1))
 
-   confirmation = 3  # number of identical results needed for each of NI and NJ
-   max_failures = 100  # maximum number of failed random cells for each of NI and NJ
-   min_cell_length = 10.0 * tolerance
+    confirmation = 3  # number of identical results needed for each of NI and NJ
+    max_failures = 100  # maximum number of failed random cells for each of NI and NJ
+    min_cell_length = 10.0 * tolerance
 
-   cell_count = corner_points.shape[2]
-   prime_factorization = factors.factorize(cell_count)
-   log.debug('cell count is ' + str(cell_count) + '; prime factorization: ' + str(prime_factorization))
-   possible_extents = factors.all_factors_from_primes(prime_factorization)
-   log.debug('possible extents are: ' + str(possible_extents))
+    cell_count = corner_points.shape[2]
+    prime_factorization = factors.factorize(cell_count)
+    log.debug('cell count is ' + str(cell_count) + '; prime factorization: ' + str(prime_factorization))
+    possible_extents = factors.all_factors_from_primes(prime_factorization)
+    log.debug('possible extents are: ' + str(possible_extents))
 
-   ni = None
-   redundancy = confirmation
-   remaining_attempts = max_failures
-   while redundancy:
-      kji_cell = random_cell(corner_points, tolerance = min_cell_length)
-      found = False
-      for e in possible_extents:
-         candidate = kji_cell[2] + e
-         if candidate >= cell_count:
-            continue
-         if neighbours(corner_points, (0, 0, kji_cell[2], 0, 1, 0), (0, 0, kji_cell[2], 0, 1, 1),
-                       (0, 0, candidate, 0, 0, 0), (0, 0, candidate, 0, 0, 1), tolerance):
-            if ni is not None and ni != e:
-               log.error('inconsistent NI values of {} and {} determined from corner points'.format(ni, e))
-               return None
-            found = True
-            ni = e
-            redundancy -= 1
-            break
-      if not found:
-         remaining_attempts -= 1
-         if remaining_attempts <= 0:
-            log.error('failed to determine NI from corner points (out of tries)')  # could assume NJ = 1 here
-            return None
+    ni = None
+    redundancy = confirmation
+    remaining_attempts = max_failures
+    while redundancy:
+        kji_cell = random_cell(corner_points, tolerance = min_cell_length)
+        found = False
+        for e in possible_extents:
+            candidate = kji_cell[2] + e
+            if candidate >= cell_count:
+                continue
+            if neighbours(corner_points, (0, 0, kji_cell[2], 0, 1, 0), (0, 0, kji_cell[2], 0, 1, 1),
+                          (0, 0, candidate, 0, 0, 0), (0, 0, candidate, 0, 0, 1), tolerance):
+                if ni is not None and ni != e:
+                    log.error('inconsistent NI values of {} and {} determined from corner points'.format(ni, e))
+                    return None
+                found = True
+                ni = e
+                redundancy -= 1
+                break
+        if not found:
+            remaining_attempts -= 1
+            if remaining_attempts <= 0:
+                log.error('failed to determine NI from corner points (out of tries)')  # could assume NJ = 1 here
+                return None
 
-   log.info('NI determined from corner points to be ' + str(ni))
+    log.info('NI determined from corner points to be ' + str(ni))
 
-   if ni > 1:
-      ni_prime_factors = factors.factorize(ni)
-      factors.remove_subset(prime_factorization, ni_prime_factors)
-      log.debug('remaining prime factors after accounting for NI are: ' + str(prime_factorization))
-      possible_extents = factors.all_factors_from_primes(prime_factorization)
-      log.debug('possible extents for NJ & NK are: ' + str(possible_extents))
+    if ni > 1:
+        ni_prime_factors = factors.factorize(ni)
+        factors.remove_subset(prime_factorization, ni_prime_factors)
+        log.debug('remaining prime factors after accounting for NI are: ' + str(prime_factorization))
+        possible_extents = factors.all_factors_from_primes(prime_factorization)
+        log.debug('possible extents for NJ & NK are: ' + str(possible_extents))
 
-   nj = None
-   redundancy = confirmation
-   remaining_attempts = max_failures
-   while redundancy:
-      kji_cell = random_cell(corner_points)
-      found = False
-      for e in possible_extents:
-         candidate = kji_cell[2] + (e * ni)
-         if candidate >= cell_count:
-            continue
-         if vec.manhatten_distance(corner_points[0, 0, kji_cell[2], 1, 0, 0], corner_points[0, 0, candidate, 0, 0,
-                                                                                            0]) <= tolerance:
-            if nj is not None and nj != e:
-               log.error('inconsistent NJ values of {} and {} determined from corner points'.format(nj, e))
-               return None
-            found = True
-            nj = e
-            redundancy -= 1
-            break
-      if not found:
-         remaining_attempts -= 1
-         if remaining_attempts <= 0:
-            log.error(
-               'failed to determine NJ from corner points (out of tries)')  # could assume or check if NK = 1 here
-            return None
+    nj = None
+    redundancy = confirmation
+    remaining_attempts = max_failures
+    while redundancy:
+        kji_cell = random_cell(corner_points)
+        found = False
+        for e in possible_extents:
+            candidate = kji_cell[2] + (e * ni)
+            if candidate >= cell_count:
+                continue
+            if vec.manhatten_distance(corner_points[0, 0, kji_cell[2], 1, 0, 0], corner_points[0, 0, candidate, 0, 0,
+                                                                                               0]) <= tolerance:
+                if nj is not None and nj != e:
+                    log.error('inconsistent NJ values of {} and {} determined from corner points'.format(nj, e))
+                    return None
+                found = True
+                nj = e
+                redundancy -= 1
+                break
+        if not found:
+            remaining_attempts -= 1
+            if remaining_attempts <= 0:
+                log.error(
+                    'failed to determine NJ from corner points (out of tries)')  # could assume or check if NK = 1 here
+                return None
 
-   log.info('NJ determined from corner points to be ' + str(nj))
+    log.info('NJ determined from corner points to be ' + str(nj))
 
-   nk, remainder = divmod(cell_count, ni * nj)
-   assert (remainder == 0)
-   log.info('NK determined from corner points to be ' + str(nk))
-   assert (nk in possible_extents)
+    nk, remainder = divmod(cell_count, ni * nj)
+    assert (remainder == 0)
+    log.info('NK determined from corner points to be ' + str(nk))
+    assert (nk in possible_extents)
 
-   return [nk, nj, ni]
+    return [nk, nj, ni]
 
 
 # end def determine_corp_extent():
@@ -376,29 +376,29 @@ def determine_corp_extent(corner_points, tolerance = 0.003):
 
 
 def translate_corp(corner_points, x_shift = None, y_shift = None, min_xy = None, preserve_digits = None):
-   """Adjusts x and y values of corner points by a constant offset."""
+    """Adjusts x and y values of corner points by a constant offset."""
 
-   assert (corner_points.ndim == 7)
-   if min_xy is None:
-      minimum_xy = 0.0
-   else:
-      minimum_xy = min_xy
-   if x_shift is None:
-      x_sub = np.min(corner_points[:, :, :, :, :, :, 0]) - minimum_xy
-   else:
-      x_sub = -x_shift
-   if y_shift is None:
-      y_sub = np.min(corner_points[:, :, :, :, :, :, 1]) - minimum_xy
-   else:
-      y_sub = -y_shift
-   if preserve_digits is not None:
-      divisor = maths.pow(10.0, preserve_digits)
-      x_sub = divisor * maths.floor(x_sub / divisor)
-      y_sub = divisor * maths.floor(y_sub / divisor)
+    assert (corner_points.ndim == 7)
+    if min_xy is None:
+        minimum_xy = 0.0
+    else:
+        minimum_xy = min_xy
+    if x_shift is None:
+        x_sub = np.min(corner_points[:, :, :, :, :, :, 0]) - minimum_xy
+    else:
+        x_sub = -x_shift
+    if y_shift is None:
+        y_sub = np.min(corner_points[:, :, :, :, :, :, 1]) - minimum_xy
+    else:
+        y_sub = -y_shift
+    if preserve_digits is not None:
+        divisor = maths.pow(10.0, preserve_digits)
+        x_sub = divisor * maths.floor(x_sub / divisor)
+        y_sub = divisor * maths.floor(y_sub / divisor)
 
-   log.info('translating corner points by %3.1f in x and %3.1f in y', -x_sub, -y_sub)
-   corner_points[:, :, :, :, :, :, 0] -= x_sub
-   corner_points[:, :, :, :, :, :, 1] -= y_sub
+    log.info('translating corner points by %3.1f in x and %3.1f in y', -x_sub, -y_sub)
+    corner_points[:, :, :, :, :, :, 0] -= x_sub
+    corner_points[:, :, :, :, :, :, 1] -= y_sub
 
 
 # end of def translate_corp()
@@ -406,7 +406,7 @@ def translate_corp(corner_points, x_shift = None, y_shift = None, min_xy = None,
 
 
 def triangles_for_cell_faces(cp):
-   """Returns numpy array of shape (3, 2, 4, 3, 3) with axes being kji, -+, triangle within face, triangle corner, xyz.
+    """Returns numpy array of shape (3, 2, 4, 3, 3) with axes being kji, -+, triangle within face, triangle corner, xyz.
 
    args:
       cp (numpy float array of shape (2, 2, 2, 3)): single cell corner point array in pagoda protocol
@@ -419,47 +419,47 @@ def triangles_for_cell_faces(cp):
       resqpy.surface also contains methods for working with cell faces as triangulated sets
    """
 
-   tri = np.empty((3, 2, 4, 3, 3))
+    tri = np.empty((3, 2, 4, 3, 3))
 
-   # create face centre points and assign as one vertex in each of 4 trangles for face
-   tri[0, :, :, 0] = np.mean(cp, axis = (1, 2)).reshape((2, 1, 3)).repeat(4, axis = 1).reshape(
-      (2, 4, 3))  # k face centres
-   tri[1, :, :, 0] = np.mean(cp, axis = (0, 2)).reshape((2, 1, 3)).repeat(4, axis = 1).reshape(
-      (2, 4, 3))  # j face centres
-   tri[2, :, :, 0] = np.mean(cp, axis = (0, 1)).reshape((2, 1, 3)).repeat(4, axis = 1).reshape(
-      (2, 4, 3))  # i face centres
+    # create face centre points and assign as one vertex in each of 4 trangles for face
+    tri[0, :, :, 0] = np.mean(cp, axis = (1, 2)).reshape((2, 1, 3)).repeat(4, axis = 1).reshape(
+        (2, 4, 3))  # k face centres
+    tri[1, :, :, 0] = np.mean(cp, axis = (0, 2)).reshape((2, 1, 3)).repeat(4, axis = 1).reshape(
+        (2, 4, 3))  # j face centres
+    tri[2, :, :, 0] = np.mean(cp, axis = (0, 1)).reshape((2, 1, 3)).repeat(4, axis = 1).reshape(
+        (2, 4, 3))  # i face centres
 
-   # k faces
-   tri[0, :, 0, 1] = cp[:, 0, 0]
-   tri[0, :, 0, 2] = cp[:, 0, 1]
-   tri[0, :, 1, 1] = cp[:, 0, 1]
-   tri[0, :, 1, 2] = cp[:, 1, 1]
-   tri[0, :, 2, 1] = cp[:, 1, 1]
-   tri[0, :, 2, 2] = cp[:, 1, 0]
-   tri[0, :, 3, 1] = cp[:, 1, 0]
-   tri[0, :, 3, 2] = cp[:, 0, 0]
+    # k faces
+    tri[0, :, 0, 1] = cp[:, 0, 0]
+    tri[0, :, 0, 2] = cp[:, 0, 1]
+    tri[0, :, 1, 1] = cp[:, 0, 1]
+    tri[0, :, 1, 2] = cp[:, 1, 1]
+    tri[0, :, 2, 1] = cp[:, 1, 1]
+    tri[0, :, 2, 2] = cp[:, 1, 0]
+    tri[0, :, 3, 1] = cp[:, 1, 0]
+    tri[0, :, 3, 2] = cp[:, 0, 0]
 
-   # j faces
-   tri[1, :, 0, 1] = cp[0, :, 0]
-   tri[1, :, 0, 2] = cp[0, :, 1]
-   tri[1, :, 1, 1] = cp[0, :, 1]
-   tri[1, :, 1, 2] = cp[1, :, 1]
-   tri[1, :, 2, 1] = cp[1, :, 1]
-   tri[1, :, 2, 2] = cp[1, :, 0]
-   tri[1, :, 3, 1] = cp[1, :, 0]
-   tri[1, :, 3, 2] = cp[0, :, 0]
+    # j faces
+    tri[1, :, 0, 1] = cp[0, :, 0]
+    tri[1, :, 0, 2] = cp[0, :, 1]
+    tri[1, :, 1, 1] = cp[0, :, 1]
+    tri[1, :, 1, 2] = cp[1, :, 1]
+    tri[1, :, 2, 1] = cp[1, :, 1]
+    tri[1, :, 2, 2] = cp[1, :, 0]
+    tri[1, :, 3, 1] = cp[1, :, 0]
+    tri[1, :, 3, 2] = cp[0, :, 0]
 
-   # i faces
-   tri[2, :, 0, 1] = cp[0, 0, :]
-   tri[2, :, 0, 2] = cp[0, 1, :]
-   tri[2, :, 1, 1] = cp[0, 1, :]
-   tri[2, :, 1, 2] = cp[1, 1, :]
-   tri[2, :, 2, 1] = cp[1, 1, :]
-   tri[2, :, 2, 2] = cp[1, 0, :]
-   tri[2, :, 3, 1] = cp[1, 0, :]
-   tri[2, :, 3, 2] = cp[0, 0, :]
+    # i faces
+    tri[2, :, 0, 1] = cp[0, 0, :]
+    tri[2, :, 0, 2] = cp[0, 1, :]
+    tri[2, :, 1, 1] = cp[0, 1, :]
+    tri[2, :, 1, 2] = cp[1, 1, :]
+    tri[2, :, 2, 1] = cp[1, 1, :]
+    tri[2, :, 2, 2] = cp[1, 0, :]
+    tri[2, :, 3, 1] = cp[1, 0, :]
+    tri[2, :, 3, 2] = cp[0, 0, :]
 
-   return tri
+    return tri
 
 
 # end of grid_functions module
@@ -467,116 +467,116 @@ def triangles_for_cell_faces(cp):
 
 
 def actual_pillar_shape(pillar_points, tolerance = 0.001):
-   """Returns 'curved', 'straight' or 'vertical' for shape of fully defined points array of shape (nk + k_gaps + 1, ..., 3)."""
+    """Returns 'curved', 'straight' or 'vertical' for shape of fully defined points array of shape (nk + k_gaps + 1, ..., 3)."""
 
-   assert pillar_points.ndim >= 3 and pillar_points.shape[-1] == 3
+    assert pillar_points.ndim >= 3 and pillar_points.shape[-1] == 3
 
-   pp = pillar_points.reshape((pillar_points.shape[0], -1, 3))
+    pp = pillar_points.reshape((pillar_points.shape[0], -1, 3))
 
-   from_top = pp - pp[0]
-   xy_drift = np.abs(from_top[:, :, 0]) + np.abs(from_top[:, :,
-                                                          1])  # use Manhattan distance as cheap proxy for true distance
-   if np.max(xy_drift) <= tolerance:
-      return 'vertical'
-   if np.max(xy_drift[-1]) <= tolerance:
-      return 'curved'  # top & bottom are vertically aligned, so pillar must be curved
+    from_top = pp - pp[0]
+    xy_drift = np.abs(from_top[:, :, 0]) + np.abs(
+        from_top[:, :, 1])  # use Manhattan distance as cheap proxy for true distance
+    if np.max(xy_drift) <= tolerance:
+        return 'vertical'
+    if np.max(xy_drift[-1]) <= tolerance:
+        return 'curved'  # top & bottom are vertically aligned, so pillar must be curved
 
-   # where z variation is tiny (null pillar), don't interpolate, just treat these pillars as straight
-   # elsewhere find drift from vector defined by from_top[-1]
-   null_pillar_mask = (abs(from_top[-1, :, 2]) <= tolerance)
-   from_top[-1, :, 2] = np.where(null_pillar_mask, tolerance, from_top[-1, :, 2])  # avoid divide by zero issues
-   z_fraction = from_top[:, :, 2] / from_top[-1, :, 2]
-   xy_drift = from_top[:, :, :2] - z_fraction.reshape((pp.shape[0], pp.shape[1], 1)) * from_top[-1, :, :2].reshape(
-      (1, pp.shape[1], 2))
-   straight = (np.max(np.sum(np.abs(xy_drift), axis = -1), axis = 0) <= tolerance)
-   masked_straight = np.where(null_pillar_mask, True, straight)
-   if np.all(masked_straight):
-      return 'straight'
-   return 'curved'
+    # where z variation is tiny (null pillar), don't interpolate, just treat these pillars as straight
+    # elsewhere find drift from vector defined by from_top[-1]
+    null_pillar_mask = (abs(from_top[-1, :, 2]) <= tolerance)
+    from_top[-1, :, 2] = np.where(null_pillar_mask, tolerance, from_top[-1, :, 2])  # avoid divide by zero issues
+    z_fraction = from_top[:, :, 2] / from_top[-1, :, 2]
+    xy_drift = from_top[:, :, :2] - z_fraction.reshape((pp.shape[0], pp.shape[1], 1)) * from_top[-1, :, :2].reshape(
+        (1, pp.shape[1], 2))
+    straight = (np.max(np.sum(np.abs(xy_drift), axis = -1), axis = 0) <= tolerance)
+    masked_straight = np.where(null_pillar_mask, True, straight)
+    if np.all(masked_straight):
+        return 'straight'
+    return 'curved'
 
 
 ##########################################################################################
 
 
 def columns_to_nearest_split_face(grid):
-   """Returns a numpy integer array of shape (NJ, NI) being number of cells to nearest split edge (Manhattan distance)."""
+    """Returns a numpy integer array of shape (NJ, NI) being number of cells to nearest split edge (Manhattan distance)."""
 
-   if not grid.has_split_coordinate_lines:
-      return None
+    if not grid.has_split_coordinate_lines:
+        return None
 
-   j_col_faces_split, i_col_faces_split = grid.split_column_faces()
-   abutting = np.zeros((grid.nj, grid.ni), dtype = bool)
-   abutting[:-1, :] = j_col_faces_split
-   abutting[1:, :] = np.logical_or(abutting[1:, :], j_col_faces_split)
-   abutting[:, :-1] = np.logical_or(abutting[:, :-1], i_col_faces_split)
-   abutting[:, 1:] = np.logical_or(abutting[:, 1:], i_col_faces_split)
-   framed = np.full((grid.nj + 2, grid.ni + 2), grid.nj + grid.ni, dtype = int)
-   framed[1:-1, 1:-1] = np.where(abutting, 0, grid.nj + grid.ni)
+    j_col_faces_split, i_col_faces_split = grid.split_column_faces()
+    abutting = np.zeros((grid.nj, grid.ni), dtype = bool)
+    abutting[:-1, :] = j_col_faces_split
+    abutting[1:, :] = np.logical_or(abutting[1:, :], j_col_faces_split)
+    abutting[:, :-1] = np.logical_or(abutting[:, :-1], i_col_faces_split)
+    abutting[:, 1:] = np.logical_or(abutting[:, 1:], i_col_faces_split)
+    framed = np.full((grid.nj + 2, grid.ni + 2), grid.nj + grid.ni, dtype = int)
+    framed[1:-1, 1:-1] = np.where(abutting, 0, grid.nj + grid.ni)
 
-   while True:
-      plus_one = framed + 1
-      updated = np.minimum(framed[1:-1, 1:-1], plus_one[:-2, 1:-1])
-      updated[:] = np.minimum(updated, plus_one[2:, 1:-1])
-      updated[:] = np.minimum(updated, plus_one[1:-1, :-2])
-      updated[:] = np.minimum(updated, plus_one[1:-1, 2:])
-      if np.all(updated == framed[1:-1, 1:-1]):
-         break
-      framed[1:-1, 1:-1] = updated
+    while True:
+        plus_one = framed + 1
+        updated = np.minimum(framed[1:-1, 1:-1], plus_one[:-2, 1:-1])
+        updated[:] = np.minimum(updated, plus_one[2:, 1:-1])
+        updated[:] = np.minimum(updated, plus_one[1:-1, :-2])
+        updated[:] = np.minimum(updated, plus_one[1:-1, 2:])
+        if np.all(updated == framed[1:-1, 1:-1]):
+            break
+        framed[1:-1, 1:-1] = updated
 
-   return framed[1:-1, 1:-1]
+    return framed[1:-1, 1:-1]
 
 
 ##########################################################################################
 
 
 def left_right_foursome(full_pillar_list, p_index):
-   """Returns (2, 2) bool numpy array indicating which columns around a primary pillar are to the right of a line."""
+    """Returns (2, 2) bool numpy array indicating which columns around a primary pillar are to the right of a line."""
 
-   assert 0 < p_index < len(full_pillar_list) - 1
-   here = np.array(full_pillar_list[p_index], dtype = int)
-   previous = np.array(full_pillar_list[p_index - 1], dtype = int)
-   next = np.array(full_pillar_list[p_index + 1], dtype = int)
-   entry = tuple(here - previous)
-   exit = tuple(next - here)
-   if entry == (0, 1):
-      if exit == (-1, 0):
-         return np.array([[False, True], [True, True]], dtype = bool)
-      elif exit == (0, 1):
-         return np.array([[False, False], [True, True]], dtype = bool)
-      elif exit == (1, 0):
-         return np.array([[False, False], [True, False]], dtype = bool)
-      else:
-         raise Exception('code failure whilst taking exit sides from dubious full pillar list')
-   elif entry == (0, -1):
-      if exit == (-1, 0):
-         return np.array([[False, True], [False, False]], dtype = bool)
-      elif exit == (0, -1):
-         return np.array([[True, True], [False, False]], dtype = bool)
-      elif exit == (1, 0):
-         return np.array([[True, True], [True, False]], dtype = bool)
-      else:
-         raise Exception('code failure whilst taking exit sides from dubious full pillar list')
-   elif entry == (1, 0):
-      if exit == (0, -1):
-         return np.array([[True, False], [False, False]], dtype = bool)
-      elif exit == (1, 0):
-         return np.array([[True, False], [True, False]], dtype = bool)
-      elif exit == (0, 1):
-         return np.array([[True, False], [True, True]], dtype = bool)
-      else:
-         raise Exception('code failure whilst taking exit sides from dubious full pillar list')
-   elif entry == (-1, 0):
-      if exit == (0, -1):
-         return np.array([[True, True], [False, True]], dtype = bool)
-      elif exit == (-1, 0):
-         return np.array([[False, True], [False, True]], dtype = bool)
-      elif exit == (0, 1):
-         return np.array([[False, False], [False, True]], dtype = bool)
-      else:
-         raise Exception('code failure whilst taking exit sides from dubious full pillar list')
-   else:
-      log.debug(f'entry pair: {entry}')
-      raise Exception('code failure whilst taking entry sides from dubious full pillar list')
+    assert 0 < p_index < len(full_pillar_list) - 1
+    here = np.array(full_pillar_list[p_index], dtype = int)
+    previous = np.array(full_pillar_list[p_index - 1], dtype = int)
+    next = np.array(full_pillar_list[p_index + 1], dtype = int)
+    entry = tuple(here - previous)
+    exit = tuple(next - here)
+    if entry == (0, 1):
+        if exit == (-1, 0):
+            return np.array([[False, True], [True, True]], dtype = bool)
+        elif exit == (0, 1):
+            return np.array([[False, False], [True, True]], dtype = bool)
+        elif exit == (1, 0):
+            return np.array([[False, False], [True, False]], dtype = bool)
+        else:
+            raise Exception('code failure whilst taking exit sides from dubious full pillar list')
+    elif entry == (0, -1):
+        if exit == (-1, 0):
+            return np.array([[False, True], [False, False]], dtype = bool)
+        elif exit == (0, -1):
+            return np.array([[True, True], [False, False]], dtype = bool)
+        elif exit == (1, 0):
+            return np.array([[True, True], [True, False]], dtype = bool)
+        else:
+            raise Exception('code failure whilst taking exit sides from dubious full pillar list')
+    elif entry == (1, 0):
+        if exit == (0, -1):
+            return np.array([[True, False], [False, False]], dtype = bool)
+        elif exit == (1, 0):
+            return np.array([[True, False], [True, False]], dtype = bool)
+        elif exit == (0, 1):
+            return np.array([[True, False], [True, True]], dtype = bool)
+        else:
+            raise Exception('code failure whilst taking exit sides from dubious full pillar list')
+    elif entry == (-1, 0):
+        if exit == (0, -1):
+            return np.array([[True, True], [False, True]], dtype = bool)
+        elif exit == (-1, 0):
+            return np.array([[False, True], [False, True]], dtype = bool)
+        elif exit == (0, 1):
+            return np.array([[False, False], [False, True]], dtype = bool)
+        else:
+            raise Exception('code failure whilst taking exit sides from dubious full pillar list')
+    else:
+        log.debug(f'entry pair: {entry}')
+        raise Exception('code failure whilst taking entry sides from dubious full pillar list')
 
 
 ##########################################################################################

--- a/resqpy/olio/intersection.py
+++ b/resqpy/olio/intersection.py
@@ -11,7 +11,7 @@ import numpy as np
 
 
 def line_plane_intersect(line_p, line_v, triangle):
-   """Find the intersection of a line with a plane defined by a triangle.
+    """Find the intersection of a line with a plane defined by a triangle.
 
       arguments:
          line_p (3 element numpy vector): a point on the line
@@ -23,19 +23,19 @@ def line_plane_intersect(line_p, line_v, triangle):
          or None if line is parallel to plane
    """
 
-   p01 = triangle[1] - triangle[0]
-   p02 = triangle[2] - triangle[0]
+    p01 = triangle[1] - triangle[0]
+    p02 = triangle[2] - triangle[0]
 
-   norm = np.cross(p01, p02)  # normal to plane
-   denom = np.dot(np.negative(line_v), norm)
-   if denom == 0.0:
-      return None  # line is parallel to plane
-   t = np.dot(norm, line_p - triangle[0]) / denom
-   return line_p + t * line_v
+    norm = np.cross(p01, p02)  # normal to plane
+    denom = np.dot(np.negative(line_v), norm)
+    if denom == 0.0:
+        return None  # line is parallel to plane
+    t = np.dot(norm, line_p - triangle[0]) / denom
+    return line_p + t * line_v
 
 
 def line_triangle_intersect(line_p, line_v, triangle, line_segment = False):
-   """Find the intersection of a line within a triangle in 3D space.
+    """Find the intersection of a line within a triangle in 3D space.
 
       arguments:
          line_p (3 element numpy vector): a point on the line
@@ -49,30 +49,30 @@ def line_triangle_intersect(line_p, line_v, triangle, line_segment = False):
          outside the triangle
    """
 
-   p01 = triangle[1] - triangle[0]
-   p02 = triangle[2] - triangle[0]
+    p01 = triangle[1] - triangle[0]
+    p02 = triangle[2] - triangle[0]
 
-   norm = np.cross(p01, p02)  # normal to plane
-   line_rv = np.negative(line_v)
-   denom = np.dot(line_rv, norm)
-   if denom == 0.0:
-      return None  # line is parallel to plane
-   lp_t0 = line_p - triangle[0]
-   t = np.dot(norm, lp_t0) / denom
-   if line_segment and (t < 0.0 or t > 1.0):
-      return None
-   u = np.dot(np.cross(p02, line_rv), lp_t0) / denom
-   if u < 0.0 or u > 1.0:
-      return None
-   v = np.dot(np.cross(line_rv, p01), lp_t0) / denom
-   if v < 0.0 or u + v > 1.0:
-      return None
+    norm = np.cross(p01, p02)  # normal to plane
+    line_rv = np.negative(line_v)
+    denom = np.dot(line_rv, norm)
+    if denom == 0.0:
+        return None  # line is parallel to plane
+    lp_t0 = line_p - triangle[0]
+    t = np.dot(norm, lp_t0) / denom
+    if line_segment and (t < 0.0 or t > 1.0):
+        return None
+    u = np.dot(np.cross(p02, line_rv), lp_t0) / denom
+    if u < 0.0 or u > 1.0:
+        return None
+    v = np.dot(np.cross(line_rv, p01), lp_t0) / denom
+    if v < 0.0 or u + v > 1.0:
+        return None
 
-   return line_p + t * line_v
+    return line_p + t * line_v
 
 
 def line_triangles_intersects(line_p, line_v, triangles, line_segment = False):
-   """Find the intersections of a line within each of a set of triangles in 3D space.
+    """Find the intersections of a line within each of a set of triangles in 3D space.
 
       arguments:
          line_p (3 element numpy vector): a point on the line
@@ -87,46 +87,46 @@ def line_triangles_intersects(line_p, line_v, triangles, line_segment = False):
          outside the triangle (or beyond the ends of the segment if applicable)
    """
 
-   n = triangles.shape[0]  # number of triangles
+    n = triangles.shape[0]  # number of triangles
 
-   p01s = triangles[:, 1, :] - triangles[:, 0, :]  # p01s has shape (n, 3)
-   p02s = triangles[:, 2, :] - triangles[:, 0, :]  # p02s has shape (n, 3)
+    p01s = triangles[:, 1, :] - triangles[:, 0, :]  # p01s has shape (n, 3)
+    p02s = triangles[:, 2, :] - triangles[:, 0, :]  # p02s has shape (n, 3)
 
-   norms = np.cross(p01s, p02s)  # normals to planes, shape (n, 3)
-   line_rv = np.negative(line_v)
-   denoms = np.dot(norms, line_rv)  # shape (n)
-   #  if denom == 0.0: return None  # line is parallel to plane
-   lp_t0s = line_p - triangles[:, 0]  # shape (n, 3)
-   ts = np.empty(n)
-   ts.fill(np.nan)
-   us = ts.copy()
-   vs = ts.copy()
-   nz = (denoms != 0.0)
-   #  np.divide(np.dot(norms, lp_t0s), denoms, out = ts, where = nz)
-   np.seterr(divide = 'ignore')
-   np.divide(np.sum(norms * lp_t0s, axis = 1), denoms, out = ts, where = nz)
-   np.seterr(invalid = 'ignore')
-   if line_segment:
-      ts[:] = np.where(np.logical_or(ts < 0.0, ts > 1.0), np.nan, ts)
-   np.divide(np.sum(np.cross(p02s, line_rv) * lp_t0s, axis = 1), denoms, out = us, where = nz)
-   np.divide(np.sum(np.cross(line_rv, p01s) * lp_t0s, axis = 1), denoms, out = vs, where = nz)
-   ts[:] = np.where(np.logical_or(np.logical_or(us < 0.0, us > 1.0), np.logical_or(vs < 0.0, us + vs > 1.0)), np.nan,
-                    ts)
+    norms = np.cross(p01s, p02s)  # normals to planes, shape (n, 3)
+    line_rv = np.negative(line_v)
+    denoms = np.dot(norms, line_rv)  # shape (n)
+    #  if denom == 0.0: return None  # line is parallel to plane
+    lp_t0s = line_p - triangles[:, 0]  # shape (n, 3)
+    ts = np.empty(n)
+    ts.fill(np.nan)
+    us = ts.copy()
+    vs = ts.copy()
+    nz = (denoms != 0.0)
+    #  np.divide(np.dot(norms, lp_t0s), denoms, out = ts, where = nz)
+    np.seterr(divide = 'ignore')
+    np.divide(np.sum(norms * lp_t0s, axis = 1), denoms, out = ts, where = nz)
+    np.seterr(invalid = 'ignore')
+    if line_segment:
+        ts[:] = np.where(np.logical_or(ts < 0.0, ts > 1.0), np.nan, ts)
+    np.divide(np.sum(np.cross(p02s, line_rv) * lp_t0s, axis = 1), denoms, out = us, where = nz)
+    np.divide(np.sum(np.cross(line_rv, p01s) * lp_t0s, axis = 1), denoms, out = vs, where = nz)
+    ts[:] = np.where(np.logical_or(np.logical_or(us < 0.0, us > 1.0), np.logical_or(vs < 0.0, us + vs > 1.0)), np.nan,
+                     ts)
 
-   intersects = np.empty((n, 3))
-   intersects[:] = line_v * np.repeat(ts, 3).reshape((n, 3)) + line_p
-   np.seterr(all = 'warn')
-   return intersects
+    intersects = np.empty((n, 3))
+    intersects[:] = line_v * np.repeat(ts, 3).reshape((n, 3)) + line_p
+    np.seterr(all = 'warn')
+    return intersects
 
 
 def intersects_indices(single_line_intersects):
-   """Returns a list of the (triangle) indices where a valid intersection has been found for a single line."""
+    """Returns a list of the (triangle) indices where a valid intersection has been found for a single line."""
 
-   return list(np.where(np.logical_not(np.isnan(single_line_intersects[..., 0])))[0])
+    return list(np.where(np.logical_not(np.isnan(single_line_intersects[..., 0])))[0])
 
 
 def line_set_triangles_intersects(line_ps, line_vs, triangles, line_segment = False):
-   """Find the intersections of each of set of lines within each of a set of triangles in 3D space.
+    """Find the intersections of each of set of lines within each of a set of triangles in 3D space.
 
       arguments:
          line_ps ((c, 3) numpy array): a point on each of c lines
@@ -144,43 +144,43 @@ def line_set_triangles_intersects(line_ps, line_vs, triangles, line_segment = Fa
          this function is computationally and memory intensive; it could benefit from parallelisation
    """
 
-   c = line_ps.shape[0]  # number of lines
-   n = triangles.shape[0]  # number of triangles
+    c = line_ps.shape[0]  # number of lines
+    n = triangles.shape[0]  # number of triangles
 
-   p01s = triangles[:, 1, :] - triangles[:, 0, :]  # p01s has shape (n, 3)
-   p02s = triangles[:, 2, :] - triangles[:, 0, :]  # p02s has shape (n, 3)
+    p01s = triangles[:, 1, :] - triangles[:, 0, :]  # p01s has shape (n, 3)
+    p02s = triangles[:, 2, :] - triangles[:, 0, :]  # p02s has shape (n, 3)
 
-   norms = np.cross(p01s, p02s)  # normals to planes, shape (n, 3)
-   line_rvs = np.negative(line_vs)  # shape (c, 3)
-   denoms = np.dot(line_rvs, norms.T)  # shape (c, n)  where denoms == 0.0 line is parallel to plane of triangle
-   lps_t0s = line_ps.reshape((c, 1, 3)) - triangles[:, 0, :].reshape((1, n, 3))  # shape (c, n, 3)
-   ts = np.empty((c, n))  # shape (c, n)
-   ts.fill(np.nan)
-   us = ts.copy()  # shape (c, n)
-   vs = ts.copy()  # shape (c, n)
-   nz = (denoms != 0.0)  # shape (c, n)
-   # the np.sum() clause implememts a dot product over the xyz axis
-   np.seterr(divide = 'ignore')
-   np.divide(np.sum(norms.reshape((1, n, 3)) * lps_t0s, axis = 2), denoms, out = ts, where = nz)  # shape (c, n)
-   np.seterr(invalid = 'ignore')
-   if line_segment:
-      ts[:] = np.where(np.logical_or(ts < 0.0, ts > 1.0), np.nan, ts)
-   cp02s = p02s.reshape((1, n, 3)).repeat(c, axis = 0)  # shape (c, n, 3)
-   cl_rvs = line_rvs.reshape((c, 1, 3)).repeat(n, axis = 1)  # shape (c, n, 3)
-   np.divide(np.sum(np.cross(cp02s, cl_rvs) * lps_t0s, axis = 2), denoms, out = us, where = nz)  # shape (c, n)
-   cp01s = p01s.reshape((1, n, 3)).repeat(c, axis = 0)  # shape (c, n, 3)
-   np.divide(np.sum(np.cross(cl_rvs, cp01s) * lps_t0s, axis = 2), denoms, out = vs, where = nz)
-   ts[:] = np.where(np.logical_or(np.logical_or(us < 0.0, us > 1.0), np.logical_or(vs < 0.0, us + vs > 1.0)), np.nan,
-                    ts)
+    norms = np.cross(p01s, p02s)  # normals to planes, shape (n, 3)
+    line_rvs = np.negative(line_vs)  # shape (c, 3)
+    denoms = np.dot(line_rvs, norms.T)  # shape (c, n)  where denoms == 0.0 line is parallel to plane of triangle
+    lps_t0s = line_ps.reshape((c, 1, 3)) - triangles[:, 0, :].reshape((1, n, 3))  # shape (c, n, 3)
+    ts = np.empty((c, n))  # shape (c, n)
+    ts.fill(np.nan)
+    us = ts.copy()  # shape (c, n)
+    vs = ts.copy()  # shape (c, n)
+    nz = (denoms != 0.0)  # shape (c, n)
+    # the np.sum() clause implememts a dot product over the xyz axis
+    np.seterr(divide = 'ignore')
+    np.divide(np.sum(norms.reshape((1, n, 3)) * lps_t0s, axis = 2), denoms, out = ts, where = nz)  # shape (c, n)
+    np.seterr(invalid = 'ignore')
+    if line_segment:
+        ts[:] = np.where(np.logical_or(ts < 0.0, ts > 1.0), np.nan, ts)
+    cp02s = p02s.reshape((1, n, 3)).repeat(c, axis = 0)  # shape (c, n, 3)
+    cl_rvs = line_rvs.reshape((c, 1, 3)).repeat(n, axis = 1)  # shape (c, n, 3)
+    np.divide(np.sum(np.cross(cp02s, cl_rvs) * lps_t0s, axis = 2), denoms, out = us, where = nz)  # shape (c, n)
+    cp01s = p01s.reshape((1, n, 3)).repeat(c, axis = 0)  # shape (c, n, 3)
+    np.divide(np.sum(np.cross(cl_rvs, cp01s) * lps_t0s, axis = 2), denoms, out = vs, where = nz)
+    ts[:] = np.where(np.logical_or(np.logical_or(us < 0.0, us > 1.0), np.logical_or(vs < 0.0, us + vs > 1.0)), np.nan,
+                     ts)
 
-   intersects = np.empty((c, n, 3))
-   intersects[:] = line_vs.reshape((c, 1, 3)) * np.repeat(ts, 3).reshape((c, n, 3)) + line_ps.reshape((c, 1, 3))
-   np.seterr(all = 'warn')
-   return intersects
+    intersects = np.empty((c, n, 3))
+    intersects[:] = line_vs.reshape((c, 1, 3)) * np.repeat(ts, 3).reshape((c, n, 3)) + line_ps.reshape((c, 1, 3))
+    np.seterr(all = 'warn')
+    return intersects
 
 
 def poly_line_triangles_intersects(line_ps, triangles):
-   """Find the intersections of each segment of an open poly-line with each of a set of triangles in 3D space.
+    """Find the intersections of each segment of an open poly-line with each of a set of triangles in 3D space.
 
       arguments:
          line_ps ((c, 3) numpy array): ordered points on each of c-1 segments of a poly-line
@@ -195,11 +195,11 @@ def poly_line_triangles_intersects(line_ps, triangles):
          this function is computationally and memory intensive; it could benefit from parallelisation
    """
 
-   return line_set_triangles_intersects(line_ps[:-1], line_ps[1:] - line_ps[:-1], triangles, line_segment = True)
+    return line_set_triangles_intersects(line_ps[:-1], line_ps[1:] - line_ps[:-1], triangles, line_segment = True)
 
 
 def distilled_intersects(line_set_intersections):
-   """Returns lists of line and triangle indices, and corresponding intersection points.
+    """Returns lists of line and triangle indices, and corresponding intersection points.
 
    argument:
       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
@@ -213,12 +213,12 @@ def distilled_intersects(line_set_intersections):
          third array contains the (x, y, z) coordinates of the intersection points
    """
 
-   lines, triangles = np.where(np.logical_not(np.isnan(line_set_intersections[:, :, 0])))
-   return lines, triangles, line_set_intersections[lines, triangles, :]
+    lines, triangles = np.where(np.logical_not(np.isnan(line_set_intersections[:, :, 0])))
+    return lines, triangles, line_set_intersections[lines, triangles, :]
 
 
 def last_intersects(line_set_intersections):
-   """From the result of line_set_triangles_intersects(), returns a vector of intersection points, one per line.
+    """From the result of line_set_triangles_intersects(), returns a vector of intersection points, one per line.
 
    argument:
       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
@@ -239,19 +239,19 @@ def last_intersects(line_set_intersections):
       If no triangles are intersected by a line, the resulting point will be (nan, nan, nan).
    """
 
-   assert line_set_intersections.ndim == 3 and line_set_intersections.shape[2] == 3
-   c = line_set_intersections.shape[0]
+    assert line_set_intersections.ndim == 3 and line_set_intersections.shape[2] == 3
+    c = line_set_intersections.shape[0]
 
-   pick = np.empty((c, 3))
-   pick.fill(np.nan)
-   pair_l, pair_t = np.where(np.logical_not(np.isnan(line_set_intersections[:, :, 0])))
-   pick[pair_l, :] = line_set_intersections[pair_l, pair_t, :]
+    pick = np.empty((c, 3))
+    pick.fill(np.nan)
+    pair_l, pair_t = np.where(np.logical_not(np.isnan(line_set_intersections[:, :, 0])))
+    pick[pair_l, :] = line_set_intersections[pair_l, pair_t, :]
 
-   return pick
+    return pick
 
 
 def triangles_for_line(line_set_intersections, line_index):
-   """From the result of line_set_triangles_intersects(), returns a list of intersected triangles for a line.
+    """From the result of line_set_triangles_intersects(), returns a list of intersected triangles for a line.
 
    arguments:
       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
@@ -269,12 +269,12 @@ def triangles_for_line(line_set_intersections, line_index):
       if the line does not intersect any triangles, both the resulting arrays will have size zero
    """
 
-   triangles = np.where(np.logical_not(np.isnan(line_set_intersections[line_index, :, 0])))[0]
-   return triangles, line_set_intersections[line_index, triangles, :]
+    triangles = np.where(np.logical_not(np.isnan(line_set_intersections[line_index, :, 0])))[0]
+    return triangles, line_set_intersections[line_index, triangles, :]
 
 
 def lines_for_triangle(line_set_intersections, triangle_index):
-   """From the result of line_set_triangles_intersects(), returns a list of lines intersecing given triangle.
+    """From the result of line_set_triangles_intersects(), returns a list of lines intersecing given triangle.
 
    arguments:
       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
@@ -292,12 +292,12 @@ def lines_for_triangle(line_set_intersections, triangle_index):
       if no lines intersect the triangle, both the resulting arrays will have size zero
    """
 
-   lines = np.where(np.logical_not(np.isnan(line_set_intersections[:, triangle_index, 0])))[0]
-   return lines, line_set_intersections[lines, triangle_index, :]
+    lines = np.where(np.logical_not(np.isnan(line_set_intersections[:, triangle_index, 0])))[0]
+    return lines, line_set_intersections[lines, triangle_index, :]
 
 
 def poly_line_triangles_first_intersect(line_ps, triangles, start = 0):
-   """Finds the first intersection of a segment of an open poly-line with any of a set of triangles in 3D space.
+    """Finds the first intersection of a segment of an open poly-line with any of a set of triangles in 3D space.
 
       arguments:
          line_ps ((c, 3) numpy array): ordered points on each of c-1 segments of a poly-line
@@ -313,17 +313,17 @@ def poly_line_triangles_first_intersect(line_ps, triangles, start = 0):
          this function is computationally and memory intensive; it could benefit from parallelisation
    """
 
-   for c in range(start, len(line_ps) - 1):
-      points = line_triangles_intersects(line_ps[c], line_ps[c + 1] - line_ps[c], triangles, line_segment = True)
-      if np.all(np.isnan(points)):
-         continue  # no intersection found
-      xyz = last_intersects(points.reshape((1, -1, 3))).reshape((3,))
-      return c, xyz
-   return (None, None)
+    for c in range(start, len(line_ps) - 1):
+        points = line_triangles_intersects(line_ps[c], line_ps[c + 1] - line_ps[c], triangles, line_segment = True)
+        if np.all(np.isnan(points)):
+            continue  # no intersection found
+        xyz = last_intersects(points.reshape((1, -1, 3))).reshape((3,))
+        return c, xyz
+    return (None, None)
 
 
 def line_line_intersect(x1, y1, x2, y2, x3, y3, x4, y4, line_segment = False, half_segment = False):
-   """Returns the intersection x',y' of two lines x,y 1 to 2 and x,y 3 to 4.
+    """Returns the intersection x',y' of two lines x,y 1 to 2 and x,y 3 to 4.
 
    arguments:
       x1, y1, x2, y2: coordinates of two points defining first line
@@ -341,24 +341,24 @@ def line_line_intersect(x1, y1, x2, y2, x3, y3, x4, y4, line_segment = False, ha
       in the case of bounded line segments, both end points are 'included' in the segment
    """
 
-   divisor = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
-   if divisor == 0.0:
-      return None, None  # parallel or coincident lines
+    divisor = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
+    if divisor == 0.0:
+        return None, None  # parallel or coincident lines
 
-   if line_segment:
-      t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / divisor
-      if t < 0.0 or (not half_segment and t > 1.0):
-         return None, None
-      u = -((x1 - x2) * (y1 - y3) - (y1 - y2) * (x1 - x3)) / divisor
-      if not (0.0 <= u <= 1.0):
-         return None, None
-      x = x1 + t * (x2 - x1)
-      y = y1 + t * (y2 - y1)
+    if line_segment:
+        t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / divisor
+        if t < 0.0 or (not half_segment and t > 1.0):
+            return None, None
+        u = -((x1 - x2) * (y1 - y3) - (y1 - y2) * (x1 - x3)) / divisor
+        if not (0.0 <= u <= 1.0):
+            return None, None
+        x = x1 + t * (x2 - x1)
+        y = y1 + t * (y2 - y1)
 
-   else:
-      a = x1 * y2 - y1 * x2
-      b = x3 * y4 - y3 * x4
-      x = (a * (x3 - x4) - (x1 - x2) * b) / divisor
-      y = (a * (y3 - y4) - (y1 - y2) * b) / divisor
+    else:
+        a = x1 * y2 - y1 * x2
+        b = x3 * y4 - y3 * x4
+        x = (a * (x3 - x4) - (x1 - x2) * b) / divisor
+        y = (a * (y3 - y4) - (y1 - y2) * b) / divisor
 
-   return x, y
+    return x, y

--- a/resqpy/olio/keyword_files.py
+++ b/resqpy/olio/keyword_files.py
@@ -28,235 +28,235 @@ log.debug('keyword_files.py version %s', version)
 
 
 def substring(shorter, longer):
-   """Returns True if the first argument is a substring of the second."""
-   try:
-      longer.index(shorter)
-      return True
-   except Exception:
-      return False
+    """Returns True if the first argument is a substring of the second."""
+    try:
+        longer.index(shorter)
+        return True
+    except Exception:
+        return False
 
 
 def end_of_file(ascii_file):
-   """Returns True if the end of the file has been reached."""
-   file_pos = ascii_file.tell()
-   line = ascii_file.readline()
-   if len(line) == 0:
-      return True  # end of file
-   ascii_file.seek(file_pos)
-   return False
+    """Returns True if the end of the file has been reached."""
+    file_pos = ascii_file.tell()
+    line = ascii_file.readline()
+    if len(line) == 0:
+        return True  # end of file
+    ascii_file.seek(file_pos)
+    return False
 
 
 def find_keyword(ascii_file, keyword, max_lines = None):
-   """Looks for line starting with given keyword; file pointer is left at start of that line."""
-   start_pos = ascii_file.tell()
-   while True:
-      if max_lines is not None:
-         if max_lines <= 0:
+    """Looks for line starting with given keyword; file pointer is left at start of that line."""
+    start_pos = ascii_file.tell()
+    while True:
+        if max_lines is not None:
+            if max_lines <= 0:
+                ascii_file.seek(start_pos)
+                return False
+            max_lines -= 1
+        file_pos = ascii_file.tell()
+        line = ascii_file.readline()
+        if len(line) == 0:
             ascii_file.seek(start_pos)
-            return False
-         max_lines -= 1
-      file_pos = ascii_file.tell()
-      line = ascii_file.readline()
-      if len(line) == 0:
-         ascii_file.seek(start_pos)
-         return False  # end of file
-      words = line.split()
-      if len(words) > 0 and words[0].upper() == keyword.upper():
-         ascii_file.seek(file_pos)
-         return True
+            return False  # end of file
+        words = line.split()
+        if len(words) > 0 and words[0].upper() == keyword.upper():
+            ascii_file.seek(file_pos)
+            return True
 
 
 def skip_blank_lines_and_comments(ascii_file, comment_char = '!', skip_c_space = True):
-   """Skips any lines containing only white space or comment."""
-   while True:
-      file_pos = ascii_file.tell()
-      line = ascii_file.readline()
-      if len(line) == 0:
-         return  # end of file
-      words = line.split()
-      if len(words) == 0:
-         continue
-      if words[0][0] == comment_char:
-         continue
-      if skip_c_space and len(words[0]) == 1 and (words[0][0] == 'C' or words[0][0] == 'c'):
-         continue
-      ascii_file.seek(file_pos)
-      return
+    """Skips any lines containing only white space or comment."""
+    while True:
+        file_pos = ascii_file.tell()
+        line = ascii_file.readline()
+        if len(line) == 0:
+            return  # end of file
+        words = line.split()
+        if len(words) == 0:
+            continue
+        if words[0][0] == comment_char:
+            continue
+        if skip_c_space and len(words[0]) == 1 and (words[0][0] == 'C' or words[0][0] == 'c'):
+            continue
+        ascii_file.seek(file_pos)
+        return
 
 
 def skip_comments(ascii_file, comment_char = '!', skip_c_space = True):
-   """Skips any lines containing only a comment."""
-   while True:
-      file_pos = ascii_file.tell()
-      line = ascii_file.readline()
-      if len(line) == 0:
-         return  # end of file
-      words = line.split()
-      if len(words) > 0:  # not a blank line
-         if words[0][0] == comment_char:
-            continue
-         if skip_c_space and len(words[0]) == 1 and (words[0][0] == 'C' or words[0][0] == 'c'):
-            continue
-      ascii_file.seek(file_pos)
-      return
+    """Skips any lines containing only a comment."""
+    while True:
+        file_pos = ascii_file.tell()
+        line = ascii_file.readline()
+        if len(line) == 0:
+            return  # end of file
+        words = line.split()
+        if len(words) > 0:  # not a blank line
+            if words[0][0] == comment_char:
+                continue
+            if skip_c_space and len(words[0]) == 1 and (words[0][0] == 'C' or words[0][0] == 'c'):
+                continue
+        ascii_file.seek(file_pos)
+        return
 
 
 def split_trailing_comment(line, comment_char = '!'):
-   """Returns a pair of strings: (line stripped of trailing comment, trailing comment)."""
-   # also removes trailing newline
-   comment = ''
-   local_line = line
-   while len(local_line) > 0 and local_line[-1] in ['\n', '\r']:
-      local_line = local_line[:-1]
-   try:
-      pling = local_line.index(comment_char)
-      if pling < len(local_line) - 2:
-         comment = local_line[pling + 1:]
-      return (local_line[:pling], comment)
-   except Exception:
-      return (local_line, '')
+    """Returns a pair of strings: (line stripped of trailing comment, trailing comment)."""
+    # also removes trailing newline
+    comment = ''
+    local_line = line
+    while len(local_line) > 0 and local_line[-1] in ['\n', '\r']:
+        local_line = local_line[:-1]
+    try:
+        pling = local_line.index(comment_char)
+        if pling < len(local_line) - 2:
+            comment = local_line[pling + 1:]
+        return (local_line[:pling], comment)
+    except Exception:
+        return (local_line, '')
 
 
 def strip_trailing_comment(line, comment_char = '!'):
-   """Returns a copy of line with any trailing comment removed."""
-   (result, comment) = split_trailing_comment(line, comment_char = comment_char)
-   return result
+    """Returns a copy of line with any trailing comment removed."""
+    (result, comment) = split_trailing_comment(line, comment_char = comment_char)
+    return result
 
 
 def find_keyword_without_passing(ascii_file, keyword, no_pass_keyword):
-   """Looks for line starting with keyword, but without passing line starting with no_pass_keyword."""
-   while True:
-      file_pos = ascii_file.tell()
-      line = ascii_file.readline()
-      if len(line) == 0:
-         return False  # end of file
-      words = line.split()
-      if len(words) > 0:
-         if words[0].upper() == keyword.upper():
-            ascii_file.seek(file_pos)
-            return True
-         if words[0].upper() == no_pass_keyword.upper():
-            ascii_file.seek(file_pos)
-            return False
+    """Looks for line starting with keyword, but without passing line starting with no_pass_keyword."""
+    while True:
+        file_pos = ascii_file.tell()
+        line = ascii_file.readline()
+        if len(line) == 0:
+            return False  # end of file
+        words = line.split()
+        if len(words) > 0:
+            if words[0].upper() == keyword.upper():
+                ascii_file.seek(file_pos)
+                return True
+            if words[0].upper() == no_pass_keyword.upper():
+                ascii_file.seek(file_pos)
+                return False
 
 
 def find_keyword_with_copy(ascii_file_in, keyword, ascii_file_out):
-   """Looks for line starting with given keyword, copying lines in the meantime."""
-   while True:
-      file_pos = ascii_file_in.tell()
-      line = ascii_file_in.readline()
-      if len(line) == 0:
-         return False  # end of file
-      words = line.split()
-      if len(words) > 0 and words[0].upper() == keyword.upper():
-         ascii_file_in.seek(file_pos)
-         return True
-      else:
-         ascii_file_out.write(line)
+    """Looks for line starting with given keyword, copying lines in the meantime."""
+    while True:
+        file_pos = ascii_file_in.tell()
+        line = ascii_file_in.readline()
+        if len(line) == 0:
+            return False  # end of file
+        words = line.split()
+        if len(words) > 0 and words[0].upper() == keyword.upper():
+            ascii_file_in.seek(file_pos)
+            return True
+        else:
+            ascii_file_out.write(line)
 
 
 def find_keyword_pair(ascii_file, primary_keyword, secondary_keyword):
-   """Looks for line starting with a given pair of keywords."""
-   while True:
-      if not find_keyword(ascii_file, primary_keyword):
-         return False
-      file_pos = ascii_file.tell()
-      line = ascii_file.readline()
-      if len(line) == 0:
-         return False  # end of file
-      words = line.split()
-      if len(words) >= 2 and words[1].upper() == secondary_keyword.upper():
-         ascii_file.seek(file_pos)
-         return True
-
-
-def find_number(ascii_file):
-   """Looks for line starting with any number."""
-   while True:
-      file_pos = ascii_file.tell()
-      line = ascii_file.readline()
-      if len(line) == 0:
-         return False  # end of file
-      words = line.split()
-      if len(words) > 0:
-         try:
-            float(words[0])
-         except Exception:  # todo: should only catch a particular exception (type conversion)
-            continue
-         else:
+    """Looks for line starting with a given pair of keywords."""
+    while True:
+        if not find_keyword(ascii_file, primary_keyword):
+            return False
+        file_pos = ascii_file.tell()
+        line = ascii_file.readline()
+        if len(line) == 0:
+            return False  # end of file
+        words = line.split()
+        if len(words) >= 2 and words[1].upper() == secondary_keyword.upper():
             ascii_file.seek(file_pos)
             return True
 
 
+def find_number(ascii_file):
+    """Looks for line starting with any number."""
+    while True:
+        file_pos = ascii_file.tell()
+        line = ascii_file.readline()
+        if len(line) == 0:
+            return False  # end of file
+        words = line.split()
+        if len(words) > 0:
+            try:
+                float(words[0])
+            except Exception:  # todo: should only catch a particular exception (type conversion)
+                continue
+            else:
+                ascii_file.seek(file_pos)
+                return True
+
+
 def specific_keyword_next(ascii_file, keyword, skip_blank_lines = True, comment_char = '!'):
-   """Returns True if next token in file is the specified keyword."""
-   file_pos = ascii_file.tell()  # will restore file pos to original, which may be before blank lines
-   while True:
-      if (skip_blank_lines):
-         file_pos = ascii_file.tell()  # will advance file pos to next non-blank line
-      line = ascii_file.readline()
-      if len(line) == 0:  # end of file
-         ascii_file.seek(file_pos)
-         return False
-      words = line.split()
-      if len(words) == 0 or words[0][0] == comment_char:
-         continue  # blank line or comment
-      ascii_file.seek(file_pos)  # restore file position whether or not keyword match
-      if words[0].upper() == keyword.upper():
-         return True
-      return False
+    """Returns True if next token in file is the specified keyword."""
+    file_pos = ascii_file.tell()  # will restore file pos to original, which may be before blank lines
+    while True:
+        if (skip_blank_lines):
+            file_pos = ascii_file.tell()  # will advance file pos to next non-blank line
+        line = ascii_file.readline()
+        if len(line) == 0:  # end of file
+            ascii_file.seek(file_pos)
+            return False
+        words = line.split()
+        if len(words) == 0 or words[0][0] == comment_char:
+            continue  # blank line or comment
+        ascii_file.seek(file_pos)  # restore file position whether or not keyword match
+        if words[0].upper() == keyword.upper():
+            return True
+        return False
 
 
 def number_next(ascii_file, skip_blank_lines = True, comment_char = '!'):
-   """Returns True if next token in file is a number."""
-   file_pos = ascii_file.tell()
-   while True:
-      if (skip_blank_lines):
-         file_pos = ascii_file.tell()  # will advance file pos to next non-blank line
-      line = ascii_file.readline()
-      if len(line) == 0:  # end of file
-         ascii_file.seek(file_pos)
-         return False
-      words = line.split()
-      if len(words) == 0 or words[0][0] == comment_char:
-         continue  # blank line or comment
-      ascii_file.seek(file_pos)  # restore file position whether or not number found
-      try:
-         float(words[0])
-      except Exception:  # todo: should only catch a particular exception (type conversion)
-         return False
-      else:
-         return True
+    """Returns True if next token in file is a number."""
+    file_pos = ascii_file.tell()
+    while True:
+        if (skip_blank_lines):
+            file_pos = ascii_file.tell()  # will advance file pos to next non-blank line
+        line = ascii_file.readline()
+        if len(line) == 0:  # end of file
+            ascii_file.seek(file_pos)
+            return False
+        words = line.split()
+        if len(words) == 0 or words[0][0] == comment_char:
+            continue  # blank line or comment
+        ascii_file.seek(file_pos)  # restore file position whether or not number found
+        try:
+            float(words[0])
+        except Exception:  # todo: should only catch a particular exception (type conversion)
+            return False
+        else:
+            return True
 
 
 def blank_line(ascii_file):
-   """Returns True if the next line contains only white space; False otherwise (including comments)."""
+    """Returns True if the next line contains only white space; False otherwise (including comments)."""
 
-   file_pos = ascii_file.tell()
-   line = ascii_file.readline()
-   ascii_file.seek(file_pos)
-   if len(line) == 0:
-      return True  # end of file
-   words = line.split()
-   return len(words) == 0
+    file_pos = ascii_file.tell()
+    line = ascii_file.readline()
+    ascii_file.seek(file_pos)
+    if len(line) == 0:
+        return True  # end of file
+    words = line.split()
+    return len(words) == 0
 
 
 def guess_comment_char(ascii_file):
-   """Returns a string (usually one character) being the guess as to the comment character, or None."""
-   file_pos = ascii_file.tell()  # will restore file pos to original
-   max_lines = 10
-   ch = None
-   while max_lines:
-      line = ascii_file.readline()
-      max_lines -= 1
-      if not line:
-         break
-      words = line.split()
-      if len(words) and words[0] in ['!', 'C', '#', '--']:
-         ch = words[0]
-         break
-   ascii_file.seek(file_pos)
-   return ch
+    """Returns a string (usually one character) being the guess as to the comment character, or None."""
+    file_pos = ascii_file.tell()  # will restore file pos to original
+    max_lines = 10
+    ch = None
+    while max_lines:
+        line = ascii_file.readline()
+        max_lines -= 1
+        if not line:
+            break
+        words = line.split()
+        if len(words) and words[0] in ['!', 'C', '#', '--']:
+            ch = words[0]
+            break
+    ascii_file.seek(file_pos)
+    return ch
 
 
 # end of keyword_files module

--- a/resqpy/olio/load_data.py
+++ b/resqpy/olio/load_data.py
@@ -32,17 +32,17 @@ import resqpy.olio.ab_toolbox as abt
 
 
 def file_exists(file_name, must_be_more_recent_than_file = None):
-   """Returns True if the file exists (and is more recent than other file, if given)."""
+    """Returns True if the file exists (and is more recent than other file, if given)."""
 
-   if file_name is None or len(file_name) == 0:
-      return False
-   existe = os.path.exists(file_name)
-   if not existe:
-      return False
-   if not must_be_more_recent_than_file or file_name == must_be_more_recent_than_file or  \
-      not os.path.exists(must_be_more_recent_than_file):
-      return True
-   return os.path.getmtime(file_name) > os.path.getmtime(must_be_more_recent_than_file)
+    if file_name is None or len(file_name) == 0:
+        return False
+    existe = os.path.exists(file_name)
+    if not existe:
+        return False
+    if not must_be_more_recent_than_file or file_name == must_be_more_recent_than_file or  \
+       not os.path.exists(must_be_more_recent_than_file):
+        return True
+    return os.path.getmtime(file_name) > os.path.getmtime(must_be_more_recent_than_file)
 
 
 ######################################################################################################
@@ -63,7 +63,7 @@ def load_corp_array_from_file(file_name,
                               use_binary = False,
                               eight_mode = False,
                               use_numbers_only = None):
-   """Loads a nexus corner point (CORP) array from a file, returns a 7D numpy array in pagoda ordering.
+    """Loads a nexus corner point (CORP) array from a file, returns a 7D numpy array in pagoda ordering.
 
       arguments:
          file_name: The name of an ascii file holding the CORP data (no other keywords with numeric data
@@ -93,56 +93,56 @@ def load_corp_array_from_file(file_name,
          shape of the array is determined from the corner point data unless extent_kji has been specified.
    """
 
-   #   assert(extent_kji is not None or data_free_of_comments)   # no longer a requirement
+    #   assert(extent_kji is not None or data_free_of_comments)   # no longer a requirement
 
-   if extent_kji is None:
-      extent = None
-   else:
-      extent = [extent_kji[0] * extent_kji[1] * extent_kji[2], 8, 3]
+    if extent_kji is None:
+        extent = None
+    else:
+        extent = [extent_kji[0] * extent_kji[1] * extent_kji[2], 8, 3]
 
-   if corp_bin:
-      bin_file_size = os.path.getsize(file_name)
-      bin_cell_count, remainder = divmod(bin_file_size,
-                                         26 * 4)  # corp bin format has records of 24 + 2 (head, tail) 32 bit words
-      if remainder:
-         log.error('corp binary file ' + str(file_name) + ' is not a whole number of records')
-         return None
-      dt = np.dtype('float32')
-      if swap_bytes:
-         dt = dt.newbyteorder()
-      cp_array = np.fromfile(file_name, dtype = dt, count = 26 * bin_cell_count).reshape((-1, 26))[:, 1:25]
-      if extent_kji is not None:
-         if bin_cell_count != (extent_kji[0] * extent_kji[1] * extent_kji[2]):
-            log.error('corp binary file ' + str(file_name) + ' contains data for ' + str(bin_cell_count) +
-                      ' cells; extent requires ' + str(extent_kji[0] * extent_kji[1] * extent_kji[2]))
+    if corp_bin:
+        bin_file_size = os.path.getsize(file_name)
+        bin_cell_count, remainder = divmod(bin_file_size,
+                                           26 * 4)  # corp bin format has records of 24 + 2 (head, tail) 32 bit words
+        if remainder:
+            log.error('corp binary file ' + str(file_name) + ' is not a whole number of records')
+            return None
+        dt = np.dtype('float32')
+        if swap_bytes:
+            dt = dt.newbyteorder()
+        cp_array = np.fromfile(file_name, dtype = dt, count = 26 * bin_cell_count).reshape((-1, 26))[:, 1:25]
+        if extent_kji is not None:
+            if bin_cell_count != (extent_kji[0] * extent_kji[1] * extent_kji[2]):
+                log.error('corp binary file ' + str(file_name) + ' contains data for ' + str(bin_cell_count) +
+                          ' cells; extent requires ' + str(extent_kji[0] * extent_kji[1] * extent_kji[2]))
 
-   else:
-      cp_array = load_array_from_file(file_name,
-                                      extent = extent,
-                                      data_type = 'real',
-                                      keyword = 'CORP',
-                                      max_lines_for_keyword = max_lines_for_keyword,
-                                      comment_char = comment_char,
-                                      data_free_of_comments = data_free_of_comments,
-                                      use_binary = use_binary)
+    else:
+        cp_array = load_array_from_file(file_name,
+                                        extent = extent,
+                                        data_type = 'real',
+                                        keyword = 'CORP',
+                                        max_lines_for_keyword = max_lines_for_keyword,
+                                        comment_char = comment_char,
+                                        data_free_of_comments = data_free_of_comments,
+                                        use_binary = use_binary)
 
-   cell_count, remainder = divmod(cp_array.size, 24)
-   if remainder:
-      log.error('file ' + file_name + ' contains ' + str(cp_array.size) + ' data, which is not a multiple of 24')
-      return None
+    cell_count, remainder = divmod(cp_array.size, 24)
+    if remainder:
+        log.error('file ' + file_name + ' contains ' + str(cp_array.size) + ' data, which is not a multiple of 24')
+        return None
 
-   cp_array = cp_array.reshape(1, 1, cell_count, 2, 2, 2, 3)  # pagoda 7D, temporarily with all cells on I axis
-   log.debug('resequencing corner point data')
-   gf.resequence_nexus_corp(cp_array, eight_mode = eight_mode)  # switches IP points where JP = 1 (unless eight_mode)
+    cp_array = cp_array.reshape(1, 1, cell_count, 2, 2, 2, 3)  # pagoda 7D, temporarily with all cells on I axis
+    log.debug('resequencing corner point data')
+    gf.resequence_nexus_corp(cp_array, eight_mode = eight_mode)  # switches IP points where JP = 1 (unless eight_mode)
 
-   if extent_kji is None:
-      log.info('determining grid extent from corner points')
-      extent_kji = gf.determine_corp_extent(cp_array)
-      if extent_kji is None:
-         log.error('failed to determine extent of grid from corner points')
-         return cp_array
+    if extent_kji is None:
+        log.info('determining grid extent from corner points')
+        extent_kji = gf.determine_corp_extent(cp_array)
+        if extent_kji is None:
+            log.error('failed to determine extent of grid from corner points')
+            return cp_array
 
-   return cp_array.reshape(extent_kji[0], extent_kji[1], extent_kji[2], 2, 2, 2, 3)
+    return cp_array.reshape(extent_kji[0], extent_kji[1], extent_kji[2], 2, 2, 2, 3)
 
 
 ######################################################################################################
@@ -162,13 +162,56 @@ def load_array_from_file(file_name,
                          data_free_of_comments = False,
                          use_binary = False,
                          use_numbers_only = None):
-   """Load an array from an ascii (or pure binary) file.
+    """Load an array from an ascii (or pure binary) file.
 
       Arguments are similar to those for load_corp_array_from_file().
    """
 
-   if not use_binary:
-      return load_array_from_ascii_file(file_name,
+    if not use_binary:
+        return load_array_from_ascii_file(file_name,
+                                          extent = extent,
+                                          data_type = data_type,
+                                          keyword = keyword,
+                                          max_lines_for_keyword = max_lines_for_keyword,
+                                          comment_char = comment_char,
+                                          data_free_of_comments = data_free_of_comments)
+
+    (extension, ab_type) = abt.binary_file_extension_and_np_type_for_data_type(data_type)
+
+    if extent is None:
+        cell_count = -1  # np.fromfile interprets this as 'read everything'
+        log.debug('Loading unknown number of array data elements from file ' + file_name)
+    else:
+        cell_count = pu.cell_count_from_extent(extent)
+        log.debug('Loading %1d array data elements from file %s', cell_count, file_name)
+
+    ascii_file_name = file_name
+    binary_file_name = file_name
+    if len(binary_file_name) < 4 or binary_file_name[-3:] != extension:
+        binary_file_name += extension
+    else:
+        ascii_file_name = ascii_file_name[:-3]  # strip off '.db' or similar
+
+    try:  # tentatively try to read data from an existing binary file, if present
+        if file_exists(binary_file_name, must_be_more_recent_than_file = ascii_file_name):
+            with open(binary_file_name, 'rb') as binary_file_in:
+                result = np.fromfile(binary_file_in, dtype = ab_type, count = cell_count)
+                if extent is not None:
+                    result = result.reshape(extent)
+                # check that end of file has been reached, ie. not too much data in file
+                try:  # expected to return null
+                    c = binary_file_in.read(1)
+                    if len(c):
+                        log.warning('binary file contains more data than expected: ' + binary_file_name)
+                except Exception:
+                    pass
+                log.info('Data loaded from binary file %s', binary_file_name)
+                return result
+    except Exception:
+        pass
+
+    # read from ascii file
+    result = load_array_from_ascii_file(file_name,
                                         extent = extent,
                                         data_type = data_type,
                                         keyword = keyword,
@@ -176,57 +219,14 @@ def load_array_from_file(file_name,
                                         comment_char = comment_char,
                                         data_free_of_comments = data_free_of_comments)
 
-   (extension, ab_type) = abt.binary_file_extension_and_np_type_for_data_type(data_type)
+    # create a binary file (to be used next time)
+    try:
+        wd.write_pure_binary_data(binary_file_name, result)
+    except Exception:
+        log.warn('Failed to write data to binary file %s', binary_file_name)
+        # todo: could delete the binary file in case a corrupt file is left for use next time
 
-   if extent is None:
-      cell_count = -1  # np.fromfile interprets this as 'read everything'
-      log.debug('Loading unknown number of array data elements from file ' + file_name)
-   else:
-      cell_count = pu.cell_count_from_extent(extent)
-      log.debug('Loading %1d array data elements from file %s', cell_count, file_name)
-
-   ascii_file_name = file_name
-   binary_file_name = file_name
-   if len(binary_file_name) < 4 or binary_file_name[-3:] != extension:
-      binary_file_name += extension
-   else:
-      ascii_file_name = ascii_file_name[:-3]  # strip off '.db' or similar
-
-   try:  # tentatively try to read data from an existing binary file, if present
-      if file_exists(binary_file_name, must_be_more_recent_than_file = ascii_file_name):
-         with open(binary_file_name, 'rb') as binary_file_in:
-            result = np.fromfile(binary_file_in, dtype = ab_type, count = cell_count)
-            if extent is not None:
-               result = result.reshape(extent)
-            # check that end of file has been reached, ie. not too much data in file
-            try:  # expected to return null
-               c = binary_file_in.read(1)
-               if len(c):
-                  log.warning('binary file contains more data than expected: ' + binary_file_name)
-            except Exception:
-               pass
-            log.info('Data loaded from binary file %s', binary_file_name)
-            return result
-   except Exception:
-      pass
-
-   # read from ascii file
-   result = load_array_from_ascii_file(file_name,
-                                       extent = extent,
-                                       data_type = data_type,
-                                       keyword = keyword,
-                                       max_lines_for_keyword = max_lines_for_keyword,
-                                       comment_char = comment_char,
-                                       data_free_of_comments = data_free_of_comments)
-
-   # create a binary file (to be used next time)
-   try:
-      wd.write_pure_binary_data(binary_file_name, result)
-   except Exception:
-      log.warn('Failed to write data to binary file %s', binary_file_name)
-      # todo: could delete the binary file in case a corrupt file is left for use next time
-
-   return result
+    return result
 
 
 # end of load_array_from_file() def
@@ -248,7 +248,7 @@ def load_array_from_ascii_file(file_name,
                                data_free_of_comments = False,
                                skip_c_space = True,
                                use_numbers_only = None):
-   """Returns a numpy array with data loaded from an ascii file.
+    """Returns a numpy array with data loaded from an ascii file.
 
    arguments:
       file_name: string holding name of the existing ascii data file, eg. 'Cell_depth.dat'
@@ -291,138 +291,138 @@ def load_array_from_ascii_file(file_name,
       'bool' and 'boolean' are synonymous; default is 'real'
       The numpy data type will be the default 64 bit float or 64 bit int
    """
-   # todo: Code enhancement could cater for 32 bit options (and 8 bit for bool) if needed to reduce memory usage
+    # todo: Code enhancement could cater for 32 bit options (and 8 bit for bool) if needed to reduce memory usage
 
-   if extent is None:
-      cell_count = -1  # np.fromfile interprets this as 'read everything'
-      log.debug('Loading unknown number of array data elements from ascii file ' + file_name)
-   else:
-      cell_count = pu.cell_count_from_extent(extent)
-      log.debug('Loading %1d array data elements from ascii file %s', cell_count, file_name)
+    if extent is None:
+        cell_count = -1  # np.fromfile interprets this as 'read everything'
+        log.debug('Loading unknown number of array data elements from ascii file ' + file_name)
+    else:
+        cell_count = pu.cell_count_from_extent(extent)
+        log.debug('Loading %1d array data elements from ascii file %s', cell_count, file_name)
 
-   if data_type in ['real', 'float', float]:
-      d_type = 'float'
-   elif data_type in ['int', 'integer', int]:
-      d_type = 'int'
-   elif data_type in ['bool', 'boolean', bool]:
-      d_type = 'int'  # read booleans as 0 or 1 and convert after
-   else:
-      assert False, 'Unknown data_type passed to load_array_from_ascii_file' + str(data_type)
+    if data_type in ['real', 'float', float]:
+        d_type = 'float'
+    elif data_type in ['int', 'integer', int]:
+        d_type = 'int'
+    elif data_type in ['bool', 'boolean', bool]:
+        d_type = 'int'  # read booleans as 0 or 1 and convert after
+    else:
+        assert False, 'Unknown data_type passed to load_array_from_ascii_file' + str(data_type)
 
-   read_file_name = file_name
+    read_file_name = file_name
 
-   with open(read_file_name, 'r') as data_file:
+    with open(read_file_name, 'r') as data_file:
 
-      if not comment_char and not data_free_of_comments:
-         comment_char = kf.guess_comment_char(data_file)
-         if not comment_char:
-            comment_char = '!'
+        if not comment_char and not data_free_of_comments:
+            comment_char = kf.guess_comment_char(data_file)
+            if not comment_char:
+                comment_char = '!'
 
-      if keyword:
-         keyword_found = kf.find_keyword(data_file, keyword, max_lines = max_lines_for_keyword)
-         if keyword_found:
-            data_file.readline()  # skip keyword line
+        if keyword:
+            keyword_found = kf.find_keyword(data_file, keyword, max_lines = max_lines_for_keyword)
+            if keyword_found:
+                data_file.readline()  # skip keyword line
 
-      kf.skip_blank_lines_and_comments(data_file, comment_char = comment_char, skip_c_space = skip_c_space)
+        kf.skip_blank_lines_and_comments(data_file, comment_char = comment_char, skip_c_space = skip_c_space)
 
-      result = None
+        result = None
 
-      if data_free_of_comments:  # use numpy fromfile function after passing header comments
+        if data_free_of_comments:  # use numpy fromfile function after passing header comments
 
-         result = np.fromfile(data_file, dtype = d_type, count = cell_count, sep = ' ')
+            result = np.fromfile(data_file, dtype = d_type, count = cell_count, sep = ' ')
 
-         if result is None:
-            data_file.seek(0)
+            if result is None:
+                data_file.seek(0)
 
-      if result is None:
+        if result is None:
 
-         # builds one very big string, stripping trailing comments
+            # builds one very big string, stripping trailing comments
 
-         #         s = ''
-         #         while True:
-         #            r = data_file.readline()
-         #            if len(r) == 0: break
-         #            s += r.partition(comment_char)[0] + ' '
-         #         result = np.fromstring(s, dtype = d_type, count = cell_count, sep = ' ')
-         #         # note: extra data will go unnoticed if cell count known!
-         #         del s
+            #         s = ''
+            #         while True:
+            #            r = data_file.readline()
+            #            if len(r) == 0: break
+            #            s += r.partition(comment_char)[0] + ' '
+            #         result = np.fromstring(s, dtype = d_type, count = cell_count, sep = ' ')
+            #         # note: extra data will go unnoticed if cell count known!
+            #         del s
 
-         b = bytearray(data_file.read().encode())
-         bc = comment_char.encode()
-         nl = b'\n'
-         sp = b' '
-         i = 0
-         while True:
-            i = b.find(bc, i)
-            if i < 0:
-               break
-            eol = b.find(nl, i)
-            if eol < 0:
-               eol = len(b)
-            b[i:eol] = sp * (eol - i)
-
-         result = np.fromstring(b.decode(), dtype = d_type, count = cell_count, sep = ' ')
-         # note: extra data will go unnoticed if cell count known!
-         del b
-
-      if result is None:
-
-         assert (extent is not None)  # TODO: remove this restriction by dynamically extending a flat array
-
-         view_1D = np.zeros(extent, dtype = d_type).flatten()
-         elements = view_1D.size
-         start_of_line = True
-
-         for index in range(elements):
-
+            b = bytearray(data_file.read().encode())
+            bc = comment_char.encode()
+            nl = b'\n'
+            sp = b' '
+            i = 0
             while True:
-               ch = data_file.read(1)
-               assert (ch != '')  # premature end of file
-               if ch == comment_char:
-                  data_file.readline()
-                  start_of_line = True
-                  continue
-               if skip_c_space and start_of_line and ch in ['C', 'c']:
-                  next_ch = data_file.read(1)
-                  if next_ch in ' \t\n':
-                     if next_ch != '\n':
+                i = b.find(bc, i)
+                if i < 0:
+                    break
+                eol = b.find(nl, i)
+                if eol < 0:
+                    eol = len(b)
+                b[i:eol] = sp * (eol - i)
+
+            result = np.fromstring(b.decode(), dtype = d_type, count = cell_count, sep = ' ')
+            # note: extra data will go unnoticed if cell count known!
+            del b
+
+        if result is None:
+
+            assert (extent is not None)  # TODO: remove this restriction by dynamically extending a flat array
+
+            view_1D = np.zeros(extent, dtype = d_type).flatten()
+            elements = view_1D.size
+            start_of_line = True
+
+            for index in range(elements):
+
+                while True:
+                    ch = data_file.read(1)
+                    assert (ch != '')  # premature end of file
+                    if ch == comment_char:
                         data_file.readline()
-                     continue
-                  ch += next_ch
-                  break
-               if ch not in ' \t\n':
-                  break
+                        start_of_line = True
+                        continue
+                    if skip_c_space and start_of_line and ch in ['C', 'c']:
+                        next_ch = data_file.read(1)
+                        if next_ch in ' \t\n':
+                            if next_ch != '\n':
+                                data_file.readline()
+                            continue
+                        ch += next_ch
+                        break
+                    if ch not in ' \t\n':
+                        break
 
-            start_of_line = False
-            word = ch
-            while True:
-               ch = data_file.read(1)
-               if ch == '':  # end of file (this assumes a whitespace character after last datum)
-                  log.error('Not enough data in file %s: %1d of %1d numbers read', file_name, index, elements)
-                  assert False, 'not enough data in file'
-               if ch in ' \t\n':
-                  break
-               word += ch
-            if ch == '\n':
-               start_of_line = True
-            if d_type == 'float':
-               view_1D[index] = float(word)
-            else:
-               view_1D[index] = int(word)
+                start_of_line = False
+                word = ch
+                while True:
+                    ch = data_file.read(1)
+                    if ch == '':  # end of file (this assumes a whitespace character after last datum)
+                        log.error('Not enough data in file %s: %1d of %1d numbers read', file_name, index, elements)
+                        assert False, 'not enough data in file'
+                    if ch in ' \t\n':
+                        break
+                    word += ch
+                if ch == '\n':
+                    start_of_line = True
+                if d_type == 'float':
+                    view_1D[index] = float(word)
+                else:
+                    view_1D[index] = int(word)
 
-         result = view_1D
+            result = view_1D
 
-      kf.skip_blank_lines_and_comments(data_file, comment_char = comment_char, skip_c_space = skip_c_space)
-      if not kf.end_of_file(data_file):
-         assert False, 'too much data in ascii file: ' + file_name
+        kf.skip_blank_lines_and_comments(data_file, comment_char = comment_char, skip_c_space = skip_c_space)
+        if not kf.end_of_file(data_file):
+            assert False, 'too much data in ascii file: ' + file_name
 
-   if result is not None and extent is not None:
-      result = result.reshape(extent)
+    if result is not None and extent is not None:
+        result = result.reshape(extent)
 
-   if data_type in ['bool', 'boolean', bool]:
-      return result != 0  # convert to boolean
-   else:
-      return result
+    if data_type in ['bool', 'boolean', bool]:
+        return result != 0  # convert to boolean
+    else:
+        return result
 
 
 # end of load_array_from_ascii_file() def
@@ -438,7 +438,7 @@ def load_array_from_ascii_file(file_name,
 
 
 def load_fault_mask(file_name, direction, fault_mask, use_binary = False):
-   """Modifies a 3D numpy boolean array representing fault locations on cell faces in i,j or k.
+    """Modifies a 3D numpy boolean array representing fault locations on cell faces in i,j or k.
 
    arguments:
       file_name: string giving name of existing ascii file holding nexus MULT keywords in input deck format
@@ -457,86 +457,86 @@ def load_fault_mask(file_name, direction, fault_mask, use_binary = False):
       whatever function is being applied, and whatever value is specified the function returns None (nothing)
    """
 
-   trans_keyword_dict = {'i': 'TX', 'j': 'TY', 'k': 'TZ'}
+    trans_keyword_dict = {'i': 'TX', 'j': 'TY', 'k': 'TZ'}
 
-   assert (direction in 'ijk')
-   assert (fault_mask.ndim == 3)
-   mask_extent_kji = fault_mask.shape
-   ascii_file_name = file_name
-   binary_file_name = file_name
+    assert (direction in 'ijk')
+    assert (fault_mask.ndim == 3)
+    mask_extent_kji = fault_mask.shape
+    ascii_file_name = file_name
+    binary_file_name = file_name
 
-   face_count = pu.cell_count_from_extent(mask_extent_kji)
-   log.debug('Loading %1d fault mask elements from file %s', face_count, file_name)
+    face_count = pu.cell_count_from_extent(mask_extent_kji)
+    log.debug('Loading %1d fault mask elements from file %s', face_count, file_name)
 
-   if use_binary:
-      # try reading mask from binary file
-      if len(binary_file_name) > 5 and binary_file_name[-5:] == '.' + direction.lower() + '.bb':
-         ascii_file_name = ascii_file_name[:-5]
-      else:
-         binary_file_name = binary_file_name + '.' + direction.lower() + '.bb'
-      try:
-         with open(binary_file_name, 'rb') as binary_data_file:
-            result = np.fromfile(binary_data_file, dtype = 'bool', count = face_count).reshape(mask_extent_kji)
-            fault_mask.data = result.data
-            # todo: check that end of file has been reached, ie. not too much data in file
-            log.info('Fault mask data loaded from binary file %s', binary_file_name)
-            return
-      except Exception:
-         pass
+    if use_binary:
+        # try reading mask from binary file
+        if len(binary_file_name) > 5 and binary_file_name[-5:] == '.' + direction.lower() + '.bb':
+            ascii_file_name = ascii_file_name[:-5]
+        else:
+            binary_file_name = binary_file_name + '.' + direction.lower() + '.bb'
+        try:
+            with open(binary_file_name, 'rb') as binary_data_file:
+                result = np.fromfile(binary_data_file, dtype = 'bool', count = face_count).reshape(mask_extent_kji)
+                fault_mask.data = result.data
+                # todo: check that end of file has been reached, ie. not too much data in file
+                log.info('Fault mask data loaded from binary file %s', binary_file_name)
+                return
+        except Exception:
+            pass
 
-   with open(ascii_file_name, 'r') as data_file:
+    with open(ascii_file_name, 'r') as data_file:
 
-      while kf.find_keyword_pair(data_file, 'MULT', trans_keyword_dict[direction]):
+        while kf.find_keyword_pair(data_file, 'MULT', trans_keyword_dict[direction]):
 
-         line = data_file.readline().upper()
-         line = line.partition('!')[0]  # removes trailing comment
-         plus_minus_offset = [0, 0, 0]  # only possibly set to 1 in direction of interest
-         if ('MINUS' not in line.split()):  # indicates data apply to 'negative' faces of specified cells
-            plus_minus_offset['kji'.index(direction)] = 1
-
-         if not kf.find_keyword(data_file, 'FNAME'):
-            continue  # will mess up if not present for this MULT
-         line = data_file.readline().upper()
-         words = line.split()
-
-         if not kf.find_number(data_file):
-            continue  # will mess up if no numbers before next MULT
-
-         count = 0
-         while kf.number_next(data_file):
-            # fetch a new box from the input file (usually the box contains just one cell)
             line = data_file.readline().upper()
             line = line.partition('!')[0]  # removes trailing comment
+            plus_minus_offset = [0, 0, 0]  # only possibly set to 1 in direction of interest
+            if ('MINUS' not in line.split()):  # indicates data apply to 'negative' faces of specified cells
+                plus_minus_offset['kji'.index(direction)] = 1
+
+            if not kf.find_keyword(data_file, 'FNAME'):
+                continue  # will mess up if not present for this MULT
+            line = data_file.readline().upper()
             words = line.split()
-            box_kji0 = box.box_kji0_from_words_iijjkk1(words)
-            box_kji0[0] = box_kji0[0] + plus_minus_offset  # adjust min indices
-            box_kji0[1] = box_kji0[1] + plus_minus_offset  # adjust max indices
-            # check that box is within extent of fault_mask
-            for dir in range(2):
-               assert (box_kji0[0, dir] >= 0)
-               assert (box_kji0[1, dir] < mask_extent_kji[dir])
-            # set fault_mask to True for face of every cell in box (usually just one cell, or column)
+
+            if not kf.find_number(data_file):
+                continue  # will mess up if no numbers before next MULT
+
+            count = 0
+            while kf.number_next(data_file):
+                # fetch a new box from the input file (usually the box contains just one cell)
+                line = data_file.readline().upper()
+                line = line.partition('!')[0]  # removes trailing comment
+                words = line.split()
+                box_kji0 = box.box_kji0_from_words_iijjkk1(words)
+                box_kji0[0] = box_kji0[0] + plus_minus_offset  # adjust min indices
+                box_kji0[1] = box_kji0[1] + plus_minus_offset  # adjust max indices
+                # check that box is within extent of fault_mask
+                for dir in range(2):
+                    assert (box_kji0[0, dir] >= 0)
+                    assert (box_kji0[1, dir] < mask_extent_kji[dir])
+                # set fault_mask to True for face of every cell in box (usually just one cell, or column)
 #            for k in range(box_kji0[0, 0], box_kji0[1, 0] + 1):
 #               for j in range(box_kji0[0, 1], box_kji0[1, 1] + 1):
 #                  for i in range(box_kji0[0, 2], box_kji0[1, 2] + 1):
 #                     if not fault_mask[k,j,i]:
 #                        fault_mask[k, j, i] = True
 #                        count += 1
-            count += (box.volume_of_box(box_kji0) -
-                      np.count_nonzero(fault_mask[box_kji0[0, 0]:box_kji0[1, 0] + 1, box_kji0[0, 1]:box_kji0[1, 1] + 1,
-                                                  box_kji0[0, 2]:box_kji0[1, 2] + 1]))
-            fault_mask[box_kji0[0, 0]:box_kji0[1, 0] + 1, box_kji0[0, 1]:box_kji0[1, 1] + 1,
-                       box_kji0[0, 2]:box_kji0[1, 2] + 1] = True
+                count += (box.volume_of_box(box_kji0) -
+                          np.count_nonzero(fault_mask[box_kji0[0, 0]:box_kji0[1, 0] + 1, box_kji0[0, 1]:box_kji0[1, 1] +
+                                                      1, box_kji0[0, 2]:box_kji0[1, 2] + 1]))
+                fault_mask[box_kji0[0, 0]:box_kji0[1, 0] + 1, box_kji0[0, 1]:box_kji0[1, 1] + 1,
+                           box_kji0[0, 2]:box_kji0[1, 2] + 1] = True
 
-   if use_binary:
-      # create binary file for use next time
-      try:
-         with open(binary_file_name, 'wb') as binary_file_out:
-            fault_mask.tofile(binary_file_out)
-         log.info('Binary fault mask data file %s created', binary_file_name)
-      except Exception:
-         log.warn('Failed to write data to binary fault mask file %s', binary_file_name)
-         # todo: could delete the binary file in case a corrupt file is left for use next time
+    if use_binary:
+        # create binary file for use next time
+        try:
+            with open(binary_file_name, 'wb') as binary_file_out:
+                fault_mask.tofile(binary_file_out)
+            log.info('Binary fault mask data file %s created', binary_file_name)
+        except Exception:
+            log.warn('Failed to write data to binary fault mask file %s', binary_file_name)
+            # todo: could delete the binary file in case a corrupt file is left for use next time
 
 
 # end of load_fault_mask() def

--- a/resqpy/olio/point_inclusion.py
+++ b/resqpy/olio/point_inclusion.py
@@ -15,7 +15,7 @@ import resqpy.olio.simple_lines as sl
 
 
 def pip_cn(p, poly):
-   """2D point inclusion: returns True if point is inside polygon (uses crossing number algorithm).
+    """2D point inclusion: returns True if point is inside polygon (uses crossing number algorithm).
 
    arguments:
       p (numpy array, tuple or list of at least 2 floats): xy point to test for inclusion in polygon
@@ -29,26 +29,26 @@ def pip_cn(p, poly):
       if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
    """
 
-   # p should be a tuple-like object with first two elements x, y
-   # poly should be a numpy array with first axis being the different vertices
-   #    and the second starting x, y
+    # p should be a tuple-like object with first two elements x, y
+    # poly should be a numpy array with first axis being the different vertices
+    #    and the second starting x, y
 
-   crossings = 0
+    crossings = 0
 
-   for edge in range(len(poly)):
-      v1 = poly[edge - 1]
-      v2 = poly[edge]
-      if ((v1[0] > p[0] or v2[0] > p[0]) and ((v1[1] <= p[1] and v2[1] > p[1]) or (v1[1] > p[1] and v2[1] <= p[1]))):
-         if v1[0] > p[0] and v2[0] > p[0]:
-            crossings += 1
-         elif p[0] < v1[0] + (v2[0] - v1[0]) * (p[1] - v1[1]) / (v2[1] - v1[1]):
-            crossings += 1
+    for edge in range(len(poly)):
+        v1 = poly[edge - 1]
+        v2 = poly[edge]
+        if ((v1[0] > p[0] or v2[0] > p[0]) and ((v1[1] <= p[1] and v2[1] > p[1]) or (v1[1] > p[1] and v2[1] <= p[1]))):
+            if v1[0] > p[0] and v2[0] > p[0]:
+                crossings += 1
+            elif p[0] < v1[0] + (v2[0] - v1[0]) * (p[1] - v1[1]) / (v2[1] - v1[1]):
+                crossings += 1
 
-   return bool(crossings & 1)
+    return bool(crossings & 1)
 
 
 def pip_wn(p, poly):
-   """2D point inclusion: returns True if point is inside polygon (uses winding number algorithm).
+    """2D point inclusion: returns True if point is inside polygon (uses winding number algorithm).
 
    arguments:
       p (numpy array, tuple or list of at least 2 floats): xy point to test for inclusion in polygon
@@ -62,29 +62,29 @@ def pip_wn(p, poly):
       if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
    """
 
-   winding = 0
+    winding = 0
 
-   for edge in range(len(poly)):
-      v1 = poly[edge - 1]
-      v2 = poly[edge]
-      if v1[0] <= p[0] and v2[0] <= p[0]:
-         continue
-      if v1[1] <= p[1] and v2[1] > p[1]:
-         if v1[0] > p[0] and v2[0] > p[0]:
-            winding += 1
-         elif p[0] < v1[0] + (v2[0] - v1[0]) * (p[1] - v1[1]) / (v2[1] - v1[1]):
-            winding += 1
-      elif v1[1] > p[1] and v2[1] <= p[1]:
-         if v1[0] > p[0] and v2[0] > p[0]:
-            winding -= 1
-         elif p[0] < v1[0] + (v2[0] - v1[0]) * (p[1] - v1[1]) / (v2[1] - v1[1]):
-            winding -= 1
+    for edge in range(len(poly)):
+        v1 = poly[edge - 1]
+        v2 = poly[edge]
+        if v1[0] <= p[0] and v2[0] <= p[0]:
+            continue
+        if v1[1] <= p[1] and v2[1] > p[1]:
+            if v1[0] > p[0] and v2[0] > p[0]:
+                winding += 1
+            elif p[0] < v1[0] + (v2[0] - v1[0]) * (p[1] - v1[1]) / (v2[1] - v1[1]):
+                winding += 1
+        elif v1[1] > p[1] and v2[1] <= p[1]:
+            if v1[0] > p[0] and v2[0] > p[0]:
+                winding -= 1
+            elif p[0] < v1[0] + (v2[0] - v1[0]) * (p[1] - v1[1]) / (v2[1] - v1[1]):
+                winding -= 1
 
-   return bool(winding)
+    return bool(winding)
 
 
 def pip_array_cn(p_a, poly):
-   """array of 2D points inclusion: returns bool array True where point is inside polygon (uses crossing number algorithm).
+    """array of 2D points inclusion: returns bool array True where point is inside polygon (uses crossing number algorithm).
 
    arguments:
       p_a (2D numpy float array): set of xy points to test for inclusion in polygon
@@ -98,84 +98,84 @@ def pip_array_cn(p_a, poly):
       if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
    """
 
-   # p_array should be a numpy array of 2 or more axes; the final axis has extent at least 2, being x, y, ...
-   # returned boolean array has shape of p_array less the final axis
+    # p_array should be a numpy array of 2 or more axes; the final axis has extent at least 2, being x, y, ...
+    # returned boolean array has shape of p_array less the final axis
 
-   elements = np.prod(list(p_a.shape)[:-1], dtype = int)
-   p = p_a.reshape((elements, -1))
-   crossings = np.zeros((elements,), dtype = int)
+    elements = np.prod(list(p_a.shape)[:-1], dtype = int)
+    p = p_a.reshape((elements, -1))
+    crossings = np.zeros((elements,), dtype = int)
 
-   np_err_dict = np.geterr()
-   np.seterr(divide = 'ignore', invalid = 'ignore')
-   for edge in range(len(poly)):
-      v1 = poly[edge - 1]
-      v2 = poly[edge]
-      crossings += np.where(
-         np.logical_and(
+    np_err_dict = np.geterr()
+    np.seterr(divide = 'ignore', invalid = 'ignore')
+    for edge in range(len(poly)):
+        v1 = poly[edge - 1]
+        v2 = poly[edge]
+        crossings += np.where(
             np.logical_and(
-               np.logical_or(v1[0] > p[:, 0], v2[0] > p[:, 0]),
-               np.logical_or(np.logical_and(v1[1] <= p[:, 1], v2[1] > p[:, 1]),
-                             np.logical_and(v1[1] > p[:, 1], v2[1] <= p[:, 1]))),
-            np.logical_or(np.logical_and(v1[0] > p[:, 0], v2[0] > p[:, 0]),
-                          (p[:, 0] < (v1[0] + (v2[0] - v1[0]) * (p[:, 1] - v1[1]) / (v2[1] - v1[1]))))), 1, 0)
-   if 'divide' in np_err_dict:
-      np.seterr(divide = np_err_dict['divide'])
-   if 'invalid' in np_err_dict:
-      np.seterr(invalid = np_err_dict['invalid'])
+                np.logical_and(
+                    np.logical_or(v1[0] > p[:, 0], v2[0] > p[:, 0]),
+                    np.logical_or(np.logical_and(v1[1] <= p[:, 1], v2[1] > p[:, 1]),
+                                  np.logical_and(v1[1] > p[:, 1], v2[1] <= p[:, 1]))),
+                np.logical_or(np.logical_and(v1[0] > p[:, 0], v2[0] > p[:, 0]),
+                              (p[:, 0] < (v1[0] + (v2[0] - v1[0]) * (p[:, 1] - v1[1]) / (v2[1] - v1[1]))))), 1, 0)
+    if 'divide' in np_err_dict:
+        np.seterr(divide = np_err_dict['divide'])
+    if 'invalid' in np_err_dict:
+        np.seterr(invalid = np_err_dict['invalid'])
 
-   return np.array(np.bitwise_and(crossings, 1), dtype = bool).reshape(list(p_a.shape)[:-1])
+    return np.array(np.bitwise_and(crossings, 1), dtype = bool).reshape(list(p_a.shape)[:-1])
 
 
 def points_in_polygon(x, y, polygon_file, poly_unit_multiplier = None):
-   """Takes a pair of numpy arrays x, y defining points to be tested against polygon specified in polygon_file."""
+    """Takes a pair of numpy arrays x, y defining points to be tested against polygon specified in polygon_file."""
 
-   assert x.shape == y.shape, 'x and y arrays have differing shapes or are not numpy arrays'
-   assert polygon_file and os.path.exists(polygon_file), 'polygon file is missing'
-   if poly_unit_multiplier is not None:
-      assert poly_unit_multiplier != 0.0, 'zero multiplier for polygon units not allowed'
+    assert x.shape == y.shape, 'x and y arrays have differing shapes or are not numpy arrays'
+    assert polygon_file and os.path.exists(polygon_file), 'polygon file is missing'
+    if poly_unit_multiplier is not None:
+        assert poly_unit_multiplier != 0.0, 'zero multiplier for polygon units not allowed'
 
-   try:
-      polygon_list = sl.read_lines(polygon_file)
-      assert len(polygon_list) > 0, 'unable to read polygon from file ' + polygon_file
-      assert len(polygon_list) == 1, 'more than one polygon in file ' + polygon_file
-      polygon = polygon_list[0]
-      if poly_unit_multiplier is not None:
-         polygon[:] *= poly_unit_multiplier
-      points = np.stack((x, y), axis = -1)
-      return pip_array_cn(points, polygon)
-   except Exception:
-      log.exception('failed to determine points in polygon')
+    try:
+        polygon_list = sl.read_lines(polygon_file)
+        assert len(polygon_list) > 0, 'unable to read polygon from file ' + polygon_file
+        assert len(polygon_list) == 1, 'more than one polygon in file ' + polygon_file
+        polygon = polygon_list[0]
+        if poly_unit_multiplier is not None:
+            polygon[:] *= poly_unit_multiplier
+        points = np.stack((x, y), axis = -1)
+        return pip_array_cn(points, polygon)
+    except Exception:
+        log.exception('failed to determine points in polygon')
 
-   return None
+    return None
 
 
 def scan(origin, ncol, nrow, dx, dy, poly):
-   """Scans lines of pixels returning 2D boolean array of points within convex polygon."""
+    """Scans lines of pixels returning 2D boolean array of points within convex polygon."""
 
-   inside = np.zeros((nrow, ncol), dtype = bool)
-   ix = np.empty((2))
+    inside = np.zeros((nrow, ncol), dtype = bool)
+    ix = np.empty((2))
 
-   for row in range(nrow):
-      ix[:] = 0.0
-      y = origin[1] + dy * row
-      ic = 0
-      for edge in range(len(poly)):
-         v1 = poly[edge - 1]
-         v2 = poly[edge]
-         if (v1[1] > y and v2[1] > y) or (v1[1] <= y and v2[1] <= y):
+    for row in range(nrow):
+        ix[:] = 0.0
+        y = origin[1] + dy * row
+        ic = 0
+        for edge in range(len(poly)):
+            v1 = poly[edge - 1]
+            v2 = poly[edge]
+            if (v1[1] > y and v2[1] > y) or (v1[1] <= y and v2[1] <= y):
+                continue
+            ix[ic] = v1[0] + (v2[0] - v1[0]) * (y - v1[1]) / (v2[1] - v1[1])
+            ic += 1
+            if ic == 2:
+                break
+        if ic < 2:
             continue
-         ix[ic] = v1[0] + (v2[0] - v1[0]) * (y - v1[1]) / (v2[1] - v1[1])
-         ic += 1
-         if ic == 2:
-            break
-      if ic < 2:
-         continue
-      if ix[1] < ix[0]:
-         sx, ex = ix[1], ix[0]
-      else:
-         sx, ex = ix[0], ix[1]
-      scol = maths.ceil((sx - origin[0]) / dx)
-      ecol = int((ex - origin[0]) / dx)
-      inside[row, scol:ecol + 1] = True
+        if ix[1] < ix[0]:
+            sx, ex = ix[1], ix[0]
+        else:
+            sx, ex = ix[0], ix[1]
+        scol = maths.ceil((sx - origin[0]) / dx)
+        ecol = int((ex - origin[0]) / dx)
+        inside[row, scol:ecol + 1] = True
 
-   return inside
+    return inside

--- a/resqpy/olio/random_seed.py
+++ b/resqpy/olio/random_seed.py
@@ -7,7 +7,7 @@ import numpy
 
 
 def seed(seed, package = 'all'):
-   """Set seed for random number generator of one or more packages, to allow for repeatable behaviour.
+    """Set seed for random number generator of one or more packages, to allow for repeatable behaviour.
 
    arguments:
       seed (int or long): the value to use to seed the random number generator(s); a value of None will
@@ -16,20 +16,20 @@ def seed(seed, package = 'all'):
          passing 'all' will cause all packages known to have a random number generator to be re-seeded
    """
 
-   known_list = ['random', 'numpy']
+    known_list = ['random', 'numpy']
 
-   if isinstance(package, str):
-      if package == 'all':
-         package = known_list
-      else:
-         package = [package]
+    if isinstance(package, str):
+        if package == 'all':
+            package = known_list
+        else:
+            package = [package]
 
-   assert isinstance(package, list)
+    assert isinstance(package, list)
 
-   for pack in package:
-      assert pack in known_list, 'unknown package for random number seeding: ' + str(pack)
+    for pack in package:
+        assert pack in known_list, 'unknown package for random number seeding: ' + str(pack)
 
-      if pack == 'random':
-         random.seed(seed)
-      elif pack == 'numpy':
-         numpy.random.seed(seed = seed)
+        if pack == 'random':
+            random.seed(seed)
+        elif pack == 'numpy':
+            numpy.random.seed(seed = seed)

--- a/resqpy/olio/read_nexus_fault.py
+++ b/resqpy/olio/read_nexus_fault.py
@@ -23,49 +23,99 @@ import pandas as pd
 
 
 def load_nexus_fault_mult_table(file_name):
-   """Reads a Nexus (!) format file containing one or more MULT keywords and returns a dataframe with the MULT rows."""
+    """Reads a Nexus (!) format file containing one or more MULT keywords and returns a dataframe with the MULT rows."""
 
-   def is_number(s):
-      try:
-         float(s)
-         return True
-      except ValueError:
-         pass
+    def is_number(s):
+        try:
+            float(s)
+            return True
+        except ValueError:
+            pass
 
-      try:
-         unicodedata.numeric(s)
-         return True
-      except (TypeError, ValueError):
-         pass
+        try:
+            unicodedata.numeric(s)
+            return True
+        except (TypeError, ValueError):
+            pass
 
-      return False
+        return False
 
-   names = []
-   grids = []
-   faces = []
-   dfs = []
+    names = []
+    grids = []
+    faces = []
+    dfs = []
 
-   num_tables = 0
-   ISTABLE = False
-   ISRECORD = False
-   grid = name = face = None
+    num_tables = 0
+    ISTABLE = False
+    ISRECORD = False
+    grid = name = face = None
 
-   face_dict = {'TX': 'I', 'TY': 'J', 'TZ': 'K', 'TI': 'I', 'TJ': 'J', 'TK': 'K'}
+    face_dict = {'TX': 'I', 'TY': 'J', 'TZ': 'K', 'TI': 'I', 'TJ': 'J', 'TK': 'K'}
 
-   if os.path.isfile(file_name):
-      chunks = []
-      with open(file_name) as f:
-         for line in f:
-            if len(line.strip()):
-               if (not line.strip()[0] == '!') & (not line.strip()[0] == 'C'):
-                  line = line.partition('!')[0]  # removing trailing comments
-                  # line = line.partition('C')[0]  # removing trailing comments
-                  tokens = line.split()
-                  if ISTABLE:
-                     if is_number(tokens[0]):
-                        ISRECORD = True
+    if os.path.isfile(file_name):
+        chunks = []
+        with open(file_name) as f:
+            for line in f:
+                if len(line.strip()):
+                    if (not line.strip()[0] == '!') & (not line.strip()[0] == 'C'):
+                        line = line.partition('!')[0]  # removing trailing comments
+                        # line = line.partition('C')[0]  # removing trailing comments
+                        tokens = line.split()
+                        if ISTABLE:
+                            if is_number(tokens[0]):
+                                ISRECORD = True
 
-                     if ISRECORD and (not is_number(tokens[0])):
+                            if ISRECORD and (not is_number(tokens[0])):
+                                data = chunks[0:]
+                                d_elems = np.array([np.array(data[i].split()) for i in range(len(data))])
+                                # fill empty elements with zero
+                                lens = np.array([len(i) for i in d_elems])
+                                # Mask of valid places in each row
+                                mask = np.arange(lens.max()) < lens[:, None]
+                                # Setup output array and put elements from data into masked positions
+                                outdata = np.zeros(mask.shape, dtype = d_elems.dtype)
+                                outdata[mask] = np.concatenate(d_elems)
+                                df = pd.DataFrame(outdata)
+                                for column in df.columns:
+                                    df[column] = pd.to_numeric(df[column], errors = 'ignore')
+                                df.columns = ['i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult']
+                                grids.append(grid)
+                                names.append(name)
+                                faces.append(face)
+                                dfs.append(df)
+                                num_tables += 1
+
+                                ISTABLE = False
+                                ISRECORD = False
+                                chunks = []
+
+                        if ISTABLE:
+                            if re.match("(.*)GRID(.*)", tokens[0]):
+                                if len(tokens) > 0:
+                                    grid = tokens[1]
+                            elif re.match("(.*)FNAME(.*)", tokens[0]):
+                                if len(tokens) > 0:
+                                    name = tokens[1]
+                            else:
+                                if re.match(r"^MULT$", tokens[0]):
+                                    ISTABLE = False
+                                    ISRECORD = False
+                                    chunks = []
+                                else:
+                                    chunks.append(line.strip())
+
+                        if re.match(r"^MULT$", tokens[0]):
+                            if len(tokens) > 0:
+                                face = face_dict[tokens[1]]
+                            if 'MINUS' in tokens:
+                                face += '-'  # indicates data apply to 'negative' faces of specified cells
+                            grid = 'ROOT'  # nexus default
+                            name = 'NONE'
+                            ISTABLE = True
+
+            else:
+                if ISTABLE:
+                    if ISRECORD:
                         data = chunks[0:]
                         d_elems = np.array([np.array(data[i].split()) for i in range(len(data))])
                         # fill empty elements with zero
@@ -77,8 +127,9 @@ def load_nexus_fault_mult_table(file_name):
                         outdata[mask] = np.concatenate(d_elems)
                         df = pd.DataFrame(outdata)
                         for column in df.columns:
-                           df[column] = pd.to_numeric(df[column], errors = 'ignore')
+                            df[column] = pd.to_numeric(df[column], errors = 'ignore')
                         df.columns = ['i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult']
+
                         grids.append(grid)
                         names.append(name)
                         faces.append(face)
@@ -89,72 +140,21 @@ def load_nexus_fault_mult_table(file_name):
                         ISRECORD = False
                         chunks = []
 
-                  if ISTABLE:
-                     if re.match("(.*)GRID(.*)", tokens[0]):
-                        if len(tokens) > 0:
-                           grid = tokens[1]
-                     elif re.match("(.*)FNAME(.*)", tokens[0]):
-                        if len(tokens) > 0:
-                           name = tokens[1]
-                     else:
-                        if re.match(r"^MULT$", tokens[0]):
-                           ISTABLE = False
-                           ISRECORD = False
-                           chunks = []
-                        else:
-                           chunks.append(line.strip())
+    fault_df = pd.DataFrame()
+    for i in range(0, len(dfs)):
+        dfi = dfs[i]
+        dfi['grid'] = grids[i]
+        dfi['name'] = names[i]
+        dfi['face'] = faces[i]
+        fault_df = fault_df.append(dfi, ignore_index = True)
 
-                  if re.match(r"^MULT$", tokens[0]):
-                     if len(tokens) > 0:
-                        face = face_dict[tokens[1]]
-                     if 'MINUS' in tokens:
-                        face += '-'  # indicates data apply to 'negative' faces of specified cells
-                     grid = 'ROOT'  # nexus default
-                     name = 'NONE'
-                     ISTABLE = True
+    convert_dict = {'i1': int, 'i2': int, 'j1': int, 'j2': int, 'k1': int, 'k2': int, 'mult': float}
+    fault_df = fault_df.astype(convert_dict)
 
-         else:
-            if ISTABLE:
-               if ISRECORD:
-                  data = chunks[0:]
-                  d_elems = np.array([np.array(data[i].split()) for i in range(len(data))])
-                  # fill empty elements with zero
-                  lens = np.array([len(i) for i in d_elems])
-                  # Mask of valid places in each row
-                  mask = np.arange(lens.max()) < lens[:, None]
-                  # Setup output array and put elements from data into masked positions
-                  outdata = np.zeros(mask.shape, dtype = d_elems.dtype)
-                  outdata[mask] = np.concatenate(d_elems)
-                  df = pd.DataFrame(outdata)
-                  for column in df.columns:
-                     df[column] = pd.to_numeric(df[column], errors = 'ignore')
-                  df.columns = ['i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult']
-
-                  grids.append(grid)
-                  names.append(name)
-                  faces.append(face)
-                  dfs.append(df)
-                  num_tables += 1
-
-                  ISTABLE = False
-                  ISRECORD = False
-                  chunks = []
-
-   fault_df = pd.DataFrame()
-   for i in range(0, len(dfs)):
-      dfi = dfs[i]
-      dfi['grid'] = grids[i]
-      dfi['name'] = names[i]
-      dfi['face'] = faces[i]
-      fault_df = fault_df.append(dfi, ignore_index = True)
-
-   convert_dict = {'i1': int, 'i2': int, 'j1': int, 'j2': int, 'k1': int, 'k2': int, 'mult': float}
-   fault_df = fault_df.astype(convert_dict)
-
-   return fault_df
+    return fault_df
 
 
 def load_nexus_fault_mult_table_new(file_name):
-   """Reads a Nexus (!) format file containing one or more MULT keywords and returns a dataframe with the MULT rows."""
+    """Reads a Nexus (!) format file containing one or more MULT keywords and returns a dataframe with the MULT rows."""
 
-   return load_nexus_fault_mult_table(file_name)
+    return load_nexus_fault_mult_table(file_name)

--- a/resqpy/olio/relperm.py
+++ b/resqpy/olio/relperm.py
@@ -21,25 +21,25 @@ log.debug(f'dataframe.py version {version}')
 
 
 class RelPerm(DataFrame):
-   """Class for storing and retrieving a pandas dataframe of relative permeability data.
+    """Class for storing and retrieving a pandas dataframe of relative permeability data.
 
    note:
       inherits from DataFrame class
    """
 
-   def __init__(self,
-                model,
-                uuid = None,
-                df = None,
-                uom_list = None,
-                realization = None,
-                phase_combo = None,
-                low_sal = False,
-                table_index = None,
-                title = 'relperm_table',
-                column_lookup_uuid = None,
-                uom_lookup_uuid = None):
-      """Create a new RelPerm object from either a previously stored object or a pandas dataframe.
+    def __init__(self,
+                 model,
+                 uuid = None,
+                 df = None,
+                 uom_list = None,
+                 realization = None,
+                 phase_combo = None,
+                 low_sal = False,
+                 table_index = None,
+                 title = 'relperm_table',
+                 column_lookup_uuid = None,
+                 uom_lookup_uuid = None):
+        """Create a new RelPerm object from either a previously stored object or a pandas dataframe.
 
       arguments:
          phase_combo (str, optional): the combination of phases whose relative permeability behaviour is described.
@@ -53,121 +53,122 @@ class RelPerm(DataFrame):
          see DataFrame class docstring for details of other arguments
       """
 
-      # check that either a uuid OR dataframe has been provided
-      if df is None and uuid is None:
-         raise ValueError('either a uuid or a dataframe must be provided')
+        # check that either a uuid OR dataframe has been provided
+        if df is None and uuid is None:
+            raise ValueError('either a uuid or a dataframe must be provided')
 
-      # check extra_metadata for arguments if uuid is provided
-      if uuid is not None:
-         model_root = model.root(uuid = uuid)
-         uuid_metadata_dict = rqet.load_metadata_from_xml(model_root)
-         phase_combo = uuid_metadata_dict['phase_combo']
-         low_sal = uuid_metadata_dict['low_sal']
-         table_index = uuid_metadata_dict['table_index']
+        # check extra_metadata for arguments if uuid is provided
+        if uuid is not None:
+            model_root = model.root(uuid = uuid)
+            uuid_metadata_dict = rqet.load_metadata_from_xml(model_root)
+            phase_combo = uuid_metadata_dict['phase_combo']
+            low_sal = uuid_metadata_dict['low_sal']
+            table_index = uuid_metadata_dict['table_index']
 
-      elif df is not None:
-         # check that 'phase_combo' parameter is valid
-         processed_phase_combo = set([x.strip() for x in str(phase_combo).split('-')])
-         if processed_phase_combo not in [{'water', 'oil'}, {'gas', 'oil'}, {'gas', 'water'}, {'None'}]:
-            raise ValueError('invalid phase_combo provided')
-         # check that table_index is >= 1
-         if table_index is not None:
-            if table_index < 1:
-               raise ValueError('table_index cannot be less than 1')
-         # check that the column names and order are as expected
-         df.columns = [x.capitalize() for x in df.columns]
-         if 'Pc' in df.columns:
-            if df.columns[-1] != 'Pc':
-               raise ValueError('Pc', 'capillary pressure data should be in the last column of the dataframe')
-         if phase_combo is not None:
-            if processed_phase_combo == {'water', 'oil'}:
-               expected_cols = {'Sw', 'So', 'Krw', 'Kro', 'Pc'}
-               sat_cols = {'Sw', 'So'}
-               if df.columns[0] not in sat_cols or len(set(df.columns).intersection(sat_cols)) != 1:
-                  raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
-               if not set(df.columns).issubset(expected_cols):
-                  raise ValueError(f'incorrect column name(s) {set(df.columns).difference(expected_cols)}')
-            elif processed_phase_combo == {'gas', 'oil'}:
-               expected_cols = {'Sg', 'So', 'Krg', 'Kro', 'Pc'}
-               sat_cols = {'Sg', 'So'}
-               if df.columns[0] not in sat_cols or len(set(df.columns).intersection(sat_cols)) != 1:
-                  raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
-               if not set(df.columns).issubset(expected_cols):
-                  raise ValueError(f'incorrect column name(s) {set(df.columns).difference(expected_cols)}')
-            elif processed_phase_combo == {'gas', 'water'}:
-               expected_cols = {'Sg', 'Sw', 'Krg', 'Krw', 'Pc'}
-               sat_cols = {'Sg', 'Sw'}
-               if df.columns[0] not in sat_cols or len(set(df.columns).intersection(sat_cols)) != 1:
-                  raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
-               if not set(df.columns).issubset(expected_cols):
-                  raise ValueError(f'incorrect column name(s) {set(df.columns).difference(expected_cols)}')
-         elif phase_combo is None:
-            if df.columns[0] not in ['Sw', 'Sg', 'So'] or len(set(df.columns).intersection({'Sw', 'Sg', 'So'})) != 1:
-               raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
-            if set(df.columns).issubset({'Sw', 'So', 'Krw', 'Kro', 'Pc'}) and len(set(df.columns)) >= 3:
-               phase_combo = 'water-oil'
-            elif set(df.columns).issubset({'Sg', 'So', 'Krg', 'Kro', 'Pc'}) and len(set(df.columns)) >= 3:
-               phase_combo = 'gas-oil'
-            elif set(df.columns).issubset({'Sg', 'Sw', 'Krg', 'Krw', 'Pc'}) and len(set(df.columns)) >= 3:
-               phase_combo = 'gas-water'
+        elif df is not None:
+            # check that 'phase_combo' parameter is valid
+            processed_phase_combo = set([x.strip() for x in str(phase_combo).split('-')])
+            if processed_phase_combo not in [{'water', 'oil'}, {'gas', 'oil'}, {'gas', 'water'}, {'None'}]:
+                raise ValueError('invalid phase_combo provided')
+            # check that table_index is >= 1
+            if table_index is not None:
+                if table_index < 1:
+                    raise ValueError('table_index cannot be less than 1')
+            # check that the column names and order are as expected
+            df.columns = [x.capitalize() for x in df.columns]
+            if 'Pc' in df.columns:
+                if df.columns[-1] != 'Pc':
+                    raise ValueError('Pc', 'capillary pressure data should be in the last column of the dataframe')
+            if phase_combo is not None:
+                if processed_phase_combo == {'water', 'oil'}:
+                    expected_cols = {'Sw', 'So', 'Krw', 'Kro', 'Pc'}
+                    sat_cols = {'Sw', 'So'}
+                    if df.columns[0] not in sat_cols or len(set(df.columns).intersection(sat_cols)) != 1:
+                        raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
+                    if not set(df.columns).issubset(expected_cols):
+                        raise ValueError(f'incorrect column name(s) {set(df.columns).difference(expected_cols)}')
+                elif processed_phase_combo == {'gas', 'oil'}:
+                    expected_cols = {'Sg', 'So', 'Krg', 'Kro', 'Pc'}
+                    sat_cols = {'Sg', 'So'}
+                    if df.columns[0] not in sat_cols or len(set(df.columns).intersection(sat_cols)) != 1:
+                        raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
+                    if not set(df.columns).issubset(expected_cols):
+                        raise ValueError(f'incorrect column name(s) {set(df.columns).difference(expected_cols)}')
+                elif processed_phase_combo == {'gas', 'water'}:
+                    expected_cols = {'Sg', 'Sw', 'Krg', 'Krw', 'Pc'}
+                    sat_cols = {'Sg', 'Sw'}
+                    if df.columns[0] not in sat_cols or len(set(df.columns).intersection(sat_cols)) != 1:
+                        raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
+                    if not set(df.columns).issubset(expected_cols):
+                        raise ValueError(f'incorrect column name(s) {set(df.columns).difference(expected_cols)}')
+            elif phase_combo is None:
+                if df.columns[0] not in ['Sw', 'Sg', 'So'
+                                        ] or len(set(df.columns).intersection({'Sw', 'Sg', 'So'})) != 1:
+                    raise ValueError('incorrect saturation column name and/or multiple saturation columns exist')
+                if set(df.columns).issubset({'Sw', 'So', 'Krw', 'Kro', 'Pc'}) and len(set(df.columns)) >= 3:
+                    phase_combo = 'water-oil'
+                elif set(df.columns).issubset({'Sg', 'So', 'Krg', 'Kro', 'Pc'}) and len(set(df.columns)) >= 3:
+                    phase_combo = 'gas-oil'
+                elif set(df.columns).issubset({'Sg', 'Sw', 'Krg', 'Krw', 'Pc'}) and len(set(df.columns)) >= 3:
+                    phase_combo = 'gas-water'
+                else:
+                    raise Exception('unexpected number of columns and/or column headers')
+
+            # ensure that missing capillary pressure values are stored as np.nan
+            for col in df.columns:
+                if col.capitalize() == 'Pc':
+                    df[col].replace('None', np.nan, inplace = True)
+
+            # convert all values in the dataframe to numeric type
+            df_cols = df.columns
+            df[df_cols] = df[df_cols].apply(pd.to_numeric, errors = 'coerce')
+
+            # ensure that no other column besides Pc has missing values
+            cols_no_pc = [x for x in df.columns if 'pc' != x.lower()]
+            for col in cols_no_pc:
+                if (df[col].isnull().sum() > 0) | ('None' in list(df[col])):
+                    raise Exception(f'missing values found in {col} column')
+
+            # check that Sw, Kr and Pc values are monotonic and that the Sw and Kr values are within the range 0-1
+            sat_col = [x for x in df.columns if x[0] == 'S'][0]
+            relp_corr_col = [x for x in df.columns if x == 'Kr' + sat_col[-1]][0]
+            relp_opp_col = [x for x in df.columns if (x[0:2] == 'Kr') & (x[-1] != sat_col[-1])][0]
+            if (df[sat_col].is_monotonic and df[relp_corr_col].is_monotonic and df[
+                relp_opp_col].is_monotonic_decreasing) or \
+                (df[sat_col].is_monotonic_decreasing and df[relp_corr_col].is_monotonic_decreasing and
+                    df[relp_opp_col].is_monotonic):
+                pass
             else:
-               raise Exception('unexpected number of columns and/or column headers')
+                raise ValueError(f'{sat_col, relp_corr_col, relp_opp_col} combo is not monotonic')
+            if 'Pc' in df.columns:
+                if not df['Pc'].dropna().is_monotonic and not df['Pc'].dropna().is_monotonic_decreasing:
+                    raise ValueError('Pc values are not monotonic')
+            for col in ['Sw', 'Sg', 'So', 'Krw', 'Krg', 'Kro']:
+                if col in df.columns:
+                    if df[col].min() < 0 or df[col].max() > 1:
+                        raise ValueError(f'{col} is not within the range 0-1')
 
-         # ensure that missing capillary pressure values are stored as np.nan
-         for col in df.columns:
-            if col.capitalize() == 'Pc':
-               df[col].replace('None', np.nan, inplace = True)
+        super().__init__(model,
+                         uuid = uuid,
+                         support_root = None,
+                         df = df,
+                         uom_list = uom_list,
+                         realization = realization,
+                         title = title,
+                         column_lookup_uuid = column_lookup_uuid,
+                         uom_lookup_uuid = uom_lookup_uuid,
+                         extra_metadata = {
+                             'relperm_table': 'true',
+                             'phase_combo': phase_combo,
+                             'low_sal': str(low_sal).lower(),
+                             'table_index': str(table_index)
+                         })
+        self.phase_combo = phase_combo
+        self.low_sal = low_sal
+        self.table_index = table_index
 
-         # convert all values in the dataframe to numeric type
-         df_cols = df.columns
-         df[df_cols] = df[df_cols].apply(pd.to_numeric, errors = 'coerce')
-
-         # ensure that no other column besides Pc has missing values
-         cols_no_pc = [x for x in df.columns if 'pc' != x.lower()]
-         for col in cols_no_pc:
-            if (df[col].isnull().sum() > 0) | ('None' in list(df[col])):
-               raise Exception(f'missing values found in {col} column')
-
-         # check that Sw, Kr and Pc values are monotonic and that the Sw and Kr values are within the range 0-1
-         sat_col = [x for x in df.columns if x[0] == 'S'][0]
-         relp_corr_col = [x for x in df.columns if x == 'Kr' + sat_col[-1]][0]
-         relp_opp_col = [x for x in df.columns if (x[0:2] == 'Kr') & (x[-1] != sat_col[-1])][0]
-         if (df[sat_col].is_monotonic and df[relp_corr_col].is_monotonic and df[
-             relp_opp_col].is_monotonic_decreasing) or \
-             (df[sat_col].is_monotonic_decreasing and df[relp_corr_col].is_monotonic_decreasing and
-                 df[relp_opp_col].is_monotonic):
-            pass
-         else:
-            raise ValueError(f'{sat_col, relp_corr_col, relp_opp_col} combo is not monotonic')
-         if 'Pc' in df.columns:
-            if not df['Pc'].dropna().is_monotonic and not df['Pc'].dropna().is_monotonic_decreasing:
-               raise ValueError('Pc values are not monotonic')
-         for col in ['Sw', 'Sg', 'So', 'Krw', 'Krg', 'Kro']:
-            if col in df.columns:
-               if df[col].min() < 0 or df[col].max() > 1:
-                  raise ValueError(f'{col} is not within the range 0-1')
-
-      super().__init__(model,
-                       uuid = uuid,
-                       support_root = None,
-                       df = df,
-                       uom_list = uom_list,
-                       realization = realization,
-                       title = title,
-                       column_lookup_uuid = column_lookup_uuid,
-                       uom_lookup_uuid = uom_lookup_uuid,
-                       extra_metadata = {
-                          'relperm_table': 'true',
-                          'phase_combo': phase_combo,
-                          'low_sal': str(low_sal).lower(),
-                          'table_index': str(table_index)
-                       })
-      self.phase_combo = phase_combo
-      self.low_sal = low_sal
-      self.table_index = table_index
-
-   def interpolate_point(self, saturation, kr_or_pc_col):
-      """Returns a tuple of the saturation value and the corresponding interpolated rel. perm. or cap. pressure value.
+    def interpolate_point(self, saturation, kr_or_pc_col):
+        """Returns a tuple of the saturation value and the corresponding interpolated rel. perm. or cap. pressure value.
 
       arguments:
          saturation (float): the saturation at which the relative permeability or cap. pressure will be interpolated
@@ -179,24 +180,24 @@ class RelPerm(DataFrame):
       note:
          A simple linear interpolation is performed.
       """
-      df = self.df.copy()
-      if kr_or_pc_col.capitalize() not in df.columns or kr_or_pc_col.capitalize() == df.columns[0]:
-         raise ValueError('incorrect column name provided for interpolation')
-      if kr_or_pc_col == 'PC':
-         df = df[df['PC'].notnull()]
-      sat_col = df.columns[0]
-      # ensure that the saturation values are monotonically increasing
-      df = df.sort_values(by = sat_col)
-      x = df[sat_col]
-      y = df[kr_or_pc_col]
-      x_new = saturation
-      if x_new < x.min() or x_new > x.max():
-         raise ValueError('saturation value is outside the interpolation range')
-      y_new = np.interp(x_new, x, y)
-      return saturation, y_new
+        df = self.df.copy()
+        if kr_or_pc_col.capitalize() not in df.columns or kr_or_pc_col.capitalize() == df.columns[0]:
+            raise ValueError('incorrect column name provided for interpolation')
+        if kr_or_pc_col == 'PC':
+            df = df[df['PC'].notnull()]
+        sat_col = df.columns[0]
+        # ensure that the saturation values are monotonically increasing
+        df = df.sort_values(by = sat_col)
+        x = df[sat_col]
+        y = df[kr_or_pc_col]
+        x_new = saturation
+        if x_new < x.min() or x_new > x.max():
+            raise ValueError('saturation value is outside the interpolation range')
+        y_new = np.interp(x_new, x, y)
+        return saturation, y_new
 
-   def df_to_text(self, filepath, filename):
-      """Creates a text file from a dataframe of relative permeability and capillary pressure data.
+    def df_to_text(self, filepath, filename):
+        """Creates a text file from a dataframe of relative permeability and capillary pressure data.
 
       arguments:
          filepath (str): location where new text file is written to
@@ -209,52 +210,52 @@ class RelPerm(DataFrame):
          Only Nexus compatible text files are currently supported. Text files that are compatible with other reservoir
             simulators may be supported in the future.
       """
-      df = self.df.copy()
-      ascii_file = os.path.join(filepath, filename + '.dat')
-      df.columns = map(str.upper, df.columns)
-      if {'KRW', 'KRO'}.issubset(set(df.columns)):
-         if self.low_sal:
-            table_name_keyword = 'WOTABLE (LOW_SAL)\n'
-         else:
-            table_name_keyword = 'WOTABLE\n'
-         df.rename(columns = {'SW': 'SW', 'KRW': 'KRW', 'KRO': 'KROW', 'PC': 'PCWO'}, inplace = True)
-      elif {'KRG', 'KRO'}.issubset(set(df.columns)):
-         table_name_keyword = 'GOTABLE\n'
-         df.rename(columns = {'SG': 'SG', 'KRG': 'KRG', 'KRO': 'KROG', 'PC': 'PCGO'}, inplace = True)
-      elif {'KRW', 'KRW'}.issubset(set(df.columns)):
-         table_name_keyword = 'GWTABLE\n'
-         df.rename(columns = {'SG': 'SG', 'KRG': 'KRG', 'KRW': 'KRWG', 'PC': 'PCGW'}, inplace = True)
-      else:
-         raise Exception('incorrect rel. perm. column combination encountered')
+        df = self.df.copy()
+        ascii_file = os.path.join(filepath, filename + '.dat')
+        df.columns = map(str.upper, df.columns)
+        if {'KRW', 'KRO'}.issubset(set(df.columns)):
+            if self.low_sal:
+                table_name_keyword = 'WOTABLE (LOW_SAL)\n'
+            else:
+                table_name_keyword = 'WOTABLE\n'
+            df.rename(columns = {'SW': 'SW', 'KRW': 'KRW', 'KRO': 'KROW', 'PC': 'PCWO'}, inplace = True)
+        elif {'KRG', 'KRO'}.issubset(set(df.columns)):
+            table_name_keyword = 'GOTABLE\n'
+            df.rename(columns = {'SG': 'SG', 'KRG': 'KRG', 'KRO': 'KROG', 'PC': 'PCGO'}, inplace = True)
+        elif {'KRW', 'KRW'}.issubset(set(df.columns)):
+            table_name_keyword = 'GWTABLE\n'
+            df.rename(columns = {'SG': 'SG', 'KRG': 'KRG', 'KRW': 'KRWG', 'PC': 'PCGW'}, inplace = True)
+        else:
+            raise Exception('incorrect rel. perm. column combination encountered')
 
-      if filename + '.dat' not in os.listdir(filepath):
-         with open(ascii_file, 'w') as f:
-            f.write(table_name_keyword)
-            df_str = df.to_string(na_rep = '', index = False)
-            f.write(df_str)
-            f.close()
-            print(f'Created new DAT file: {filename} at {filepath}')
-      else:
-         with open(ascii_file, 'a') as f:
-            f.write('\n\n')
-            f.write(table_name_keyword)
-            df_str = df.to_string(na_rep = '', index = False)
-            f.write(df_str)
-            f.close()
-            print(f'Appended to DAT file: {filename} at {filepath}')
+        if filename + '.dat' not in os.listdir(filepath):
+            with open(ascii_file, 'w') as f:
+                f.write(table_name_keyword)
+                df_str = df.to_string(na_rep = '', index = False)
+                f.write(df_str)
+                f.close()
+                print(f'Created new DAT file: {filename} at {filepath}')
+        else:
+            with open(ascii_file, 'a') as f:
+                f.write('\n\n')
+                f.write(table_name_keyword)
+                df_str = df.to_string(na_rep = '', index = False)
+                f.write(df_str)
+                f.close()
+                print(f'Appended to DAT file: {filename} at {filepath}')
 
-   def write_hdf5_and_create_xml(self):
-      """Write relative permeability table data to hdf5 file and create xml for RESQML objects to represent dataframe.
+    def write_hdf5_and_create_xml(self):
+        """Write relative permeability table data to hdf5 file and create xml for RESQML objects to represent dataframe.
 
       """
-      super().write_hdf5_and_create_xml()
-      mesh_root = self.mesh.root
-      # create an xml of extra metadata to indicate that this is a relative permeability table
-      rqet.create_metadata_xml(mesh_root, self.extra_metadata)
+        super().write_hdf5_and_create_xml()
+        mesh_root = self.mesh.root
+        # create an xml of extra metadata to indicate that this is a relative permeability table
+        rqet.create_metadata_xml(mesh_root, self.extra_metadata)
 
 
 def text_to_relperm_dict(relperm_data, is_file = True):
-   """Returns a dictionary that contains dataframes with relative permeability and capillary pressure data and phase combinations.
+    """Returns a dictionary that contains dataframes with relative permeability and capillary pressure data and phase combinations.
 
    arguments:
       relperm_data (str): relative or full path of the text file to be processed or string of relative permeability data
@@ -268,63 +269,63 @@ def text_to_relperm_dict(relperm_data, is_file = True):
       Only Nexus compatible text files are currently supported. Text files from other reservoir simulators may be
          supported in the future.
    """
-   if is_file:
-      with open(relperm_data) as f:
-         string_original = f.read()
-   else:
-      string_original = relperm_data
-   # split the string based on newlines and remove any comments or other escape characters
-   escapes = ''.join([chr(char) for char in range(1, 32)])
-   string_formatted = [x.strip(escapes).split(' ') for x in filter(None, string_original.split('\n')) if '!' not in x]
-   # remove all empty strings
-   data = [list(filter(None, x)) for x in string_formatted]
-   # get indices of start of each new relperm table based on Nexus keywords
-   table_start_positions = [
-      i for i, l in enumerate(data) if len({'WOTABLE', 'GOTABLE', 'GWTABLE'}.intersection(set(l))) == 1
-   ]
-   df_cols_dict = {
-      'SW': 'Sw',
-      'SG': 'Sg',
-      'KRW': 'Krw',
-      'KRG': 'Krg',
-      'KROW': 'Kro',
-      'KROG': 'Kro',
-      'KRWG': 'Krw',
-      'PCWO': 'Pc',
-      'PCGO': 'Pc',
-      'PCGW': 'Pc',
-      'PC': 'Pc'
-   }
-   relperm_table_idx = 1
-   rel_perm_dict = {}
-   for i, l in enumerate(table_start_positions):
-      key = 'relperm_table' + str(relperm_table_idx)
-      rel_perm_dict[key] = {}
-      relperm_table_idx += 1
-      if 'WOTABLE' in data[l]:
-         phase_combo = 'water-oil'
-         rel_perm_dict[key]['phase_combo'] = phase_combo
-      elif 'GOTABLE' in data[l]:
-         phase_combo = 'gas-oil'
-         rel_perm_dict[key]['phase_combo'] = phase_combo
-      elif 'GWTABLE' in data[l]:
-         phase_combo = 'gas-water'
-         rel_perm_dict[key]['phase_combo'] = phase_combo
-      else:
-         raise Exception('incorrect table key word encountered')
-      if i < (len(table_start_positions) - 1):
-         table_end = table_start_positions[i + 1]
-      else:
-         table_end = len(data)
-      table_cols = data[l + 1]
-      table_rows = data[l + 2:table_end]
-      df = pd.DataFrame(table_rows, columns = table_cols)
-      df.columns = df.columns.map(df_cols_dict)
-      sat_col = [x for x in df.columns if 'S' in x][0]
-      df = df.apply(pd.to_numeric, errors = 'coerce')
-      df = df[df[sat_col].notnull()]
-      rel_perm_dict[key]['df'] = df
-   return rel_perm_dict
+    if is_file:
+        with open(relperm_data) as f:
+            string_original = f.read()
+    else:
+        string_original = relperm_data
+    # split the string based on newlines and remove any comments or other escape characters
+    escapes = ''.join([chr(char) for char in range(1, 32)])
+    string_formatted = [x.strip(escapes).split(' ') for x in filter(None, string_original.split('\n')) if '!' not in x]
+    # remove all empty strings
+    data = [list(filter(None, x)) for x in string_formatted]
+    # get indices of start of each new relperm table based on Nexus keywords
+    table_start_positions = [
+        i for i, l in enumerate(data) if len({'WOTABLE', 'GOTABLE', 'GWTABLE'}.intersection(set(l))) == 1
+    ]
+    df_cols_dict = {
+        'SW': 'Sw',
+        'SG': 'Sg',
+        'KRW': 'Krw',
+        'KRG': 'Krg',
+        'KROW': 'Kro',
+        'KROG': 'Kro',
+        'KRWG': 'Krw',
+        'PCWO': 'Pc',
+        'PCGO': 'Pc',
+        'PCGW': 'Pc',
+        'PC': 'Pc'
+    }
+    relperm_table_idx = 1
+    rel_perm_dict = {}
+    for i, l in enumerate(table_start_positions):
+        key = 'relperm_table' + str(relperm_table_idx)
+        rel_perm_dict[key] = {}
+        relperm_table_idx += 1
+        if 'WOTABLE' in data[l]:
+            phase_combo = 'water-oil'
+            rel_perm_dict[key]['phase_combo'] = phase_combo
+        elif 'GOTABLE' in data[l]:
+            phase_combo = 'gas-oil'
+            rel_perm_dict[key]['phase_combo'] = phase_combo
+        elif 'GWTABLE' in data[l]:
+            phase_combo = 'gas-water'
+            rel_perm_dict[key]['phase_combo'] = phase_combo
+        else:
+            raise Exception('incorrect table key word encountered')
+        if i < (len(table_start_positions) - 1):
+            table_end = table_start_positions[i + 1]
+        else:
+            table_end = len(data)
+        table_cols = data[l + 1]
+        table_rows = data[l + 2:table_end]
+        df = pd.DataFrame(table_rows, columns = table_cols)
+        df.columns = df.columns.map(df_cols_dict)
+        sat_col = [x for x in df.columns if 'S' in x][0]
+        df = df.apply(pd.to_numeric, errors = 'coerce')
+        df = df[df[sat_col].notnull()]
+        rel_perm_dict[key]['df'] = df
+    return rel_perm_dict
 
 
 def relperm_parts_in_model(model,
@@ -333,7 +334,7 @@ def relperm_parts_in_model(model,
                            table_index = None,
                            title = None,
                            related_uuid = None):
-   """Returns list of part names within model that are representing RelPerm dataframe support objects.
+    """Returns list of part names within model that are representing RelPerm dataframe support objects.
 
    arguments:
       model (model.Model): the model to be inspected for dataframes
@@ -349,16 +350,16 @@ def relperm_parts_in_model(model,
    returns:
       list of str, each element in the list is a part name, within model, which is representing the support for a RelPerm object
    """
-   extra_metadata_orig = {
-      'relperm_table': 'true',
-      'phase_combo': phase_combo,
-      'low_sal': low_sal,
-      'table_index': table_index
-   }
-   extra_metadata = {k: str(v).lower() for k, v in extra_metadata_orig.items() if v is not None}
-   df_parts_list = model.parts(obj_type = 'Grid2dRepresentation',
-                               title = title,
-                               extra = extra_metadata,
-                               related_uuid = related_uuid)
+    extra_metadata_orig = {
+        'relperm_table': 'true',
+        'phase_combo': phase_combo,
+        'low_sal': low_sal,
+        'table_index': table_index
+    }
+    extra_metadata = {k: str(v).lower() for k, v in extra_metadata_orig.items() if v is not None}
+    df_parts_list = model.parts(obj_type = 'Grid2dRepresentation',
+                                title = title,
+                                extra = extra_metadata,
+                                related_uuid = related_uuid)
 
-   return df_parts_list
+    return df_parts_list

--- a/resqpy/olio/rq_print.py
+++ b/resqpy/olio/rq_print.py
@@ -24,782 +24,783 @@ import resqpy.well as rqw
 
 
 def pl(n, use_e = False):
-   if n == 1:
-      return ''
-   if use_e:
-      return 'es'
-   return 's'
+    if n == 1:
+        return ''
+    if use_e:
+        return 'es'
+    return 's'
 
 
 def required(value):
-   if value is None:
-      return '(missing)'
-   text = str(value)
-   if len(text):
-      return text
-   return '(empty)'
+    if value is None:
+        return '(missing)'
+    text = str(value)
+    if len(text):
+        return text
+    return '(empty)'
 
 
 def optional(value):
-   if value is None:
-      return '(not present)'
-   text = str(value)
-   if len(text):
-      return text
-   return '(empty)'
+    if value is None:
+        return '(not present)'
+    text = str(value)
+    if len(text):
+        return text
+    return '(empty)'
 
 
 def format_xyz(xyz):
-   x, y, z = xyz
-   if x is None or y is None or z is None:
-      return '(invalid)'
-   return '(x: {0:5.3f}, y: {1:5.3f}, z: {2:5.3f})'.format(x, y, z)
+    x, y, z = xyz
+    if x is None or y is None or z is None:
+        return '(invalid)'
+    return '(x: {0:5.3f}, y: {1:5.3f}, z: {2:5.3f})'.format(x, y, z)
 
 
 def point_3d(node, flavour):
-   p3d_node = rqet.find_tag(node, flavour)
-   if p3d_node is None:
-      return '(missing)'
-   x = rqet.find_tag_float(p3d_node, 'Coordinate1')
-   y = rqet.find_tag_float(p3d_node, 'Coordinate2')
-   z = rqet.find_tag_float(p3d_node, 'Coordinate3')
-   return (x, y, z)
+    p3d_node = rqet.find_tag(node, flavour)
+    if p3d_node is None:
+        return '(missing)'
+    x = rqet.find_tag_float(p3d_node, 'Coordinate1')
+    y = rqet.find_tag_float(p3d_node, 'Coordinate2')
+    z = rqet.find_tag_float(p3d_node, 'Coordinate3')
+    return (x, y, z)
 
 
 def print_citation(node):
-   """Prints information from a citation xml tree."""
+    """Prints information from a citation xml tree."""
 
-   if node is None:
-      return
-   c_node = rqet.find_tag(node, 'Citation')
-   if c_node is None:
-      return
-   print('citation:')
-   print('   title:   ' + str(rqet.node_text(rqet.find_tag(c_node, 'Title'))))
-   print('   user:    ' + str(rqet.node_text(rqet.find_tag(c_node, 'Originator'))))
-   print('   created: ' + str(rqet.node_text(rqet.find_tag(c_node, 'Creation'))))
-   print('   format:  ' + str(rqet.node_text(rqet.find_tag(c_node, 'Format'))))
-   description = rqet.find_tag_text(c_node, 'Description')
-   if description:
-      print('   description: ' + str(description))
+    if node is None:
+        return
+    c_node = rqet.find_tag(node, 'Citation')
+    if c_node is None:
+        return
+    print('citation:')
+    print('   title:   ' + str(rqet.node_text(rqet.find_tag(c_node, 'Title'))))
+    print('   user:    ' + str(rqet.node_text(rqet.find_tag(c_node, 'Originator'))))
+    print('   created: ' + str(rqet.node_text(rqet.find_tag(c_node, 'Creation'))))
+    print('   format:  ' + str(rqet.node_text(rqet.find_tag(c_node, 'Format'))))
+    description = rqet.find_tag_text(c_node, 'Description')
+    if description:
+        print('   description: ' + str(description))
 
 
 def print_LocalDepth3dCrs(model, node, z_is_time = False):
-   """Prints information from a coordinate reference system xml tree."""
+    """Prints information from a coordinate reference system xml tree."""
 
-   print('units xy: ' + str(rqet.length_units_from_node(rqet.find_tag(node, 'ProjectedUom'))))
-   print('units z:  ' + str(rqet.length_units_from_node(rqet.find_tag(node, 'VerticalUom'))))  # applicable to time?
-   xy_axes = rqet.node_text(rqet.find_tag(node, 'ProjectedAxisOrder'))
-   print('x y axes: ' + str(xy_axes))
-   z_inc_down = rqet.bool_from_text(rqet.node_text(rqet.find_tag(
-      node, 'ZIncreasingDownward')))  # todo: check applicability to Time3dCrs?
-   if z_inc_down is None:
-      z_dir = 'unknown'
-   elif z_inc_down:
-      z_dir = 'downwards'
-   else:
-      z_dir = 'upwards'
-   print('z increases: ' + str(z_dir))
-   print('(xyz handedness: ' + str(rqet.xyz_handedness(xy_axes, z_inc_down) + ')'))
-   print('x offset: ' + str(rqet.node_text(rqet.find_tag(node, 'XOffset'))))
-   print('y offset: ' + str(rqet.node_text(rqet.find_tag(node, 'YOffset'))))
-   print('z offset: ' + str(rqet.node_text(rqet.find_tag(node, 'ZOffset'))))  # todo: check applicability to Time3dCrs?
-   print('rotation: ' + str(rqet.node_text(rqet.find_tag(node, 'ArealRotation'))))
-   parent_xy_crs_node = rqet.find_tag(node, 'ProjectedCrs')
-   parent_xy_crs_node_type = rqet.node_type(parent_xy_crs_node)
-   if parent_xy_crs_node_type == 'ProjectedCrsEpsgCode':
-      print('parent xy crs: EPSG code ' + str(rqet.node_text(rqet.find_tag(parent_xy_crs_node, 'EpsgCode'))))
-   elif parent_xy_crs_node_type == 'ProjectedUnknownCrs':
-      print('parent xy crs: unknown')
-   parent_z_crs_node = rqet.find_tag(node, 'VerticalCrs')  # todo: check applicability to Time3dCrs?
-   parent_z_crs_node_type = rqet.node_type(parent_z_crs_node)
-   if parent_z_crs_node_type == 'VerticalCrsEpsgCode':
-      print('parent z crs: EPSG code ' + str(rqet.node_text(rqet.find_tag(parent_z_crs_node, 'EpsgCode'))))
-   elif parent_z_crs_node_type == 'VerticalUnknownCrs':
-      print('parent z crs: unknown')
-   # todo: something with parent xy Crs & z Crs other than EPSG or Unknown
+    print('units xy: ' + str(rqet.length_units_from_node(rqet.find_tag(node, 'ProjectedUom'))))
+    print('units z:  ' + str(rqet.length_units_from_node(rqet.find_tag(node, 'VerticalUom'))))  # applicable to time?
+    xy_axes = rqet.node_text(rqet.find_tag(node, 'ProjectedAxisOrder'))
+    print('x y axes: ' + str(xy_axes))
+    z_inc_down = rqet.bool_from_text(rqet.node_text(rqet.find_tag(
+        node, 'ZIncreasingDownward')))  # todo: check applicability to Time3dCrs?
+    if z_inc_down is None:
+        z_dir = 'unknown'
+    elif z_inc_down:
+        z_dir = 'downwards'
+    else:
+        z_dir = 'upwards'
+    print('z increases: ' + str(z_dir))
+    print('(xyz handedness: ' + str(rqet.xyz_handedness(xy_axes, z_inc_down) + ')'))
+    print('x offset: ' + str(rqet.node_text(rqet.find_tag(node, 'XOffset'))))
+    print('y offset: ' + str(rqet.node_text(rqet.find_tag(node, 'YOffset'))))
+    print('z offset: ' + str(rqet.node_text(rqet.find_tag(node, 'ZOffset'))))  # todo: check applicability to Time3dCrs?
+    print('rotation: ' + str(rqet.node_text(rqet.find_tag(node, 'ArealRotation'))))
+    parent_xy_crs_node = rqet.find_tag(node, 'ProjectedCrs')
+    parent_xy_crs_node_type = rqet.node_type(parent_xy_crs_node)
+    if parent_xy_crs_node_type == 'ProjectedCrsEpsgCode':
+        print('parent xy crs: EPSG code ' + str(rqet.node_text(rqet.find_tag(parent_xy_crs_node, 'EpsgCode'))))
+    elif parent_xy_crs_node_type == 'ProjectedUnknownCrs':
+        print('parent xy crs: unknown')
+    parent_z_crs_node = rqet.find_tag(node, 'VerticalCrs')  # todo: check applicability to Time3dCrs?
+    parent_z_crs_node_type = rqet.node_type(parent_z_crs_node)
+    if parent_z_crs_node_type == 'VerticalCrsEpsgCode':
+        print('parent z crs: EPSG code ' + str(rqet.node_text(rqet.find_tag(parent_z_crs_node, 'EpsgCode'))))
+    elif parent_z_crs_node_type == 'VerticalUnknownCrs':
+        print('parent z crs: unknown')
+    # todo: something with parent xy Crs & z Crs other than EPSG or Unknown
 
 
 def print_LocalTime3dCrs(model, node):
-   """Prints information from a time based (seismic) coordinate reference system xml tree."""
+    """Prints information from a time based (seismic) coordinate reference system xml tree."""
 
-   # very similar to obj_LocalDepth3dCrs, with added TimeUom
-   print_LocalDepth3dCrs(model, node, z_is_time = True)
-   print('time units: ' + str(rqet.time_units_from_node(rqet.find_tag(node, 'TimeUom'))))
+    # very similar to obj_LocalDepth3dCrs, with added TimeUom
+    print_LocalDepth3dCrs(model, node, z_is_time = True)
+    print('time units: ' + str(rqet.time_units_from_node(rqet.find_tag(node, 'TimeUom'))))
 
 
 def print_IjkGridRepresentation(model, node, detail_level = 0, grid = None):
-   """Prints information about an IJK Grid object, mostly from the xml tree."""
+    """Prints information about an IJK Grid object, mostly from the xml tree."""
 
-   print('ni: ' + str(rqet.node_text(rqet.find_tag(node, 'Ni'))))
-   print('nj: ' + str(rqet.node_text(rqet.find_tag(node, 'Nj'))))
-   print('nk: ' + str(rqet.node_text(rqet.find_tag(node, 'Nk'))))
-   k_gaps_node = rqet.find_tag(node, 'KGaps')
-   if k_gaps_node is None:
-      print('grid does not have k gaps')
-   else:
-      k_gaps_count = rqet.find_tag_int(k_gaps_node, 'Count')
-      print('number of k gaps: ' + str(k_gaps_count))
-   pw_node = rqet.find_tag(node, 'ParentWindow')
-   if pw_node is not None:
-      parent_uuid = rqet.find_nested_tags_text(pw_node, ['ParentGrid', 'UUID'])
-      print('parent window present (grid is a local grid); parent uuid: ' + str(parent_uuid))
-   geom_node = rqet.find_tag(node, 'Geometry')
-   if geom_node is None:
-      if pw_node is not None:
-         print('geometry is not present (to be derived from parent grid)')
-      else:
-         print('geometry is missing!')
-      return
-   print('k increases: ' + str(rqet.find_tag_text(geom_node, 'KDirection')))
-   print('ijk handedness: ' + str(rqet.ijk_handedness(geom_node)))
-   print('pillar shape: ' + str(rqet.find_tag_text(geom_node, 'PillarShape')))
-   if not detail_level:
-      return
-   # create a Grid object and interrogate for extra details
-   if grid is None:
-      grid = grr.Grid(model, grid_root = node)
-   cell_count = grid.cell_count()
-   print('(number of cells: ' + str(cell_count) + ')')
-   if grid.has_split_coordinate_lines:
-      print('grid has split pillars (faults)')
-      split_root = grid.resolve_geometry_child('SplitCoordinateLines')
-      assert split_root is not None
-      print('number of split pillars: ' + str(rqet.node_text(rqet.find_tag(split_root, 'Count'))))
-   else:
-      print('grid does not have split pillars (grid is unfaulted)')
-   pillar_is_def_root = grid.resolve_geometry_child('PillarGeometryIsDefined')
-   cells_all_defined = True
-   if pillar_is_def_root is None:
-      print('grid does not include boolean array indicating which pillar geometries are defined!')
-   else:
-      pillar_is_def_type = rqet.node_type(pillar_is_def_root)
-      if pillar_is_def_type == 'BooleanConstantArray':
-         pillars_all_defined = grid.pillar_geometry_is_defined()
-         assert pillars_all_defined is not None
-         if pillars_all_defined:
-            print('geometry is defined for all pillars')
-         else:
-            print('geometry is not defined for any pillar!')
-         cells_all_defined = pillars_all_defined
-      else:
-         assert pillar_is_def_type == 'BooleanHdf5Array'
-         if detail_level > 1:
-            if grid.geometry_defined_for_all_pillars():
-               print('geometry is defined for all pillars with explicit boolean array')
+    print('ni: ' + str(rqet.node_text(rqet.find_tag(node, 'Ni'))))
+    print('nj: ' + str(rqet.node_text(rqet.find_tag(node, 'Nj'))))
+    print('nk: ' + str(rqet.node_text(rqet.find_tag(node, 'Nk'))))
+    k_gaps_node = rqet.find_tag(node, 'KGaps')
+    if k_gaps_node is None:
+        print('grid does not have k gaps')
+    else:
+        k_gaps_count = rqet.find_tag_int(k_gaps_node, 'Count')
+        print('number of k gaps: ' + str(k_gaps_count))
+    pw_node = rqet.find_tag(node, 'ParentWindow')
+    if pw_node is not None:
+        parent_uuid = rqet.find_nested_tags_text(pw_node, ['ParentGrid', 'UUID'])
+        print('parent window present (grid is a local grid); parent uuid: ' + str(parent_uuid))
+    geom_node = rqet.find_tag(node, 'Geometry')
+    if geom_node is None:
+        if pw_node is not None:
+            print('geometry is not present (to be derived from parent grid)')
+        else:
+            print('geometry is missing!')
+        return
+    print('k increases: ' + str(rqet.find_tag_text(geom_node, 'KDirection')))
+    print('ijk handedness: ' + str(rqet.ijk_handedness(geom_node)))
+    print('pillar shape: ' + str(rqet.find_tag_text(geom_node, 'PillarShape')))
+    if not detail_level:
+        return
+    # create a Grid object and interrogate for extra details
+    if grid is None:
+        grid = grr.Grid(model, grid_root = node)
+    cell_count = grid.cell_count()
+    print('(number of cells: ' + str(cell_count) + ')')
+    if grid.has_split_coordinate_lines:
+        print('grid has split pillars (faults)')
+        split_root = grid.resolve_geometry_child('SplitCoordinateLines')
+        assert split_root is not None
+        print('number of split pillars: ' + str(rqet.node_text(rqet.find_tag(split_root, 'Count'))))
+    else:
+        print('grid does not have split pillars (grid is unfaulted)')
+    pillar_is_def_root = grid.resolve_geometry_child('PillarGeometryIsDefined')
+    cells_all_defined = True
+    if pillar_is_def_root is None:
+        print('grid does not include boolean array indicating which pillar geometries are defined!')
+    else:
+        pillar_is_def_type = rqet.node_type(pillar_is_def_root)
+        if pillar_is_def_type == 'BooleanConstantArray':
+            pillars_all_defined = grid.pillar_geometry_is_defined()
+            assert pillars_all_defined is not None
+            if pillars_all_defined:
+                print('geometry is defined for all pillars')
             else:
-               print('geometry is not defined for all pillars')
-               cells_all_defined = False
-   cell_is_def_root = grid.resolve_geometry_child('CellGeometryIsDefined')
-   cells_all_defined = False
-   if cell_is_def_root is None:
-      print('grid does not include boolean array indicating which cell geometries are defined!')
-   else:
-      cell_is_def_type = rqet.node_type(cell_is_def_root)
-      if cell_is_def_type == 'BooleanConstantArray':
-         cells_all_defined = grid.cell_geometry_is_defined()
-         assert cells_all_defined is not None
-         if cells_all_defined:
-            print('geometry is defined for all cells')
-         else:
-            print('geometry is not defined for any cells!')
-      else:
-         assert cell_is_def_type == 'BooleanHdf5Array'
-         if detail_level > 1:
-            cell_is_def_array = grid.cell_geometry_is_defined_ref()
-            if grid.geometry_defined_for_all_cells_cached is None or not grid.geometry_defined_for_all_cells_cached:
-               assert cell_is_def_array is not None
-               cells_defined = np.count_nonzero(cell_is_def_array)
-               print('geometry is defined for {0:1d} cells ({1:4.2f}%)'.format(
-                  cells_defined, 100.0 * float(cells_defined) / float(cell_count)))
-               cells_all_defined = (cells_defined == cell_count)
-            else:
-               cells_all_defined = True
+                print('geometry is not defined for any pillar!')
+            cells_all_defined = pillars_all_defined
+        else:
+            assert pillar_is_def_type == 'BooleanHdf5Array'
+            if detail_level > 1:
+                if grid.geometry_defined_for_all_pillars():
+                    print('geometry is defined for all pillars with explicit boolean array')
+                else:
+                    print('geometry is not defined for all pillars')
+                    cells_all_defined = False
+    cell_is_def_root = grid.resolve_geometry_child('CellGeometryIsDefined')
+    cells_all_defined = False
+    if cell_is_def_root is None:
+        print('grid does not include boolean array indicating which cell geometries are defined!')
+    else:
+        cell_is_def_type = rqet.node_type(cell_is_def_root)
+        if cell_is_def_type == 'BooleanConstantArray':
+            cells_all_defined = grid.cell_geometry_is_defined()
+            assert cells_all_defined is not None
             if cells_all_defined:
-               print('geometry is defined for all cells with explicit boolean array')
-   points_root = grid.resolve_geometry_child('Points')
-   if points_root is None:
-      print('grid does not include (corner) points data!')
+                print('geometry is defined for all cells')
+            else:
+                print('geometry is not defined for any cells!')
+        else:
+            assert cell_is_def_type == 'BooleanHdf5Array'
+            if detail_level > 1:
+                cell_is_def_array = grid.cell_geometry_is_defined_ref()
+                if grid.geometry_defined_for_all_cells_cached is None or not grid.geometry_defined_for_all_cells_cached:
+                    assert cell_is_def_array is not None
+                    cells_defined = np.count_nonzero(cell_is_def_array)
+                    print('geometry is defined for {0:1d} cells ({1:4.2f}%)'.format(
+                        cells_defined, 100.0 * float(cells_defined) / float(cell_count)))
+                    cells_all_defined = (cells_defined == cell_count)
+                else:
+                    cells_all_defined = True
+                if cells_all_defined:
+                    print('geometry is defined for all cells with explicit boolean array')
+    points_root = grid.resolve_geometry_child('Points')
+    if points_root is None:
+        print('grid does not include (corner) points data!')
 
 
 #   elif cells_all_defined:
-   else:
-      laziness = (detail_level < 2)
-      for local in [True, False]:
-         xyz_box = grid.xyz_box(points_root = points_root, lazy = laziness, local = local)
-         if local:
-            local_str = 'local'
-         else:
-            local_str = 'global'
-         if laziness:
-            laziness_str = 'lazy'
-         else:
-            laziness_str = 'thorough'
-         print(local_str + ' bounding values of geometry min, max (' + laziness_str + '):')
-         for xyz in range(3):
-            print(' {0}: {1:12.3f} {2:12.3f}'.format('xyz'[xyz], xyz_box[0, xyz], xyz_box[1, xyz]))
-   # todo: check whether all HDF5 refs are to same file
+    else:
+        laziness = (detail_level < 2)
+        for local in [True, False]:
+            xyz_box = grid.xyz_box(points_root = points_root, lazy = laziness, local = local)
+            if local:
+                local_str = 'local'
+            else:
+                local_str = 'global'
+            if laziness:
+                laziness_str = 'lazy'
+            else:
+                laziness_str = 'thorough'
+            print(local_str + ' bounding values of geometry min, max (' + laziness_str + '):')
+            for xyz in range(3):
+                print(' {0}: {1:12.3f} {2:12.3f}'.format('xyz'[xyz], xyz_box[0, xyz], xyz_box[1, xyz]))
+    # todo: check whether all HDF5 refs are to same file
 
 hdf5_dataset_count = 0
 
 
 def print_hdf5_line(name, group_or_dataset):
-   """Prints information about one dataset (array) in an hdf5 file.
+    """Prints information about one dataset (array) in an hdf5 file.
 
       :meta private:
    """
 
-   global hdf5_dataset_count
-   if isinstance(group_or_dataset, h5py.Group):
-      return None
-   print(name + '  ' + str(group_or_dataset.shape) + '  ' + str(group_or_dataset.dtype))
-   hdf5_dataset_count += 1
-   return None
+    global hdf5_dataset_count
+    if isinstance(group_or_dataset, h5py.Group):
+        return None
+    print(name + '  ' + str(group_or_dataset.shape) + '  ' + str(group_or_dataset.dtype))
+    hdf5_dataset_count += 1
+    return None
 
 
 def print_EpcExternalPartReference(model, node, detail_level = 0):
-   """Prints information about an hdf5 external part."""
+    """Prints information about an hdf5 external part."""
 
-   global hdf5_dataset_count
-   print('mime type: ' + str(rqet.node_text(rqet.find_tag(node, 'MimeType'))))
-   if not detail_level or 'uuid' not in node.attrib.keys():
-      return
-   uuid = bu.uuid_from_string(node.attrib['uuid'])
-   file_name = model.h5_file_name(uuid)
-   print('hdf5 file: ' + str(file_name))
-   hdf5 = model.h5_access(uuid)
-   hdf5_dataset_count = 0
-   if hdf5 is not None:
-      for (key, group) in hdf5.items():
-         print('*** ' + str(key) + ': ' + str(group))
-         group.visititems(print_hdf5_line)
-   print('number of data sets (arrays): ' + str(hdf5_dataset_count))
+    global hdf5_dataset_count
+    print('mime type: ' + str(rqet.node_text(rqet.find_tag(node, 'MimeType'))))
+    if not detail_level or 'uuid' not in node.attrib.keys():
+        return
+    uuid = bu.uuid_from_string(node.attrib['uuid'])
+    file_name = model.h5_file_name(uuid)
+    print('hdf5 file: ' + str(file_name))
+    hdf5 = model.h5_access(uuid)
+    hdf5_dataset_count = 0
+    if hdf5 is not None:
+        for (key, group) in hdf5.items():
+            print('*** ' + str(key) + ': ' + str(group))
+            group.visititems(print_hdf5_line)
+    print('number of data sets (arrays): ' + str(hdf5_dataset_count))
 
 
 def print_TimeSeries(model, node, detail_level = 0):
-   """Prints information form a time series xml tree."""
+    """Prints information form a time series xml tree."""
 
-   if node is None:
-      return
-   print('number of timestamps: ' + str(rqet.count_tag(node, 'Time')))
-   if not detail_level:
-      return
-   time_series = rts.any_time_series(model, uuid = node.attrib['uuid'])
-   for index in range(time_series.number_of_timestamps()):
-      if time_series.timeframe == 'geologic':
-         print(f'{index:>5d}  {time_series.timestamp(index)}')
-      elif index:
-         print('{0:>5d}  {1} {2:>5d}'.format(index, rts.simplified_timestamp(time_series.timestamp(index)),
-                                             time_series.step_days(index)))
-      else:
-         print('{0:>5d}  {1}  step (days)'.format(0, rts.simplified_timestamp(time_series.timestamp(0))))
+    if node is None:
+        return
+    print('number of timestamps: ' + str(rqet.count_tag(node, 'Time')))
+    if not detail_level:
+        return
+    time_series = rts.any_time_series(model, uuid = node.attrib['uuid'])
+    for index in range(time_series.number_of_timestamps()):
+        if time_series.timeframe == 'geologic':
+            print(f'{index:>5d}  {time_series.timestamp(index)}')
+        elif index:
+            print('{0:>5d}  {1} {2:>5d}'.format(index, rts.simplified_timestamp(time_series.timestamp(index)),
+                                                time_series.step_days(index)))
+        else:
+            print('{0:>5d}  {1}  step (days)'.format(0, rts.simplified_timestamp(time_series.timestamp(0))))
 
 
 def print_StringTableLookup(model, node, detail_level = 0):
-   """Prints information from a string lookup table xml tree."""
+    """Prints information from a string lookup table xml tree."""
 
-   entries_node_list = rqet.list_of_tag(node, 'Value')
-   if entries_node_list is None or len(entries_node_list) == 0:
-      print('no entries in lookup table')
-      return
-   print(str(len(entries_node_list)) + ' entries in lookup table:')
-   if not detail_level:
-      return
-   entries_pair_list = []
-   for entry_node in entries_node_list:
-      key_node = rqet.find_tag(entry_node, 'Key')
-      if key_node is None:
-         continue
-      key_type = rqet.node_type(key_node)
-      if key_type == 'integer':
-         key = int(key_node.text)
-      else:
-         key = key_node.text
-      value = rqet.node_text(rqet.find_tag(entry_node, 'Value'))
-      entries_pair_list.append((key, value))
-   entries_pair_list.sort()
-   for (key, value) in entries_pair_list:
-      if isinstance(key, int):
-         print('{0:>4d}: {1}'.format(key, value))
-      else:
-         print(str(key) + ': ' + str(value))
+    entries_node_list = rqet.list_of_tag(node, 'Value')
+    if entries_node_list is None or len(entries_node_list) == 0:
+        print('no entries in lookup table')
+        return
+    print(str(len(entries_node_list)) + ' entries in lookup table:')
+    if not detail_level:
+        return
+    entries_pair_list = []
+    for entry_node in entries_node_list:
+        key_node = rqet.find_tag(entry_node, 'Key')
+        if key_node is None:
+            continue
+        key_type = rqet.node_type(key_node)
+        if key_type == 'integer':
+            key = int(key_node.text)
+        else:
+            key = key_node.text
+        value = rqet.node_text(rqet.find_tag(entry_node, 'Value'))
+        entries_pair_list.append((key, value))
+    entries_pair_list.sort()
+    for (key, value) in entries_pair_list:
+        if isinstance(key, int):
+            print('{0:>4d}: {1}'.format(key, value))
+        else:
+            print(str(key) + ': ' + str(value))
 
 
 def print_reference_node_and_return_referenced_part(node, heading):
-   """Prints some information about a part being referenced in an xml node."""
+    """Prints some information about a part being referenced in an xml node."""
 
-   if node is None:
-      print(str(heading) + ': (missing)')
-      return None
-   print(str(heading) + ':')
-   print('   title: ' + str(rqet.node_text(rqet.find_tag(node, 'Title'))))
-   content_type = rqet.content_type(rqet.node_text(rqet.find_tag(node, 'ContentType')))
-   if content_type is not None:
-      print('   type:  ' + str(rcd.readable_class(content_type)))
-   uuid_str = rqet.node_text(rqet.find_tag(node, 'UUID'))
-   if uuid_str is not None:
-      print('   uuid:  ' + str(uuid_str))
-   if content_type is None or content_type[:4] != 'obj_' or uuid_str is None:
-      return None
-   if uuid_str[0] == '_':
-      uuid_str = uuid_str[1:]  # tolerate fesapi quirk
-   return content_type + '_' + uuid_str + '.xml'
+    if node is None:
+        print(str(heading) + ': (missing)')
+        return None
+    print(str(heading) + ':')
+    print('   title: ' + str(rqet.node_text(rqet.find_tag(node, 'Title'))))
+    content_type = rqet.content_type(rqet.node_text(rqet.find_tag(node, 'ContentType')))
+    if content_type is not None:
+        print('   type:  ' + str(rcd.readable_class(content_type)))
+    uuid_str = rqet.node_text(rqet.find_tag(node, 'UUID'))
+    if uuid_str is not None:
+        print('   uuid:  ' + str(uuid_str))
+    if content_type is None or content_type[:4] != 'obj_' or uuid_str is None:
+        return None
+    if uuid_str[0] == '_':
+        uuid_str = uuid_str[1:]  # tolerate fesapi quirk
+    return content_type + '_' + uuid_str + '.xml'
 
 
 def print_Property(model, node, detail_level = 0):
-   """Prints information about a grid property, mostly from the xml tree."""
+    """Prints information about a grid property, mostly from the xml tree."""
 
-   property_kind = None
-   property_kind_node = rqet.find_tag(node, 'PropertyKind')
-   if property_kind_node is None:
-      print('property kind is missing!')
-   else:
-      kind_node = rqet.find_tag(property_kind_node, 'Kind')
-      if kind_node is not None:
-         property_kind = rqet.node_text(kind_node)
-         print('kind: ' + str(property_kind))
-      else:
-         local_kind_node = rqet.find_tag(property_kind_node, 'LocalPropertyKind')
-         if local_kind_node is not None:
-            print('kind: ' + str(rqet.find_tag_text(local_kind_node, 'Title')))
-         else:
-            print('property kind xml not recognised!')
-   facet_type = None
-   facet = None
-   facet_node_list = rqet.list_of_tag(node, 'Facet')
-   if facet_node_list is not None:
-      for facet_node in facet_node_list:
-         print('facet: ' + str(rqet.node_text(rqet.find_tag(facet_node, 'Facet'))) + ': ' +
-               str(rqet.find_tag_text(facet_node, 'Value')))
-         if not facet_type:  # arbitrarily pick up first facet in list to use in helping to guess uom, if needed
-            facet_type = rqet.node_text(rqet.find_tag(facet_node, 'Facet'))
-            facet = rqet.node_text(rqet.find_tag(facet_node, 'Value'))
-   citation_title = rqet.node_text(rqet.find_tag(rqet.find_tag(node, 'Citation'), 'Title'))
-   if citation_title is not None:
-      (derived_property_kind, derived_facet_type,
-       derived_facet) = rprop.property_kind_and_facet_from_keyword(citation_title)
-      if derived_property_kind is not None:
-         if property_kind is None:
-            property_kind = derived_property_kind
-         if derived_facet_type is None:
-            print('(derived kind: ' + derived_property_kind + ')')
-         else:
-            print('(derived kind: ' + str(derived_property_kind) + '; facet: ' + str(derived_facet_type) + ': ' +
-                  str(derived_facet) + ')')
-   print('realization: ' + optional(rqet.find_tag_int(node, 'RealizationIndex')))
-   grid = None
-   time_series = time_series_uuid = time_series_part = None
-   time_index_node = rqet.find_tag(node, 'TimeIndex')
-   if time_index_node is None:
-      print('static property (no time index)')
-   else:
-      index_node = rqet.find_tag(time_index_node, 'Index')
-      print('time index: ' + str(rqet.node_text(index_node)))
-      if index_node is None:
-         time_index = None
-      else:
-         time_index = int(index_node.text)
-      time_series_ref_node = rqet.find_tag(time_index_node, 'TimeSeries')
-      time_series_part = print_reference_node_and_return_referenced_part(time_series_ref_node, 'time series')
-      if detail_level > 0:
-         time_series_uuid = model.uuid_for_part(time_series_part)
-         if time_series_uuid is None:
-            print('   time series part not found!')
-            log.warning('missing time series part: ' + str(time_series_part))
-         else:
-            time_series = rts.any_time_series(model, uuid = time_series_uuid)
-            print('   number of timestamps in series: ' + str(time_series.number_of_timestamps()))
-         if time_index is not None and time_series is not None:
-            print('timestamp for this part: ' + str(rts.simplified_timestamp(time_series.timestamp(time_index))))
-   minimum = rqet.node_text(rqet.find_tag(node, 'MinimumValue'))
-   print('minimum (xml): ' + str(minimum))
-   maximum = rqet.node_text(rqet.find_tag(node, 'MaximumValue'))
-   print('maximum (xml): ' + str(maximum))
-   units = rqet.find_tag_text(node, 'UOM')
-   if units is not None:
-      print('units: ' + units)
-      if units in ['unknown', 'Euc'] and property_kind is not None and detail_level > 0:
-         guessed_uom = rprop.guess_uom(property_kind, minimum, maximum, grid, facet_type = facet_type, facet = facet)
-         if guessed_uom:
-            print('(guessed units: ' + str(guessed_uom) + ')')
-   print('count: ' + str(rqet.find_tag_text(node, 'Count')))
-   print('indexable element: ' + str(rqet.find_tag_text(node, 'IndexableElement')))
-   values_node = rqet.find_tag(node, 'PatchOfValues')
-   if values_node is None:
-      print('patch of values is missing!')
-      return
-   print('patch of values is present in xml')
-   if detail_level < 2 or grid is None:
-      return
-   single_prop_collection = rprop.GridPropertyCollection()
-   single_prop_collection.set_grid(grid)
-   part_name = rqet.part_name_for_part_root(node)
-   single_prop_collection.add_part_to_dict(part_name,
-                                           trust_uom = units is not None and units not in ['', 'unknown', 'Euc'])
-   cached_array = single_prop_collection.cached_part_array_ref(part_name)
-   if cached_array is None:
-      print('failed to cache array for part ' + str(part_name))
-      return None
-   print('type of array elements: ' + str(cached_array.dtype))
-   print('shape of array (nk, nj, ni): ' + str(cached_array.shape))
-   print('number of elements in array: ' + str(cached_array.size))
-   non_zero_count = np.count_nonzero(cached_array)
-   print('number of non-zero elements: ' + str(non_zero_count))
-   print('minimum (data, all cells): ' + str(np.nanmin(cached_array)))
-   print('maximum (data, all cells): ' + str(np.nanmax(cached_array)))
-   if cached_array.dtype == 'float':
-      average = np.mean(cached_array)  # todo: handle NaN and Inf in a better way
-      print('mean value (all cells): ' + str(average))
-      if property_kind in ['rock volume', 'pore volume']:
-         print('sum of values (all cells): ' + str(np.sum(cached_array)))
-   if grid and grid.inactive is not None:
-      masked_array = single_prop_collection.cached_part_array_ref(part_name, masked = True)
-      inactive_count = np.count_nonzero(masked_array.mask)
-      print('active cell count: ' + str(cached_array.size - inactive_count))
-      print('inactive cell count: ' + str(inactive_count))
-      print('minimum (data, active cells): ' + str(np.nanmin(masked_array)))
-      print('maximum (data, active cells): ' + str(np.nanmax(masked_array)))
-      if cached_array.dtype == 'float':
-         average = np.mean(masked_array)  # todo: handle NaN and Inf in a better way
-         print('mean value (active cells): ' + str(average))
-         if property_kind in ['rock volume', 'pore volume']:
-            print('sum of values (active cells): ' + str(np.nansum(masked_array)))
-   single_prop_collection.uncache_part_array(part_name)
+    property_kind = None
+    property_kind_node = rqet.find_tag(node, 'PropertyKind')
+    if property_kind_node is None:
+        print('property kind is missing!')
+    else:
+        kind_node = rqet.find_tag(property_kind_node, 'Kind')
+        if kind_node is not None:
+            property_kind = rqet.node_text(kind_node)
+            print('kind: ' + str(property_kind))
+        else:
+            local_kind_node = rqet.find_tag(property_kind_node, 'LocalPropertyKind')
+            if local_kind_node is not None:
+                print('kind: ' + str(rqet.find_tag_text(local_kind_node, 'Title')))
+            else:
+                print('property kind xml not recognised!')
+    facet_type = None
+    facet = None
+    facet_node_list = rqet.list_of_tag(node, 'Facet')
+    if facet_node_list is not None:
+        for facet_node in facet_node_list:
+            print('facet: ' + str(rqet.node_text(rqet.find_tag(facet_node, 'Facet'))) + ': ' +
+                  str(rqet.find_tag_text(facet_node, 'Value')))
+            if not facet_type:  # arbitrarily pick up first facet in list to use in helping to guess uom, if needed
+                facet_type = rqet.node_text(rqet.find_tag(facet_node, 'Facet'))
+                facet = rqet.node_text(rqet.find_tag(facet_node, 'Value'))
+    citation_title = rqet.node_text(rqet.find_tag(rqet.find_tag(node, 'Citation'), 'Title'))
+    if citation_title is not None:
+        (derived_property_kind, derived_facet_type,
+         derived_facet) = rprop.property_kind_and_facet_from_keyword(citation_title)
+        if derived_property_kind is not None:
+            if property_kind is None:
+                property_kind = derived_property_kind
+            if derived_facet_type is None:
+                print('(derived kind: ' + derived_property_kind + ')')
+            else:
+                print('(derived kind: ' + str(derived_property_kind) + '; facet: ' + str(derived_facet_type) + ': ' +
+                      str(derived_facet) + ')')
+    print('realization: ' + optional(rqet.find_tag_int(node, 'RealizationIndex')))
+    grid = None
+    time_series = time_series_uuid = time_series_part = None
+    time_index_node = rqet.find_tag(node, 'TimeIndex')
+    if time_index_node is None:
+        print('static property (no time index)')
+    else:
+        index_node = rqet.find_tag(time_index_node, 'Index')
+        print('time index: ' + str(rqet.node_text(index_node)))
+        if index_node is None:
+            time_index = None
+        else:
+            time_index = int(index_node.text)
+        time_series_ref_node = rqet.find_tag(time_index_node, 'TimeSeries')
+        time_series_part = print_reference_node_and_return_referenced_part(time_series_ref_node, 'time series')
+        if detail_level > 0:
+            time_series_uuid = model.uuid_for_part(time_series_part)
+            if time_series_uuid is None:
+                print('   time series part not found!')
+                log.warning('missing time series part: ' + str(time_series_part))
+            else:
+                time_series = rts.any_time_series(model, uuid = time_series_uuid)
+                print('   number of timestamps in series: ' + str(time_series.number_of_timestamps()))
+            if time_index is not None and time_series is not None:
+                print('timestamp for this part: ' + str(rts.simplified_timestamp(time_series.timestamp(time_index))))
+    minimum = rqet.node_text(rqet.find_tag(node, 'MinimumValue'))
+    print('minimum (xml): ' + str(minimum))
+    maximum = rqet.node_text(rqet.find_tag(node, 'MaximumValue'))
+    print('maximum (xml): ' + str(maximum))
+    units = rqet.find_tag_text(node, 'UOM')
+    if units is not None:
+        print('units: ' + units)
+        if units in ['unknown', 'Euc'] and property_kind is not None and detail_level > 0:
+            guessed_uom = rprop.guess_uom(property_kind, minimum, maximum, grid, facet_type = facet_type, facet = facet)
+            if guessed_uom:
+                print('(guessed units: ' + str(guessed_uom) + ')')
+    print('count: ' + str(rqet.find_tag_text(node, 'Count')))
+    print('indexable element: ' + str(rqet.find_tag_text(node, 'IndexableElement')))
+    values_node = rqet.find_tag(node, 'PatchOfValues')
+    if values_node is None:
+        print('patch of values is missing!')
+        return
+    print('patch of values is present in xml')
+    if detail_level < 2 or grid is None:
+        return
+    single_prop_collection = rprop.GridPropertyCollection()
+    single_prop_collection.set_grid(grid)
+    part_name = rqet.part_name_for_part_root(node)
+    single_prop_collection.add_part_to_dict(part_name,
+                                            trust_uom = units is not None and units not in ['', 'unknown', 'Euc'])
+    cached_array = single_prop_collection.cached_part_array_ref(part_name)
+    if cached_array is None:
+        print('failed to cache array for part ' + str(part_name))
+        return None
+    print('type of array elements: ' + str(cached_array.dtype))
+    print('shape of array (nk, nj, ni): ' + str(cached_array.shape))
+    print('number of elements in array: ' + str(cached_array.size))
+    non_zero_count = np.count_nonzero(cached_array)
+    print('number of non-zero elements: ' + str(non_zero_count))
+    print('minimum (data, all cells): ' + str(np.nanmin(cached_array)))
+    print('maximum (data, all cells): ' + str(np.nanmax(cached_array)))
+    if cached_array.dtype == 'float':
+        average = np.mean(cached_array)  # todo: handle NaN and Inf in a better way
+        print('mean value (all cells): ' + str(average))
+        if property_kind in ['rock volume', 'pore volume']:
+            print('sum of values (all cells): ' + str(np.sum(cached_array)))
+    if grid and grid.inactive is not None:
+        masked_array = single_prop_collection.cached_part_array_ref(part_name, masked = True)
+        inactive_count = np.count_nonzero(masked_array.mask)
+        print('active cell count: ' + str(cached_array.size - inactive_count))
+        print('inactive cell count: ' + str(inactive_count))
+        print('minimum (data, active cells): ' + str(np.nanmin(masked_array)))
+        print('maximum (data, active cells): ' + str(np.nanmax(masked_array)))
+        if cached_array.dtype == 'float':
+            average = np.mean(masked_array)  # todo: handle NaN and Inf in a better way
+            print('mean value (active cells): ' + str(average))
+            if property_kind in ['rock volume', 'pore volume']:
+                print('sum of values (active cells): ' + str(np.nansum(masked_array)))
+    single_prop_collection.uncache_part_array(part_name)
 
 
 def print_CategoricalProperty(model, node, detail_level = 0):
-   """Prints information about a categorical grid property, mostly from the xml tree."""
+    """Prints information about a categorical grid property, mostly from the xml tree."""
 
-   print_Property(model, node, detail_level = detail_level)
-   lookup_node = rqet.find_tag(node, 'Lookup')
-   if lookup_node is None:
-      print('no lookup table referenced')
-   else:
-      print_reference_node_and_return_referenced_part(lookup_node, 'lookup table reference')
+    print_Property(model, node, detail_level = detail_level)
+    lookup_node = rqet.find_tag(node, 'Lookup')
+    if lookup_node is None:
+        print('no lookup table referenced')
+    else:
+        print_reference_node_and_return_referenced_part(lookup_node, 'lookup table reference')
 
 
 def print_ContinuousProperty(model, node, detail_level = 0):
-   """Prints information about a continuous (float) grid property, mostly from the xml tree."""
+    """Prints information about a continuous (float) grid property, mostly from the xml tree."""
 
-   print_Property(model, node, detail_level = detail_level)
+    print_Property(model, node, detail_level = detail_level)
 
 
 def print_DiscreteProperty(model, node, detail_level = 0):
-   """Prints information about a discrete (integer) grid property, mostly from the xml tree."""
+    """Prints information about a discrete (integer) grid property, mostly from the xml tree."""
 
-   print_Property(model, node, detail_level = detail_level)
+    print_Property(model, node, detail_level = detail_level)
 
 
 def print_TriangulatedSetRepresentation(model, node, detail_level = 0):
-   """Prints information about a triangulated set representation (surface) from the xml tree."""
+    """Prints information about a triangulated set representation (surface) from the xml tree."""
 
-   print('surface role: ' + required(rqet.find_tag_text(node, 'SurfaceRole')))
-   patch_count = rqet.count_tag(node, 'TrianglePatch')
-   print('patch count:  ' + str(patch_count))
-   if detail_level > 0:
-      for patch in rqet.list_of_tag(node, 'TrianglePatch'):
-         print('   patch index:     ' + required(rqet.find_tag_int(patch, 'PatchIndex')))
-         print('   triangle count:  ' + required(rqet.find_tag_int(patch, 'Count')))
-         print('   node count:      ' + required(rqet.find_tag_int(patch, 'NodeCount')))
-         if detail_level > 1:
-            print('   node null value: ' + optional(rqet.find_tag_int(patch, 'NullValue')))
+    print('surface role: ' + required(rqet.find_tag_text(node, 'SurfaceRole')))
+    patch_count = rqet.count_tag(node, 'TrianglePatch')
+    print('patch count:  ' + str(patch_count))
+    if detail_level > 0:
+        for patch in rqet.list_of_tag(node, 'TrianglePatch'):
+            print('   patch index:     ' + required(rqet.find_tag_int(patch, 'PatchIndex')))
+            print('   triangle count:  ' + required(rqet.find_tag_int(patch, 'Count')))
+            print('   node count:      ' + required(rqet.find_tag_int(patch, 'NodeCount')))
+            if detail_level > 1:
+                print('   node null value: ' + optional(rqet.find_tag_int(patch, 'NullValue')))
 
 
 def print_PointSetRepresentation(model, node, detail_level = 0):
-   """Prints information about a point set representation from the xml tree."""
+    """Prints information about a point set representation from the xml tree."""
 
-   patch_count = rqet.count_tag(node, 'NodePatch')
-   print('patch count:  ' + str(patch_count))
-   if detail_level > 0:
-      total_count = 0
-      for patch in rqet.list_of_tag(node, 'NodePatch'):
-         print('   patch index: ' + required(rqet.find_tag_int(patch, 'PatchIndex')))
-         point_count = rqet.find_tag_int(patch, 'Count')
-         print('   point count: ' + required(point_count))
-         if point_count:
-            total_count += point_count
-      print('(total point count: {})'.format(total_count))
+    patch_count = rqet.count_tag(node, 'NodePatch')
+    print('patch count:  ' + str(patch_count))
+    if detail_level > 0:
+        total_count = 0
+        for patch in rqet.list_of_tag(node, 'NodePatch'):
+            print('   patch index: ' + required(rqet.find_tag_int(patch, 'PatchIndex')))
+            point_count = rqet.find_tag_int(patch, 'Count')
+            print('   point count: ' + required(point_count))
+            if point_count:
+                total_count += point_count
+        print('(total point count: {})'.format(total_count))
 
 
 def print_GridConnectionSetRepresentation(model, node, detail_level = 0):
-   """Prints information about a grid connection set representation (fault cell face set), mostly from the xml tree."""
+    """Prints information about a grid connection set representation (fault cell face set), mostly from the xml tree."""
 
-   print('face count: ' + required(rqet.find_tag_int(node, 'Count')))
-   ci_node = rqet.find_tag(node, 'ConnectionInterpretations')
-   if ci_node is None:
-      print('(connection interpretations missing)')
-      return
-   feature_count = rqet.count_tag(ci_node, 'FeatureInterpretation')
-   print('feature (fault or fracture) count: ' + str(feature_count))
-   if detail_level > 0:
-      if detail_level > 1:
-         gcs = rqf.GridConnectionSet(model, connection_set_root = node)
-      feature_index = 0
-      for feature in rqet.list_of_tag(ci_node, 'FeatureInterpretation'):
-         print_reference_node_and_return_referenced_part(feature, 'feature interpretation reference')
-         if detail_level > 1:
-            face_count_per_feature = len(gcs.raw_list_of_cell_face_pairs_for_feature_index(feature_index)[0])
-            print('   face pair count: ' + str(face_count_per_feature))
-         feature_index += 1
+    print('face count: ' + required(rqet.find_tag_int(node, 'Count')))
+    ci_node = rqet.find_tag(node, 'ConnectionInterpretations')
+    if ci_node is None:
+        print('(connection interpretations missing)')
+        return
+    feature_count = rqet.count_tag(ci_node, 'FeatureInterpretation')
+    print('feature (fault or fracture) count: ' + str(feature_count))
+    if detail_level > 0:
+        if detail_level > 1:
+            gcs = rqf.GridConnectionSet(model, connection_set_root = node)
+        feature_index = 0
+        for feature in rqet.list_of_tag(ci_node, 'FeatureInterpretation'):
+            print_reference_node_and_return_referenced_part(feature, 'feature interpretation reference')
+            if detail_level > 1:
+                face_count_per_feature = len(gcs.raw_list_of_cell_face_pairs_for_feature_index(feature_index)[0])
+                print('   face pair count: ' + str(face_count_per_feature))
+            feature_index += 1
 
 
 def print_MdDatum(model, node, detail_level = 0):
-   """Prints information about a measured depth datum, from the xml tree."""
+    """Prints information about a measured depth datum, from the xml tree."""
 
-   print('reference: ' + required(rqet.find_tag_text(node, 'MdReference')))
-   location_xyz = point_3d(node, 'Location')
-   print('location:  ' + format_xyz(location_xyz))
-   if detail_level > 0:
-      crs_ref = rqet.find_tag(node, 'LocalCrs')
-      crs_part = print_reference_node_and_return_referenced_part(crs_ref, 'local coordinate reference system reference')
-      if detail_level > 1:
-         crs = rqc.Crs(model, uuid = rqet.uuid_in_part_name(crs_part))
-         global_xyz = crs.local_to_global(location_xyz)
-         print('global location: ' + format_xyz(global_xyz))
+    print('reference: ' + required(rqet.find_tag_text(node, 'MdReference')))
+    location_xyz = point_3d(node, 'Location')
+    print('location:  ' + format_xyz(location_xyz))
+    if detail_level > 0:
+        crs_ref = rqet.find_tag(node, 'LocalCrs')
+        crs_part = print_reference_node_and_return_referenced_part(crs_ref,
+                                                                   'local coordinate reference system reference')
+        if detail_level > 1:
+            crs = rqc.Crs(model, uuid = rqet.uuid_in_part_name(crs_part))
+            global_xyz = crs.local_to_global(location_xyz)
+            print('global location: ' + format_xyz(global_xyz))
 
 
 def print_WellboreFrameRepresentation(model, node, detail_level = 0):
-   """Prints information about a wellbore frame representation, from the xml tree."""
+    """Prints information about a wellbore frame representation, from the xml tree."""
 
-   print('md mode count: ' + required(rqet.find_tag_int(node, 'NodeCount')))
-   trajectory_ref = rqet.find_tag(node, 'Trajectory')
-   print_reference_node_and_return_referenced_part(trajectory_ref, 'wellbore trajectory reference')
+    print('md mode count: ' + required(rqet.find_tag_int(node, 'NodeCount')))
+    trajectory_ref = rqet.find_tag(node, 'Trajectory')
+    print_reference_node_and_return_referenced_part(trajectory_ref, 'wellbore trajectory reference')
 
 
 def print_WellboreMarkerFrameRepresentation(model, node, detail_level = 0):
-   """Prints information about a wellbore marker frame representation, from the xml tree."""
+    """Prints information about a wellbore marker frame representation, from the xml tree."""
 
-   print_WellboreFrameRepresentation(model, node, detail_level = detail_level)
-   # todo: add details
-   marker_count = len(rqet.list_of_tag(node, 'WellboreMarker'))
-   print('marker count: ' + str(marker_count))
-   print('(other details not yet available for this type of object)')
+    print_WellboreFrameRepresentation(model, node, detail_level = detail_level)
+    # todo: add details
+    marker_count = len(rqet.list_of_tag(node, 'WellboreMarker'))
+    print('marker count: ' + str(marker_count))
+    print('(other details not yet available for this type of object)')
 
 
 def print_BlockedWellboreRepresentation(model, node, detail_level = 0):
-   """Prints information about a blocked wellbore representation, from the xml tree."""
+    """Prints information about a blocked wellbore representation, from the xml tree."""
 
-   print_WellboreFrameRepresentation(model, node, detail_level = detail_level)
-   print('cell count: ' + required(rqet.find_tag_int(node, 'CellCount')))
-   print('grid count: ' + required(rqet.count_tag(node, 'Grid')))
-   if detail_level > 0:
-      for grid_ref_node in rqet.list_of_tag(node, 'Grid'):
-         print_reference_node_and_return_referenced_part(grid_ref_node, 'grid reference')
+    print_WellboreFrameRepresentation(model, node, detail_level = detail_level)
+    print('cell count: ' + required(rqet.find_tag_int(node, 'CellCount')))
+    print('grid count: ' + required(rqet.count_tag(node, 'Grid')))
+    if detail_level > 0:
+        for grid_ref_node in rqet.list_of_tag(node, 'Grid'):
+            print_reference_node_and_return_referenced_part(grid_ref_node, 'grid reference')
 
 
 def print_WellboreTrajectoryRepresentation(model, node, detail_level = 0):
-   """Prints information about a wellbore trajectory representation, from the xml tree."""
+    """Prints information about a wellbore trajectory representation, from the xml tree."""
 
-   lk_dict = {
-      -1: 'null - no line',
-      0: 'vertical)',
-      1: 'linear spline',
-      2: 'natural cubic spline',
-      3: 'cubic spline',
-      4: 'z linear cubic spline',
-      5: 'minimum-curvature spline'
-   }
-   unit_str = rqet.find_tag_text(node, 'MdUom')
-   if unit_str is None:
-      unit_str = '(missing units)'
-   print('start md:  ' + required(rqet.find_tag_float(node, 'StartMd')) + ' ' + unit_str)
-   print('finish md: ' + required(rqet.find_tag_float(node, 'FinishMd')) + ' ' + unit_str)
-   print('md units:  ' + unit_str)
-   md_ref_node = rqet.find_tag(node, 'MdDatum')
-   if md_ref_node is None:
-      print('(missing measured depth datum reference)')
-   else:
-      print_reference_node_and_return_referenced_part(md_ref_node, 'measured depth datum reference')
-   geom_node = rqet.find_tag(node, 'Geometry')
-   if geom_node is None:
-      print('(presumed vertical - no geometry)')
-      return
-   line_kind = rqet.find_tag_int(geom_node, 'LineKindIndex')
-   if line_kind is None:
-      lk_str = '(missing)'
-   elif line_kind >= -1 and line_kind <= 5:
-      lk_str = str(line_kind) + ' (' + lk_dict[line_kind] + ')'
-   else:
-      lk_str = str(line_kind) + ' (invalid value)'
-   print('line kind:  ' + lk_str)
-   print('knot count: ' + required(rqet.find_tag_int(geom_node, 'KnotCount')))
-   tv_node = rqet.find_tag(geom_node, 'TangentVectors')
-   if tv_node:
-      print('(tangent vectors are present)')
-   else:
-      print('(optional tangent vectors are not present)')
-   print('domain:     ' + optional(rqet.find_tag_text(node, 'MdDomain')))
-   ds_ref_node = rqet.find_tag(node, 'DeviationSurvey')
-   if detail_level > 0:
-      crs_ref = rqet.find_tag(geom_node, 'LocalCrs')
-      print_reference_node_and_return_referenced_part(crs_ref, 'local coordinate reference system reference')
-   if ds_ref_node is not None:
-      print_reference_node_and_return_referenced_part(ds_ref_node, 'deviation survey reference')
-   if detail_level > 1:
-      try:
-         trajectory = rqw.Trajectory(model, trajectory_root = node)
-         print('min xyz: ' + str(np.amin(trajectory.control_points, axis = 0)))
-         print('max xyz: ' + str(np.amax(trajectory.control_points, axis = 0)))
-         print('    x        y       z')
-         for (x, y, z) in trajectory.control_points:
-            print(f' {x:8.1f} {y:8.1f} {z:7.1f}')
-      except Exception:
-         print('(problem displaying control points)')
-         log.exception('trajectory issue')
+    lk_dict = {
+        -1: 'null - no line',
+        0: 'vertical)',
+        1: 'linear spline',
+        2: 'natural cubic spline',
+        3: 'cubic spline',
+        4: 'z linear cubic spline',
+        5: 'minimum-curvature spline'
+    }
+    unit_str = rqet.find_tag_text(node, 'MdUom')
+    if unit_str is None:
+        unit_str = '(missing units)'
+    print('start md:  ' + required(rqet.find_tag_float(node, 'StartMd')) + ' ' + unit_str)
+    print('finish md: ' + required(rqet.find_tag_float(node, 'FinishMd')) + ' ' + unit_str)
+    print('md units:  ' + unit_str)
+    md_ref_node = rqet.find_tag(node, 'MdDatum')
+    if md_ref_node is None:
+        print('(missing measured depth datum reference)')
+    else:
+        print_reference_node_and_return_referenced_part(md_ref_node, 'measured depth datum reference')
+    geom_node = rqet.find_tag(node, 'Geometry')
+    if geom_node is None:
+        print('(presumed vertical - no geometry)')
+        return
+    line_kind = rqet.find_tag_int(geom_node, 'LineKindIndex')
+    if line_kind is None:
+        lk_str = '(missing)'
+    elif line_kind >= -1 and line_kind <= 5:
+        lk_str = str(line_kind) + ' (' + lk_dict[line_kind] + ')'
+    else:
+        lk_str = str(line_kind) + ' (invalid value)'
+    print('line kind:  ' + lk_str)
+    print('knot count: ' + required(rqet.find_tag_int(geom_node, 'KnotCount')))
+    tv_node = rqet.find_tag(geom_node, 'TangentVectors')
+    if tv_node:
+        print('(tangent vectors are present)')
+    else:
+        print('(optional tangent vectors are not present)')
+    print('domain:     ' + optional(rqet.find_tag_text(node, 'MdDomain')))
+    ds_ref_node = rqet.find_tag(node, 'DeviationSurvey')
+    if detail_level > 0:
+        crs_ref = rqet.find_tag(geom_node, 'LocalCrs')
+        print_reference_node_and_return_referenced_part(crs_ref, 'local coordinate reference system reference')
+    if ds_ref_node is not None:
+        print_reference_node_and_return_referenced_part(ds_ref_node, 'deviation survey reference')
+    if detail_level > 1:
+        try:
+            trajectory = rqw.Trajectory(model, trajectory_root = node)
+            print('min xyz: ' + str(np.amin(trajectory.control_points, axis = 0)))
+            print('max xyz: ' + str(np.amax(trajectory.control_points, axis = 0)))
+            print('    x        y       z')
+            for (x, y, z) in trajectory.control_points:
+                print(f' {x:8.1f} {y:8.1f} {z:7.1f}')
+        except Exception:
+            print('(problem displaying control points)')
+            log.exception('trajectory issue')
 
 
 def print_TectonicBoundaryFeature(model, node, detail_level = 0):
-   """Prints information about a tectonic boundary feature (fault or fracture), from the xml tree."""
+    """Prints information about a tectonic boundary feature (fault or fracture), from the xml tree."""
 
-   print('tectonic boundary kind: ' + required(rqet.find_tag_text(node, 'TectonicBoundaryKind')))
+    print('tectonic boundary kind: ' + required(rqet.find_tag_text(node, 'TectonicBoundaryKind')))
 
 
 def print_GeneticBoundaryFeature(model, node, detail_level = 0):
-   """Prints information about a genetic boundary feature (horizon or geobody boundary), from the xml tree."""
+    """Prints information about a genetic boundary feature (horizon or geobody boundary), from the xml tree."""
 
-   print('genetic boundary kind: ' + required(rqet.find_tag_text(node, 'GeneticBoundaryKind')))
-   # todo: optional absolute age
+    print('genetic boundary kind: ' + required(rqet.find_tag_text(node, 'GeneticBoundaryKind')))
+    # todo: optional absolute age
 
 
 def print_WellboreFeature(model, node, detail_level = 0):
-   """Prints information about a wellbore feature, from the xml tree."""
+    """Prints information about a wellbore feature, from the xml tree."""
 
-   pass  # nothing but citation block in this feature class
+    pass  # nothing but citation block in this feature class
 
 
 def print_OrganizationFeature(model, node, detail_level = 0):
-   """Prints information about an organization feature, from the xml tree."""
+    """Prints information about an organization feature, from the xml tree."""
 
-   pass  # nothing but citation block in this feature class
+    pass  # nothing but citation block in this feature class
 
 
 def print_FaultInterpretation(model, node, detail_level = 0):
-   """Prints information about a fault interpretation, from the xml tree."""
+    """Prints information about a fault interpretation, from the xml tree."""
 
-   print('domain:        ' + required(rqet.find_tag_text(node, 'Domain')))
-   print('is listric:    ' + optional(rqet.find_tag_text(node, 'IsListric')))
-   print('maximum throw: ' + optional(rqet.find_tag_float(node, 'MaximumThrow')))
-   print('mean azimuth:  ' + optional(rqet.find_tag_float(node, 'MeanAzimuth')))
-   print('mean dip:      ' + optional(rqet.find_tag_float(node, 'MeanDip')))
-   throw_understanding = rqet.find_tag_text(node, 'ThrowInterpretation')
-   if not throw_understanding:
-      throw_understanding = '(presumed normal)'
-   print('throw interpretation: ' + throw_understanding)
+    print('domain:        ' + required(rqet.find_tag_text(node, 'Domain')))
+    print('is listric:    ' + optional(rqet.find_tag_text(node, 'IsListric')))
+    print('maximum throw: ' + optional(rqet.find_tag_float(node, 'MaximumThrow')))
+    print('mean azimuth:  ' + optional(rqet.find_tag_float(node, 'MeanAzimuth')))
+    print('mean dip:      ' + optional(rqet.find_tag_float(node, 'MeanDip')))
+    throw_understanding = rqet.find_tag_text(node, 'ThrowInterpretation')
+    if not throw_understanding:
+        throw_understanding = '(presumed normal)'
+    print('throw interpretation: ' + throw_understanding)
 
 
 def print_HorizonInterpretation(model, node, detail_level = 0):
-   """Prints information about a horizon interpretation, from the xml tree."""
+    """Prints information about a horizon interpretation, from the xml tree."""
 
-   print('domain: ' + required(rqet.find_tag_text(node, 'Domain')))
-   br_node_list = rqet.list_of_tag(node, 'BoundaryRelation')
-   if len(br_node_list):
-      for br_node in br_node_list:
-         print('boundary relation: ' + required(br_node.text))
-   else:
-      print('(no boundary relation(s) specified)')
-   sss_node_list = rqet.list_of_tag(node, 'SequenceStratigraphySurface')
-   if len(sss_node_list):
-      for sss_node in sss_node_list:
-         print('sequence stratigraphy surface: ' + required(sss_node.text))
-   else:
-      print('(no sequence stratigraphy surface(s) specified)')
+    print('domain: ' + required(rqet.find_tag_text(node, 'Domain')))
+    br_node_list = rqet.list_of_tag(node, 'BoundaryRelation')
+    if len(br_node_list):
+        for br_node in br_node_list:
+            print('boundary relation: ' + required(br_node.text))
+    else:
+        print('(no boundary relation(s) specified)')
+    sss_node_list = rqet.list_of_tag(node, 'SequenceStratigraphySurface')
+    if len(sss_node_list):
+        for sss_node in sss_node_list:
+            print('sequence stratigraphy surface: ' + required(sss_node.text))
+    else:
+        print('(no sequence stratigraphy surface(s) specified)')
 
 
 def print_WellboreInterpretation(model, node, detail_level = 0):
-   """Prints information about a wellbore interpretation, from the xml tree."""
+    """Prints information about a wellbore interpretation, from the xml tree."""
 
-   print('is drilled: ' + required(rqet.find_tag_bool(node, 'IsDrilled')))
+    print('is drilled: ' + required(rqet.find_tag_bool(node, 'IsDrilled')))
 
 
 def print_EarthModelInterpretation(model, node, detail_level = 0):
-   """Prints information about an earth model interpretation, from the xml tree."""
+    """Prints information about an earth model interpretation, from the xml tree."""
 
-   print('domain: ' + required(rqet.find_tag_text(node, 'Domain')))
+    print('domain: ' + required(rqet.find_tag_text(node, 'Domain')))
 
 
 def print_node(model, node, detail_level = 0):
-   """Prints information about an object from an xml node."""
+    """Prints information about an object from an xml node."""
 
-   if node is None:
-      return
-   title = rqet.citation_title_for_node(node)
-   if title:
-      print('title: ' + str(title))
-   obj_type = rqet.node_type(node)
-   if obj_type is None:
-      return
-   print('object type: ' + str(rcd.readable_class(obj_type)))
-   if 'uuid' in node.attrib.keys():
-      print('uuid: ' + str(node.attrib['uuid']))
-   if obj_type.endswith('Property'):
-      support_node = rqet.find_tag(node, 'SupportingRepresentation')
-      if support_node is None:
-         print('no supporting representation referenced')
-      else:
-         print_reference_node_and_return_referenced_part(support_node, 'supporting representation reference')
-   elif obj_type.endswith('Representation'):
-      interp_node = rqet.find_tag(node, 'RepresentedInterpretation')
-      if interp_node is None:
-         print('no represented interpretation referenced')
-      else:
-         print_reference_node_and_return_referenced_part(interp_node, 'represented interpretation reference')
-   elif obj_type.endswith('Interpretation'):
-      feature_node = rqet.find_tag(node, 'InterpretedFeature')
-      if feature_node is None:
-         print('no interpreted feature referenced')
-      else:
-         print_reference_node_and_return_referenced_part(feature_node, 'interpreted feature reference')
-   if obj_type == 'obj_LocalDepth3dCrs':
-      print_LocalDepth3dCrs(model, node)
-   elif obj_type == 'obj_LocalTime3dCrs':
-      print_LocalTime3dCrs(model, node)
-   elif obj_type == 'obj_IjkGridRepresentation':
-      print_IjkGridRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_EpcExternalPartReference':
-      print_EpcExternalPartReference(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_TimeSeries':
-      print_TimeSeries(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_StringTableLookup':
-      print_StringTableLookup(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_ContinuousProperty':
-      print_ContinuousProperty(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_DiscreteProperty':
-      print_DiscreteProperty(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_CategoricalProperty':
-      print_CategoricalProperty(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_TriangulatedSetRepresentation':
-      print_TriangulatedSetRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_PointSetRepresentation':
-      print_PointSetRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_GridConnectionSetRepresentation':
-      print_GridConnectionSetRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_MdDatum':
-      print_MdDatum(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_WellboreFrameRepresentation':
-      print_WellboreFrameRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_WellboreMarkerFrameRepresentation':
-      print_WellboreMarkerFrameRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_BlockedWellboreRepresentation':
-      print_BlockedWellboreRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_WellboreTrajectoryRepresentation':
-      print_WellboreTrajectoryRepresentation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_TectonicBoundaryFeature':
-      print_TectonicBoundaryFeature(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_GeneticBoundaryFeature':
-      print_GeneticBoundaryFeature(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_WellboreFeature':
-      print_WellboreFeature(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_FaultInterpretation':
-      print_FaultInterpretation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_HorizonInterpretation':
-      print_HorizonInterpretation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_WellboreInterpretation':
-      print_WellboreInterpretation(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_OrganizationFeature':
-      print_OrganizationFeature(model, node, detail_level = detail_level)
-   elif obj_type == 'obj_EarthModelInterpretation':
-      print_EarthModelInterpretation(model, node, detail_level = detail_level)
-      # todo: other object types
-   else:
-      print('(details unavailable for this type of object)')
-   print_citation(node)
+    if node is None:
+        return
+    title = rqet.citation_title_for_node(node)
+    if title:
+        print('title: ' + str(title))
+    obj_type = rqet.node_type(node)
+    if obj_type is None:
+        return
+    print('object type: ' + str(rcd.readable_class(obj_type)))
+    if 'uuid' in node.attrib.keys():
+        print('uuid: ' + str(node.attrib['uuid']))
+    if obj_type.endswith('Property'):
+        support_node = rqet.find_tag(node, 'SupportingRepresentation')
+        if support_node is None:
+            print('no supporting representation referenced')
+        else:
+            print_reference_node_and_return_referenced_part(support_node, 'supporting representation reference')
+    elif obj_type.endswith('Representation'):
+        interp_node = rqet.find_tag(node, 'RepresentedInterpretation')
+        if interp_node is None:
+            print('no represented interpretation referenced')
+        else:
+            print_reference_node_and_return_referenced_part(interp_node, 'represented interpretation reference')
+    elif obj_type.endswith('Interpretation'):
+        feature_node = rqet.find_tag(node, 'InterpretedFeature')
+        if feature_node is None:
+            print('no interpreted feature referenced')
+        else:
+            print_reference_node_and_return_referenced_part(feature_node, 'interpreted feature reference')
+    if obj_type == 'obj_LocalDepth3dCrs':
+        print_LocalDepth3dCrs(model, node)
+    elif obj_type == 'obj_LocalTime3dCrs':
+        print_LocalTime3dCrs(model, node)
+    elif obj_type == 'obj_IjkGridRepresentation':
+        print_IjkGridRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_EpcExternalPartReference':
+        print_EpcExternalPartReference(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_TimeSeries':
+        print_TimeSeries(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_StringTableLookup':
+        print_StringTableLookup(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_ContinuousProperty':
+        print_ContinuousProperty(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_DiscreteProperty':
+        print_DiscreteProperty(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_CategoricalProperty':
+        print_CategoricalProperty(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_TriangulatedSetRepresentation':
+        print_TriangulatedSetRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_PointSetRepresentation':
+        print_PointSetRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_GridConnectionSetRepresentation':
+        print_GridConnectionSetRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_MdDatum':
+        print_MdDatum(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_WellboreFrameRepresentation':
+        print_WellboreFrameRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_WellboreMarkerFrameRepresentation':
+        print_WellboreMarkerFrameRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_BlockedWellboreRepresentation':
+        print_BlockedWellboreRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_WellboreTrajectoryRepresentation':
+        print_WellboreTrajectoryRepresentation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_TectonicBoundaryFeature':
+        print_TectonicBoundaryFeature(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_GeneticBoundaryFeature':
+        print_GeneticBoundaryFeature(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_WellboreFeature':
+        print_WellboreFeature(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_FaultInterpretation':
+        print_FaultInterpretation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_HorizonInterpretation':
+        print_HorizonInterpretation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_WellboreInterpretation':
+        print_WellboreInterpretation(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_OrganizationFeature':
+        print_OrganizationFeature(model, node, detail_level = detail_level)
+    elif obj_type == 'obj_EarthModelInterpretation':
+        print_EarthModelInterpretation(model, node, detail_level = detail_level)
+        # todo: other object types
+    else:
+        print('(details unavailable for this type of object)')
+    print_citation(node)

--- a/resqpy/olio/simple_lines.py
+++ b/resqpy/olio/simple_lines.py
@@ -13,7 +13,7 @@ import numpy as np
 
 
 def read_lines(filename):
-   """Returns a list of line arrays, read from ascii file.
+    """Returns a list of line arrays, read from ascii file.
 
       argument:
          filename (string): the path of the ascii file holding a set of poly-lines
@@ -28,44 +28,44 @@ def read_lines(filename):
          those of a crs for a grid object
    """
 
-   lines_list = []
-   end_of_line = np.array([999.0, 999.0, 999.0])
-   try:
-      with open(filename, 'r') as fp:
-         point_count = 0
-         point_list = None
-         while True:
-            line = fp.readline()
-            if len(line) == 0:
-               assert point_count == 0, 'unterminated list of line points at end of file'
-               break
-            words = line.split()
-            if len(words) == 0:
-               continue  # blank line
-            assert len(words) == 3, 'badly formed line (expecting 3 reals)'
-            point = np.empty(3)
-            for p in range(3):
-               point[p] = float(words[p])
-            if np.all(np.isclose(point, end_of_line)):
-               if point_count:
-                  lines_list.append(point_list)
-                  point_count = 0
-            elif point_count:
-               point_list = np.concatenate((point_list, point.reshape((1, 3))), axis = 0)
-               point_count += 1
-            else:
-               point_list = np.empty((1, 3))
-               point_list[0, :] = point
-               point_count = 1
-   except Exception:
-      log.exception('failed to read simple lines from ascii file: ' + filename)
-      lines_list = []
-   log.info(str(len(lines_list)) + ' line(s) read from file: ' + filename)
-   return lines_list
+    lines_list = []
+    end_of_line = np.array([999.0, 999.0, 999.0])
+    try:
+        with open(filename, 'r') as fp:
+            point_count = 0
+            point_list = None
+            while True:
+                line = fp.readline()
+                if len(line) == 0:
+                    assert point_count == 0, 'unterminated list of line points at end of file'
+                    break
+                words = line.split()
+                if len(words) == 0:
+                    continue  # blank line
+                assert len(words) == 3, 'badly formed line (expecting 3 reals)'
+                point = np.empty(3)
+                for p in range(3):
+                    point[p] = float(words[p])
+                if np.all(np.isclose(point, end_of_line)):
+                    if point_count:
+                        lines_list.append(point_list)
+                        point_count = 0
+                elif point_count:
+                    point_list = np.concatenate((point_list, point.reshape((1, 3))), axis = 0)
+                    point_count += 1
+                else:
+                    point_list = np.empty((1, 3))
+                    point_list[0, :] = point
+                    point_count = 1
+    except Exception:
+        log.exception('failed to read simple lines from ascii file: ' + filename)
+        lines_list = []
+    log.info(str(len(lines_list)) + ' line(s) read from file: ' + filename)
+    return lines_list
 
 
 def polygon_line(line, tolerance = 0.001):
-   """Returns a copy of the line with the last vertex stripped off if it is close to the first vertex.
+    """Returns a copy of the line with the last vertex stripped off if it is close to the first vertex.
 
       arguments:
          line (numpy array of floats): representation of a poly-line which might be closed (last vertex
@@ -78,20 +78,20 @@ def polygon_line(line, tolerance = 0.001):
          removed
    """
 
-   last = len(line) - 1
-   if last < 1:
-      return line
-   dims = len(line[0])
-   manhattan = 0.0
-   for d in range(dims):
-      manhattan += abs(line[0][d] - line[last][d])
-   if manhattan > tolerance:
-      return line
-   return line[:-1]
+    last = len(line) - 1
+    if last < 1:
+        return line
+    dims = len(line[0])
+    manhattan = 0.0
+    for d in range(dims):
+        manhattan += abs(line[0][d] - line[last][d])
+    if manhattan > tolerance:
+        return line
+    return line[:-1]
 
 
 def duplicate_vertices_removed(line, tolerance = 0.001):
-   """Returns a copy of the line with neighbouring duplicate vertices removed.
+    """Returns a copy of the line with neighbouring duplicate vertices removed.
 
       arguments:
          line (2D numpy array of floats): representation of a poly-line
@@ -108,28 +108,28 @@ def duplicate_vertices_removed(line, tolerance = 0.001):
          always preserves first and last point, even if they are identical and there are no other vertices
    """
 
-   assert line.ndim == 2
-   if len(line) < 3:
-      return line
-   dims = line.shape[1]
-   whittled = np.zeros(line.shape)
-   whittled[0] = line[0]
-   c_i = 0
-   for i in range(1, len(line)):
-      manhattan = 0.0
-      for d in range(dims):
-         manhattan += abs(line[i, d] - whittled[c_i, d])
-      if manhattan > tolerance:
-         c_i += 1
-         whittled[c_i] = line[i]
-   if c_i == len(line) - 1:
-      return line
-   whittled[c_i] = line[-1]
-   return whittled[:c_i + 1]
+    assert line.ndim == 2
+    if len(line) < 3:
+        return line
+    dims = line.shape[1]
+    whittled = np.zeros(line.shape)
+    whittled[0] = line[0]
+    c_i = 0
+    for i in range(1, len(line)):
+        manhattan = 0.0
+        for d in range(dims):
+            manhattan += abs(line[i, d] - whittled[c_i, d])
+        if manhattan > tolerance:
+            c_i += 1
+            whittled[c_i] = line[i]
+    if c_i == len(line) - 1:
+        return line
+    whittled[c_i] = line[-1]
+    return whittled[:c_i + 1]
 
 
 def nearest_pillars(line_list, grid, ref_k = 0, ref_kp = 0):
-   """Finds pillars nearest to each point on each line; returns list of lists of (j0, i0).
+    """Finds pillars nearest to each point on each line; returns list of lists of (j0, i0).
 
       arguments:
          line_list (list of numpy arrays of floats): set of poly-lines, the points of which are used
@@ -148,20 +148,20 @@ def nearest_pillars(line_list, grid, ref_k = 0, ref_kp = 0):
          poly-line x, y values must implicitly be in the same crs as the grid's points data
    """
 
-   pillar_list_list = []
-   for line in line_list:
-      pillar_list = []
-      p_count = line.shape[0]
-      for p in range(p_count):
-         xy = line[p, 0:2]
-         ji = grid.nearest_pillar(xy, ref_k0 = ref_k + ref_kp)
-         pillar_list.append(ji)
-      pillar_list_list.append(pillar_list)
-   return pillar_list_list
+    pillar_list_list = []
+    for line in line_list:
+        pillar_list = []
+        p_count = line.shape[0]
+        for p in range(p_count):
+            xy = line[p, 0:2]
+            ji = grid.nearest_pillar(xy, ref_k0 = ref_k + ref_kp)
+            pillar_list.append(ji)
+        pillar_list_list.append(pillar_list)
+    return pillar_list_list
 
 
 def nearest_rods(line_list, projection, grid, axis, ref_slice0 = 0, plus_face = False):
-   """Finds rods nearest to each point on each line; returns list of lists of (k0, j0) or (k0, i0).
+    """Finds rods nearest to each point on each line; returns list of lists of (k0, j0) or (k0, i0).
 
       arguments:
          line_list (list of numpy arrays of floats): set of poly-lines, the points of which are used
@@ -183,18 +183,18 @@ def nearest_rods(line_list, projection, grid, axis, ref_slice0 = 0, plus_face = 
          poly-line x, y, z values must implicitly be in the same crs as the grid's points data
    """
 
-   assert projection in ['xz', 'yz']
-   assert axis.upper() in ['J', 'I']
+    assert projection in ['xz', 'yz']
+    assert axis.upper() in ['J', 'I']
 
-   rod_list_list = []
-   for line in line_list:
-      line_a = np.array(line)
-      rod_list_list.append(grid.nearest_rod(line_a, projection, axis, ref_slice0 = ref_slice0, plus_face = plus_face))
-   return rod_list_list
+    rod_list_list = []
+    for line in line_list:
+        line_a = np.array(line)
+        rod_list_list.append(grid.nearest_rod(line_a, projection, axis, ref_slice0 = ref_slice0, plus_face = plus_face))
+    return rod_list_list
 
 
 def drape_lines(line_list, pillar_list_list, grid, ref_k = 0, ref_kp = 0, offset = -1.0, snap = False):
-   """Roughly drapes lines over grid horizon; draped lines are suitable for 3D visualisation.
+    """Roughly drapes lines over grid horizon; draped lines are suitable for 3D visualisation.
 
       arguments:
          line_list (list of numpy arrays of floats): the undraped poly-lines
@@ -219,27 +219,27 @@ def drape_lines(line_list, pillar_list_list, grid, ref_k = 0, ref_kp = 0, offset
          the spacing of the vertices compared to cell sizes
    """
 
-   assert len(line_list) == len(pillar_list_list)
+    assert len(line_list) == len(pillar_list_list)
 
-   # note: currently uses primary pillars only: expect draping disasters by faults
-   # pe_j = grid.extent_kji[1] + 1
-   # pe_i = grid.extent_kji[2] + 1
-   pillar_points = grid.horizon_points(ref_k0 = ref_k + ref_kp)
+    # note: currently uses primary pillars only: expect draping disasters by faults
+    # pe_j = grid.extent_kji[1] + 1
+    # pe_i = grid.extent_kji[2] + 1
+    pillar_points = grid.horizon_points(ref_k0 = ref_k + ref_kp)
 
-   draped_list = []
-   for line, pillar_list in zip(line_list, pillar_list_list):
-      drape = line.copy()
-      p_count = line.shape[0]
-      for p in range(p_count):
-         ji = pillar_list[p]
-         if snap:
-            drape[p, :] = pillar_points[tuple(ji)]
-         else:
-            drape[p, 2] = pillar_points[tuple(ji)][2]
-      drape[:, 2] += offset
-      draped_list.append(drape)
+    draped_list = []
+    for line, pillar_list in zip(line_list, pillar_list_list):
+        drape = line.copy()
+        p_count = line.shape[0]
+        for p in range(p_count):
+            ji = pillar_list[p]
+            if snap:
+                drape[p, :] = pillar_points[tuple(ji)]
+            else:
+                drape[p, 2] = pillar_points[tuple(ji)][2]
+        drape[:, 2] += offset
+        draped_list.append(drape)
 
-   return draped_list
+    return draped_list
 
 
 def drape_lines_to_rods(line_list,
@@ -251,7 +251,7 @@ def drape_lines_to_rods(line_list,
                         plus_face = False,
                         offset = -1.0,
                         snap = False):
-   """Roughly drapes lines near grid cross section; draped lines are suitable for 3D visualisation.
+    """Roughly drapes lines near grid cross section; draped lines are suitable for 3D visualisation.
 
       arguments:
          line_list (list of numpy arrays of floats): the undraped poly-lines
@@ -275,28 +275,28 @@ def drape_lines_to_rods(line_list,
          the spacing of the vertices compared to cell sizes
    """
 
-   assert projection in ['xz', 'yz']
-   assert axis.upper() in ['I', 'J']
-   assert len(line_list) == len(rod_list_list)
+    assert projection in ['xz', 'yz']
+    assert axis.upper() in ['I', 'J']
+    assert len(line_list) == len(rod_list_list)
 
-   x_sect = grid.x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
+    x_sect = grid.x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
 
-   draped_list = []
-   for line, rod_list in zip(line_list, rod_list_list):
-      drape = line.copy()
-      p_count = line.shape[0]
-      for p in range(p_count):
-         kj_or_ki = rod_list[p]
-         if snap:
-            drape[p, :] = x_sect[tuple(kj_or_ki)]
-         elif projection == 'xz':
-            drape[p, 1] = x_sect[tuple(kj_or_ki)][1]
-         else:
-            drape[p, 0] = x_sect[tuple(kj_or_ki)][0]
-      if projection == 'xz':
-         drape[:, 1] += offset
-      else:
-         drape[:, 0] += offset
-      draped_list.append(drape)
+    draped_list = []
+    for line, rod_list in zip(line_list, rod_list_list):
+        drape = line.copy()
+        p_count = line.shape[0]
+        for p in range(p_count):
+            kj_or_ki = rod_list[p]
+            if snap:
+                drape[p, :] = x_sect[tuple(kj_or_ki)]
+            elif projection == 'xz':
+                drape[p, 1] = x_sect[tuple(kj_or_ki)][1]
+            else:
+                drape[p, 0] = x_sect[tuple(kj_or_ki)][0]
+        if projection == 'xz':
+            drape[:, 1] += offset
+        else:
+            drape[:, 0] += offset
+        draped_list.append(drape)
 
-   return draped_list
+    return draped_list

--- a/resqpy/olio/time.py
+++ b/resqpy/olio/time.py
@@ -6,7 +6,7 @@ import datetime as dt
 
 
 def now(use_utc = False):
-   """Returns an iso format string representation of the current time, to the nearest second.
+    """Returns an iso format string representation of the current time, to the nearest second.
 
       argument:
          use_utc (boolean, default False): if True, the current UTC time is used, otherwise local time
@@ -18,8 +18,8 @@ def now(use_utc = False):
          this is the format used by the resqml standard for representing date-times
    """
 
-   if use_utc:
-      stamp = dt.datetime.utcnow()  # NB: naive use of UTC time
-   else:
-      stamp = dt.datetime.now()
-   return str(stamp.isoformat(sep = 'T', timespec = 'seconds')) + 'Z'
+    if use_utc:
+        stamp = dt.datetime.utcnow()  # NB: naive use of UTC time
+    else:
+        stamp = dt.datetime.now()
+    return str(stamp.isoformat(sep = 'T', timespec = 'seconds')) + 'Z'

--- a/resqpy/olio/trademark.py
+++ b/resqpy/olio/trademark.py
@@ -12,10 +12,10 @@ nexus_tm_level = None
 
 
 def log_nexus_tm(level = lg.INFO):
-   global nexus_tm_level
-   if isinstance(level, str):
-      level = lg.__dict__[level.upper()]
-   if nexus_tm_level is None or level > nexus_tm_level:
-      preamble = '(ignore severity) ' if level > 20 else ''
-      log.log(level, preamble + 'Nexus is a registered trademark of the Halliburton Company')
-      nexus_tm_level = level
+    global nexus_tm_level
+    if isinstance(level, str):
+        level = lg.__dict__[level.upper()]
+    if nexus_tm_level is None or level > nexus_tm_level:
+        preamble = '(ignore severity) ' if level > 20 else ''
+        log.log(level, preamble + 'Nexus is a registered trademark of the Halliburton Company')
+        nexus_tm_level = level

--- a/resqpy/olio/transmission.py
+++ b/resqpy/olio/transmission.py
@@ -25,7 +25,7 @@ def half_cell_t(grid,
                 realization = None,
                 darcy_constant = None,
                 tolerance = 1.0e-6):
-   """Creates a half cell transmissibilty property array for a regular or irregular IJK grid.
+    """Creates a half cell transmissibilty property array for a regular or irregular IJK grid.
 
    arguments:
       grid (grid.Grid or grid.RegularGrid): the grid for which half cell transmissibilities are required
@@ -55,49 +55,49 @@ def half_cell_t(grid,
       see also notes for half_cell_t_irregular() and half_cell_t_regular()
    """
 
-   import resqpy.grid as grr
+    import resqpy.grid as grr
 
-   if darcy_constant is None:
-      length_units = grid.xy_units()
-      assert length_units == 'm' or length_units.startswith('ft'), "Darcy constant must be specified"
-      assert grid.z_units() == length_units
-      darcy_constant = 0.008527 if length_units == 'm' else 0.001127  # these values from Nexus keyword ref.
+    if darcy_constant is None:
+        length_units = grid.xy_units()
+        assert length_units == 'm' or length_units.startswith('ft'), "Darcy constant must be specified"
+        assert grid.z_units() == length_units
+        darcy_constant = 0.008527 if length_units == 'm' else 0.001127  # these values from Nexus keyword ref.
 
-   if perm_k is None or perm_j is None or perm_i is None or ntg is None:
-      pc = grid.extract_property_collection()
-      basic_5_parts = pc.basic_static_property_parts(realization = realization, share_perm_parts = True)
-      if ntg is None and basic_5_parts[0] is not None:
-         ntg = pc.cached_part_array_ref(basic_5_parts[0])
-      if perm_k is None and basic_5_parts[4] is not None:
-         perm_k = pc.cached_part_array_ref(basic_5_parts[4])
-      if perm_j is None and basic_5_parts[3] is not None:
-         perm_j = pc.cached_part_array_ref(basic_5_parts[3])
-      if perm_i is None and basic_5_parts[2] is not None:
-         perm_i = pc.cached_part_array_ref(basic_5_parts[2])
+    if perm_k is None or perm_j is None or perm_i is None or ntg is None:
+        pc = grid.extract_property_collection()
+        basic_5_parts = pc.basic_static_property_parts(realization = realization, share_perm_parts = True)
+        if ntg is None and basic_5_parts[0] is not None:
+            ntg = pc.cached_part_array_ref(basic_5_parts[0])
+        if perm_k is None and basic_5_parts[4] is not None:
+            perm_k = pc.cached_part_array_ref(basic_5_parts[4])
+        if perm_j is None and basic_5_parts[3] is not None:
+            perm_j = pc.cached_part_array_ref(basic_5_parts[3])
+        if perm_i is None and basic_5_parts[2] is not None:
+            perm_i = pc.cached_part_array_ref(basic_5_parts[2])
 
-   assert perm_k is not None and perm_j is not None and perm_i is not None
+    assert perm_k is not None and perm_j is not None and perm_i is not None
 
-   if isinstance(grid, grr.RegularGrid):
-      return half_cell_t_regular(grid,
-                                 perm_k = perm_k,
-                                 perm_j = perm_j,
-                                 perm_i = perm_i,
-                                 ntg = ntg,
-                                 darcy_constant = darcy_constant)
-   elif isinstance(grid, grr.Grid):
-      return half_cell_t_irregular(grid,
+    if isinstance(grid, grr.RegularGrid):
+        return half_cell_t_regular(grid,
                                    perm_k = perm_k,
                                    perm_j = perm_j,
                                    perm_i = perm_i,
                                    ntg = ntg,
-                                   darcy_constant = darcy_constant,
-                                   tolerance = tolerance)
-   else:
-      raise ValueError(f'grid {type(grid)} is neither RegularGrid nor Grid object in call to half_cell_t()')
+                                   darcy_constant = darcy_constant)
+    elif isinstance(grid, grr.Grid):
+        return half_cell_t_irregular(grid,
+                                     perm_k = perm_k,
+                                     perm_j = perm_j,
+                                     perm_i = perm_i,
+                                     ntg = ntg,
+                                     darcy_constant = darcy_constant,
+                                     tolerance = tolerance)
+    else:
+        raise ValueError(f'grid {type(grid)} is neither RegularGrid nor Grid object in call to half_cell_t()')
 
 
 def half_cell_t_regular(grid, perm_k = None, perm_j = None, perm_i = None, ntg = None, darcy_constant = None):
-   """Creates a half cell transmissibilty property array for a RegularGrid.
+    """Creates a half cell transmissibilty property array for a RegularGrid.
 
    arguments:
       grid (grid.RegularGrid): the grid for which half cell transmissibilities are required
@@ -128,20 +128,20 @@ def half_cell_t_regular(grid, perm_k = None, perm_j = None, perm_i = None, ntg =
       function
    """
 
-   assert perm_k is not None and perm_j is not None and perm_i is not None
-   if ntg is None:
-      ntg = 1.0
+    assert perm_k is not None and perm_j is not None and perm_i is not None
+    if ntg is None:
+        ntg = 1.0
 
-   axis_lengths = vec.naive_lengths(grid.block_dxyz_dkji)
-   face_areas = np.array(
-      (axis_lengths[1] * axis_lengths[2], axis_lengths[2] * axis_lengths[0], axis_lengths[0] * axis_lengths[1]))
+    axis_lengths = vec.naive_lengths(grid.block_dxyz_dkji)
+    face_areas = np.array(
+        (axis_lengths[1] * axis_lengths[2], axis_lengths[2] * axis_lengths[0], axis_lengths[0] * axis_lengths[1]))
 
-   half_t = np.empty((grid.nk, grid.nj, grid.ni, 3))  # 3 is K,J,I
-   half_t[..., 0] = perm_k * face_areas[0] / (0.5 * axis_lengths[0])
-   half_t[..., 1] = ntg * perm_j * face_areas[1] / (0.5 * axis_lengths[1])
-   half_t[..., 2] = ntg * perm_i * face_areas[2] / (0.5 * axis_lengths[2])
+    half_t = np.empty((grid.nk, grid.nj, grid.ni, 3))  # 3 is K,J,I
+    half_t[..., 0] = perm_k * face_areas[0] / (0.5 * axis_lengths[0])
+    half_t[..., 1] = ntg * perm_j * face_areas[1] / (0.5 * axis_lengths[1])
+    half_t[..., 2] = ntg * perm_i * face_areas[2] / (0.5 * axis_lengths[2])
 
-   return darcy_constant * half_t
+    return darcy_constant * half_t
 
 
 def half_cell_t_irregular(grid,
@@ -151,7 +151,7 @@ def half_cell_t_irregular(grid,
                           ntg = None,
                           darcy_constant = None,
                           tolerance = 1.0e-6):
-   """Creates a half cell transmissibilty property array for an IJK grid.
+    """Creates a half cell transmissibilty property array for an IJK grid.
 
    arguments:
       grid (grid.Grid): the grid for which half cell transmissibilities are required
@@ -188,169 +188,177 @@ def half_cell_t_irregular(grid,
       the coordinate referemce system for the grid must have the same length units for xy and z
    """
 
-   # NB: axis argument is KJI index; this function also uses axes in xyz space
+    # NB: axis argument is KJI index; this function also uses axes in xyz space
 
-   assert perm_k is not None and perm_j is not None and perm_i is not None
+    assert perm_k is not None and perm_j is not None and perm_i is not None
 
-   tolerance_sqr = tolerance * tolerance
+    tolerance_sqr = tolerance * tolerance
 
-   p = grid.points_ref(masked = False)
-   edge_vectors = []
-   pfc = None  # pillars for column mapping, for use when split pillars are present
-   km = kp = None  # raw points k indices for K- and K+ faces, by layer, when K gaps present
-   if grid.k_gaps:
-      km = grid.k_raw_index_array
-      kp = km + 1
-   if grid.has_split_coordinate_lines:
-      pfc = grid.create_column_pillar_mapping()
-      if grid.k_gaps:
-         edge_vectors.append(p[kp][:, pfc] - p[km][:, pfc])  # k edge vectors, shape (nk, nj, ni, 2, 2, 3)
-         edge_vectors.append(
-            p[:, pfc[:, :, 1, :]] -
-            p[:, pfc[:, :, 0, :]])  # j edge vectors, shape (nk + k_gaps + 1, nj, ni, 2, 3) with jp removed
-         edge_vectors.append(
-            p[:, pfc[:, :, :, 1]] -
-            p[:, pfc[:, :, :, 0]])  # i edge vectors, shape (nk + k_gaps + 1, nj, ni, 2, 3) with ip removed
-      else:
-         edge_vectors.append(p[1:, pfc] - p[:-1, pfc])  # k edge vectors, shape (nk, nj, ni, 2, 2, 3)
-         edge_vectors.append(p[:, pfc[:, :, 1, :]] -
-                             p[:, pfc[:, :, 0, :]])  # j edge vectors, shape (nk + 1, nj, ni, 2, 3) with jp removed
-         edge_vectors.append(p[:, pfc[:, :, :, 1]] -
-                             p[:, pfc[:, :, :, 0]])  # i edge vectors, shape (nk + 1, nj, ni, 2, 3) with ip removed
-   else:
-      if grid.k_gaps:
-         edge_vectors.append(p[kp] - p[km])  # k edge vectors, shape (nk, nj + 1, ni + 1, 3)
-         edge_vectors.append(p[:, 1:, :] - p[:, :-1, :])  # j edge vectors, shape (nk + k_gaps + 1, nj, ni + 1, 3)
-         edge_vectors.append(p[:, :, 1:] - p[:, :, :-1])  # i edge vectors, shape (nk + k_gaps + 1, nj + 1, ni, 3)
-      else:
-         edge_vectors.append(p[1:] - p[:-1])  # k edge vectors, shape (nk, nj + 1, ni + 1, 3)
-         edge_vectors.append(p[:, 1:] - p[:, :-1])  # j edge vectors, shape (nk + 1, nj, ni + 1, 3)
-         edge_vectors.append(p[:, :, 1:] - p[:, :, :-1])  # i edge vectors, shape (nk + 1, nj + 1, ni, 3)
+    p = grid.points_ref(masked = False)
+    edge_vectors = []
+    pfc = None  # pillars for column mapping, for use when split pillars are present
+    km = kp = None  # raw points k indices for K- and K+ faces, by layer, when K gaps present
+    if grid.k_gaps:
+        km = grid.k_raw_index_array
+        kp = km + 1
+    if grid.has_split_coordinate_lines:
+        pfc = grid.create_column_pillar_mapping()
+        if grid.k_gaps:
+            edge_vectors.append(p[kp][:, pfc] - p[km][:, pfc])  # k edge vectors, shape (nk, nj, ni, 2, 2, 3)
+            edge_vectors.append(
+                p[:, pfc[:, :, 1, :]] -
+                p[:, pfc[:, :, 0, :]])  # j edge vectors, shape (nk + k_gaps + 1, nj, ni, 2, 3) with jp removed
+            edge_vectors.append(
+                p[:, pfc[:, :, :, 1]] -
+                p[:, pfc[:, :, :, 0]])  # i edge vectors, shape (nk + k_gaps + 1, nj, ni, 2, 3) with ip removed
+        else:
+            edge_vectors.append(p[1:, pfc] - p[:-1, pfc])  # k edge vectors, shape (nk, nj, ni, 2, 2, 3)
+            edge_vectors.append(p[:, pfc[:, :, 1, :]] -
+                                p[:, pfc[:, :, 0, :]])  # j edge vectors, shape (nk + 1, nj, ni, 2, 3) with jp removed
+            edge_vectors.append(p[:, pfc[:, :, :, 1]] -
+                                p[:, pfc[:, :, :, 0]])  # i edge vectors, shape (nk + 1, nj, ni, 2, 3) with ip removed
+    else:
+        if grid.k_gaps:
+            edge_vectors.append(p[kp] - p[km])  # k edge vectors, shape (nk, nj + 1, ni + 1, 3)
+            edge_vectors.append(p[:, 1:, :] - p[:, :-1, :])  # j edge vectors, shape (nk + k_gaps + 1, nj, ni + 1, 3)
+            edge_vectors.append(p[:, :, 1:] - p[:, :, :-1])  # i edge vectors, shape (nk + k_gaps + 1, nj + 1, ni, 3)
+        else:
+            edge_vectors.append(p[1:] - p[:-1])  # k edge vectors, shape (nk, nj + 1, ni + 1, 3)
+            edge_vectors.append(p[:, 1:] - p[:, :-1])  # j edge vectors, shape (nk + 1, nj, ni + 1, 3)
+            edge_vectors.append(p[:, :, 1:] - p[:, :, :-1])  # i edge vectors, shape (nk + 1, nj + 1, ni, 3)
 
-   half_t = np.empty((grid.nk, grid.nj, grid.ni, 3, 2))  # 3 is K,J,I; 2 is -/+ polarity (face)
+    half_t = np.empty((grid.nk, grid.nj, grid.ni, 3, 2))  # 3 is K,J,I; 2 is -/+ polarity (face)
 
-   # note: for some reason half_axis_length_sqr values of 0.0 yield invalid value in numpy divide, rahter than divide by zero
-   np.seterr(divide = 'ignore', invalid = 'ignore')
+    # note: for some reason half_axis_length_sqr values of 0.0 yield invalid value in numpy divide, rahter than divide by zero
+    np.seterr(divide = 'ignore', invalid = 'ignore')
 
-   for axis in range(3):
+    for axis in range(3):
 
-      if axis == 0:  # k
-         if grid.has_split_coordinate_lines:
-            half_axis_vectors = 0.125 * np.abs(np.sum(
-               edge_vectors[0], axis = (3, 4)))  # shape (nk, nj, ni, 3) with 3 being xyz length components of vector
-            face_areas = (projected_tri_area(p[:, pfc[:, :, 0, 0]], p[:, pfc[:, :, 0, 1]], p[:, pfc[:, :, 1, 1]]) +
-                          projected_tri_area(p[:, pfc[:, :, 0, 0]], p[:, pfc[:, :, 1, 1]], p[:, pfc[:, :, 1, 0]])
-                         )  # shape (nk + k_gaps + 1, nj, ni, 3)
-         else:
-            half_axis_vectors = 0.125 * np.abs(edge_vectors[0][:, 1:, 1:] + edge_vectors[0][:, 1:, :-1] +
-                                               edge_vectors[0][:, :-1, 1:] + edge_vectors[0][:, :-1, :-1])
-            face_areas = (projected_tri_area(p[:, :-1, :-1], p[:, :-1, 1:], p[:, 1:, 1:]) +
-                          projected_tri_area(p[:, :-1, :-1], p[:, 1:, 1:], p[:, 1:, :-1])
-                         )  # shape (nk + k_gaps + 1, nj, ni, 3) where 3 is xyz projection axis
-         if grid.k_gaps:
-            minus_face_areas = face_areas[
-               km]  # shape (nk, nj, ni, 3) where 3 is xyz projection axis (ie. yz plane, xz plane, xy plane)
-            plus_face_areas = face_areas[kp]
-         else:
-            minus_face_areas = face_areas[:-1]
-            plus_face_areas = face_areas[1:]
-         half_axis_length_sqr = np.sum(half_axis_vectors * half_axis_vectors, axis = -1)  # shape (nk, nj, ni)
-         zero_length_mask = np.logical_or(np.any(np.isnan(half_axis_vectors), axis = -1),
-                                          half_axis_length_sqr < tolerance_sqr)
-         minus_face_t = np.where(
-            zero_length_mask, np.NaN,
-            perm_k * np.sum(half_axis_vectors * minus_face_areas, axis = -1) / half_axis_length_sqr)
-         plus_face_t = np.where(zero_length_mask, np.NaN,
-                                perm_k * np.sum(half_axis_vectors * plus_face_areas, axis = -1) / half_axis_length_sqr)
-
-      elif axis == 1:  # j
-         if grid.has_split_coordinate_lines:
-            if grid.k_gaps:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[1][kp][:, :, :, 1] + edge_vectors[1][kp][:, :, :, 0] +
-                                                  edge_vectors[1][km][:, :, :, 1] + edge_vectors[1][km][:, :, :, 0])
-               face_areas = (
-                  projected_tri_area(p[km][:, pfc[:, :, :, 0]], p[km][:, pfc[:, :, :, 1]], p[kp][:, pfc[:, :, :, 1]]) +
-                  projected_tri_area(p[km][:, pfc[:, :, :, 0]], p[kp][:, pfc[:, :, :, 1]], p[kp][:, pfc[:, :, :, 0]])
-               )  # shape (nk, nj, ni, 2) where 2 is jp
+        if axis == 0:  # k
+            if grid.has_split_coordinate_lines:
+                half_axis_vectors = 0.125 * np.abs(np.sum(edge_vectors[0], axis = (
+                    3, 4)))  # shape (nk, nj, ni, 3) with 3 being xyz length components of vector
+                face_areas = (projected_tri_area(p[:, pfc[:, :, 0, 0]], p[:, pfc[:, :, 0, 1]], p[:, pfc[:, :, 1, 1]]) +
+                              projected_tri_area(p[:, pfc[:, :, 0, 0]], p[:, pfc[:, :, 1, 1]], p[:, pfc[:, :, 1, 0]])
+                             )  # shape (nk + k_gaps + 1, nj, ni, 3)
             else:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[1][1:, :, :, 1] + edge_vectors[1][1:, :, :, 0] +
-                                                  edge_vectors[1][:-1, :, :, 1] + edge_vectors[1][:-1, :, :, 0])
-               face_areas = (
-                  projected_tri_area(p[:-1, pfc[:, :, :, 0]], p[:-1, pfc[:, :, :, 1]], p[1:, pfc[:, :, :, 1]]) +
-                  projected_tri_area(p[:-1, pfc[:, :, :, 0]], p[1:, pfc[:, :, :, 1]], p[1:, pfc[:, :, :, 0]])
-               )  # shape (nk, nj, ni, 2) where 2 is jp
-            minus_face_areas = face_areas[:, :, :, 0]
-            plus_face_areas = face_areas[:, :, :, 1]
-         else:
+                half_axis_vectors = 0.125 * np.abs(edge_vectors[0][:, 1:, 1:] + edge_vectors[0][:, 1:, :-1] +
+                                                   edge_vectors[0][:, :-1, 1:] + edge_vectors[0][:, :-1, :-1])
+                face_areas = (projected_tri_area(p[:, :-1, :-1], p[:, :-1, 1:], p[:, 1:, 1:]) +
+                              projected_tri_area(p[:, :-1, :-1], p[:, 1:, 1:], p[:, 1:, :-1])
+                             )  # shape (nk + k_gaps + 1, nj, ni, 3) where 3 is xyz projection axis
             if grid.k_gaps:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[1][kp][:, :, 1:] + edge_vectors[1][kp][:, :, :-1] +
-                                                  edge_vectors[1][km][:, :, 1:] + edge_vectors[1][km][:, :, :-1])
-               face_areas = (projected_tri_area(p[km][:, :-1], p[km][:, :, 1:], p[kp][:, :, 1:]) +
-                             projected_tri_area(p[km][:, :-1], p[kp][:, :, 1:], p[kp][:, :, :-1]))
+                minus_face_areas = face_areas[
+                    km]  # shape (nk, nj, ni, 3) where 3 is xyz projection axis (ie. yz plane, xz plane, xy plane)
+                plus_face_areas = face_areas[kp]
             else:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[1][1:, :, 1:] + edge_vectors[1][1:, :, :-1] +
-                                                  edge_vectors[1][:-1, :, 1:] + edge_vectors[1][:-1, :, :-1])
-               face_areas = (projected_tri_area(p[:-1, :, :-1], p[:-1, :, 1:], p[1:, :, 1:]) +
-                             projected_tri_area(p[:-1, :, :-1], p[1:, :, 1:], p[1:, :, :-1]))  # shape (nk, nj + 1, ni)
-            minus_face_areas = face_areas[:, :-1]
-            plus_face_areas = face_areas[:, 1:]
-         half_axis_length_sqr = np.sum(half_axis_vectors * half_axis_vectors, axis = -1)
-         zero_length_mask = (half_axis_length_sqr < tolerance_sqr)
-         minus_face_t = np.where(
-            zero_length_mask, np.NaN,
-            perm_j * np.sum(half_axis_vectors * minus_face_areas, axis = -1) / half_axis_length_sqr)
-         plus_face_t = np.where(zero_length_mask, np.NaN,
-                                perm_j * np.sum(half_axis_vectors * plus_face_areas, axis = -1) / half_axis_length_sqr)
+                minus_face_areas = face_areas[:-1]
+                plus_face_areas = face_areas[1:]
+            half_axis_length_sqr = np.sum(half_axis_vectors * half_axis_vectors, axis = -1)  # shape (nk, nj, ni)
+            zero_length_mask = np.logical_or(np.any(np.isnan(half_axis_vectors), axis = -1),
+                                             half_axis_length_sqr < tolerance_sqr)
+            minus_face_t = np.where(
+                zero_length_mask, np.NaN,
+                perm_k * np.sum(half_axis_vectors * minus_face_areas, axis = -1) / half_axis_length_sqr)
+            plus_face_t = np.where(
+                zero_length_mask, np.NaN,
+                perm_k * np.sum(half_axis_vectors * plus_face_areas, axis = -1) / half_axis_length_sqr)
 
-      else:  # i
-         if grid.has_split_coordinate_lines:
-            if grid.k_gaps:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[2][kp][:, :, :, 1] + edge_vectors[2][kp][:, :, :, 0] +
-                                                  edge_vectors[2][km][:, :, :, 1] + edge_vectors[2][km][:, :, :, 0])
-               face_areas = (
-                  projected_tri_area(p[km][:, pfc[:, :, 0, :]], p[km][:, pfc[:, :, 1, :]], p[kp][:, pfc[:, :, 1, :]]) +
-                  projected_tri_area(p[km][:, pfc[:, :, 0, :]], p[kp][:, pfc[:, :, 1, :]], p[kp][:, pfc[:, :, 0, :]])
-               )  # shape (nk, nj, ni, 2) where 2 is ip
+        elif axis == 1:  # j
+            if grid.has_split_coordinate_lines:
+                if grid.k_gaps:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[1][kp][:, :, :, 1] +
+                                                       edge_vectors[1][kp][:, :, :, 0] +
+                                                       edge_vectors[1][km][:, :, :, 1] +
+                                                       edge_vectors[1][km][:, :, :, 0])
+                    face_areas = (projected_tri_area(p[km][:, pfc[:, :, :, 0]], p[km][:, pfc[:, :, :, 1]],
+                                                     p[kp][:, pfc[:, :, :, 1]]) +
+                                  projected_tri_area(p[km][:, pfc[:, :, :, 0]], p[kp][:, pfc[:, :, :, 1]],
+                                                     p[kp][:, pfc[:, :, :, 0]]))  # shape (nk, nj, ni, 2) where 2 is jp
+                else:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[1][1:, :, :, 1] + edge_vectors[1][1:, :, :, 0] +
+                                                       edge_vectors[1][:-1, :, :, 1] + edge_vectors[1][:-1, :, :, 0])
+                    face_areas = (
+                        projected_tri_area(p[:-1, pfc[:, :, :, 0]], p[:-1, pfc[:, :, :, 1]], p[1:, pfc[:, :, :, 1]]) +
+                        projected_tri_area(p[:-1, pfc[:, :, :, 0]], p[1:, pfc[:, :, :, 1]], p[1:, pfc[:, :, :, 0]])
+                    )  # shape (nk, nj, ni, 2) where 2 is jp
+                minus_face_areas = face_areas[:, :, :, 0]
+                plus_face_areas = face_areas[:, :, :, 1]
             else:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[2][1:, :, :, 1] + edge_vectors[2][1:, :, :, 0] +
-                                                  edge_vectors[2][:-1, :, :, 1] + edge_vectors[2][:-1, :, :, 0])
-               face_areas = (
-                  projected_tri_area(p[:-1, pfc[:, :, 0, :]], p[:-1, pfc[:, :, 1, :]], p[1:, pfc[:, :, 1, :]]) +
-                  projected_tri_area(p[:-1, pfc[:, :, 0, :]], p[1:, pfc[:, :, 1, :]], p[1:, pfc[:, :, 0, :]])
-               )  # shape (nk, nj, ni, 2) where 2 is ip
-            minus_face_areas = face_areas[:, :, :, 0]
-            plus_face_areas = face_areas[:, :, :, 1]
-         else:
-            if grid.k_gaps:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[2][kp][:, 1:, :] + edge_vectors[2][kp][:, :-1, :] +
-                                                  edge_vectors[2][km][:, 1:, :] + edge_vectors[2][km][:, :-1, :])
-               face_areas = (projected_tri_area(p[km][:, :-1, :], p[km][:, 1:, :], p[kp][:, 1:, :]) +
-                             projected_tri_area(p[km][:, :-1, :], p[kp][:, 1:, :], p[kp][:, :-1, :]))
+                if grid.k_gaps:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[1][kp][:, :, 1:] + edge_vectors[1][kp][:, :, :-1] +
+                                                       edge_vectors[1][km][:, :, 1:] + edge_vectors[1][km][:, :, :-1])
+                    face_areas = (projected_tri_area(p[km][:, :-1], p[km][:, :, 1:], p[kp][:, :, 1:]) +
+                                  projected_tri_area(p[km][:, :-1], p[kp][:, :, 1:], p[kp][:, :, :-1]))
+                else:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[1][1:, :, 1:] + edge_vectors[1][1:, :, :-1] +
+                                                       edge_vectors[1][:-1, :, 1:] + edge_vectors[1][:-1, :, :-1])
+                    face_areas = (projected_tri_area(p[:-1, :, :-1], p[:-1, :, 1:], p[1:, :, 1:]) +
+                                  projected_tri_area(p[:-1, :, :-1], p[1:, :, 1:], p[1:, :, :-1])
+                                 )  # shape (nk, nj + 1, ni)
+                minus_face_areas = face_areas[:, :-1]
+                plus_face_areas = face_areas[:, 1:]
+            half_axis_length_sqr = np.sum(half_axis_vectors * half_axis_vectors, axis = -1)
+            zero_length_mask = (half_axis_length_sqr < tolerance_sqr)
+            minus_face_t = np.where(
+                zero_length_mask, np.NaN,
+                perm_j * np.sum(half_axis_vectors * minus_face_areas, axis = -1) / half_axis_length_sqr)
+            plus_face_t = np.where(
+                zero_length_mask, np.NaN,
+                perm_j * np.sum(half_axis_vectors * plus_face_areas, axis = -1) / half_axis_length_sqr)
+
+        else:  # i
+            if grid.has_split_coordinate_lines:
+                if grid.k_gaps:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[2][kp][:, :, :, 1] +
+                                                       edge_vectors[2][kp][:, :, :, 0] +
+                                                       edge_vectors[2][km][:, :, :, 1] +
+                                                       edge_vectors[2][km][:, :, :, 0])
+                    face_areas = (projected_tri_area(p[km][:, pfc[:, :, 0, :]], p[km][:, pfc[:, :, 1, :]],
+                                                     p[kp][:, pfc[:, :, 1, :]]) +
+                                  projected_tri_area(p[km][:, pfc[:, :, 0, :]], p[kp][:, pfc[:, :, 1, :]],
+                                                     p[kp][:, pfc[:, :, 0, :]]))  # shape (nk, nj, ni, 2) where 2 is ip
+                else:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[2][1:, :, :, 1] + edge_vectors[2][1:, :, :, 0] +
+                                                       edge_vectors[2][:-1, :, :, 1] + edge_vectors[2][:-1, :, :, 0])
+                    face_areas = (
+                        projected_tri_area(p[:-1, pfc[:, :, 0, :]], p[:-1, pfc[:, :, 1, :]], p[1:, pfc[:, :, 1, :]]) +
+                        projected_tri_area(p[:-1, pfc[:, :, 0, :]], p[1:, pfc[:, :, 1, :]], p[1:, pfc[:, :, 0, :]])
+                    )  # shape (nk, nj, ni, 2) where 2 is ip
+                minus_face_areas = face_areas[:, :, :, 0]
+                plus_face_areas = face_areas[:, :, :, 1]
             else:
-               half_axis_vectors = 0.125 * np.abs(edge_vectors[2][1:, 1:, :] + edge_vectors[2][1:, :-1, :] +
-                                                  edge_vectors[2][:-1, 1:, :] + edge_vectors[2][:-1, :-1, :])
-               face_areas = (projected_tri_area(p[:-1, :-1, :], p[:-1, 1:, :], p[1:, 1:, :]) +
-                             projected_tri_area(p[:-1, :-1, :], p[1:, 1:, :], p[1:, :-1, :]))
-            minus_face_areas = face_areas[:, :, :-1]
-            plus_face_areas = face_areas[:, :, 1:]
-         half_axis_length_sqr = np.sum(half_axis_vectors * half_axis_vectors, axis = -1)
-         zero_length_mask = (half_axis_length_sqr < tolerance_sqr)
-         minus_face_t = np.where(
-            zero_length_mask, np.NaN,
-            perm_i * np.sum(half_axis_vectors * minus_face_areas, axis = -1) / half_axis_length_sqr)
-         plus_face_t = np.where(zero_length_mask, np.NaN,
-                                perm_i * np.sum(half_axis_vectors * plus_face_areas, axis = -1) / half_axis_length_sqr)
+                if grid.k_gaps:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[2][kp][:, 1:, :] + edge_vectors[2][kp][:, :-1, :] +
+                                                       edge_vectors[2][km][:, 1:, :] + edge_vectors[2][km][:, :-1, :])
+                    face_areas = (projected_tri_area(p[km][:, :-1, :], p[km][:, 1:, :], p[kp][:, 1:, :]) +
+                                  projected_tri_area(p[km][:, :-1, :], p[kp][:, 1:, :], p[kp][:, :-1, :]))
+                else:
+                    half_axis_vectors = 0.125 * np.abs(edge_vectors[2][1:, 1:, :] + edge_vectors[2][1:, :-1, :] +
+                                                       edge_vectors[2][:-1, 1:, :] + edge_vectors[2][:-1, :-1, :])
+                    face_areas = (projected_tri_area(p[:-1, :-1, :], p[:-1, 1:, :], p[1:, 1:, :]) +
+                                  projected_tri_area(p[:-1, :-1, :], p[1:, 1:, :], p[1:, :-1, :]))
+                minus_face_areas = face_areas[:, :, :-1]
+                plus_face_areas = face_areas[:, :, 1:]
+            half_axis_length_sqr = np.sum(half_axis_vectors * half_axis_vectors, axis = -1)
+            zero_length_mask = (half_axis_length_sqr < tolerance_sqr)
+            minus_face_t = np.where(
+                zero_length_mask, np.NaN,
+                perm_i * np.sum(half_axis_vectors * minus_face_areas, axis = -1) / half_axis_length_sqr)
+            plus_face_t = np.where(
+                zero_length_mask, np.NaN,
+                perm_i * np.sum(half_axis_vectors * plus_face_areas, axis = -1) / half_axis_length_sqr)
 
-      if axis != 0 and ntg is not None:
-         minus_face_t *= ntg
-         plus_face_t *= ntg
+        if axis != 0 and ntg is not None:
+            minus_face_t *= ntg
+            plus_face_t *= ntg
 
-      half_t[:, :, :, axis, 0] = minus_face_t
-      half_t[:, :, :, axis, 1] = plus_face_t
+        half_t[:, :, :, axis, 0] = minus_face_t
+        half_t[:, :, :, axis, 1] = plus_face_t
 
-   np.seterr(divide = 'warn', invalid = 'warn')
+    np.seterr(divide = 'warn', invalid = 'warn')
 
-   return np.abs(darcy_constant * half_t)
+    return np.abs(darcy_constant * half_t)
 
 
 def half_cell_t_vertical_prism(vpg,
@@ -359,7 +367,7 @@ def half_cell_t_vertical_prism(vpg,
                                ntg = None,
                                darcy_constant = None,
                                tolerance = 1.0e-6):
-   """Creates a half cell transmissibilty property array for a vertical prism grid.
+    """Creates a half cell transmissibilty property array for a vertical prism grid.
 
    arguments:
       vpg (VerticalPrismGrid): the grid for which the half cell transmissibilities are required
@@ -381,48 +389,48 @@ def half_cell_t_vertical_prism(vpg,
       order of 5 faces matches those of faces per cell, ie. top, base, then the 3 vertical faces
    """
 
-   assert triple_perm_horizontal is not None
-   assert triple_perm_horizontal.shape == (vpg.cell_count, 3)
-   if perm_k is None:
-      perm_k = np.mean(triple_perm_horizontal, axis = 1)
-   if darcy_constant is None:
-      length_units = vpg.xy_units()
-      assert length_units == 'm' or length_units.startswith('ft')
-      assert vpg.z_units() == length_units
-      darcy_constant = 0.008527 if length_units == 'm' else 0.001127  # these values from Nexus keyword ref.
+    assert triple_perm_horizontal is not None
+    assert triple_perm_horizontal.shape == (vpg.cell_count, 3)
+    if perm_k is None:
+        perm_k = np.mean(triple_perm_horizontal, axis = 1)
+    if darcy_constant is None:
+        length_units = vpg.xy_units()
+        assert length_units == 'm' or length_units.startswith('ft')
+        assert vpg.z_units() == length_units
+        darcy_constant = 0.008527 if length_units == 'm' else 0.001127  # these values from Nexus keyword ref.
 
-   # fetch triangulation and call precursor function
-   p = vpg.points_ref()
-   t = vpg.triangulation()
-   a_t, d_t = half_cell_t_2d_triangular_precursor(p, t)
-   # find heights of cells and faces
-   # find horizontal area of triangles
-   triangle_areas = vec.area_of_triangles(p, t, xy_projection = True).reshape((1, -1))
-   cp = vpg.corner_points()
-   half_thickness = 0.5 * vpg.thickness().reshape((vpg.nk, -1))
+    # fetch triangulation and call precursor function
+    p = vpg.points_ref()
+    t = vpg.triangulation()
+    a_t, d_t = half_cell_t_2d_triangular_precursor(p, t)
+    # find heights of cells and faces
+    # find horizontal area of triangles
+    triangle_areas = vec.area_of_triangles(p, t, xy_projection = True).reshape((1, -1))
+    cp = vpg.corner_points()
+    half_thickness = 0.5 * vpg.thickness().reshape((vpg.nk, -1))
 
-   # compute transmissibilities
-   tr = np.zeros((vpg.cell_count, 5), dtype = float)
-   # vertical
-   tr[:, 0] = np.where(half_thickness < tolerance, np.NaN, (perm_k.reshape(
-      (vpg.nk, -1)) * triangle_areas / half_thickness)).flatten()
-   tr[:, 1] = tr[:, 0]
-   # horizontal
-   # TODO: compute dip adjustments for non-vertical transmissibilities
-   dt_full = np.empty((vpg.nk, vpg.cell_count // vpg.nk, 3), dtype = float)
-   dt_full[:] = d_t
-   tr[:, 2:] = np.where(dt_full < tolerance, np.NaN,
-                        triple_perm_horizontal.reshape((vpg.nk, -1, 3)) * a_t.reshape((1, -1, 3)) / dt_full).reshape(
-                           (-1, 3))
-   if ntg is not None:
-      tr[:, 2:] *= ntg.reshape((-1, 1))
+    # compute transmissibilities
+    tr = np.zeros((vpg.cell_count, 5), dtype = float)
+    # vertical
+    tr[:, 0] = np.where(half_thickness < tolerance, np.NaN, (perm_k.reshape(
+        (vpg.nk, -1)) * triangle_areas / half_thickness)).flatten()
+    tr[:, 1] = tr[:, 0]
+    # horizontal
+    # TODO: compute dip adjustments for non-vertical transmissibilities
+    dt_full = np.empty((vpg.nk, vpg.cell_count // vpg.nk, 3), dtype = float)
+    dt_full[:] = d_t
+    tr[:, 2:] = np.where(dt_full < tolerance, np.NaN,
+                         triple_perm_horizontal.reshape((vpg.nk, -1, 3)) * a_t.reshape((1, -1, 3)) / dt_full).reshape(
+                             (-1, 3))
+    if ntg is not None:
+        tr[:, 2:] *= ntg.reshape((-1, 1))
 
-   tr *= darcy_constant
-   return tr
+    tr *= darcy_constant
+    return tr
 
 
 def half_cell_t_2d_triangular_precursor(p, t):
-   """Creates a precursor to horizontal transmissibility for prism grids (see notes).
+    """Creates a precursor to horizontal transmissibility for prism grids (see notes).
 
    arguments:
       p (numpy float array of shape (N, 2 or 3)): the xy(&z) locations of cell vertices
@@ -446,39 +454,39 @@ def half_cell_t_2d_triangular_precursor(p, t):
       cell transmissibility in the xy plane
    """
 
-   assert p.ndim == 2 and p.shape[1] in [2, 3]
-   assert t.ndim == 2 and t.shape[1] == 3
+    assert p.ndim == 2 and p.shape[1] in [2, 3]
+    assert t.ndim == 2 and t.shape[1] == 3
 
-   # centre points of triangles, in xy
-   centres = np.mean(p[t], axis = 1)[:, :2]
-   # midpoints of edges of triangles, in xy
-   edge_midpoints = np.empty(tuple(list(t.shape) + [2]), dtype = float)
-   edge_midpoints[:, 0, :] = 0.5 * (p[t[:, 1]] + p[t[:, 2]])[:, :2]
-   edge_midpoints[:, 1, :] = 0.5 * (p[t[:, 2]] + p[t[:, 0]])[:, :2]
-   edge_midpoints[:, 2, :] = 0.5 * (p[t[:, 0]] + p[t[:, 1]])[:, :2]
-   # triangle edge vectors, projected in xy
-   edge_vectors = np.empty(edge_midpoints.shape, dtype = float)
-   edge_vectors[:, 0] = (p[t[:, 2]] - p[t[:, 1]])[:, :2]
-   edge_vectors[:, 1] = (p[t[:, 0]] - p[t[:, 2]])[:, :2]
-   edge_vectors[:, 2] = (p[t[:, 1]] - p[t[:, 0]])[:, :2]
-   # vectors from triangle centres to mid points of edges (3 per triangle), in xy plane
-   cem_vectors = edge_midpoints - centres.reshape((-1, 1, 2))
-   cem_lengths = vec.naive_lengths(cem_vectors)
-   # unit length vectors normal to cem_vectors, in the xy plane
-   normal_vectors = np.zeros(edge_midpoints.shape)
-   normal_vectors[:, :, 0] = cem_vectors[:, :, 1]
-   normal_vectors[:, :, 1] = -cem_vectors[:, :, 0]
-   normal_vectors = vec.unit_vectors(normal_vectors)
-   # edge lengths projected onto normal vectors (length perpendicular to nominal flow direction)
-   normal_lengths = np.abs(vec.dot_products(edge_vectors, normal_vectors))
-   # return normal (cross-sectional) lengths and nominal flow direction lengths
-   assert normal_lengths.shape == t.shape and cem_lengths.shape == t.shape
+    # centre points of triangles, in xy
+    centres = np.mean(p[t], axis = 1)[:, :2]
+    # midpoints of edges of triangles, in xy
+    edge_midpoints = np.empty(tuple(list(t.shape) + [2]), dtype = float)
+    edge_midpoints[:, 0, :] = 0.5 * (p[t[:, 1]] + p[t[:, 2]])[:, :2]
+    edge_midpoints[:, 1, :] = 0.5 * (p[t[:, 2]] + p[t[:, 0]])[:, :2]
+    edge_midpoints[:, 2, :] = 0.5 * (p[t[:, 0]] + p[t[:, 1]])[:, :2]
+    # triangle edge vectors, projected in xy
+    edge_vectors = np.empty(edge_midpoints.shape, dtype = float)
+    edge_vectors[:, 0] = (p[t[:, 2]] - p[t[:, 1]])[:, :2]
+    edge_vectors[:, 1] = (p[t[:, 0]] - p[t[:, 2]])[:, :2]
+    edge_vectors[:, 2] = (p[t[:, 1]] - p[t[:, 0]])[:, :2]
+    # vectors from triangle centres to mid points of edges (3 per triangle), in xy plane
+    cem_vectors = edge_midpoints - centres.reshape((-1, 1, 2))
+    cem_lengths = vec.naive_lengths(cem_vectors)
+    # unit length vectors normal to cem_vectors, in the xy plane
+    normal_vectors = np.zeros(edge_midpoints.shape)
+    normal_vectors[:, :, 0] = cem_vectors[:, :, 1]
+    normal_vectors[:, :, 1] = -cem_vectors[:, :, 0]
+    normal_vectors = vec.unit_vectors(normal_vectors)
+    # edge lengths projected onto normal vectors (length perpendicular to nominal flow direction)
+    normal_lengths = np.abs(vec.dot_products(edge_vectors, normal_vectors))
+    # return normal (cross-sectional) lengths and nominal flow direction lengths
+    assert normal_lengths.shape == t.shape and cem_lengths.shape == t.shape
 
-   return normal_lengths, cem_lengths
+    return normal_lengths, cem_lengths
 
 
 def fault_connection_set(grid, skip_inactive = False):
-   """Builds a GridConnectionSet for juxtaposed faces where there is a split pillar, with fractional area data.
+    """Builds a GridConnectionSet for juxtaposed faces where there is a split pillar, with fractional area data.
 
    arguments:
       grid (grid.Grid object): the grid for which a fault connection set is required
@@ -497,636 +505,645 @@ def fault_connection_set(grid, skip_inactive = False):
       there are no qualifying connections across faults, then (None, None) will be returned
    """
 
-   def all_nan(pillar):
-      # return True if no valid points in pillar
-      return np.all(np.any(np.isnan(pillar), axis = -1))
+    def all_nan(pillar):
+        # return True if no valid points in pillar
+        return np.all(np.any(np.isnan(pillar), axis = -1))
 
-   def juxtapose(grid, p, pv, pam, pap, pbm, pbp, tol = 0.001):
-      # return list of juxtaposed layer pairs and fractional areas: list of (ka, kb, fa, fb) and error info
-      # TODO: orthogonal offset tolerance on pillars
+    def juxtapose(grid, p, pv, pam, pap, pbm, pbp, tol = 0.001):
+        # return list of juxtaposed layer pairs and fractional areas: list of (ka, kb, fa, fb) and error info
+        # TODO: orthogonal offset tolerance on pillars
 
-      def pillar_flavour(pml_top, pml_bot, ppl_top, ppl_bot, tol = 0.001):
-         # return flavour of points pattern on one pillar:
-         # 1: both p above m top
-         # 2: p top above m top, p bot within m
-         # 3: p top above m top, p bot below m bot
-         # 4: both p within m
-         # 5: p top within m, p bot below m bot
-         # 6: both p below m
-         if ppl_top >= pml_top - tol and ppl_bot <= pml_bot + tol:
-            return 4  # tolerance bias towards simplest flavour
-         if ppl_bot <= pml_top + tol:
-            return 1
-         if ppl_top >= pml_bot - tol:
-            return 6
-         if ppl_top <= pml_top + tol:
-            if ppl_bot <= pml_bot + tol:
-               return 2
-            return 3
-         return 5
+        def pillar_flavour(pml_top, pml_bot, ppl_top, ppl_bot, tol = 0.001):
+            # return flavour of points pattern on one pillar:
+            # 1: both p above m top
+            # 2: p top above m top, p bot within m
+            # 3: p top above m top, p bot below m bot
+            # 4: both p within m
+            # 5: p top within m, p bot below m bot
+            # 6: both p below m
+            if ppl_top >= pml_top - tol and ppl_bot <= pml_bot + tol:
+                return 4  # tolerance bias towards simplest flavour
+            if ppl_bot <= pml_top + tol:
+                return 1
+            if ppl_top >= pml_bot - tol:
+                return 6
+            if ppl_top <= pml_top + tol:
+                if ppl_bot <= pml_bot + tol:
+                    return 2
+                return 3
+            return 5
 
-      def basic_fr(g, h, ea, eb, tol):
-         # returns fractional area for simple patterns (2 sides of overlap quadrilateral lie on pillars)
-         if ea + eb < tol:
-            return 0.0
-         return (g + h) / (ea + eb)
+        def basic_fr(g, h, ea, eb, tol):
+            # returns fractional area for simple patterns (2 sides of overlap quadrilateral lie on pillars)
+            if ea + eb < tol:
+                return 0.0
+            return (g + h) / (ea + eb)
 
-      def fractional_area(paml_top, paml_bot, papl_top, papl_bot, pbml_top, pbml_bot, pbpl_top, pbpl_bot, tol = 0.001):
-         # calculate fractional area of overlap, from m perspective (calling code swaps m & p for other perspective)
-         fla = pillar_flavour(paml_top, paml_bot, papl_top, papl_bot, tol = tol)
-         flb = pillar_flavour(pbml_top, pbml_bot, pbpl_top, pbpl_bot, tol = tol)
-         if (fla, flb) == (4, 4):  # diagram 1
-            return basic_fr(papl_bot - papl_top, pbpl_bot - pbpl_top, paml_bot - paml_top, pbml_bot - pbml_top, tol)
-         elif (fla, flb) == (3, 3):  # diagram 1 (reverse perspective); diagram 3
-            return 1.0
-         elif (fla, flb) == (5, 5):  # diagram 2
-            return basic_fr(paml_bot - papl_top, pbml_bot - pbpl_top, paml_bot - paml_top, pbml_bot - pbml_top, tol)
-         elif (fla, flb) == (2, 2):  # diagram 2 (reverse perspective)
-            return basic_fr(papl_bot - paml_top, pbpl_bot - pbml_top, paml_bot - paml_top, pbml_bot - pbml_top, tol)
-         elif (fla, flb) == (5, 4):  # diagram 5 (diagram 4 is a special case of 5 and 2)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbml_bot - pbpl_bot
-            if eb < tol or g < tol:
-               sub = 0.0
+        def fractional_area(paml_top,
+                            paml_bot,
+                            papl_top,
+                            papl_bot,
+                            pbml_top,
+                            pbml_bot,
+                            pbpl_top,
+                            pbpl_bot,
+                            tol = 0.001):
+            # calculate fractional area of overlap, from m perspective (calling code swaps m & p for other perspective)
+            fla = pillar_flavour(paml_top, paml_bot, papl_top, papl_bot, tol = tol)
+            flb = pillar_flavour(pbml_top, pbml_bot, pbpl_top, pbpl_bot, tol = tol)
+            if (fla, flb) == (4, 4):  # diagram 1
+                return basic_fr(papl_bot - papl_top, pbpl_bot - pbpl_top, paml_bot - paml_top, pbml_bot - pbml_top, tol)
+            elif (fla, flb) == (3, 3):  # diagram 1 (reverse perspective); diagram 3
+                return 1.0
+            elif (fla, flb) == (5, 5):  # diagram 2
+                return basic_fr(paml_bot - papl_top, pbml_bot - pbpl_top, paml_bot - paml_top, pbml_bot - pbml_top, tol)
+            elif (fla, flb) == (2, 2):  # diagram 2 (reverse perspective)
+                return basic_fr(papl_bot - paml_top, pbpl_bot - pbml_top, paml_bot - paml_top, pbml_bot - pbml_top, tol)
+            elif (fla, flb) == (5, 4):  # diagram 5 (diagram 4 is a special case of 5 and 2)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbml_bot - pbpl_bot
+                if eb < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = papl_bot - paml_bot
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                return basic_fr(paml_bot - papl_top, pbml_bot - pbpl_top, paml_bot - paml_top, pbml_bot - pbml_top,
+                                tol) - sub
+            elif (fla, flb) == (4, 5):  # diagram 5 mirror (diagram 4 is a special case of 5)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = paml_bot - papl_bot
+                if ea < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = pbpl_bot - pbml_bot
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                return basic_fr(pbml_bot - pbpl_top, paml_bot - papl_top, pbml_bot - pbml_top, paml_bot - paml_top,
+                                tol) - sub
+            elif (fla, flb) == (2, 3):  # diagram 5 (reverse perspective), similar to 1.0 - diagram 10
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = paml_bot - papl_bot
+                if ea < tol or g < tol:
+                    return 1.0
+                v = pbpl_bot - pbml_bot
+                return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (3, 2):  # diagram 5 mirror (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbml_bot - pbpl_bot
+                if eb < tol or g < tol:
+                    return 1.0
+                v = papl_bot - paml_bot
+                return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (5, 2):  # diagram 6
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = papl_top - paml_top
+                if ea < tol or g < tol:
+                    suba = 0.0
+                else:
+                    v = pbml_top - pbpl_top
+                    suba = (g / (ea + eb)) * (1.0 - v / (v + g))
+                g = pbml_bot - pbpl_bot
+                if eb < tol or g < tol:
+                    subb = 0.0
+                else:
+                    v = papl_bot - paml_bot
+                    subb = (g / (ea + eb)) * (1.0 - v / (v + g))
+                sub = suba + subb
+                return 1.0 - sub
+            elif (fla, flb) == (2, 5):  # diagram 6 mirror
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbpl_top - pbml_top
+                if eb < tol or g < tol:
+                    subb = 0.0
+                else:
+                    v = paml_top - papl_top
+                    subb = (g / (ea + eb)) * (1.0 - v / (v + g))
+                g = paml_bot - papl_bot
+                if ea < tol or g < tol:
+                    suba = 0.0
+                else:
+                    v = pbpl_bot - pbml_bot
+                    suba = (g / (ea + eb)) * (1.0 - v / (v + g))
+                sub = suba + subb
+                return 1.0 - sub
+            elif (fla, flb) == (2, 1):  # diagram 10
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = papl_bot - paml_top
+                if ea < tol or g < tol:
+                    return 0.0
+                v = pbml_top - pbpl_bot
+                return (g / (ea + eb)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (1, 2):  # diagram 10 mirror
+                eb = pbml_bot - pbml_top
+                ea = paml_bot - paml_top
+                g = pbpl_bot - pbml_top
+                if eb < tol or g < tol:
+                    return 0.0
+                v = paml_top - papl_bot
+                return (g / (eb + ea)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (5, 6):  # diagram 10 (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = paml_bot - papl_top
+                if ea < tol or g < tol:
+                    return 0.0
+                v = pbpl_top - pbml_bot
+                return (g / (ea + eb)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (6, 5):  # diagram 10 mirror (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbml_bot - pbpl_top
+                if eb < tol or g < tol:
+                    return 0.0
+                v = papl_top - paml_bot
+                return (g / (ea + eb)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (2, 4):  # diagram 11
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbpl_top - pbml_top
+                if eb < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = paml_top - papl_top
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                return basic_fr(papl_bot - paml_top, pbpl_bot - pbml_top, paml_bot - paml_top, pbml_bot - pbml_top,
+                                tol) - sub
+            elif (fla, flb) == (4, 2):  # diagram 11 mirror
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = papl_top - paml_top
+                if ea < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = pbml_top - pbpl_top
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                return basic_fr(pbpl_bot - pbml_top, papl_bot - paml_top, pbml_bot - pbml_top, paml_bot - paml_top,
+                                tol) - sub
+            elif (fla, flb) == (5, 3):  # diagram 11 (reverse perspective) similar to 1.0 - diagram 10
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = papl_top - paml_top
+                if ea < tol or g < tol:
+                    return 1.0
+                v = pbml_top - pbpl_top
+                return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (3, 5):  # diagram 11 mirror (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbpl_top - pbml_top
+                if eb < tol or g < tol:
+                    return 1.0
+                v = paml_top - papl_top
+                return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
+            elif (fla, flb) == (3, 1):  # diagram 7 (only accurate if pillars parallel and layer constant thickness?)
+                s = papl_bot - paml_bot
+                ea = paml_bot - paml_top
+                if s + ea <= tol:
+                    return 0.0
+                t = pbml_bot - pbpl_bot
+                v = pbml_top - pbpl_bot
+                if t + v <= tol:
+                    return 1.0
+                return 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s))
+            elif (fla, flb) == (1, 3):  # diagram 7 mirror
+                # (only accurate if pillars parallel and layer constant thickness?)
+                s = pbpl_bot - pbml_bot
+                eb = pbml_bot - pbml_top
+                if s + eb <= tol:
+                    return 0.0
+                t = paml_bot - papl_bot
+                v = paml_top - papl_bot
+                if t + v <= tol:
+                    return 1.0
+                return 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s))
+            elif (fla, flb) == (4, 6):  # diagram 7 (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = paml_bot - papl_top
+                if ea < tol or g < tol:
+                    return 0.0
+                v = pbpl_top - pbml_bot
+                gs = paml_bot - papl_bot
+                if gs < tol:
+                    sub = 0.0
+                else:
+                    vs = pbpl_bot - pbml_bot
+                    sub = (gs / (ea + eb)) * (1.0 - vs / (vs + gs))
+                return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
+            elif (fla, flb) == (6, 4):  # diagram 7 mirror (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbml_bot - pbpl_top
+                if eb < tol or g < tol:
+                    return 0.0
+                v = papl_top - paml_bot
+                gs = pbml_bot - pbpl_bot
+                if gs < tol:
+                    sub = 0.0
+                else:
+                    vs = papl_bot - paml_bot
+                    sub = (gs / (ea + eb)) * (1.0 - vs / (vs + gs))
+                return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
+            elif (fla, flb) == (4, 1):  # diagram 12
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = papl_bot - paml_top
+                if ea < tol or g < tol:
+                    return 0.0
+                gs = papl_top - paml_top
+                if gs < tol:
+                    sub = 0.0
+                else:
+                    v = pbml_top - pbpl_top
+                    sub = (gs / (ea + eb)) * (1.0 - v / (v + gs))
+                v = pbml_top - pbpl_bot
+                return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
+            elif (fla, flb) == (1, 4):  # diagram 12 mirror
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbpl_bot - pbml_top
+                if eb < tol or g < tol:
+                    return 0.0
+                gs = pbpl_top - pbml_top
+                if gs < tol:
+                    sub = 0.0
+                else:
+                    v = paml_top - papl_top
+                    sub = (gs / (ea + eb)) * (1.0 - v / (v + gs))
+                v = paml_top - papl_bot
+                return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
+            elif (fla, flb) == (3, 6):  # diagram 12 (reverse perspective)
+                s = pbpl_top - pbml_bot
+                eb = pbml_bot - pbml_top
+                if s + eb <= tol:
+                    return 1.0
+                t = paml_bot - papl_top
+                v = paml_top - papl_top
+                if t + v <= tol:
+                    return 0.0
+                return 1.0 - (0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)))
+            elif (fla, flb) == (6, 3):  # diagram 12 mirror (reverse perspective)
+                s = papl_top - paml_bot
+                ea = paml_bot - paml_top
+                if s + ea <= tol:
+                    return 1.0
+                t = pbml_bot - pbpl_top
+                v = pbml_top - pbpl_top
+                if t + v <= tol:
+                    return 0.0
+                return 1.0 - (0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)))
+            elif (fla, flb) == (5, 1):  # diagram 9 (only accurate if pillars parallel and layer constant thickness?)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = papl_top - paml_top
+                if ea < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = pbml_top - pbpl_top
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                s = papl_bot - paml_bot
+                if s + ea <= tol:
+                    return 0.0
+                t = pbml_bot - pbpl_bot
+                v = pbml_top - pbpl_bot
+                if t + v <= tol:
+                    return 1.0 - sub
+                return 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) - sub
+            elif (fla, flb) == (1, 5):  # diagram 9 mirror
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbpl_top - pbml_top
+                if eb < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = paml_top - papl_top
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                s = pbpl_bot - pbml_bot
+                if s + eb <= tol:
+                    return 0.0
+                t = paml_bot - papl_bot
+                v = paml_top - papl_bot
+                if t + v <= tol:
+                    return 1.0 - sub
+                return 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) - sub
+            elif (fla, flb) == (2, 6):  # diagram 9 (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = paml_bot - papl_bot
+                if ea < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = pbpl_bot - pbml_bot
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                s = paml_top - papl_top
+                if s + ea <= tol:
+                    return 0.0
+                t = pbpl_top - pbml_top
+                v = pbpl_top - pbml_bot
+                if t + v <= tol:
+                    return 1.0 - sub
+                return 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) - sub
+            elif (fla, flb) == (6, 2):  # diagram 9 mirror (reverse perspective)
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                g = pbml_bot - pbpl_bot
+                if eb < tol or g < tol:
+                    sub = 0.0
+                else:
+                    v = papl_bot - paml_bot
+                    sub = (g / (ea + eb)) * (1.0 - v / (v + g))
+                s = pbml_top - pbpl_top
+                if s + eb <= tol:
+                    return 0.0
+                t = papl_top - paml_top
+                v = papl_top - paml_bot
+                if t + v <= tol:
+                    return 1.0 - sub
+                return 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) - sub
+            elif (fla, flb) == (6, 1):  # diagram 8; solution only accurate if pillars are parallel
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                s = papl_top - paml_bot
+                if s + ea <= tol:
+                    suba = 0.0
+                else:
+                    t = pbml_bot - pbpl_top
+                    v = pbml_top - pbpl_top
+                    suba = 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) if t + v > tol else 1.0
+                s = pbml_top - pbpl_bot
+                if s + eb <= tol:
+                    subb = 0.0
+                else:
+                    t = papl_bot - paml_top
+                    v = papl_bot - paml_bot
+                    subb = 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) if t + v > tol else 1.0
+                sub = suba + subb
+                return max(1.0 - sub, 0.0)
+            elif (fla, flb) == (1, 6):  # diagram 8 mirror or reverse perspective
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                s = pbpl_top - pbml_bot
+                if s + eb <= tol:
+                    subb = 0.0
+                else:
+                    t = paml_bot - papl_top
+                    v = paml_top - papl_top
+                    subb = 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) if t + v > tol else 1.0
+                s = paml_top - papl_bot
+                if s + ea <= tol:
+                    suba = 0.0
+                else:
+                    t = pbpl_bot - pbml_top
+                    v = pbpl_bot - pbml_bot
+                    suba = 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) if t + v > tol else 1.0
+                sub = suba + subb
+                return max(1.0 - sub, 0.0)
+            elif (fla, flb) == (4, 3):  # diagram 13
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                if ea < tol:
+                    return 1.0
+                g = papl_top - paml_top
+                if g < tol:
+                    sub1 = 0.0
+                else:
+                    v = pbml_top - pbpl_top
+                    sub1 = (g / (ea + eb)) * (1.0 - v / (v + g))
+                g = paml_bot - papl_bot
+                if g < tol:
+                    sub2 = 0.0
+                else:
+                    v = pbpl_bot - pbml_bot
+                    sub2 = (g / (ea + eb)) * (1.0 - v / (v + g))
+                return 1.0 - (sub1 + sub2)
+            elif (fla, flb) == (3, 4):  # diagram 13 mirror or reverse perspective
+                ea = paml_bot - paml_top
+                eb = pbml_bot - pbml_top
+                if eb < tol:
+                    return 1.0
+                g = pbpl_top - pbml_top
+                if g < tol:
+                    sub1 = 0.0
+                else:
+                    v = paml_top - papl_top
+                    sub1 = (g / (ea + eb)) * (1.0 - v / (v + g))
+                g = pbml_bot - pbpl_bot
+                if g < tol:
+                    sub2 = 0.0
+                else:
+                    v = papl_bot - paml_bot
+                    sub2 = (g / (ea + eb)) * (1.0 - v / (v + g))
+                return 1.0 - (sub1 + sub2)
             else:
-               v = papl_bot - paml_bot
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            return basic_fr(paml_bot - papl_top, pbml_bot - pbpl_top, paml_bot - paml_top, pbml_bot - pbml_top,
-                            tol) - sub
-         elif (fla, flb) == (4, 5):  # diagram 5 mirror (diagram 4 is a special case of 5)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = paml_bot - papl_bot
-            if ea < tol or g < tol:
-               sub = 0.0
-            else:
-               v = pbpl_bot - pbml_bot
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            return basic_fr(pbml_bot - pbpl_top, paml_bot - papl_top, pbml_bot - pbml_top, paml_bot - paml_top,
-                            tol) - sub
-         elif (fla, flb) == (2, 3):  # diagram 5 (reverse perspective), similar to 1.0 - diagram 10
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = paml_bot - papl_bot
-            if ea < tol or g < tol:
-               return 1.0
-            v = pbpl_bot - pbml_bot
-            return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (3, 2):  # diagram 5 mirror (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbml_bot - pbpl_bot
-            if eb < tol or g < tol:
-               return 1.0
-            v = papl_bot - paml_bot
-            return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (5, 2):  # diagram 6
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = papl_top - paml_top
-            if ea < tol or g < tol:
-               suba = 0.0
-            else:
-               v = pbml_top - pbpl_top
-               suba = (g / (ea + eb)) * (1.0 - v / (v + g))
-            g = pbml_bot - pbpl_bot
-            if eb < tol or g < tol:
-               subb = 0.0
-            else:
-               v = papl_bot - paml_bot
-               subb = (g / (ea + eb)) * (1.0 - v / (v + g))
-            sub = suba + subb
-            return 1.0 - sub
-         elif (fla, flb) == (2, 5):  # diagram 6 mirror
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbpl_top - pbml_top
-            if eb < tol or g < tol:
-               subb = 0.0
-            else:
-               v = paml_top - papl_top
-               subb = (g / (ea + eb)) * (1.0 - v / (v + g))
-            g = paml_bot - papl_bot
-            if ea < tol or g < tol:
-               suba = 0.0
-            else:
-               v = pbpl_bot - pbml_bot
-               suba = (g / (ea + eb)) * (1.0 - v / (v + g))
-            sub = suba + subb
-            return 1.0 - sub
-         elif (fla, flb) == (2, 1):  # diagram 10
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = papl_bot - paml_top
-            if ea < tol or g < tol:
-               return 0.0
-            v = pbml_top - pbpl_bot
-            return (g / (ea + eb)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (1, 2):  # diagram 10 mirror
-            eb = pbml_bot - pbml_top
-            ea = paml_bot - paml_top
-            g = pbpl_bot - pbml_top
-            if eb < tol or g < tol:
-               return 0.0
-            v = paml_top - papl_bot
-            return (g / (eb + ea)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (5, 6):  # diagram 10 (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = paml_bot - papl_top
-            if ea < tol or g < tol:
-               return 0.0
-            v = pbpl_top - pbml_bot
-            return (g / (ea + eb)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (6, 5):  # diagram 10 mirror (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbml_bot - pbpl_top
-            if eb < tol or g < tol:
-               return 0.0
-            v = papl_top - paml_bot
-            return (g / (ea + eb)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (2, 4):  # diagram 11
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbpl_top - pbml_top
-            if eb < tol or g < tol:
-               sub = 0.0
-            else:
-               v = paml_top - papl_top
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            return basic_fr(papl_bot - paml_top, pbpl_bot - pbml_top, paml_bot - paml_top, pbml_bot - pbml_top,
-                            tol) - sub
-         elif (fla, flb) == (4, 2):  # diagram 11 mirror
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = papl_top - paml_top
-            if ea < tol or g < tol:
-               sub = 0.0
-            else:
-               v = pbml_top - pbpl_top
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            return basic_fr(pbpl_bot - pbml_top, papl_bot - paml_top, pbml_bot - pbml_top, paml_bot - paml_top,
-                            tol) - sub
-         elif (fla, flb) == (5, 3):  # diagram 11 (reverse perspective) similar to 1.0 - diagram 10
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = papl_top - paml_top
-            if ea < tol or g < tol:
-               return 1.0
-            v = pbml_top - pbpl_top
-            return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (3, 5):  # diagram 11 mirror (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbpl_top - pbml_top
-            if eb < tol or g < tol:
-               return 1.0
-            v = paml_top - papl_top
-            return 1.0 - (g / (ea + eb)) * (1.0 - v / (v + g))
-         elif (fla, flb) == (3, 1):  # diagram 7 (only accurate if pillars parallel and layer constant thickness?)
-            s = papl_bot - paml_bot
-            ea = paml_bot - paml_top
-            if s + ea <= tol:
-               return 0.0
-            t = pbml_bot - pbpl_bot
-            v = pbml_top - pbpl_bot
-            if t + v <= tol:
-               return 1.0
-            return 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s))
-         elif (fla, flb) == (1, 3):  # diagram 7 mirror
-            # (only accurate if pillars parallel and layer constant thickness?)
-            s = pbpl_bot - pbml_bot
-            eb = pbml_bot - pbml_top
-            if s + eb <= tol:
-               return 0.0
-            t = paml_bot - papl_bot
-            v = paml_top - papl_bot
-            if t + v <= tol:
-               return 1.0
-            return 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s))
-         elif (fla, flb) == (4, 6):  # diagram 7 (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = paml_bot - papl_top
-            if ea < tol or g < tol:
-               return 0.0
-            v = pbpl_top - pbml_bot
-            gs = paml_bot - papl_bot
-            if gs < tol:
-               sub = 0.0
-            else:
-               vs = pbpl_bot - pbml_bot
-               sub = (gs / (ea + eb)) * (1.0 - vs / (vs + gs))
-            return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
-         elif (fla, flb) == (6, 4):  # diagram 7 mirror (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbml_bot - pbpl_top
-            if eb < tol or g < tol:
-               return 0.0
-            v = papl_top - paml_bot
-            gs = pbml_bot - pbpl_bot
-            if gs < tol:
-               sub = 0.0
-            else:
-               vs = papl_bot - paml_bot
-               sub = (gs / (ea + eb)) * (1.0 - vs / (vs + gs))
-            return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
-         elif (fla, flb) == (4, 1):  # diagram 12
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = papl_bot - paml_top
-            if ea < tol or g < tol:
-               return 0.0
-            gs = papl_top - paml_top
-            if gs < tol:
-               sub = 0.0
-            else:
-               v = pbml_top - pbpl_top
-               sub = (gs / (ea + eb)) * (1.0 - v / (v + gs))
-            v = pbml_top - pbpl_bot
-            return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
-         elif (fla, flb) == (1, 4):  # diagram 12 mirror
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbpl_bot - pbml_top
-            if eb < tol or g < tol:
-               return 0.0
-            gs = pbpl_top - pbml_top
-            if gs < tol:
-               sub = 0.0
-            else:
-               v = paml_top - papl_top
-               sub = (gs / (ea + eb)) * (1.0 - v / (v + gs))
-            v = paml_top - papl_bot
-            return (g / (ea + eb)) * (1.0 - v / (v + g)) - sub
-         elif (fla, flb) == (3, 6):  # diagram 12 (reverse perspective)
-            s = pbpl_top - pbml_bot
-            eb = pbml_bot - pbml_top
-            if s + eb <= tol:
-               return 1.0
-            t = paml_bot - papl_top
-            v = paml_top - papl_top
-            if t + v <= tol:
-               return 0.0
-            return 1.0 - (0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)))
-         elif (fla, flb) == (6, 3):  # diagram 12 mirror (reverse perspective)
-            s = papl_top - paml_bot
-            ea = paml_bot - paml_top
-            if s + ea <= tol:
-               return 1.0
-            t = pbml_bot - pbpl_top
-            v = pbml_top - pbpl_top
-            if t + v <= tol:
-               return 0.0
-            return 1.0 - (0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)))
-         elif (fla, flb) == (5, 1):  # diagram 9 (only accurate if pillars parallel and layer constant thickness?)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = papl_top - paml_top
-            if ea < tol or g < tol:
-               sub = 0.0
-            else:
-               v = pbml_top - pbpl_top
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            s = papl_bot - paml_bot
-            if s + ea <= tol:
-               return 0.0
-            t = pbml_bot - pbpl_bot
-            v = pbml_top - pbpl_bot
-            if t + v <= tol:
-               return 1.0 - sub
-            return 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) - sub
-         elif (fla, flb) == (1, 5):  # diagram 9 mirror
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbpl_top - pbml_top
-            if eb < tol or g < tol:
-               sub = 0.0
-            else:
-               v = paml_top - papl_top
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            s = pbpl_bot - pbml_bot
-            if s + eb <= tol:
-               return 0.0
-            t = paml_bot - papl_bot
-            v = paml_top - papl_bot
-            if t + v <= tol:
-               return 1.0 - sub
-            return 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) - sub
-         elif (fla, flb) == (2, 6):  # diagram 9 (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = paml_bot - papl_bot
-            if ea < tol or g < tol:
-               sub = 0.0
-            else:
-               v = pbpl_bot - pbml_bot
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            s = paml_top - papl_top
-            if s + ea <= tol:
-               return 0.0
-            t = pbpl_top - pbml_top
-            v = pbpl_top - pbml_bot
-            if t + v <= tol:
-               return 1.0 - sub
-            return 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) - sub
-         elif (fla, flb) == (6, 2):  # diagram 9 mirror (reverse perspective)
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            g = pbml_bot - pbpl_bot
-            if eb < tol or g < tol:
-               sub = 0.0
-            else:
-               v = papl_bot - paml_bot
-               sub = (g / (ea + eb)) * (1.0 - v / (v + g))
-            s = pbml_top - pbpl_top
-            if s + eb <= tol:
-               return 0.0
-            t = papl_top - paml_top
-            v = papl_top - paml_bot
-            if t + v <= tol:
-               return 1.0 - sub
-            return 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) - sub
-         elif (fla, flb) == (6, 1):  # diagram 8; solution only accurate if pillars are parallel
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            s = papl_top - paml_bot
-            if s + ea <= tol:
-               suba = 0.0
-            else:
-               t = pbml_bot - pbpl_top
-               v = pbml_top - pbpl_top
-               suba = 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) if t + v > tol else 1.0
-            s = pbml_top - pbpl_bot
-            if s + eb <= tol:
-               subb = 0.0
-            else:
-               t = papl_bot - paml_top
-               v = papl_bot - paml_bot
-               subb = 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) if t + v > tol else 1.0
-            sub = suba + subb
-            return max(1.0 - sub, 0.0)
-         elif (fla, flb) == (1, 6):  # diagram 8 mirror or reverse perspective
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            s = pbpl_top - pbml_bot
-            if s + eb <= tol:
-               subb = 0.0
-            else:
-               t = paml_bot - papl_top
-               v = paml_top - papl_top
-               subb = 0.5 * (s / (s + t) + 1.0 - v / (v + eb + s)) if t + v > tol else 1.0
-            s = paml_top - papl_bot
-            if s + ea <= tol:
-               suba = 0.0
-            else:
-               t = pbpl_bot - pbml_top
-               v = pbpl_bot - pbml_bot
-               suba = 0.5 * (s / (s + t) + 1.0 - v / (v + ea + s)) if t + v > tol else 1.0
-            sub = suba + subb
-            return max(1.0 - sub, 0.0)
-         elif (fla, flb) == (4, 3):  # diagram 13
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            if ea < tol:
-               return 1.0
-            g = papl_top - paml_top
-            if g < tol:
-               sub1 = 0.0
-            else:
-               v = pbml_top - pbpl_top
-               sub1 = (g / (ea + eb)) * (1.0 - v / (v + g))
-            g = paml_bot - papl_bot
-            if g < tol:
-               sub2 = 0.0
-            else:
-               v = pbpl_bot - pbml_bot
-               sub2 = (g / (ea + eb)) * (1.0 - v / (v + g))
-            return 1.0 - (sub1 + sub2)
-         elif (fla, flb) == (3, 4):  # diagram 13 mirror or reverse perspective
-            ea = paml_bot - paml_top
-            eb = pbml_bot - pbml_top
-            if eb < tol:
-               return 1.0
-            g = pbpl_top - pbml_top
-            if g < tol:
-               sub1 = 0.0
-            else:
-               v = paml_top - papl_top
-               sub1 = (g / (ea + eb)) * (1.0 - v / (v + g))
-            g = pbml_bot - pbpl_bot
-            if g < tol:
-               sub2 = 0.0
-            else:
-               v = papl_bot - paml_bot
-               sub2 = (g / (ea + eb)) * (1.0 - v / (v + g))
-            return 1.0 - (sub1 + sub2)
-         else:
-            raise Exception(f'unexpected juxtaposition pattern ({fla}, {flb})')
+                raise Exception(f'unexpected juxtaposition pattern ({fla}, {flb})')
 
-      pav = 0.5 * (pv[pam] + pv[pap])  # mean pillar unit vector for -I side of J face
-      pbv = 0.5 * (pv[pbm] + pv[pbp])  # mean pillar unit vector for +I side of J face
-      if all_nan(p[:, pam, :]) or all_nan(p[:, pap, :]) or all_nan(p[:, pbm, :]) or all_nan(p[:, pbp, :]):
-         return []
-      o = np.nanmin(p[:, pam, :], axis = 0)  # arbitrary local origin
-      oe = np.expand_dims(o, 0)
-      paml = p[:, pam, :] - oe  # pillar points translated to local space
-      papl = p[:, pap, :] - oe
-      pbml = p[:, pbm, :] - oe
-      pbpl = p[:, pbp, :] - oe
-      pamln = np.empty(
-         paml.shape[0])  # pillar points normalised to scalar distances on mean pillar vector, arbitrary origin
-      for i in range(pamln.size):
-         pamln[i] = np.dot(paml[i], pav)
-      papln = np.empty(papl.shape[0])
-      for i in range(papln.size):
-         papln[i] = np.dot(papl[i], pav)
-      pbmln = np.empty(pbml.shape[0])
-      for i in range(pbmln.size):
-         pbmln[i] = np.dot(pbml[i], pbv)
-      pbpln = np.empty(pbpl.shape[0])
-      for i in range(pbpln.size):
-         pbpln[i] = np.dot(pbpl[i], pbv)
+        pav = 0.5 * (pv[pam] + pv[pap])  # mean pillar unit vector for -I side of J face
+        pbv = 0.5 * (pv[pbm] + pv[pbp])  # mean pillar unit vector for +I side of J face
+        if all_nan(p[:, pam, :]) or all_nan(p[:, pap, :]) or all_nan(p[:, pbm, :]) or all_nan(p[:, pbp, :]):
+            return []
+        o = np.nanmin(p[:, pam, :], axis = 0)  # arbitrary local origin
+        oe = np.expand_dims(o, 0)
+        paml = p[:, pam, :] - oe  # pillar points translated to local space
+        papl = p[:, pap, :] - oe
+        pbml = p[:, pbm, :] - oe
+        pbpl = p[:, pbp, :] - oe
+        pamln = np.empty(
+            paml.shape[0])  # pillar points normalised to scalar distances on mean pillar vector, arbitrary origin
+        for i in range(pamln.size):
+            pamln[i] = np.dot(paml[i], pav)
+        papln = np.empty(papl.shape[0])
+        for i in range(papln.size):
+            papln[i] = np.dot(papl[i], pav)
+        pbmln = np.empty(pbml.shape[0])
+        for i in range(pbmln.size):
+            pbmln[i] = np.dot(pbml[i], pbv)
+        pbpln = np.empty(pbpl.shape[0])
+        for i in range(pbpln.size):
+            pbpln[i] = np.dot(pbpl[i], pbv)
 
-      juxta_list = []
-      fa_p_totals = np.zeros(grid.nk)
-      fa_m_worst_scaling = 1.0
-      fa_m_downscaling_count = 0
-      for km in range(grid.nk):  # for each layer on -ve side of fault
-         km_top = grid.k_raw_index_array[km] if grid.k_gaps else km  # index of top points on -ve side of fault
-         km_bot = km_top + 1
-         paml_top = pamln[
-            km_top]  # point distances in local vector space; note local vector is different for pillars a and b
-         paml_bot = pamln[km_bot]
-         pbml_top = pbmln[km_top]
-         pbml_bot = pbmln[km_bot]
-         if np.any(np.isnan((paml_top, paml_bot, pbml_top, pbml_bot))):
-            continue
-         # scan layers on +ve side of fault looking for juxtaposition
-         kp = -1
-         km_start_index = len(juxta_list)
-         fa_m_total = 0.0
-         while True:
-            kp += 1
-            if kp >= grid.nk:
-               break
-            kp_top = grid.k_raw_index_array[kp] if grid.k_gaps else kp  # index of top points on +ve side of fault
-            kp_bot = kp_top + 1
-            papl_top = papln[
-               kp_top]  # point distances in local vector space; note local vector is different for pillars a and b
-            papl_bot = papln[kp_bot]
-            pbpl_top = pbpln[kp_top]
-            pbpl_bot = pbpln[kp_bot]
-            if np.any(np.isnan((papl_top, papl_bot, pbpl_top, pbpl_bot))):
-               continue
-            # in following comments, 'shallower' means less distance in local vector, which is a K direction vector of sorts
-            if (paml_top >= papl_bot - tol) and (pbml_top >= pbpl_bot - tol):
-               continue  # p fully shallower than m
-            if (paml_bot <= papl_top + tol) and (pbml_bot <= pbpl_top + tol):
-               continue  # p fully deeper than m
-            # juxtaposition established, now determine fractional overlap area from perspectives of both sides of fault
-            fa_m = fractional_area(paml_top,
-                                   paml_bot,
-                                   papl_top,
-                                   papl_bot,
-                                   pbml_top,
-                                   pbml_bot,
-                                   pbpl_top,
-                                   pbpl_bot,
-                                   tol = tol)
-            fa_p = fractional_area(papl_top,
-                                   papl_bot,
-                                   paml_top,
-                                   paml_bot,
-                                   pbpl_top,
-                                   pbpl_bot,
-                                   pbml_top,
-                                   pbml_bot,
-                                   tol = tol)
-            log.debug(f'K {km} {fa_m}  <->  {fa_p} {kp}')
-            fa_m = min(max(fa_m, 0.0), 1.0)
-            fa_p = min(max(fa_p, 0.0), 1.0)
-            juxta_list.append((km, kp, fa_m, fa_p))
-            fa_m_total += fa_m
-            fa_p_totals[kp] += fa_p
-         # find sum of fractional areas by layer (separately for both perspectives); normalise to max of 1.0
-         if fa_m_total > 1.0:
-            fa_m_downscaling_count += 1
-            if fa_m_total > fa_m_worst_scaling:
-               fa_m_worst_scaling = fa_m_total
-               # log.warning(f'downscaling fractional areas on minus side of fault by factor of {fa_m_total} in layer {km}')
-            for i in range(km_start_index, len(juxta_list)):
-               (km, kp, fa_m, fa_p) = juxta_list[i]
-               juxta_list[i] = (km, kp, fa_m / fa_m_total, fa_p)
-      any_p_scaling = False
-      fa_p_worst_scaling = np.nanmax(fa_p_totals)
-      fa_p_downscaling_count = 0
-      for kp in range(grid.nk):
-         if fa_p_totals[kp] > 1.0:
-            fa_p_downscaling_count += 1
-            # log.warning(f'downscaling fractional areas on plus side of fault by factor of {fa_p_totals[kp]} in layer {kp}')
-            any_p_scaling = True
-      if any_p_scaling:
-         for i in range(len(juxta_list)):
-            (km, kp, fa_m, fa_p) = juxta_list[i]
+        juxta_list = []
+        fa_p_totals = np.zeros(grid.nk)
+        fa_m_worst_scaling = 1.0
+        fa_m_downscaling_count = 0
+        for km in range(grid.nk):  # for each layer on -ve side of fault
+            km_top = grid.k_raw_index_array[km] if grid.k_gaps else km  # index of top points on -ve side of fault
+            km_bot = km_top + 1
+            paml_top = pamln[
+                km_top]  # point distances in local vector space; note local vector is different for pillars a and b
+            paml_bot = pamln[km_bot]
+            pbml_top = pbmln[km_top]
+            pbml_bot = pbmln[km_bot]
+            if np.any(np.isnan((paml_top, paml_bot, pbml_top, pbml_bot))):
+                continue
+            # scan layers on +ve side of fault looking for juxtaposition
+            kp = -1
+            km_start_index = len(juxta_list)
+            fa_m_total = 0.0
+            while True:
+                kp += 1
+                if kp >= grid.nk:
+                    break
+                kp_top = grid.k_raw_index_array[kp] if grid.k_gaps else kp  # index of top points on +ve side of fault
+                kp_bot = kp_top + 1
+                papl_top = papln[
+                    kp_top]  # point distances in local vector space; note local vector is different for pillars a and b
+                papl_bot = papln[kp_bot]
+                pbpl_top = pbpln[kp_top]
+                pbpl_bot = pbpln[kp_bot]
+                if np.any(np.isnan((papl_top, papl_bot, pbpl_top, pbpl_bot))):
+                    continue
+                # in following comments, 'shallower' means less distance in local vector, which is a K direction vector of sorts
+                if (paml_top >= papl_bot - tol) and (pbml_top >= pbpl_bot - tol):
+                    continue  # p fully shallower than m
+                if (paml_bot <= papl_top + tol) and (pbml_bot <= pbpl_top + tol):
+                    continue  # p fully deeper than m
+                # juxtaposition established, now determine fractional overlap area from perspectives of both sides of fault
+                fa_m = fractional_area(paml_top,
+                                       paml_bot,
+                                       papl_top,
+                                       papl_bot,
+                                       pbml_top,
+                                       pbml_bot,
+                                       pbpl_top,
+                                       pbpl_bot,
+                                       tol = tol)
+                fa_p = fractional_area(papl_top,
+                                       papl_bot,
+                                       paml_top,
+                                       paml_bot,
+                                       pbpl_top,
+                                       pbpl_bot,
+                                       pbml_top,
+                                       pbml_bot,
+                                       tol = tol)
+                log.debug(f'K {km} {fa_m}  <->  {fa_p} {kp}')
+                fa_m = min(max(fa_m, 0.0), 1.0)
+                fa_p = min(max(fa_p, 0.0), 1.0)
+                juxta_list.append((km, kp, fa_m, fa_p))
+                fa_m_total += fa_m
+                fa_p_totals[kp] += fa_p
+            # find sum of fractional areas by layer (separately for both perspectives); normalise to max of 1.0
+            if fa_m_total > 1.0:
+                fa_m_downscaling_count += 1
+                if fa_m_total > fa_m_worst_scaling:
+                    fa_m_worst_scaling = fa_m_total
+                    # log.warning(f'downscaling fractional areas on minus side of fault by factor of {fa_m_total} in layer {km}')
+                for i in range(km_start_index, len(juxta_list)):
+                    (km, kp, fa_m, fa_p) = juxta_list[i]
+                    juxta_list[i] = (km, kp, fa_m / fa_m_total, fa_p)
+        any_p_scaling = False
+        fa_p_worst_scaling = np.nanmax(fa_p_totals)
+        fa_p_downscaling_count = 0
+        for kp in range(grid.nk):
             if fa_p_totals[kp] > 1.0:
-               juxta_list[i] = (km, kp, fa_m, fa_p / fa_p_totals[kp])
-      return juxta_list, (fa_m_downscaling_count, fa_p_downscaling_count, fa_m_worst_scaling, fa_p_worst_scaling)
+                fa_p_downscaling_count += 1
+                # log.warning(f'downscaling fractional areas on plus side of fault by factor of {fa_p_totals[kp]} in layer {kp}')
+                any_p_scaling = True
+        if any_p_scaling:
+            for i in range(len(juxta_list)):
+                (km, kp, fa_m, fa_p) = juxta_list[i]
+                if fa_p_totals[kp] > 1.0:
+                    juxta_list[i] = (km, kp, fa_m, fa_p / fa_p_totals[kp])
+        return juxta_list, (fa_m_downscaling_count, fa_p_downscaling_count, fa_m_worst_scaling, fa_p_worst_scaling)
 
-   if not grid.has_split_coordinate_lines:
-      return None, None
-   skip_inactive = skip_inactive and hasattr(grid, 'inactive') and grid.inactive is not None
+    if not grid.has_split_coordinate_lines:
+        return None, None
+    skip_inactive = skip_inactive and hasattr(grid, 'inactive') and grid.inactive is not None
 
-   p = grid.points_ref(masked = False)  # shape (nk + k_gaps + 1, np, 3)
-   pv = vec.unit_vectors(p[-1] - p[0])  # pillar vectors; shape (np, 3); could postpone to individual pillar work
-   col_j_split, col_i_split = grid.split_column_faces()  # internal only column faces; shapes (nj - 1, ni), (nj, ni - 1)
-   pfc = grid.create_column_pillar_mapping()  # pillars for column; shape (nj, ni, 2, 2)
+    p = grid.points_ref(masked = False)  # shape (nk + k_gaps + 1, np, 3)
+    pv = vec.unit_vectors(p[-1] - p[0])  # pillar vectors; shape (np, 3); could postpone to individual pillar work
+    col_j_split, col_i_split = grid.split_column_faces(
+    )  # internal only column faces; shapes (nj - 1, ni), (nj, ni - 1)
+    pfc = grid.create_column_pillar_mapping()  # pillars for column; shape (nj, ni, 2, 2)
 
-   juxtaposed_j_list = []
-   j_ji = np.stack(np.where(col_j_split)).T  # ji0 columns where +J face is split; shape (nc, 2)
-   warning_count = 0
-   for (j, i) in j_ji:
-      log.debug(f'J, I  {j}, {i}')
-      pam = pfc[j, i, 1, 0]  # pillar index for -I edge of J face, for col on -J side of fault
-      pap = pfc[j + 1, i, 0, 0]  # pillar index for -I edge of J face, for col on +J side of fault
-      pbm = pfc[j, i, 1, 1]  # pillar index for +I edge of J face, for col on -J side of fault
-      pbp = pfc[j + 1, i, 0, 1]  # pillar index for +I edge of J face, for col on +J side of fault
-      ji_list, scaling_info = juxtapose(grid, p, pv, pam, pap, pbm, pbp)
-      if scaling_info[2] > 1.2 or scaling_info[3] > 1.2:
-         if warning_count < 20:
-            log.warning(
-               f'severe downscaling for I+ face in column ({j}, {i}); worst m {scaling_info[2]}; worst p {scaling_info[3]}'
-            )
-         elif warning_count == 20:
-            log.warning('other similar I face warnings suppressed')
-         warning_count += 1
-      for (km, kp, fa_m, fa_p) in ji_list:
-         if skip_inactive and (grid.inactive[km, j, i] or grid.inactive[kp, j + 1, i]):
-            continue
-         juxtaposed_j_list.append(((km, j, i), (kp, j + 1, i), fa_m, fa_p))
-   juxtaposed_i_list = []
-   i_ji = np.stack(np.where(col_i_split)).T  # ji0 columns where +I face is split; shape (nc, 2)
-   warning_count = 0
-   for (j, i) in i_ji:
-      pam = pfc[j, i, 0, 1]  # pillar index for -J edge of I face, for col on -I side of fault
-      pap = pfc[j, i + 1, 0, 0]  # pillar index for -J edge of I face, for col on +I side of fault
-      pbm = pfc[j, i, 1, 1]  # pillar index for +J edge of I face, for col on -I side of fault
-      pbp = pfc[j, i + 1, 1, 0]  # pillar index for +J edge of I face, for col on +I side of fault
-      ji_list, scaling_info = juxtapose(grid, p, pv, pam, pap, pbm, pbp)
-      if scaling_info[2] > 1.2 or scaling_info[3] > 1.2:
-         if warning_count < 20:
-            log.warning(
-               f'severe downscaling for J+ face in column ({j}, {i}); worst m {scaling_info[2]}; worst p {scaling_info[3]}'
-            )
-         elif warning_count == 20:
-            log.warning('other similar J face warnings suppressed')
-         warning_count += 1
-      for (km, kp, fa_m, fa_p) in ji_list:
-         if skip_inactive and (grid.inactive[km, j, i] or grid.inactive[kp, j, i + 1]):
-            continue
-         juxtaposed_i_list.append(((km, j, i), (kp, j, i + 1), fa_m, fa_p))
+    juxtaposed_j_list = []
+    j_ji = np.stack(np.where(col_j_split)).T  # ji0 columns where +J face is split; shape (nc, 2)
+    warning_count = 0
+    for (j, i) in j_ji:
+        log.debug(f'J, I  {j}, {i}')
+        pam = pfc[j, i, 1, 0]  # pillar index for -I edge of J face, for col on -J side of fault
+        pap = pfc[j + 1, i, 0, 0]  # pillar index for -I edge of J face, for col on +J side of fault
+        pbm = pfc[j, i, 1, 1]  # pillar index for +I edge of J face, for col on -J side of fault
+        pbp = pfc[j + 1, i, 0, 1]  # pillar index for +I edge of J face, for col on +J side of fault
+        ji_list, scaling_info = juxtapose(grid, p, pv, pam, pap, pbm, pbp)
+        if scaling_info[2] > 1.2 or scaling_info[3] > 1.2:
+            if warning_count < 20:
+                log.warning(
+                    f'severe downscaling for I+ face in column ({j}, {i}); worst m {scaling_info[2]}; worst p {scaling_info[3]}'
+                )
+            elif warning_count == 20:
+                log.warning('other similar I face warnings suppressed')
+            warning_count += 1
+        for (km, kp, fa_m, fa_p) in ji_list:
+            if skip_inactive and (grid.inactive[km, j, i] or grid.inactive[kp, j + 1, i]):
+                continue
+            juxtaposed_j_list.append(((km, j, i), (kp, j + 1, i), fa_m, fa_p))
+    juxtaposed_i_list = []
+    i_ji = np.stack(np.where(col_i_split)).T  # ji0 columns where +I face is split; shape (nc, 2)
+    warning_count = 0
+    for (j, i) in i_ji:
+        pam = pfc[j, i, 0, 1]  # pillar index for -J edge of I face, for col on -I side of fault
+        pap = pfc[j, i + 1, 0, 0]  # pillar index for -J edge of I face, for col on +I side of fault
+        pbm = pfc[j, i, 1, 1]  # pillar index for +J edge of I face, for col on -I side of fault
+        pbp = pfc[j, i + 1, 1, 0]  # pillar index for +J edge of I face, for col on +I side of fault
+        ji_list, scaling_info = juxtapose(grid, p, pv, pam, pap, pbm, pbp)
+        if scaling_info[2] > 1.2 or scaling_info[3] > 1.2:
+            if warning_count < 20:
+                log.warning(
+                    f'severe downscaling for J+ face in column ({j}, {i}); worst m {scaling_info[2]}; worst p {scaling_info[3]}'
+                )
+            elif warning_count == 20:
+                log.warning('other similar J face warnings suppressed')
+            warning_count += 1
+        for (km, kp, fa_m, fa_p) in ji_list:
+            if skip_inactive and (grid.inactive[km, j, i] or grid.inactive[kp, j, i + 1]):
+                continue
+            juxtaposed_i_list.append(((km, j, i), (kp, j, i + 1), fa_m, fa_p))
 
-   combo_list = juxtaposed_j_list + juxtaposed_i_list
-   count = len(combo_list)
-   if count == 0:
-      return None, None
+    combo_list = juxtaposed_j_list + juxtaposed_i_list
+    count = len(combo_list)
+    if count == 0:
+        return None, None
 
-   # build connection set
-   fcs = rqf.GridConnectionSet(grid.model, grid = grid)
-   fcs.grid_list = [grid]
-   fcs.count = count
-   fcs.grid_index_pairs = np.zeros((count, 2), dtype = int)
-   fcs.cell_index_pairs = np.zeros((count, 2), dtype = int)
-   fcs.cell_index_pairs[:] = np.array([
-      grid.natural_cell_indices(np.array([[k, j, i] for ((k, j, i), _, _, _) in combo_list])),
-      grid.natural_cell_indices(np.array([[k, j, i] for (_, (k, j, i), _, _) in combo_list]))
-   ]).T
-   fcs.face_index_pairs = np.zeros((count, 2), dtype = int)
-   fcs.face_index_pairs[:len(juxtaposed_j_list), 0] = fcs.face_index_map[1, 1]  # J+
-   fcs.face_index_pairs[:len(juxtaposed_j_list), 1] = fcs.face_index_map[1, 0]  # J-
-   fcs.face_index_pairs[len(juxtaposed_j_list):, 0] = fcs.face_index_map[2, 1]  # I+
-   fcs.face_index_pairs[len(juxtaposed_j_list):, 1] = fcs.face_index_map[2, 0]  # I-
+    # build connection set
+    fcs = rqf.GridConnectionSet(grid.model, grid = grid)
+    fcs.grid_list = [grid]
+    fcs.count = count
+    fcs.grid_index_pairs = np.zeros((count, 2), dtype = int)
+    fcs.cell_index_pairs = np.zeros((count, 2), dtype = int)
+    fcs.cell_index_pairs[:] = np.array([
+        grid.natural_cell_indices(np.array([[k, j, i] for ((k, j, i), _, _, _) in combo_list])),
+        grid.natural_cell_indices(np.array([[k, j, i] for (_, (k, j, i), _, _) in combo_list]))
+    ]).T
+    fcs.face_index_pairs = np.zeros((count, 2), dtype = int)
+    fcs.face_index_pairs[:len(juxtaposed_j_list), 0] = fcs.face_index_map[1, 1]  # J+
+    fcs.face_index_pairs[:len(juxtaposed_j_list), 1] = fcs.face_index_map[1, 0]  # J-
+    fcs.face_index_pairs[len(juxtaposed_j_list):, 0] = fcs.face_index_map[2, 1]  # I+
+    fcs.face_index_pairs[len(juxtaposed_j_list):, 1] = fcs.face_index_map[2, 0]  # I-
 
-   feature_name = 'all faults with throw'
-   fcs.feature_indices = np.zeros(count, dtype = int)  # could create seperate features by named fracture
-   tbf = rqo.TectonicBoundaryFeature(grid.model, kind = 'fault', feature_name = feature_name)
-   tbf_root = tbf.create_xml()
-   fi = rqo.FaultInterpretation(grid.model, tectonic_boundary_feature = tbf, is_normal = True)
-   fi_root = fi.create_xml(tbf_root, title_suffix = None)
-   fi_uuid = rqet.uuid_for_part_root(fi_root)
+    feature_name = 'all faults with throw'
+    fcs.feature_indices = np.zeros(count, dtype = int)  # could create seperate features by named fracture
+    tbf = rqo.TectonicBoundaryFeature(grid.model, kind = 'fault', feature_name = feature_name)
+    tbf_root = tbf.create_xml()
+    fi = rqo.FaultInterpretation(grid.model, tectonic_boundary_feature = tbf, is_normal = True)
+    fi_root = fi.create_xml(tbf_root, title_suffix = None)
+    fi_uuid = rqet.uuid_for_part_root(fi_root)
 
-   fcs.feature_list = [('obj_FaultInterpretation', fi_uuid, str(feature_name))]
+    fcs.feature_list = [('obj_FaultInterpretation', fi_uuid, str(feature_name))]
 
-   fa = np.array([[fa_m, fa_p] for (_, _, fa_m, fa_p) in combo_list])
+    fa = np.array([[fa_m, fa_p] for (_, _, fa_m, fa_p) in combo_list])
 
-   return fcs, fa
+    return fcs, fa
 
 
 def projected_tri_area(pa, pb, pc):
-   """Return array holding areas of triangles projected onto each of yz, xz, xy.
+    """Return array holding areas of triangles projected onto each of yz, xz, xy.
 
    arguments:
       pa, pb, pc (numpy float array of shape (..., 3): the corner points of a set of triangles (one corner
@@ -1140,19 +1157,19 @@ def projected_tri_area(pa, pb, pc):
       assumes that units for x, y & z are the same; returned area units are those implicit units squared
    """
 
-   assert pa.shape == pb.shape == pc.shape and pa.shape[-1] == 3
+    assert pa.shape == pb.shape == pc.shape and pa.shape[-1] == 3
 
-   area = np.empty(pa.shape)
-   for xyz in range(3):
-      xyz_0 = (xyz + 1) % 3
-      xyz_1 = (xyz + 2) % 3
-      pap = np.stack((pa[..., xyz_0], pa[..., xyz_1]), axis = -1)  # points projected onto 2D
-      pbp = np.stack((pb[..., xyz_0], pb[..., xyz_1]), axis = -1)
-      pcp = np.stack((pc[..., xyz_0], pc[..., xyz_1]), axis = -1)
-      lap = vec.naive_lengths(pbp - pap)  # 2D triangle edge vector lengths
-      lbp = vec.naive_lengths(pcp - pbp)
-      lcp = vec.naive_lengths(pap - pcp)
-      s = 0.5 * (lap + lbp + lcp)  # 2D triangle semi perimeter lengths
-      area[..., xyz] = np.sqrt(s * (s - lap) * (s - lbp) * (s - lcp))
+    area = np.empty(pa.shape)
+    for xyz in range(3):
+        xyz_0 = (xyz + 1) % 3
+        xyz_1 = (xyz + 2) % 3
+        pap = np.stack((pa[..., xyz_0], pa[..., xyz_1]), axis = -1)  # points projected onto 2D
+        pbp = np.stack((pb[..., xyz_0], pb[..., xyz_1]), axis = -1)
+        pcp = np.stack((pc[..., xyz_0], pc[..., xyz_1]), axis = -1)
+        lap = vec.naive_lengths(pbp - pap)  # 2D triangle edge vector lengths
+        lbp = vec.naive_lengths(pcp - pbp)
+        lcp = vec.naive_lengths(pap - pcp)
+        s = 0.5 * (lap + lbp + lcp)  # 2D triangle semi perimeter lengths
+        area[..., xyz] = np.sqrt(s * (s - lap) * (s - lbp) * (s - lcp))
 
-   return area
+    return area

--- a/resqpy/olio/triangulation.py
+++ b/resqpy/olio/triangulation.py
@@ -21,193 +21,193 @@ import resqpy.olio.intersection as meet
 
 
 def _dt_simple(po, plot_fn = None, progress_fn = None, container_size_factor = None):
-   # returns Delauney triangulation of po and list of hull point indices, using a simple algorithm
+    # returns Delauney triangulation of po and list of hull point indices, using a simple algorithm
 
-   def flip(ei):
-      nonlocal fm, e, t, te, p, nt, p_i, ne
-      if fm[ei]:
-         return  # this edge has already been flipped since last point insertion
-      t0, te0 = e[ei, 0]
-      t1, te1 = e[ei, 1]
-      if t0 < 0 or t1 < 0:
-         return  # no triangle on other side
-      t0n = te0 - 1
-      if t0n < 0:
-         t0n = 2
-      t1n = te1 - 1
-      if t1n < 0:
-         t1n = 2
-      if (not vec.in_circumcircle(p[t[t0, 0]], p[t[t0, 1]], p[t[t0, 2]], p[t[t1, t1n]]) and
-          not vec.in_circumcircle(p[t[t1, 0]], p[t[t1, 1]], p[t[t1, 2]], p[t[t0, t0n]])):
-         return  # not sure both are needed
-      # flip needed
-      ft0 = (t[t0, te0], t[t1, t1n], t[t0, t0n])
-      ft1 = (t[t1, te1], t[t0, t0n], t[t1, t1n])
-      e[ei, :, 1] = 1
-      fte0 = (te[t1, 3 - (te1 + t1n)], ei, te[t0, t0n])
-      fte1 = (te[t0, 3 - (te0 + t0n)], ei, te[t1, t1n])
-      if e[fte0[0], 0, 0] == t1:
-         e[fte0[0], 0] = (t0, 0)
-      elif e[fte0[0], 1, 0] == t1:
-         e[fte0[0], 1] = (t0, 0)
-      else:
-         raise Exception('edge breakdown')
-      if e[fte1[0], 0, 0] == t0:
-         e[fte1[0], 0] = (t1, 0)
-      elif e[fte1[0], 1, 0] == t0:
-         e[fte1[0], 1] = (t1, 0)
-      else:
-         raise Exception('edge breakdown')
-      if e[fte0[2], 0, 0] == t0:
-         e[fte0[2], 0, 1] = 2
-      elif e[fte0[2], 1, 0] == t0:
-         e[fte0[2], 1, 1] = 2
-      else:
-         raise Exception('edge breakdown')
-      if e[fte1[2], 0, 0] == t1:
-         e[fte1[2], 0, 1] = 2
-      elif e[fte1[2], 1, 0] == t1:
-         e[fte1[2], 1, 1] = 2
-      else:
-         raise Exception('edge breakdown')
-      t[t0] = ft0
-      t[t1] = ft1
-      te[t0] = fte0
-      te[t1] = fte1
-      fm[ei] = True
-      # debug plot here
-      if plot_fn is not None:
-         plot_fn(p, t[:nt])
-      # recursively flip, not sure all these are needed
-      flip(fte0[0])
-      flip(fte0[2])
-      flip(fte1[0])
-      flip(fte1[2])
+    def flip(ei):
+        nonlocal fm, e, t, te, p, nt, p_i, ne
+        if fm[ei]:
+            return  # this edge has already been flipped since last point insertion
+        t0, te0 = e[ei, 0]
+        t1, te1 = e[ei, 1]
+        if t0 < 0 or t1 < 0:
+            return  # no triangle on other side
+        t0n = te0 - 1
+        if t0n < 0:
+            t0n = 2
+        t1n = te1 - 1
+        if t1n < 0:
+            t1n = 2
+        if (not vec.in_circumcircle(p[t[t0, 0]], p[t[t0, 1]], p[t[t0, 2]], p[t[t1, t1n]]) and
+                not vec.in_circumcircle(p[t[t1, 0]], p[t[t1, 1]], p[t[t1, 2]], p[t[t0, t0n]])):
+            return  # not sure both are needed
+        # flip needed
+        ft0 = (t[t0, te0], t[t1, t1n], t[t0, t0n])
+        ft1 = (t[t1, te1], t[t0, t0n], t[t1, t1n])
+        e[ei, :, 1] = 1
+        fte0 = (te[t1, 3 - (te1 + t1n)], ei, te[t0, t0n])
+        fte1 = (te[t0, 3 - (te0 + t0n)], ei, te[t1, t1n])
+        if e[fte0[0], 0, 0] == t1:
+            e[fte0[0], 0] = (t0, 0)
+        elif e[fte0[0], 1, 0] == t1:
+            e[fte0[0], 1] = (t0, 0)
+        else:
+            raise Exception('edge breakdown')
+        if e[fte1[0], 0, 0] == t0:
+            e[fte1[0], 0] = (t1, 0)
+        elif e[fte1[0], 1, 0] == t0:
+            e[fte1[0], 1] = (t1, 0)
+        else:
+            raise Exception('edge breakdown')
+        if e[fte0[2], 0, 0] == t0:
+            e[fte0[2], 0, 1] = 2
+        elif e[fte0[2], 1, 0] == t0:
+            e[fte0[2], 1, 1] = 2
+        else:
+            raise Exception('edge breakdown')
+        if e[fte1[2], 0, 0] == t1:
+            e[fte1[2], 0, 1] = 2
+        elif e[fte1[2], 1, 0] == t1:
+            e[fte1[2], 1, 1] = 2
+        else:
+            raise Exception('edge breakdown')
+        t[t0] = ft0
+        t[t1] = ft1
+        te[t0] = fte0
+        te[t1] = fte1
+        fm[ei] = True
+        # debug plot here
+        if plot_fn is not None:
+            plot_fn(p, t[:nt])
+        # recursively flip, not sure all these are needed
+        flip(fte0[0])
+        flip(fte0[2])
+        flip(fte1[0])
+        flip(fte1[2])
 
-   n_p = len(po)
-   if n_p < 3:
-      return None, None  # not enough points
-   elif n_p == 3:
-      return (np.array([0, 1, 2], dtype = int).reshape((1, 3)), np.array([0, 1, 2], dtype = int))
+    n_p = len(po)
+    if n_p < 3:
+        return None, None  # not enough points
+    elif n_p == 3:
+        return (np.array([0, 1, 2], dtype = int).reshape((1, 3)), np.array([0, 1, 2], dtype = int))
 
-   if progress_fn is not None:
-      progress_fn(0.0)
+    if progress_fn is not None:
+        progress_fn(0.0)
 
-   min_xy = np.min(po[:, :2], axis = 0)
-   max_xy = np.max(po[:, :2], axis = 0)
-   dxy = max_xy - min_xy
-   assert dxy[0] > 0.0 and dxy[1] > 0.0, 'points lie in straight line or are conincident'
-   p = np.empty((n_p + 3, 2))
-   p[:-3] = po[:, :2]
-   # add 3 points sure of containing all po
-   csf = 100.0 if container_size_factor is None else max(1.0, container_size_factor)
-   p[-3] = (min_xy[0] - 0.8 * csf * dxy[0], min_xy[1] - 0.1 * csf * dxy[1])
-   p[-2] = (max_xy[0] + 0.8 * csf * dxy[0], min_xy[1] - 0.1 * csf * dxy[1])
-   p[-1] = (min_xy[0] + 0.5 * csf * dxy[0], max_xy[1] + 0.8 * csf * dxy[1])
+    min_xy = np.min(po[:, :2], axis = 0)
+    max_xy = np.max(po[:, :2], axis = 0)
+    dxy = max_xy - min_xy
+    assert dxy[0] > 0.0 and dxy[1] > 0.0, 'points lie in straight line or are conincident'
+    p = np.empty((n_p + 3, 2))
+    p[:-3] = po[:, :2]
+    # add 3 points sure of containing all po
+    csf = 100.0 if container_size_factor is None else max(1.0, container_size_factor)
+    p[-3] = (min_xy[0] - 0.8 * csf * dxy[0], min_xy[1] - 0.1 * csf * dxy[1])
+    p[-2] = (max_xy[0] + 0.8 * csf * dxy[0], min_xy[1] - 0.1 * csf * dxy[1])
+    p[-1] = (min_xy[0] + 0.5 * csf * dxy[0], max_xy[1] + 0.8 * csf * dxy[1])
 
-   # triangle vertex indices
-   t = np.empty((2 * n_p + 2, 3), dtype = int)  # empty space for triangle vertex indices
-   t[0] = (n_p, n_p + 1, n_p + 2)  # initial set of one containing triangle
-   nt = 1  # number of triangles so far populated
+    # triangle vertex indices
+    t = np.empty((2 * n_p + 2, 3), dtype = int)  # empty space for triangle vertex indices
+    t[0] = (n_p, n_p + 1, n_p + 2)  # initial set of one containing triangle
+    nt = 1  # number of triangles so far populated
 
-   # edges: list of indices of triangles and edge within triangle; -1 indicates no triangle using edge
-   e = np.full((3 * n_p + 6, 2, 2), fill_value = -1, dtype = int)
-   e[:3, 0, 0] = 0
-   for edge in range(3):
-      e[edge, 0, 1] = edge
-   ne = 3  # number of edges so far in use
+    # edges: list of indices of triangles and edge within triangle; -1 indicates no triangle using edge
+    e = np.full((3 * n_p + 6, 2, 2), fill_value = -1, dtype = int)
+    e[:3, 0, 0] = 0
+    for edge in range(3):
+        e[edge, 0, 1] = edge
+    ne = 3  # number of edges so far in use
 
-   # edge indices (in e) for each triangle, first axis indexed in sync with t
-   te = np.empty((2 * n_p + 2, 3), dtype = int)  # empty space for triangle edge indices
-   te[0] = (0, 1, 2)
+    # edge indices (in e) for each triangle, first axis indexed in sync with t
+    te = np.empty((2 * n_p + 2, 3), dtype = int)  # empty space for triangle edge indices
+    te[0] = (0, 1, 2)
 
-   # mask tracking which edges have been flipped
-   fm = np.zeros((3 * n_p + 6), dtype = bool)
+    # mask tracking which edges have been flipped
+    fm = np.zeros((3 * n_p + 6), dtype = bool)
 
-   # debug plot here
-   #   if plot_fn: plot_fn(p, t[:nt])
+    # debug plot here
+    #   if plot_fn: plot_fn(p, t[:nt])
 
-   progress_period = max(n_p // 100, 1)
-   progress_count = progress_period
+    progress_period = max(n_p // 100, 1)
+    progress_count = progress_period
 
-   for p_i in range(n_p):  # index of next point to consider
+    for p_i in range(n_p):  # index of next point to consider
 
-      if progress_fn is not None and progress_count <= 0:
-         progress_fn(float(p_i) / float(n_p))
-         progress_count = progress_period
+        if progress_fn is not None and progress_count <= 0:
+            progress_fn(float(p_i) / float(n_p))
+            progress_count = progress_period
 
-      # find triangle that contains this point
-      f_t = None
+        # find triangle that contains this point
+        f_t = None
 
-      for ti in range(nt):
-         if vec.in_triangle_edged(p[t[ti, 0]], p[t[ti, 1]], p[t[ti, 2]], p[p_i]):
-            f_t = ti
-            break
-      assert f_t is not None, 'failed to find triangle containing point'
+        for ti in range(nt):
+            if vec.in_triangle_edged(p[t[ti, 0]], p[t[ti, 1]], p[t[ti, 2]], p[p_i]):
+                f_t = ti
+                break
+        assert f_t is not None, 'failed to find triangle containing point'
 
-      # take copy of edge indices for containing triangle
-      e0, e1, e2 = te[f_t]
+        # take copy of edge indices for containing triangle
+        e0, e1, e2 = te[f_t]
 
-      # split containing triangle into 3, using new point as common vertex
-      t[nt] = (t[f_t, 1], t[f_t, 2], p_i)
-      t[nt + 1] = (t[f_t, 2], t[f_t, 0], p_i)
-      t[f_t, 2] = p_i
-      # add 3 new edges and update te
-      e[ne, 0] = (f_t, 2)
-      e[ne, 1] = (nt + 1, 1)
-      e[ne + 1, 0] = (f_t, 1)
-      e[ne + 1, 1] = (nt, 2)
-      e[ne + 2, 0] = (nt, 1)
-      e[ne + 2, 1] = (nt + 1, 2)
-      if e[e1, 0, 0] == f_t:
-         e[e1, 0] = (nt, 0)
-      elif e[e1, 1, 0] == f_t:
-         e[e1, 1] = (nt, 0)
-      else:
-         raise Exception('edge breakdown')
-      if e[e2, 0, 0] == f_t:
-         e[e2, 0] = (nt + 1, 0)
-      elif e[e2, 1, 0] == f_t:
-         e[e2, 1] = (nt + 1, 0)
-      else:
-         raise Exception('edge breakdown')
-      te[nt] = (e1, ne + 2, ne + 1)
-      te[nt + 1] = (e2, ne, ne + 2)
-      te[f_t, 1] = ne + 1
-      te[f_t, 2] = ne
+        # split containing triangle into 3, using new point as common vertex
+        t[nt] = (t[f_t, 1], t[f_t, 2], p_i)
+        t[nt + 1] = (t[f_t, 2], t[f_t, 0], p_i)
+        t[f_t, 2] = p_i
+        # add 3 new edges and update te
+        e[ne, 0] = (f_t, 2)
+        e[ne, 1] = (nt + 1, 1)
+        e[ne + 1, 0] = (f_t, 1)
+        e[ne + 1, 1] = (nt, 2)
+        e[ne + 2, 0] = (nt, 1)
+        e[ne + 2, 1] = (nt + 1, 2)
+        if e[e1, 0, 0] == f_t:
+            e[e1, 0] = (nt, 0)
+        elif e[e1, 1, 0] == f_t:
+            e[e1, 1] = (nt, 0)
+        else:
+            raise Exception('edge breakdown')
+        if e[e2, 0, 0] == f_t:
+            e[e2, 0] = (nt + 1, 0)
+        elif e[e2, 1, 0] == f_t:
+            e[e2, 1] = (nt + 1, 0)
+        else:
+            raise Exception('edge breakdown')
+        te[nt] = (e1, ne + 2, ne + 1)
+        te[nt + 1] = (e2, ne, ne + 2)
+        te[f_t, 1] = ne + 1
+        te[f_t, 2] = ne
 
-      nt += 2
-      ne += 3
+        nt += 2
+        ne += 3
 
-      # now recursively try flipping sides
-      fm[:] = False
+        # now recursively try flipping sides
+        fm[:] = False
 
-      # debug plot here, with new point, before flipping
-      if plot_fn is not None:
-         plot_fn(p, t[:nt])
+        # debug plot here, with new point, before flipping
+        if plot_fn is not None:
+            plot_fn(p, t[:nt])
 
-      flip(e0)
-      flip(e1)
-      flip(e2)
+        flip(e0)
+        flip(e1)
+        flip(e2)
 
-      progress_count -= 1
+        progress_count -= 1
 
-   # remove any triangles using invented container vertices
-   tri_set = t[np.where(np.all(t[:nt] < n_p, axis = 1))]
-   if plot_fn is not None:
-      plot_fn(p, tri_set)
+    # remove any triangles using invented container vertices
+    tri_set = t[np.where(np.all(t[:nt] < n_p, axis = 1))]
+    if plot_fn is not None:
+        plot_fn(p, tri_set)
 
-   external_t = t[np.where(np.any(t[:nt] >= n_p, axis = 1))]
-   external_pi = np.unique(external_t)[:-3]  # discard 3 invented container vertices
+    external_t = t[np.where(np.any(t[:nt] >= n_p, axis = 1))]
+    external_pi = np.unique(external_t)[:-3]  # discard 3 invented container vertices
 
-   if progress_fn is not None:
-      progress_fn(1.0)
+    if progress_fn is not None:
+        progress_fn(1.0)
 
-   return tri_set, external_pi
+    return tri_set, external_pi
 
 
 def dt(p, algorithm = None, plot_fn = None, progress_fn = None, container_size_factor = 100.0, return_hull = False):
-   """Returns the Delauney Triangulation of 2D point set p.
+    """Returns the Delauney Triangulation of 2D point set p.
 
    arguments:
       p (numpy float array of shape (N, 2): the x,y coordinates of the points
@@ -230,45 +230,45 @@ def dt(p, algorithm = None, plot_fn = None, progress_fn = None, container_size_f
          of shape (B,) - being indices into p of the clockwise ordered points on the boundary of
          the triangulation
    """
-   assert p.ndim == 2 and p.shape[1] >= 2, 'bad points shape for 2D Delauney Triangulation'
+    assert p.ndim == 2 and p.shape[1] >= 2, 'bad points shape for 2D Delauney Triangulation'
 
-   if not algorithm:
-      algorithm = 'simple'
+    if not algorithm:
+        algorithm = 'simple'
 
-   if algorithm == 'simple':
-      t, boundary = _dt_simple(p,
-                               plot_fn = plot_fn,
-                               progress_fn = progress_fn,
-                               container_size_factor = container_size_factor)
-      if return_hull:
-         return t, vec.clockwise_sorted_indices(p, boundary)
-      else:
-         return t
-   else:
-      raise Exception('unrecognised Delauney Triangulation algorithm name')
+    if algorithm == 'simple':
+        t, boundary = _dt_simple(p,
+                                 plot_fn = plot_fn,
+                                 progress_fn = progress_fn,
+                                 container_size_factor = container_size_factor)
+        if return_hull:
+            return t, vec.clockwise_sorted_indices(p, boundary)
+        else:
+            return t
+    else:
+        raise Exception('unrecognised Delauney Triangulation algorithm name')
 
 
 def ccc(p1, p2, p3):
-   """Returns the centre of the circumcircle of the three points in the xy plane."""
+    """Returns the centre of the circumcircle of the three points in the xy plane."""
 
-   # two edges as vectors
-   v12 = p2 - p1
-   v13 = p3 - p1
-   # midpoints of the two edges
-   m12 = 0.5 * (p1 + p2)
-   m13 = 0.5 * (p1 + p3)
-   # pairs of points defining two edge normals passing through the midpoints
-   o12 = m12.copy()
-   o12[0] += v12[1]
-   o12[1] -= v12[0]
-   o13 = m13.copy()
-   o13[0] += v13[1]
-   o13[1] -= v13[0]
-   return meet.line_line_intersect(m12[0], m12[1], o12[0], o12[1], m13[0], m13[1], o13[0], o13[1])
+    # two edges as vectors
+    v12 = p2 - p1
+    v13 = p3 - p1
+    # midpoints of the two edges
+    m12 = 0.5 * (p1 + p2)
+    m13 = 0.5 * (p1 + p3)
+    # pairs of points defining two edge normals passing through the midpoints
+    o12 = m12.copy()
+    o12[0] += v12[1]
+    o12[1] -= v12[0]
+    o13 = m13.copy()
+    o13[0] += v13[1]
+    o13[1] -= v13[0]
+    return meet.line_line_intersect(m12[0], m12[1], o12[0], o12[1], m13[0], m13[1], o13[0], o13[1])
 
 
 def voronoi(p, t, b, aoi):
-   """Returns dual Voronoi diagram for a Delauney triangulation.
+    """Returns dual Voronoi diagram for a Delauney triangulation.
 
    arguments:
       p (numpy float array of shape (N, 2)): seed points used in the Delauney triangulation
@@ -291,325 +291,331 @@ def voronoi(p, t, b, aoi):
       especially for smaller values of its container_size_factor argument
    """
 
-   # this code assumes that the Voronoi polygon for a seed point visits the circumcentres of
-   # all the triangles that make use of the point – currently understood to be always the case
-   # for a Delauney triangulation
+    # this code assumes that the Voronoi polygon for a seed point visits the circumcentres of
+    # all the triangles that make use of the point – currently understood to be always the case
+    # for a Delauney triangulation
 
-   def aoi_intervening_nodes(aoi_count, c_count, seg_a, seg_c):
-      nodes = []
-      seg = seg_a
-      while seg != seg_c:
-         seg = (seg + 1) % aoi_count
-         nodes.append(c_count + seg)
-      return nodes
+    def aoi_intervening_nodes(aoi_count, c_count, seg_a, seg_c):
+        nodes = []
+        seg = seg_a
+        while seg != seg_c:
+            seg = (seg + 1) % aoi_count
+            nodes.append(c_count + seg)
+        return nodes
 
-   def shorter_sides_p_i(p3):
-      max_length = -1.0
-      max_i = None
-      for i in range(3):
-         opp_length = vec.naive_length(p3[i - 1] - p3[i - 2])
-         if opp_length > max_length:
-            max_length = opp_length
-            max_i = i
-      return max_i
+    def shorter_sides_p_i(p3):
+        max_length = -1.0
+        max_i = None
+        for i in range(3):
+            opp_length = vec.naive_length(p3[i - 1] - p3[i - 2])
+            if opp_length > max_length:
+                max_length = opp_length
+                max_i = i
+        return max_i
 
-   def azi_between(a, c, t):
-      if c < a:
-         c += 360.0
-      return (a <= t <= c) or (a <= t + 360.0 <= c)
+    def azi_between(a, c, t):
+        if c < a:
+            c += 360.0
+        return (a <= t <= c) or (a <= t + 360.0 <= c)
 
-   def seg_for_ci(ci):  # returns hull segment for a boundary index
-      nonlocal ca_count, cah_count, caho_count, cahon_count, wing_hull_segments
-      if ci < ca_count:
-         return None
-      if ci < cah_count:  # hull edge intersection
-         return ci - ca_count
-      if ci < caho_count:  # wings
-         oi, wing = divmod(ci - cah_count, 2)
-         return wing_hull_segments[oi, wing]
-      if ci < cahon_count:  # virtual centre for hull edge
-         return ci - caho_count
-      # else virtual centre for hull point; arbitrarily pick clockwise segment
-      return ci - cahon_count
+    def seg_for_ci(ci):  # returns hull segment for a boundary index
+        nonlocal ca_count, cah_count, caho_count, cahon_count, wing_hull_segments
+        if ci < ca_count:
+            return None
+        if ci < cah_count:  # hull edge intersection
+            return ci - ca_count
+        if ci < caho_count:  # wings
+            oi, wing = divmod(ci - cah_count, 2)
+            return wing_hull_segments[oi, wing]
+        if ci < cahon_count:  # virtual centre for hull edge
+            return ci - caho_count
+        # else virtual centre for hull point; arbitrarily pick clockwise segment
+        return ci - cahon_count
 
-   # log.debug(f'\n\nVoronoi: nt: {len(p)}; nt: {len(t)}; hull: {len(b)}; aoi: {len(aoi.coordinates)}')
+    # log.debug(f'\n\nVoronoi: nt: {len(p)}; nt: {len(t)}; hull: {len(b)}; aoi: {len(aoi.coordinates)}')
 # todo: allow aoi to be None in which case create an aoi as hull with border
 
-   assert p.ndim == 2 and p.shape[0] > 2 and p.shape[1] >= 2
-   assert t.ndim == 2 and t.shape[1] == 3
-   assert b.ndim == 1 and b.shape[0] > 2
-   assert len(aoi.coordinates) >= 3
-   assert aoi.isclosed
-   assert aoi.is_clockwise()
+    assert p.ndim == 2 and p.shape[0] > 2 and p.shape[1] >= 2
+    assert t.ndim == 2 and t.shape[1] == 3
+    assert b.ndim == 1 and b.shape[0] > 2
+    assert len(aoi.coordinates) >= 3
+    assert aoi.isclosed
+    assert aoi.is_clockwise()
 
-   # create temporary polyline for hull of triangulation
-   hull = rql.Polyline(
-      aoi.model,
-      set_bool = True,  # polyline is closed
-      set_coord = p[b],
-      set_crs = aoi.crs_uuid,
-      title = 'triangulation hull')
-   hull_count = len(b)
+    # create temporary polyline for hull of triangulation
+    hull = rql.Polyline(
+        aoi.model,
+        set_bool = True,  # polyline is closed
+        set_coord = p[b],
+        set_crs = aoi.crs_uuid,
+        title = 'triangulation hull')
+    hull_count = len(b)
 
-   # check for concavities in hull
-   if not hull.is_convex():
-      log.warning('Delauney triangulation is not convex; Voronoi diagram construction might fail')
+    # check for concavities in hull
+    if not hull.is_convex():
+        log.warning('Delauney triangulation is not convex; Voronoi diagram construction might fail')
 
-   # compute circumcircle centres
-   c = np.zeros((t.shape[0], 2))
-   for ti in range(len(t)):
-      c[ti] = ccc(p[t[ti, 0]], p[t[ti, 1]], p[t[ti, 2]])
-   c_count = len(c)
+    # compute circumcircle centres
+    c = np.zeros((t.shape[0], 2))
+    for ti in range(len(t)):
+        c[ti] = ccc(p[t[ti, 0]], p[t[ti, 1]], p[t[ti, 2]])
+    c_count = len(c)
 
-   # make list of triangle indices whose circumcircle centres are outwith the area of interest
-   tc_outwith_aoi = [ti for ti in range(c_count) if not aoi.point_is_inside_xy(c[ti])]
-   o_count = len(tc_outwith_aoi)
+    # make list of triangle indices whose circumcircle centres are outwith the area of interest
+    tc_outwith_aoi = [ti for ti in range(c_count) if not aoi.point_is_inside_xy(c[ti])]
+    o_count = len(tc_outwith_aoi)
 
-   # make space for combined points data needed for all voronoi cell nodes:
-   # 1. circumcircle centres for triangles in delauney triangulation
-   # 2. nodes defining area of interest polygon
-   # 3. intersection of normals to triangulation hull edges with aoi polygon
-   # 4. extra intersections for normals to other two (non-hull) triangle edges, with aoi,
-   #    where circumcircle centre is outside the area of interest
-   # 5. extended ccc for hull edge normals
-   # 6. extended ccc for hull points
-   # (5 & 6 only used during construction)
-   c = np.concatenate((c, aoi.coordinates[:, :2], np.zeros(
-      (hull_count, 2), dtype = float), np.zeros(
-         (2 * o_count, 2), dtype = float), np.zeros((hull_count, 2),
-                                                    dtype = float), np.zeros((hull_count, 2), dtype = float)))
-   aoi_count = len(aoi.coordinates)
-   ca_count = c_count + aoi_count
-   cah_count = ca_count + hull_count
-   caho_count = cah_count + 2 * o_count
-   cahon_count = caho_count + hull_count
-   assert cahon_count + hull_count == len(c)
+    # make space for combined points data needed for all voronoi cell nodes:
+    # 1. circumcircle centres for triangles in delauney triangulation
+    # 2. nodes defining area of interest polygon
+    # 3. intersection of normals to triangulation hull edges with aoi polygon
+    # 4. extra intersections for normals to other two (non-hull) triangle edges, with aoi,
+    #    where circumcircle centre is outside the area of interest
+    # 5. extended ccc for hull edge normals
+    # 6. extended ccc for hull points
+    # (5 & 6 only used during construction)
+    c = np.concatenate((c, aoi.coordinates[:, :2], np.zeros(
+        (hull_count, 2), dtype = float), np.zeros(
+            (2 * o_count, 2), dtype = float), np.zeros((hull_count, 2),
+                                                       dtype = float), np.zeros((hull_count, 2), dtype = float)))
+    aoi_count = len(aoi.coordinates)
+    ca_count = c_count + aoi_count
+    cah_count = ca_count + hull_count
+    caho_count = cah_count + 2 * o_count
+    cahon_count = caho_count + hull_count
+    assert cahon_count + hull_count == len(c)
 
-   # compute intersection points between hull edge normals and aoi polyline
-   # also extended virtual centres for hull edges
-   extension_scaling = 1000.0 * np.sum((np.max(aoi.coordinates, axis = 0) - np.min(aoi.coordinates, axis = 0))[:2])
-   aoi_intersect_segments = np.empty((hull_count,), dtype = int)
-   for ei in range(len(b)):
-      # use segment midpoint and normal methods of hull to project out
-      m = hull.segment_midpoint(ei)[:2]  # midpoint
-      norm_vec = hull.segment_normal(ei)[:2]
-      n = m + norm_vec  # point on normal
-      # use first intersection method of aoi to intersect projected normal from triangulation hull
-      aoi_seg, aoi_x, aoi_y = aoi.first_line_intersection(m[0], m[1], n[0], n[1], half_segment = True)
-      assert aoi_seg is not None
-      # inject intersection points to extension area of c and take note of aoi segment of intersection
-      c[ca_count + ei] = (aoi_x, aoi_y)
-      aoi_intersect_segments[ei] = aoi_seg
-      # inject extended virtual circle centres for hull edges, a long way out
-      c[caho_count + ei] = c[ca_count + ei] + extension_scaling * norm_vec
+    # compute intersection points between hull edge normals and aoi polyline
+    # also extended virtual centres for hull edges
+    extension_scaling = 1000.0 * np.sum((np.max(aoi.coordinates, axis = 0) - np.min(aoi.coordinates, axis = 0))[:2])
+    aoi_intersect_segments = np.empty((hull_count,), dtype = int)
+    for ei in range(len(b)):
+        # use segment midpoint and normal methods of hull to project out
+        m = hull.segment_midpoint(ei)[:2]  # midpoint
+        norm_vec = hull.segment_normal(ei)[:2]
+        n = m + norm_vec  # point on normal
+        # use first intersection method of aoi to intersect projected normal from triangulation hull
+        aoi_seg, aoi_x, aoi_y = aoi.first_line_intersection(m[0], m[1], n[0], n[1], half_segment = True)
+        assert aoi_seg is not None
+        # inject intersection points to extension area of c and take note of aoi segment of intersection
+        c[ca_count + ei] = (aoi_x, aoi_y)
+        aoi_intersect_segments[ei] = aoi_seg
+        # inject extended virtual circle centres for hull edges, a long way out
+        c[caho_count + ei] = c[ca_count + ei] + extension_scaling * norm_vec
 
-   # compute extended virtual centres for hull nodes
-   for ei in range(len(b)):
-      pei = (ei - 1) % len(b)
-      vector = vec.unit_vector(hull.segment_normal(pei)[:2] + hull.segment_normal(ei)[:2])
-      c[cahon_count + ei] = hull.coordinates[ei, :2] + extension_scaling * vector
+    # compute extended virtual centres for hull nodes
+    for ei in range(len(b)):
+        pei = (ei - 1) % len(b)
+        vector = vec.unit_vector(hull.segment_normal(pei)[:2] + hull.segment_normal(ei)[:2])
+        c[cahon_count + ei] = hull.coordinates[ei, :2] + extension_scaling * vector
 
-   # where cicrumcircle centres are outwith aoi, compute intersections of normals of wing edges with aoi
-   out_pair_intersect_segments = np.empty((o_count, 2), dtype = int)
-   wing_hull_segments = np.empty((o_count, 2), dtype = int)
-   for oi, ti in enumerate(tc_outwith_aoi):
-      tpi = shorter_sides_p_i(p[t[ti]])
-      for wing in range(2):
-         # note: triangle nodes are anticlockwise
-         m = 0.5 * (p[t[ti, tpi - 1]] + p[t[ti, tpi]])[:2]  # triangle edge midpoint
-         edge_v = p[t[ti, tpi]] - p[t[ti, tpi - 1]]
-         n = m + np.array((-edge_v[1], edge_v[0]))  # point on perpendicular bisector of triangle edge
-         o_seg, o_x, o_y = aoi.first_line_intersection(m[0], m[1], n[0], n[1], half_segment = True)
-         c[cah_count + 2 * oi + wing] = (o_x, o_y)
-         out_pair_intersect_segments[oi, wing] = o_seg
-         wing_hull_segments[oi, wing], _, _ = hull.first_line_intersection(m[0], m[1], n[0], n[1], half_segment = True)
-         tpi = (tpi + 1) % 3
+    # where cicrumcircle centres are outwith aoi, compute intersections of normals of wing edges with aoi
+    out_pair_intersect_segments = np.empty((o_count, 2), dtype = int)
+    wing_hull_segments = np.empty((o_count, 2), dtype = int)
+    for oi, ti in enumerate(tc_outwith_aoi):
+        tpi = shorter_sides_p_i(p[t[ti]])
+        for wing in range(2):
+            # note: triangle nodes are anticlockwise
+            m = 0.5 * (p[t[ti, tpi - 1]] + p[t[ti, tpi]])[:2]  # triangle edge midpoint
+            edge_v = p[t[ti, tpi]] - p[t[ti, tpi - 1]]
+            n = m + np.array((-edge_v[1], edge_v[0]))  # point on perpendicular bisector of triangle edge
+            o_seg, o_x, o_y = aoi.first_line_intersection(m[0], m[1], n[0], n[1], half_segment = True)
+            c[cah_count + 2 * oi + wing] = (o_x, o_y)
+            out_pair_intersect_segments[oi, wing] = o_seg
+            wing_hull_segments[oi, wing], _, _ = hull.first_line_intersection(m[0],
+                                                                              m[1],
+                                                                              n[0],
+                                                                              n[1],
+                                                                              half_segment = True)
+            tpi = (tpi + 1) % 3
 
-   # list of voronoi cells (each a numpy list of node indices into c extended with aoi points etc)
-   v = []
+    # list of voronoi cells (each a numpy list of node indices into c extended with aoi points etc)
+    v = []
 
-   # for each seed point build the voronoi cell
-   for p_i in range(len(p)):
+    # for each seed point build the voronoi cell
+    for p_i in range(len(p)):
 
-      # find triangles making use of that point
-      ci_for_p = list(np.where(t == p_i)[0])
+        # find triangles making use of that point
+        ci_for_p = list(np.where(t == p_i)[0])
 
-      # if seed point is on hull boundary, introduce three extended virtual centres
-      b_i = None
-      if (p_i in b):
-         b_i = np.where(b == p_i)[0][0]  # index into hull coordinates
-         p_b_i = (b_i - 1) % hull_count  # predecessor, ie. anti-clockwise boundary point
-         ci_for_p += [caho_count + p_b_i, cahon_count + b_i, caho_count + b_i]
+        # if seed point is on hull boundary, introduce three extended virtual centres
+        b_i = None
+        if (p_i in b):
+            b_i = np.where(b == p_i)[0][0]  # index into hull coordinates
+            p_b_i = (b_i - 1) % hull_count  # predecessor, ie. anti-clockwise boundary point
+            ci_for_p += [caho_count + p_b_i, cahon_count + b_i, caho_count + b_i]
 
-      # find azimuths of vectors from seed point to circumcircle centres (and virtual centres)
-      azi = [vec.azimuth(centre - p[p_i, :2]) for centre in c[ci_for_p, :2]]
-      # if this is a hull seed point, make a note of azimuth to virtual centre
-      hull_node_azi = None if b_i is None else azi[-2]
-      # sort triangle indices for seed point into clockwise order of circumcircle (and virtual) centres
-      ci_for_p = [ti for (_, ti) in sorted(zip(azi, ci_for_p))]
+        # find azimuths of vectors from seed point to circumcircle centres (and virtual centres)
+        azi = [vec.azimuth(centre - p[p_i, :2]) for centre in c[ci_for_p, :2]]
+        # if this is a hull seed point, make a note of azimuth to virtual centre
+        hull_node_azi = None if b_i is None else azi[-2]
+        # sort triangle indices for seed point into clockwise order of circumcircle (and virtual) centres
+        ci_for_p = [ti for (_, ti) in sorted(zip(azi, ci_for_p))]
 
-      # where circumcirle (or virtual) centre is outwith aoi, replace with a point on aoi boundary
-      # virtual centres related to hull points (not hull edges) can be discarded
-      trimmed_ci = []
-      for ci in ci_for_p:
-         if ci < c_count:  # genuine triangle
-            if ci in tc_outwith_aoi:  # replace with one or two wing normal intersection points
-               oi = tc_outwith_aoi.index(ci)
-               wing_i = cah_count + 2 * oi
-               shorter_t_i = shorter_sides_p_i(p[t[ci]])
-               if t[ci, shorter_t_i] == p_i:
-                  trimmed_ci += [wing_i, wing_i + 1]
-               elif t[ci, shorter_t_i - 1] == p_i:
-                  trimmed_ci.append(wing_i)
-               else:
-                  trimmed_ci.append(wing_i + 1)
-            else:
-               trimmed_ci.append(ci)
-         elif ci < cahon_count:
-            # extended virtual centre for a hull edge (discard hull point virtual centres)
-            # replace with index for intersection point on aoi boundary
-            trimmed_ci.append(ca_count + ci - caho_count)
-      ci_for_p = trimmed_ci
+        # where circumcirle (or virtual) centre is outwith aoi, replace with a point on aoi boundary
+        # virtual centres related to hull points (not hull edges) can be discarded
+        trimmed_ci = []
+        for ci in ci_for_p:
+            if ci < c_count:  # genuine triangle
+                if ci in tc_outwith_aoi:  # replace with one or two wing normal intersection points
+                    oi = tc_outwith_aoi.index(ci)
+                    wing_i = cah_count + 2 * oi
+                    shorter_t_i = shorter_sides_p_i(p[t[ci]])
+                    if t[ci, shorter_t_i] == p_i:
+                        trimmed_ci += [wing_i, wing_i + 1]
+                    elif t[ci, shorter_t_i - 1] == p_i:
+                        trimmed_ci.append(wing_i)
+                    else:
+                        trimmed_ci.append(wing_i + 1)
+                else:
+                    trimmed_ci.append(ci)
+            elif ci < cahon_count:
+                # extended virtual centre for a hull edge (discard hull point virtual centres)
+                # replace with index for intersection point on aoi boundary
+                trimmed_ci.append(ca_count + ci - caho_count)
+        ci_for_p = trimmed_ci
 
-      # if this is a hull seed point, classify aoi boundary points into anti- or clockwise, and find closest to seed
-      if b_i is not None:
-         best_a_i = None
-         best_c_i = None
-         best_a_azi = -181.0
-         best_c_azi = 181.0
-         for cii in range(len(ci_for_p)):
-            if ci_for_p[cii] < c_count:
-               continue
-            azi = vec.azimuth(c[ci_for_p[cii]] - p[p_i, :2]) - hull_node_azi
-            if azi > 180.0:
-               azi -= 360.0
-            elif azi < -180.0:
-               azi += 360.0
-            if azi < 0.0:
-               if azi > best_a_azi:
-                  best_a_azi = azi
-                  best_a_i = cii
-            else:
-               if azi < best_c_azi:
-                  best_c_azi = azi
-                  best_c_i = cii
-         assert best_a_i is not None and best_c_i is not None
-         trimmed_ci = []
-         for cii in range(len(ci_for_p)):
-            if ci_for_p[cii] < c_count or cii == best_a_i or cii == best_c_i:
-               trimmed_ci.append(ci_for_p[cii])
-         ci_for_p = trimmed_ci
+        # if this is a hull seed point, classify aoi boundary points into anti- or clockwise, and find closest to seed
+        if b_i is not None:
+            best_a_i = None
+            best_c_i = None
+            best_a_azi = -181.0
+            best_c_azi = 181.0
+            for cii in range(len(ci_for_p)):
+                if ci_for_p[cii] < c_count:
+                    continue
+                azi = vec.azimuth(c[ci_for_p[cii]] - p[p_i, :2]) - hull_node_azi
+                if azi > 180.0:
+                    azi -= 360.0
+                elif azi < -180.0:
+                    azi += 360.0
+                if azi < 0.0:
+                    if azi > best_a_azi:
+                        best_a_azi = azi
+                        best_a_i = cii
+                else:
+                    if azi < best_c_azi:
+                        best_c_azi = azi
+                        best_c_i = cii
+            assert best_a_i is not None and best_c_i is not None
+            trimmed_ci = []
+            for cii in range(len(ci_for_p)):
+                if ci_for_p[cii] < c_count or cii == best_a_i or cii == best_c_i:
+                    trimmed_ci.append(ci_for_p[cii])
+            ci_for_p = trimmed_ci
 
-      # for sequences on aoi boundary, just keep those between the first and last (?)
+        # for sequences on aoi boundary, just keep those between the first and last (?)
 
 
 #      elif any([ci < c_count for ci in ci_for_p]):
-      else:
-         trimmed_ci = []
-         cii = 0
-         finish_at = len(ci_for_p)
-         while True:
-            if cii >= finish_at:
-               break
-            if ci_for_p[cii] < c_count:
-               trimmed_ci.append(ci_for_p[cii])
-               cii += 1
-               continue
-            start_cii = cii
-            cii_seg = seg_for_ci(ci_for_p[cii])
-            while cii == 0 and ci_for_p[start_cii - 1] >= c_count and seg_for_ci(ci_for_p[start_cii - 1]) == cii_seg:
-               start_cii -= 1
-            start_cii = start_cii % len(ci_for_p)
-            end_cii = cii + 1
-            while end_cii < len(ci_for_p) and ci_for_p[end_cii] >= c_count and seg_for_ci(ci_for_p[end_cii]) == cii_seg:
-               end_cii += 1
-            end_cii -= 1  # unpythonesque: end element included in scan
-            if end_cii == start_cii:
-               trimmed_ci.append(ci_for_p[cii])
-               cii += 1
-               continue
-            if end_cii < start_cii:
-               finish_at = start_cii
-            if end_cii == (start_cii + 1) % len(ci_for_p):
-               trimmed_ci.append(ci_for_p[start_cii])
-               trimmed_ci.append(ci_for_p[end_cii])
-               cii = end_cii + 1
-               continue
-            start_azi = vec.azimuth(c[ci_for_p[start_cii]] - p[p_i, :2])
-            end_azi = vec.azimuth(c[ci_for_p[end_cii]] - p[p_i, :2])
-            scan_cii = start_cii
+        else:
+            trimmed_ci = []
+            cii = 0
+            finish_at = len(ci_for_p)
             while True:
-               if scan_cii == start_cii:
-                  trimmed_ci.append(ci_for_p[scan_cii])
-               elif scan_cii == end_cii:
-                  trimmed_ci.append(ci_for_p[scan_cii])
-                  break
-               else:
-                  # if point is around a hull corner from previous, then include (?)
-                  next_cii = (scan_cii + 1) % len(ci_for_p)
-                  if b_i is None and seg_for_ci(ci_for_p[scan_cii]) != seg_for_ci(ci_for_p[next_cii]):
-                     trimmed_ci.append(ci_for_p[scan_cii])
-                     trimmed_ci.append(ci_for_p[next_cii])
-                     scan_cii = next_cii
-                  elif b_i is None and seg_for_ci(trimmed_ci[-1]) != seg_for_ci(ci_for_p[scan_cii]):
-                     trimmed_ci.append(ci_for_p[scan_cii])
-                  else:
-                     azi = vec.azimuth(c[ci_for_p[scan_cii]] - p[p_i, :2])
-                     if azi_between(start_azi, end_azi, azi):
+                if cii >= finish_at:
+                    break
+                if ci_for_p[cii] < c_count:
+                    trimmed_ci.append(ci_for_p[cii])
+                    cii += 1
+                    continue
+                start_cii = cii
+                cii_seg = seg_for_ci(ci_for_p[cii])
+                while cii == 0 and ci_for_p[start_cii - 1] >= c_count and seg_for_ci(
+                        ci_for_p[start_cii - 1]) == cii_seg:
+                    start_cii -= 1
+                start_cii = start_cii % len(ci_for_p)
+                end_cii = cii + 1
+                while end_cii < len(ci_for_p) and ci_for_p[end_cii] >= c_count and seg_for_ci(
+                        ci_for_p[end_cii]) == cii_seg:
+                    end_cii += 1
+                end_cii -= 1  # unpythonesque: end element included in scan
+                if end_cii == start_cii:
+                    trimmed_ci.append(ci_for_p[cii])
+                    cii += 1
+                    continue
+                if end_cii < start_cii:
+                    finish_at = start_cii
+                if end_cii == (start_cii + 1) % len(ci_for_p):
+                    trimmed_ci.append(ci_for_p[start_cii])
+                    trimmed_ci.append(ci_for_p[end_cii])
+                    cii = end_cii + 1
+                    continue
+                start_azi = vec.azimuth(c[ci_for_p[start_cii]] - p[p_i, :2])
+                end_azi = vec.azimuth(c[ci_for_p[end_cii]] - p[p_i, :2])
+                scan_cii = start_cii
+                while True:
+                    if scan_cii == start_cii:
                         trimmed_ci.append(ci_for_p[scan_cii])
-               if scan_cii == end_cii:
-                  break
-               scan_cii = (scan_cii + 1) % len(ci_for_p)
-            cii = end_cii + 1
-         ci_for_p = trimmed_ci
+                    elif scan_cii == end_cii:
+                        trimmed_ci.append(ci_for_p[scan_cii])
+                        break
+                    else:
+                        # if point is around a hull corner from previous, then include (?)
+                        next_cii = (scan_cii + 1) % len(ci_for_p)
+                        if b_i is None and seg_for_ci(ci_for_p[scan_cii]) != seg_for_ci(ci_for_p[next_cii]):
+                            trimmed_ci.append(ci_for_p[scan_cii])
+                            trimmed_ci.append(ci_for_p[next_cii])
+                            scan_cii = next_cii
+                        elif b_i is None and seg_for_ci(trimmed_ci[-1]) != seg_for_ci(ci_for_p[scan_cii]):
+                            trimmed_ci.append(ci_for_p[scan_cii])
+                        else:
+                            azi = vec.azimuth(c[ci_for_p[scan_cii]] - p[p_i, :2])
+                            if azi_between(start_azi, end_azi, azi):
+                                trimmed_ci.append(ci_for_p[scan_cii])
+                    if scan_cii == end_cii:
+                        break
+                    scan_cii = (scan_cii + 1) % len(ci_for_p)
+                cii = end_cii + 1
+            ci_for_p = trimmed_ci
 
-      # reverse points if needed for pair of aoi points only
-      assert len(ci_for_p) >= 2
-      if len(ci_for_p) == 2:
-         seg_0 = seg_for_ci(ci_for_p[0])
-         seg_1 = seg_for_ci(ci_for_p[1])
-         if seg_0 is not None and seg_1 is not None and seg_0 == (seg_1 + 1) % hull_count:
-            ci_for_p.reverse()
+        # reverse points if needed for pair of aoi points only
+        assert len(ci_for_p) >= 2
+        if len(ci_for_p) == 2:
+            seg_0 = seg_for_ci(ci_for_p[0])
+            seg_1 = seg_for_ci(ci_for_p[1])
+            if seg_0 is not None and seg_1 is not None and seg_0 == (seg_1 + 1) % hull_count:
+                ci_for_p.reverse()
 
-      # build list of intervening aoi boundary point indices and append to list
-      aoi_nodes = []
-      r = [0] if len(ci_for_p) == 2 else range(len(ci_for_p))
-      just_done_pair = False
-      for cii in r:
-         cip = ci_for_p[cii]
-         ci = ci_for_p[(cii + 1) % len(ci_for_p)]
-         if cip >= c_count and ci >= c_count and not just_done_pair:
-            # identify aoi segments
-            if cip < cah_count:
-               aoi_seg_a = aoi_intersect_segments[cip - ca_count]
+        # build list of intervening aoi boundary point indices and append to list
+        aoi_nodes = []
+        r = [0] if len(ci_for_p) == 2 else range(len(ci_for_p))
+        just_done_pair = False
+        for cii in r:
+            cip = ci_for_p[cii]
+            ci = ci_for_p[(cii + 1) % len(ci_for_p)]
+            if cip >= c_count and ci >= c_count and not just_done_pair:
+                # identify aoi segments
+                if cip < cah_count:
+                    aoi_seg_a = aoi_intersect_segments[cip - ca_count]
+                else:
+                    aoi_seg_a = out_pair_intersect_segments[divmod(cip - cah_count, 2)]
+                if ci < cah_count:
+                    aoi_seg_c = aoi_intersect_segments[ci - ca_count]
+                else:
+                    aoi_seg_c = out_pair_intersect_segments[divmod(ci - cah_count, 2)]
+                aoi_nodes += aoi_intervening_nodes(aoi_count, c_count, aoi_seg_a, aoi_seg_c)
+                just_done_pair = True
             else:
-               aoi_seg_a = out_pair_intersect_segments[divmod(cip - cah_count, 2)]
-            if ci < cah_count:
-               aoi_seg_c = aoi_intersect_segments[ci - ca_count]
-            else:
-               aoi_seg_c = out_pair_intersect_segments[divmod(ci - cah_count, 2)]
-            aoi_nodes += aoi_intervening_nodes(aoi_count, c_count, aoi_seg_a, aoi_seg_c)
-            just_done_pair = True
-         else:
-            just_done_pair = False
-      ci_for_p += aoi_nodes
+                just_done_pair = False
+        ci_for_p += aoi_nodes
 
-      # remove circumcircle centres that are outwith area of interest
-      ci_for_p = np.array([ti for ti in ci_for_p if ti >= c_count or ti not in tc_outwith_aoi], dtype = int)
+        # remove circumcircle centres that are outwith area of interest
+        ci_for_p = np.array([ti for ti in ci_for_p if ti >= c_count or ti not in tc_outwith_aoi], dtype = int)
 
-      # find azimuths of vectors from seed point to circumcircle centres and aoi boundary points
-      azi = [vec.azimuth(centre - p[p_i, :2]) for centre in c[ci_for_p, :2]]
+        # find azimuths of vectors from seed point to circumcircle centres and aoi boundary points
+        azi = [vec.azimuth(centre - p[p_i, :2]) for centre in c[ci_for_p, :2]]
 
-      # re-sort triangle indices for seed point into clockwise order of circumcircle centres and boundary points
-      ordered_ci = [ti for (_, ti) in sorted(zip(azi, ci_for_p))]
+        # re-sort triangle indices for seed point into clockwise order of circumcircle centres and boundary points
+        ordered_ci = [ti for (_, ti) in sorted(zip(azi, ci_for_p))]
 
-      v.append(ordered_ci)
+        v.append(ordered_ci)
 
-   return c[:caho_count], v
+    return c[:caho_count], v
 
 
 def triangulated_polygons(p, v, centres = None):
-   """Returns triangulation of polygons using centres as extra points.
+    """Returns triangulation of polygons using centres as extra points.
 
    arguments:
       p (2D numpy float array): points used as vertices of polygons
@@ -632,40 +638,40 @@ def triangulated_polygons(p, v, centres = None):
       original seed points p passed into voronoi() can be passed as centres here
    """
 
-   assert p.ndim == 2 and p.shape[1] in [2, 3]
-   assert len(v) > 0
-   if centres is not None:
-      assert centres.ndim == 2
-      assert len(centres) == len(v)
-      assert centres.shape[1] == p.shape[1]
+    assert p.ndim == 2 and p.shape[1] in [2, 3]
+    assert len(v) > 0
+    if centres is not None:
+        assert centres.ndim == 2
+        assert len(centres) == len(v)
+        assert centres.shape[1] == p.shape[1]
 
-   model = rq.Model(create_basics = True)  # temporary object for handling Polylines
-   crs = rqc.Crs(model)
+    model = rq.Model(create_basics = True)  # temporary object for handling Polylines
+    crs = rqc.Crs(model)
 
-   points = np.zeros((len(p) + len(v), p.shape[1]))  # polygon nodes, to be extended with centre points
-   points[:len(p)] = p
-   if centres is not None:
-      points[len(p):] = centres
+    points = np.zeros((len(p) + len(v), p.shape[1]))  # polygon nodes, to be extended with centre points
+    points[:len(p)] = p
+    if centres is not None:
+        points[len(p):] = centres
 
-   t_count = sum([len(x) for x in v])
-   triangles = np.empty((t_count, 3), dtype = int)
-   t_index = 0
+    t_count = sum([len(x) for x in v])
+    triangles = np.empty((t_count, 3), dtype = int)
+    t_index = 0
 
-   for cell, poly_vertices in enumerate(v):
-      # add polygon centre points to points array, if not already provided
-      centre_i = len(p) + cell
-      if centres is None:
-         polygon = rql.Polyline(model,
-                                set_coord = p[np.array(poly_vertices, dtype = int)],
-                                set_bool = True,
-                                set_crs = crs.uuid,
-                                title = 'v cell')
-         poly_centre = polygon.balanced_centre()
-         points[centre_i] = poly_centre[:p.shape[1]]
-      # and populate triangles for this polygon
-      for ti in range(len(poly_vertices)):
-         triangles[t_index] = (centre_i, poly_vertices[ti], poly_vertices[(ti + 1) % len(poly_vertices)])
-         t_index += 1
-   assert t_index == t_count
+    for cell, poly_vertices in enumerate(v):
+        # add polygon centre points to points array, if not already provided
+        centre_i = len(p) + cell
+        if centres is None:
+            polygon = rql.Polyline(model,
+                                   set_coord = p[np.array(poly_vertices, dtype = int)],
+                                   set_bool = True,
+                                   set_crs = crs.uuid,
+                                   title = 'v cell')
+            poly_centre = polygon.balanced_centre()
+            points[centre_i] = poly_centre[:p.shape[1]]
+        # and populate triangles for this polygon
+        for ti in range(len(poly_vertices)):
+            triangles[t_index] = (centre_i, poly_vertices[ti], poly_vertices[(ti + 1) % len(poly_vertices)])
+            t_index += 1
+    assert t_index == t_count
 
-   return points, triangles
+    return points, triangles

--- a/resqpy/olio/utility.py
+++ b/resqpy/olio/utility.py
@@ -17,68 +17,68 @@ import numpy as np
 
 
 def kji0_from_ijk1(index_ijk1):  # reverse order of indices and subtract 1
-   """Returns index converted from simulator protocol to python protocol."""
-   dims = index_ijk1.size
-   result = np.zeros(dims, dtype = 'int')
-   for d in range(dims):
-      result[d] = index_ijk1[dims - d - 1] - 1
-   return result
+    """Returns index converted from simulator protocol to python protocol."""
+    dims = index_ijk1.size
+    result = np.zeros(dims, dtype = 'int')
+    for d in range(dims):
+        result[d] = index_ijk1[dims - d - 1] - 1
+    return result
 
 
 def ijk1_from_kji0(index_kji0):  # reverse order of indices and add 1
-   """Returns index converted from python protocol to simulator protocol."""
-   dims = index_kji0.size
-   result = np.zeros(dims, dtype = 'int')
-   for d in range(dims):
-      result[d] = index_kji0[dims - d - 1] + 1
-   return result
+    """Returns index converted from python protocol to simulator protocol."""
+    dims = index_kji0.size
+    result = np.zeros(dims, dtype = 'int')
+    for d in range(dims):
+        result[d] = index_kji0[dims - d - 1] + 1
+    return result
 
 
 def extent_switch_ijk_kji(extent_in):  # reverse order of elements in extent
-   """Returns equivalent grid extent switched either way between simulator and python protocols."""
-   dims = extent_in.size
-   result = np.zeros(dims, dtype = 'int')
-   for d in range(dims):
-      result[d] = extent_in[dims - d - 1]
-   return result
+    """Returns equivalent grid extent switched either way between simulator and python protocols."""
+    dims = extent_in.size
+    result = np.zeros(dims, dtype = 'int')
+    for d in range(dims):
+        result[d] = extent_in[dims - d - 1]
+    return result
 
 
 def cell_count_from_extent(extent):
-   """Returns the number of cells in a grid with the given extent"""
-   result = 1
-   for d in range(len(extent)):  # list, tuple or 1D numpy array
-      result *= extent[d]
-   return result
+    """Returns the number of cells in a grid with the given extent"""
+    result = 1
+    for d in range(len(extent)):  # list, tuple or 1D numpy array
+        result *= extent[d]
+    return result
 
 
 def string_ijk1_for_cell_kji0(cell_kji0):
-   """Returns a string showing indices for a cell in simulator protocol, from data in python protocol."""
-   return '[{:}, {:}, {:}]'.format(cell_kji0[2] + 1, cell_kji0[1] + 1, cell_kji0[0] + 1)
+    """Returns a string showing indices for a cell in simulator protocol, from data in python protocol."""
+    return '[{:}, {:}, {:}]'.format(cell_kji0[2] + 1, cell_kji0[1] + 1, cell_kji0[0] + 1)
 
 
 def string_ijk1_for_cell_ijk1(cell_ijk1):
-   """Returns a string showing indices for a cell in simulator protocol, from data in simulator protocol."""
-   return '[{:}, {:}, {:}]'.format(cell_ijk1[0], cell_ijk1[1], cell_ijk1[2])
+    """Returns a string showing indices for a cell in simulator protocol, from data in simulator protocol."""
+    return '[{:}, {:}, {:}]'.format(cell_ijk1[0], cell_ijk1[1], cell_ijk1[2])
 
 
 def string_ijk_for_extent_kji(extent_kji):
-   """Returns a string showing grid extent in simulator protocol, from data in python protocol."""
-   return '[{:}, {:}, {:}]'.format(extent_kji[2], extent_kji[1], extent_kji[0])
+    """Returns a string showing grid extent in simulator protocol, from data in python protocol."""
+    return '[{:}, {:}, {:}]'.format(extent_kji[2], extent_kji[1], extent_kji[0])
 
 
 def string_xyz(xyz):
-   """Returns an xyz point as a string like (121234.56, 567890.12, 3456.789)"""
+    """Returns an xyz point as a string like (121234.56, 567890.12, 3456.789)"""
 
-   return '({0:4.2f}, {1:4.2f}, {2:5.3f})'.format(xyz[0], xyz[1], xyz[2])
+    return '({0:4.2f}, {1:4.2f}, {2:5.3f})'.format(xyz[0], xyz[1], xyz[2])
 
 
 def horizon_float(k0, plus_or_minus):
-   """Returns a floating point representation of k direction face index; eg. 3.5 for face between layers 3 and 4."""
-   result = float(k0)
-   if plus_or_minus == '+':
-      result += 0.5
-   elif plus_or_minus == '-':
-      result -= 0.5
-   else:
-      assert False
-   return result
+    """Returns a floating point representation of k direction face index; eg. 3.5 for face between layers 3 and 4."""
+    result = float(k0)
+    if plus_or_minus == '+':
+        result += 0.5
+    elif plus_or_minus == '-':
+        result -= 0.5
+    else:
+        assert False
+    return result

--- a/resqpy/olio/uuid.py
+++ b/resqpy/olio/uuid.py
@@ -17,7 +17,7 @@ max_version_string_length = 10
 
 
 def switch_on_test_mode(seed = 0):
-   """Causes subsequent calls to new_uid() to produce integer sequence starting from successor to seed.
+    """Causes subsequent calls to new_uid() to produce integer sequence starting from successor to seed.
 
    arguments:
       seed (integer, default 0): The predecessor to the first uuid returned by subsequent calls to
@@ -32,25 +32,25 @@ def switch_on_test_mode(seed = 0):
       test mode is intended to allow replicatable behaviour for testing purposes
    """
 
-   global test_mode
-   global test_latest_int
-   test_latest_int = seed
-   test_mode = True
+    global test_mode
+    global test_latest_int
+    test_latest_int = seed
+    test_mode = True
 
 
 def switch_off_test_mode():
-   """Subsequent calls to new_uid() will produce standard uuid values (default behaviour).
+    """Subsequent calls to new_uid() will produce standard uuid values (default behaviour).
 
    note:
       this function will have no effect unless switch_on_test_mode() has previously been called
    """
 
-   global test_mode
-   test_mode = False
+    global test_mode
+    test_mode = False
 
 
 def new_uuid():
-   """Returns a new uuid based on the time (to 100ns) & MAC address option of the iso standard.
+    """Returns a new uuid based on the time (to 100ns) & MAC address option of the iso standard.
 
    returns:
       uuid.UUID object
@@ -61,16 +61,16 @@ def new_uuid():
       an integer sequence is generated when in test mode
    """
 
-   global test_latest_int
-   if test_mode:
-      test_latest_int += 1
-      return uuid.UUID(bytes = test_latest_int.to_bytes(16, byte_order = 'big'))
-   else:
-      return uuid.uuid1()  # time to 100ns & MAC address
+    global test_latest_int
+    if test_mode:
+        test_latest_int += 1
+        return uuid.UUID(bytes = test_latest_int.to_bytes(16, byte_order = 'big'))
+    else:
+        return uuid.uuid1()  # time to 100ns & MAC address
 
 
 def string_from_uuid(uuid_obj):
-   """Returns standard hexadecimal string for uuid; same as str(uuid_obj).
+    """Returns standard hexadecimal string for uuid; same as str(uuid_obj).
 
    arguments:
       uuid_obj (uuid.UUID object): the uuid which is required in hexadecimal string format
@@ -79,11 +79,11 @@ def string_from_uuid(uuid_obj):
       string (40 characters: 36 lowercase hexadecimals and 4 hyphens)
    """
 
-   return str(uuid_obj)
+    return str(uuid_obj)
 
 
 def uuid_from_string(uuid_str):
-   """Returns a uuid object for the given uuid string; hyphens are ignored.
+    """Returns a uuid object for the given uuid string; hyphens are ignored.
 
    arguments:
       uuid_str (string): the hexadecimal representation of the 128 bit uuid integer;
@@ -98,26 +98,26 @@ def uuid_from_string(uuid_str):
       any tail beyond the uuid string is ignored
    """
 
-   if uuid_str is None:
-      return None
-   if isinstance(uuid_str, uuid.UUID):
-      return uuid_str  # resilience to accidentally passing a uuid object
-   try:
-      if uuid_str[0] == '_':  # tolerate one of the fesapi quirks
-         if len(uuid_str) < 37:
-            return None
-         return uuid.UUID(uuid_str[1:37])
-      else:
-         if len(uuid_str) < 36:
-            return None
-         return uuid.UUID(uuid_str[:36])
-   except Exception:
-      # could log or raise an error or warning?
-      return None
+    if uuid_str is None:
+        return None
+    if isinstance(uuid_str, uuid.UUID):
+        return uuid_str  # resilience to accidentally passing a uuid object
+    try:
+        if uuid_str[0] == '_':  # tolerate one of the fesapi quirks
+            if len(uuid_str) < 37:
+                return None
+            return uuid.UUID(uuid_str[1:37])
+        else:
+            if len(uuid_str) < 36:
+                return None
+            return uuid.UUID(uuid_str[:36])
+    except Exception:
+        # could log or raise an error or warning?
+        return None
 
 
 def uuid_as_bytes(uuid_obj):
-   """Returns the uuid as a 16 byte bytes sequence; same as uuid_obj.bytes.
+    """Returns the uuid as a 16 byte bytes sequence; same as uuid_obj.bytes.
 
    arguments:
       uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
@@ -126,15 +126,15 @@ def uuid_as_bytes(uuid_obj):
       bytes (16 bytes long)
    """
 
-   if uuid_obj is None:
-      return None
-   if isinstance(uuid_obj, str):
-      uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
-   return uuid_obj.bytes
+    if uuid_obj is None:
+        return None
+    if isinstance(uuid_obj, str):
+        uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
+    return uuid_obj.bytes
 
 
 def uuid_as_int(uuid_obj):
-   """Returns the uuid as a 128 bit int; same as uuid_obj.int.
+    """Returns the uuid as a 128 bit int; same as uuid_obj.int.
 
    arguments:
       uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
@@ -143,15 +143,15 @@ def uuid_as_int(uuid_obj):
       bytes (16 bytes long)
    """
 
-   if uuid_obj is None:
-      return None
-   if isinstance(uuid_obj, str):
-      uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
-   return uuid_obj.int
+    if uuid_obj is None:
+        return None
+    if isinstance(uuid_obj, str):
+        uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
+    return uuid_obj.int
 
 
 def matching_uuids(uuid_a, uuid_b):
-   """Returns True if the 2 uuid objects are for the same id; False otherwise.
+    """Returns True if the 2 uuid objects are for the same id; False otherwise.
 
    arguments:
       uuid_a, uuid_b (uuid.UUID objects): the two uuids to be compared
@@ -163,17 +163,17 @@ def matching_uuids(uuid_a, uuid_b):
       this function is resilient to uuids being passed in hexadecimal string format
    """
 
-   if isinstance(uuid_a, str):
-      uuid_a = uuid_from_string(uuid_a)  # resilience to accidental string arg
-   if isinstance(uuid_b, str):
-      uuid_b = uuid_from_string(uuid_b)
-   if uuid_a is None or uuid_b is None:
-      return False
-   return uuid_a.int == uuid_b.int
+    if isinstance(uuid_a, str):
+        uuid_a = uuid_from_string(uuid_a)  # resilience to accidental string arg
+    if isinstance(uuid_b, str):
+        uuid_b = uuid_from_string(uuid_b)
+    if uuid_a is None or uuid_b is None:
+        return False
+    return uuid_a.int == uuid_b.int
 
 
 def version_string(uuid_obj):
-   """Returns an integer string rendering of the time element of the uuid.
+    """Returns an integer string rendering of the time element of the uuid.
 
    arguments:
       uuid_obj (uuid.UUID): the uuid for which a string representation of the time component is required
@@ -188,9 +188,9 @@ def version_string(uuid_obj):
       (when the Gregorian calendar was adopted), as a 60 bit integer
    """
 
-   if isinstance(uuid_obj, str):
-      uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
-   v_str = str(uuid_obj.time)
-   if len(v_str) > max_version_string_length:
-      v_str = v_str[:max_version_string_length]
-   return v_str
+    if isinstance(uuid_obj, str):
+        uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg
+    v_str = str(uuid_obj.time)
+    if len(v_str) > max_version_string_length:
+        v_str = v_str[:max_version_string_length]
+    return v_str

--- a/resqpy/olio/vdb.py
+++ b/resqpy/olio/vdb.py
@@ -21,141 +21,141 @@ import resqpy.olio.grid_functions as gf
 null_uint32 = 4294967295  # -1 if interpreted as int32
 
 key_dict = {  # vdb key character mapping to: (numpy_dtype, size_in_bytes, unpack_format_ch)
-   'R': ('float32', 4, 'f'),
-   'D': ('float64', 8, 'd'),
-   #   'D': ('int64',   8, 'i'),
-   'I': ('int32', 4, 'i'),
-   'C': (None, 1, 'c'),  # could map to numpy 'byte' but seems to be used for strings
-   'P': ('uint32', 4, 'I'),
-   'K': (None, 8, 'c'),  # don't store in numpy format; 8 character strings
-   'X': (None, 0, 'c')
+    'R': ('float32', 4, 'f'),
+    'D': ('float64', 8, 'd'),
+    #   'D': ('int64',   8, 'i'),
+    'I': ('int32', 4, 'i'),
+    'C': (None, 1, 'c'),  # could map to numpy 'byte' but seems to be used for strings
+    'P': ('uint32', 4, 'I'),
+    'K': (None, 8, 'c'),  # don't store in numpy format; 8 character strings
+    'X': (None, 0, 'c')
 }  # used for invalid code character (non-ascii)
 
 init_not_packed = ['DAD', 'KID', 'UID', 'UNPACK']
 
 
 def coerce(a, dtype):
-   """Returns a version of numpy array a with elements coerced to dtype.
+    """Returns a version of numpy array a with elements coerced to dtype.
 
       :meta private:
    """
-   if dtype is None or a.dtype == dtype:
-      return a
-   b = np.empty(a.shape, dtype = dtype)
-   b[:] = a
-   return b
+    if dtype is None or a.dtype == dtype:
+        return a
+    b = np.empty(a.shape, dtype = dtype)
+    b[:] = a
+    return b
 
 
 def ensemble_vdb_list(run_dir, sort_list = True):
-   """Returns a sorted list of vdb paths found in the directory tree under run_dir."""
+    """Returns a sorted list of vdb paths found in the directory tree under run_dir."""
 
-   ensemble_list = []
+    ensemble_list = []
 
-   def recursive_vdb_list(dir):
-      nonlocal ensemble_list
-      for entry in os.scandir(dir):
-         if not entry.is_dir():
-            continue
-         if entry.name.endswith('.vdb') or entry.name.endswith('.vdb.zip'):
-            ensemble_list.append(entry.path)
-            continue
-         elif entry.name.endswith('.rst'):
-            continue  # optimisation
-         recursive_vdb_list(entry.path)
+    def recursive_vdb_list(dir):
+        nonlocal ensemble_list
+        for entry in os.scandir(dir):
+            if not entry.is_dir():
+                continue
+            if entry.name.endswith('.vdb') or entry.name.endswith('.vdb.zip'):
+                ensemble_list.append(entry.path)
+                continue
+            elif entry.name.endswith('.rst'):
+                continue  # optimisation
+            recursive_vdb_list(entry.path)
 
-   def cmp_to_key(mycmp):
-      'Convert a cmp= function into a key= function'
+    def cmp_to_key(mycmp):
+        'Convert a cmp= function into a key= function'
 
-      class K:
+        class K:
 
-         def __init__(self, obj, *args):
-            self.obj = obj
+            def __init__(self, obj, *args):
+                self.obj = obj
 
-         def __lt__(self, other):
-            return mycmp(self.obj, other.obj) < 0
+            def __lt__(self, other):
+                return mycmp(self.obj, other.obj) < 0
 
-         def __gt__(self, other):
-            return mycmp(self.obj, other.obj) > 0
+            def __gt__(self, other):
+                return mycmp(self.obj, other.obj) > 0
 
-         def __eq__(self, other):
-            return mycmp(self.obj, other.obj) == 0
+            def __eq__(self, other):
+                return mycmp(self.obj, other.obj) == 0
 
-         def __le__(self, other):
-            return mycmp(self.obj, other.obj) <= 0
+            def __le__(self, other):
+                return mycmp(self.obj, other.obj) <= 0
 
-         def __ge__(self, other):
-            return mycmp(self.obj, other.obj) >= 0
+            def __ge__(self, other):
+                return mycmp(self.obj, other.obj) >= 0
 
-         def __ne__(self, other):
-            return mycmp(self.obj, other.obj) != 0
+            def __ne__(self, other):
+                return mycmp(self.obj, other.obj) != 0
 
-      return K
+        return K
 
-   def comparison(a, b):
-      pa = 0
-      pb = 0
-      while True:
-         sa = pa
-         sb = pb
-         if pa >= len(a) and pb >= len(b):
-            return 0
-         while pa < len(a) and not a[pa].isdigit():
-            pa += 1
-         while pb < len(b) and not b[pb].isdigit():
-            pb += 1
-         if a[sa:pa].lower() < b[sb:pb].lower():
+    def comparison(a, b):
+        pa = 0
+        pb = 0
+        while True:
+            sa = pa
+            sb = pb
+            if pa >= len(a) and pb >= len(b):
+                return 0
+            while pa < len(a) and not a[pa].isdigit():
+                pa += 1
+            while pb < len(b) and not b[pb].isdigit():
+                pb += 1
+            if a[sa:pa].lower() < b[sb:pb].lower():
+                return -1
+            if a[sa:pa].lower() > b[sb:pb].lower():
+                return 1
+            if pa >= len(a) and pb >= len(b):
+                return 0
+            if pa >= len(a):
+                return -1
+            if pb >= len(b):
+                return 1
+            sa = pa
+            sb = pb
+            while pa < len(a) and a[pa].isdigit():
+                pa += 1
+            while pb < len(b) and b[pb].isdigit():
+                pb += 1
+            ia = int(a[sa:pa])
+            ib = int(b[sb:pb])
+            if ia < ib:
+                return -1
+            if ia > ib:
+                return 1
+        a_low = a.lower()
+        b_low = b.lower()
+        if a_low < b_low:
             return -1
-         if a[sa:pa].lower() > b[sb:pb].lower():
+        if a_low > b_low:
             return 1
-         if pa >= len(a) and pb >= len(b):
-            return 0
-         if pa >= len(a):
-            return -1
-         if pb >= len(b):
-            return 1
-         sa = pa
-         sb = pb
-         while pa < len(a) and a[pa].isdigit():
-            pa += 1
-         while pb < len(b) and b[pb].isdigit():
-            pb += 1
-         ia = int(a[sa:pa])
-         ib = int(b[sb:pb])
-         if ia < ib:
-            return -1
-         if ia > ib:
-            return 1
-      a_low = a.lower()
-      b_low = b.lower()
-      if a_low < b_low:
-         return -1
-      if a_low > b_low:
-         return 1
-      return 0
+        return 0
 
-   recursive_vdb_list(run_dir)
-   if sort_list:
-      sorted_list = sorted(ensemble_list, key = cmp_to_key(comparison))
-      ensemble_list = sorted_list
-   return ensemble_list
+    recursive_vdb_list(run_dir)
+    if sort_list:
+        sorted_list = sorted(ensemble_list, key = cmp_to_key(comparison))
+        ensemble_list = sorted_list
+    return ensemble_list
 
 
 class Header():
-   """Internal class for handling a Header record in a vdb file."""
+    """Internal class for handling a Header record in a vdb file."""
 
-   def __init__(self, fp, place):
-      """Creates a new Header record object."""
+    def __init__(self, fp, place):
+        """Creates a new Header record object."""
 
-      fp.seek(place)
-      block = fp.read(22)
-      #      log.debug(f'Header block at place {place} returned {len(block)} bytes')
-      self.previous, self.next, c, self.bytes_per_item, self.number_of_items, self.first_fragment, self.max_items =  \
-         unpack('=IIcBIII', block)
-      try:
-         self.item_type = c.decode()
-      except Exception:
-         self.item_type = 'X'  # non-ascii character!
-      self.data_place = place + 22
+        fp.seek(place)
+        block = fp.read(22)
+        #      log.debug(f'Header block at place {place} returned {len(block)} bytes')
+        self.previous, self.next, c, self.bytes_per_item, self.number_of_items, self.first_fragment, self.max_items =  \
+           unpack('=IIcBIII', block)
+        try:
+            self.item_type = c.decode()
+        except Exception:
+            self.item_type = 'X'  # non-ascii character!
+        self.data_place = place + 22
 
 
 #      log.debug('   header previous: ' + str(self.previous))
@@ -169,110 +169,111 @@ class Header():
 
 
 class FragmentHeader():
-   """Internal class for handling a Fragment Header record in a vdb file."""
+    """Internal class for handling a Fragment Header record in a vdb file."""
 
-   def __init__(self, fp, place):
-      """Creates a new Fragment Header record object."""
+    def __init__(self, fp, place):
+        """Creates a new Fragment Header record object."""
 
-      #      log.debug(f'FragmentHeader init at place {place}')
-      fp.seek(place)
-      block = fp.read(8)
-      self.next, self.number_of_items = unpack('=II', block)
-      self.data_place = place + 8
+        #      log.debug(f'FragmentHeader init at place {place}')
+        fp.seek(place)
+        block = fp.read(8)
+        self.next, self.number_of_items = unpack('=II', block)
+        self.data_place = place + 8
 
 
 #      log.debug(f'   fragment header number of items {self.number_of_items}; data place {self.data_place}; next {self.next}')
 
 
 class RawData():
-   """Internal class for handling Raw Data records in a vdb file."""
+    """Internal class for handling Raw Data records in a vdb file."""
 
-   def __init__(self, fp, place, item_type, count, max_count):
-      """Creates a new Raw Data record object."""
+    def __init__(self, fp, place, item_type, count, max_count):
+        """Creates a new Raw Data record object."""
 
-      if max_count is not None and count > max_count:
-         count = max_count
-      self.a = None
-      self.c = None
-      dtype, byte_size, form_ch = key_dict[item_type]
-      #      log.debug('raw data call: place {}; item type {}; count {}; dtype {}, byte size {}, form ch {}'.format(
-      #                place, item_type, count, dtype, byte_size, form_ch))
-      fp.seek(place)
-      if dtype is None:
-         if form_ch == 'c':
-            chars = fp.read(count * byte_size)
-            if item_type == 'C':
-               self.c = chars.decode()
-            else:
-               self.c = []
-               for i in range(count):
-                  self.c.append(chars[i * byte_size:(i + 1) * byte_size].decode().strip().upper())
-         else:  # shouldn't come into play
-            block = fp.read(count * byte_size)
-            form = '=' + str(count) + form_ch
-            self.c = unpack(form, block)
-      elif dtype == 'float64':  # try tentative 32bit word swap
-         b = fp.read(count * 8)
-         #         c = b''
-         #         for d in range(count):
-         #            c += b[4*d+4:4*d+8] + b[4*d:4*d+4]
-         nda = np.ndarray((count, 2), dtype = 'int32', buffer = b)
-         self.a = np.empty((count, 2), dtype = int)
-         self.a[:, :] = nda[:, :]
-      else:
-         self.a = np.empty((count,), dtype = dtype)
-         self.a.data = fp.read(count * byte_size)  # todo: check C ordering; endianess etc.
+        if max_count is not None and count > max_count:
+            count = max_count
+        self.a = None
+        self.c = None
+        dtype, byte_size, form_ch = key_dict[item_type]
+        #      log.debug('raw data call: place {}; item type {}; count {}; dtype {}, byte size {}, form ch {}'.format(
+        #                place, item_type, count, dtype, byte_size, form_ch))
+        fp.seek(place)
+        if dtype is None:
+            if form_ch == 'c':
+                chars = fp.read(count * byte_size)
+                if item_type == 'C':
+                    self.c = chars.decode()
+                else:
+                    self.c = []
+                    for i in range(count):
+                        self.c.append(chars[i * byte_size:(i + 1) * byte_size].decode().strip().upper())
+            else:  # shouldn't come into play
+                block = fp.read(count * byte_size)
+                form = '=' + str(count) + form_ch
+                self.c = unpack(form, block)
+        elif dtype == 'float64':  # try tentative 32bit word swap
+            b = fp.read(count * 8)
+            #         c = b''
+            #         for d in range(count):
+            #            c += b[4*d+4:4*d+8] + b[4*d:4*d+4]
+            nda = np.ndarray((count, 2), dtype = 'int32', buffer = b)
+            self.a = np.empty((count, 2), dtype = int)
+            self.a[:, :] = nda[:, :]
+        else:
+            self.a = np.empty((count,), dtype = dtype)
+            self.a.data = fp.read(count * byte_size)  # todo: check C ordering; endianess etc.
 
 
 class Data():
-   """Internal class for handling Data records in a vdb file."""
+    """Internal class for handling Data records in a vdb file."""
 
-   def __init__(self, fp, header):
-      """Creates a new Data object."""
+    def __init__(self, fp, header):
+        """Creates a new Data object."""
 
-      if header is None:
-         self.a = None
-         self.c = None
-      else:
-         #         log.debug(f'Data init at place {header.data_place}; type {header.item_type}; number of items {header.number_of_items}')
-         raw = RawData(fp, header.data_place, header.item_type, header.number_of_items, header.max_items)
-         if raw is not None and raw.a is not None and raw.a.size == 1 and raw.a.dtype == 'int32' and header.next != null_uint32:
-            #            log.debug('   skipping integer value of ' + str(raw.a[0]))
-            next_head = Header(fp, header.next)
-            raw = RawData(fp, next_head.data_place, next_head.item_type, next_head.number_of_items, next_head.max_items)
-            header = next_head  # making this up as I go along
-         self.a = raw.a
-         self.c = raw.c
-         if header.first_fragment != null_uint32:
-            #            log.debug(f'   chaining from {header.first_fragment}')
-            chain = FragmentChain(fp, header.first_fragment, header)
-            if self.a is not None:
-               self.a = np.append(self.a, chain.a)
-            if self.c is not None:
-               self.c += chain.c
+        if header is None:
+            self.a = None
+            self.c = None
+        else:
+            #         log.debug(f'Data init at place {header.data_place}; type {header.item_type}; number of items {header.number_of_items}')
+            raw = RawData(fp, header.data_place, header.item_type, header.number_of_items, header.max_items)
+            if raw is not None and raw.a is not None and raw.a.size == 1 and raw.a.dtype == 'int32' and header.next != null_uint32:
+                #            log.debug('   skipping integer value of ' + str(raw.a[0]))
+                next_head = Header(fp, header.next)
+                raw = RawData(fp, next_head.data_place, next_head.item_type, next_head.number_of_items,
+                              next_head.max_items)
+                header = next_head  # making this up as I go along
+            self.a = raw.a
+            self.c = raw.c
+            if header.first_fragment != null_uint32:
+                #            log.debug(f'   chaining from {header.first_fragment}')
+                chain = FragmentChain(fp, header.first_fragment, header)
+                if self.a is not None:
+                    self.a = np.append(self.a, chain.a)
+                if self.c is not None:
+                    self.c += chain.c
 
-   #   if self.c is not None:
-   #      log.debug(f'   data c {self.c}')
-   #   elif self.a is not None:
-   #      log.debug(f'   data a {self.a}')
+    #   if self.c is not None:
+    #      log.debug(f'   data c {self.c}')
+    #   elif self.a is not None:
+    #      log.debug(f'   data a {self.a}')
 
 
 class Fragment():
-   """Internal class for handling an individual Fragment record in a vdb file."""
+    """Internal class for handling an individual Fragment record in a vdb file."""
 
-   def __init__(self, fp, place, header):
-      """Creates a new Fragment record object."""
+    def __init__(self, fp, place, header):
+        """Creates a new Fragment record object."""
 
-      #      log.debug(f'Fragment init at place {place}')
-      self.head = FragmentHeader(fp, place)
-      if self.head.number_of_items == 0:
-         #         log.debug('   zero items in fragment')
-         self.c = None
-         self.a = None
-      else:
-         raw = RawData(fp, self.head.data_place, header.item_type, self.head.number_of_items, header.max_items)
-         self.a = raw.a
-         self.c = raw.c
+        #      log.debug(f'Fragment init at place {place}')
+        self.head = FragmentHeader(fp, place)
+        if self.head.number_of_items == 0:
+            #         log.debug('   zero items in fragment')
+            self.c = None
+            self.a = None
+        else:
+            raw = RawData(fp, self.head.data_place, header.item_type, self.head.number_of_items, header.max_items)
+            self.a = raw.a
+            self.c = raw.c
 
 
 #      if self.c is not None:
@@ -280,761 +281,761 @@ class Fragment():
 
 
 class FragmentChain():
-   """Internal class for handling a chain of Fragment records in a vdb file."""
+    """Internal class for handling a chain of Fragment records in a vdb file."""
 
-   def __init__(self, fp, place, header):  # returns either 1D numpy array (numeric data) or list of 8
-      """Creates a new Fragment Chain object."""
+    def __init__(self, fp, place, header):  # returns either 1D numpy array (numeric data) or list of 8
+        """Creates a new Fragment Chain object."""
 
-      self.a = None
-      self.c = None
-      #      log.debug(f'FragmentChain init at place {place}')
-      while place != null_uint32:
-         fragment = Fragment(fp, place, header)
-         if fragment.head.number_of_items > 0:
-            if fragment.a is not None:
-               if self.a is None:
-                  self.a = fragment.a
-               else:
-                  self.a = np.concatenate(self.a, fragment.a)
-            if fragment.c:
-               if self.c is None:
-                  self.c = []
-               if isinstance(fragment.c, str):
-                  self.c.append(fragment.c)
-               elif isinstance(fragment.c, list):
-                  for item in fragment.c:
-                     if item.isascii():
-                        self.c.append(item)
-         place = fragment.head.next
-      assert self.c is None or self.a is None, 'mixture of character and numeric data in fragment chain'
+        self.a = None
+        self.c = None
+        #      log.debug(f'FragmentChain init at place {place}')
+        while place != null_uint32:
+            fragment = Fragment(fp, place, header)
+            if fragment.head.number_of_items > 0:
+                if fragment.a is not None:
+                    if self.a is None:
+                        self.a = fragment.a
+                    else:
+                        self.a = np.concatenate(self.a, fragment.a)
+                if fragment.c:
+                    if self.c is None:
+                        self.c = []
+                    if isinstance(fragment.c, str):
+                        self.c.append(fragment.c)
+                    elif isinstance(fragment.c, list):
+                        for item in fragment.c:
+                            if item.isascii():
+                                self.c.append(item)
+            place = fragment.head.next
+        assert self.c is None or self.a is None, 'mixture of character and numeric data in fragment chain'
 
-   # todo: check number of elements matches header info?
+    # todo: check number of elements matches header info?
 
 
 class KP():
-   """Internal class for a (Key, Pointer) record in a vdb file."""
+    """Internal class for a (Key, Pointer) record in a vdb file."""
 
-   def __init__(self, fp, place = 4):
-      """Creates a new (Key, Pointer) record object."""
+    def __init__(self, fp, place = 4):
+        """Creates a new (Key, Pointer) record object."""
 
-      #      log.debug(f'KP init at place {place}')
-      self.k_head = Header(fp, place)
-      assert self.k_head.item_type == 'K', 'did not find expected Key header'
-      assert self.k_head.bytes_per_item == 8, 'bytes per item not 8 in Key header'
-      assert self.k_head.number_of_items > 0, 'zero items in Key header'
-      place = self.k_head.next
-      assert place != null_uint32, 'no next header in Key header'
-      self.p_head = Header(fp, place)
-      assert self.p_head.item_type == 'P', 'did not find expected Pointer header'
-      assert self.p_head.bytes_per_item == 4, 'bytes per item not 4 in Pointer header'
-      assert self.p_head.number_of_items == self.k_head.number_of_items,  \
-                'number of items in Pointer header does not match number in Key header'
-      self.keywords = Data(fp, self.k_head).c
-      assert self.keywords is not None and isinstance(self.keywords,
-                                                      list), 'list of keywords not extracted from Key record'
-      self.pointers = Data(fp, self.p_head).a
-      assert self.pointers is not None and self.pointers.dtype == 'uint32'
-      self.fp = fp
+        #      log.debug(f'KP init at place {place}')
+        self.k_head = Header(fp, place)
+        assert self.k_head.item_type == 'K', 'did not find expected Key header'
+        assert self.k_head.bytes_per_item == 8, 'bytes per item not 8 in Key header'
+        assert self.k_head.number_of_items > 0, 'zero items in Key header'
+        place = self.k_head.next
+        assert place != null_uint32, 'no next header in Key header'
+        self.p_head = Header(fp, place)
+        assert self.p_head.item_type == 'P', 'did not find expected Pointer header'
+        assert self.p_head.bytes_per_item == 4, 'bytes per item not 4 in Pointer header'
+        assert self.p_head.number_of_items == self.k_head.number_of_items,  \
+                  'number of items in Pointer header does not match number in Key header'
+        self.keywords = Data(fp, self.k_head).c
+        assert self.keywords is not None and isinstance(self.keywords,
+                                                        list), 'list of keywords not extracted from Key record'
+        self.pointers = Data(fp, self.p_head).a
+        assert self.pointers is not None and self.pointers.dtype == 'uint32'
+        self.fp = fp
 
-   def header_place_for_key(self, key, search = False):
-      """Returns file position pointer for a given key."""
+    def header_place_for_key(self, key, search = False):
+        """Returns file position pointer for a given key."""
 
-      key = key.strip().upper()
-      if key in self.keywords:
-         return self.pointers[self.keywords.index(key)]
-      if not search:
-         return None
-      for head_key in self.keywords:
-         sub_head_place = self.pointers[self.keywords.index(head_key)]
-         try:
-            sub_kp = KP(self.fp, sub_head_place)
-            sub_place = sub_kp.header_place_for_key(key, search = True)
-            if sub_place is not None:
-               return sub_place
-         except AssertionError:
-            pass  # probably not a K type subsidiary
-         except Exception:
-            raise
-      return None
+        key = key.strip().upper()
+        if key in self.keywords:
+            return self.pointers[self.keywords.index(key)]
+        if not search:
+            return None
+        for head_key in self.keywords:
+            sub_head_place = self.pointers[self.keywords.index(head_key)]
+            try:
+                sub_kp = KP(self.fp, sub_head_place)
+                sub_place = sub_kp.header_place_for_key(key, search = True)
+                if sub_place is not None:
+                    return sub_place
+            except AssertionError:
+                pass  # probably not a K type subsidiary
+            except Exception:
+                raise
+        return None
 
-   def head_for_key(self, key, search = False):
-      """Returns a Header record object for the given key."""
+    def head_for_key(self, key, search = False):
+        """Returns a Header record object for the given key."""
 
-      head_place = self.header_place_for_key(key, search = search)
-      if head_place is None:
-         return None
-      head = Header(self.fp, head_place)
-      if head.item_type == 'X':
-         return None  # invalid (non-ascii) item type character
-      return head
+        head_place = self.header_place_for_key(key, search = search)
+        if head_place is None:
+            return None
+        head = Header(self.fp, head_place)
+        if head.item_type == 'X':
+            return None  # invalid (non-ascii) item type character
+        return head
 
-   def data_for_key(self, key, search = False):
-      """Returns a Data object for the given key."""
+    def data_for_key(self, key, search = False):
+        """Returns a Data object for the given key."""
 
-      head = self.head_for_key(key, search = search)
-      if head is None:
-         return None
-      return Data(self.fp, head)
+        head = self.head_for_key(key, search = search)
+        if head is None:
+            return None
+        return Data(self.fp, head)
 
-   def key_list(self, filter = False):
-      """Returns a list of keys."""
+    def key_list(self, filter = False):
+        """Returns a list of keys."""
 
-      #      return Data(self.fp, self.k_head).c
-      if not filter:
-         return self.keywords
-      filtered_list = []
-      for key in self.keywords:
-         #        log.debug(f'key_list raw entry: {key}')
-         if key.isalnum():
-            filtered_list.append(key)
-      return filtered_list
+        #      return Data(self.fp, self.k_head).c
+        if not filter:
+            return self.keywords
+        filtered_list = []
+        for key in self.keywords:
+            #        log.debug(f'key_list raw entry: {key}')
+            if key.isalnum():
+                filtered_list.append(key)
+        return filtered_list
 
-   def sub_key_list(self, keyword, filter = False):
-      """Returns a list of keys subordinate to keyword."""
+    def sub_key_list(self, keyword, filter = False):
+        """Returns a list of keys subordinate to keyword."""
 
-      assert keyword in self.key_list(), 'keyword not present: ' + keyword
-      sub_head_place = self.pointers[self.keywords.index(keyword)]
-      sub_kp = KP(self.fp, sub_head_place)
-      return sub_kp.key_list(filter = filter)
+        assert keyword in self.key_list(), 'keyword not present: ' + keyword
+        sub_head_place = self.pointers[self.keywords.index(keyword)]
+        sub_kp = KP(self.fp, sub_head_place)
+        return sub_kp.key_list(filter = filter)
 
 
 class VDB():
-   """Class for handling a vdb, particularly to support import of grid and properties."""
+    """Class for handling a vdb, particularly to support import of grid and properties."""
 
-   def __init__(self, path):
-      """Initialises a VDB object and associates it with the given vdb directory path."""
+    def __init__(self, path):
+        """Initialises a VDB object and associates it with the given vdb directory path."""
 
-      self.path = None  # internal zip path of vdb in the case of a zip file
-      self.zip_file = None
-      self.zipped = zf.is_zipfile(path)
-      if self.zipped:
-         self.zip_file = path
-         with zf.ZipFile(path) as zfp:
-            zip_list = zfp.namelist()
-            warn = False
-            for name in zip_list:
-               if name.endswith('.vdb/'):
-                  if self.path is not None:
-                     warn = True
-                  self.path = name[:-1]
-               elif self.path is None and name == 'main.xml':
-                  self.path = ''
-         if warn:
-            log.warning('more than one vdb in zip file: using last')
-         if self.path is None:
-            raise Exception('no vdb found in zip file (at top level)')
-      else:
-         self.path = path
-         if not os.path.isdir(path):
-            log.warning('vdb path is neither a directory nor a zip file: ' + str(path))
-      self.case_list = None
-      self.use_case = None
-      self.grid_extents_kji = {}  # maps case name, grid_name to grid extent
-      self.grid_packings = {}  # maps case name, grid_name to grid unpack array
-      self.grid_lists = {}  # maps case name to grid name list
-      self.cases()  # sets use_case to first case in list for vdb
+        self.path = None  # internal zip path of vdb in the case of a zip file
+        self.zip_file = None
+        self.zipped = zf.is_zipfile(path)
+        if self.zipped:
+            self.zip_file = path
+            with zf.ZipFile(path) as zfp:
+                zip_list = zfp.namelist()
+                warn = False
+                for name in zip_list:
+                    if name.endswith('.vdb/'):
+                        if self.path is not None:
+                            warn = True
+                        self.path = name[:-1]
+                    elif self.path is None and name == 'main.xml':
+                        self.path = ''
+            if warn:
+                log.warning('more than one vdb in zip file: using last')
+            if self.path is None:
+                raise Exception('no vdb found in zip file (at top level)')
+        else:
+            self.path = path
+            if not os.path.isdir(path):
+                log.warning('vdb path is neither a directory nor a zip file: ' + str(path))
+        self.case_list = None
+        self.use_case = None
+        self.grid_extents_kji = {}  # maps case name, grid_name to grid extent
+        self.grid_packings = {}  # maps case name, grid_name to grid unpack array
+        self.grid_lists = {}  # maps case name to grid name list
+        self.cases()  # sets use_case to first case in list for vdb
 
-   def cases(self):
-      """Returns a list of simulation case strings as found in the main xml file."""
+    def cases(self):
+        """Returns a list of simulation case strings as found in the main xml file."""
 
-      if self.case_list is not None:
-         return self.case_list
-      try:
-         xml_file = os.path.join(self.path, 'main.xml')
-         if self.zipped:
-            with zf.ZipFile(self.zip_file) as zfp:
-               with zfp.open(xml_file) as fp:
-                  tree = rqet.parse(fp)
-                  root = tree.getroot()
-         else:
-            assert os.path.exists(xml_file), 'could not find vdb main xml file: ' + xml_file
-            with open(xml_file, 'r') as fp:
-               tree = rqet.parse(fp)
-               root = tree.getroot()
-         caselist = rqet.list_of_tag(rqet.find_tag(root, 'CASELIST'), 'CASE')
-         self.case_list = []
-         for case in caselist:
-            self.case_list.append(str(case.attrib['Name']).strip())
-         if self.use_case is None and len(self.case_list):
-            self.use_case = self.case_list[0]
-      except Exception:
-         log.exception('failed to extract case list')
-      return self.case_list
-
-   def set_use_case(self, case):
-      """Sets the simulation case to use in other functions."""
-
-      try:
-         assert case in self.cases(), 'failed to find case ' + case + ' in list of vdb cases'
-         self.use_case = case
-      except Exception:
-         log.exception('failed to set use case')
-
-   def print_header_tree(self, relative_path):
-      """Low level: prints out the raw header tree found in the vdb file (for debugging)."""
-
-      visited = []
-
-      def print_tree(fp, place = 4, level = 0, dots = False, file_size = None):
-         try:
-            if file_size is None:
-               fp.seek(0, 2)
-               file_size = int(fp.tell())
-            assert 0 <= int(place) < file_size, f'place {place} not within bounds of file of size {file_size}'
-            assert place not in visited, 'circular pointers in vdb file header structure'
-            visited.append(place)
-            head = Header(fp, place = place)
-            if head is None:
-               raise ValueError()
-            if dots:
-               indent = ((level - 1) * 3) * ' ' + ' ..'
+        if self.case_list is not None:
+            return self.case_list
+        try:
+            xml_file = os.path.join(self.path, 'main.xml')
+            if self.zipped:
+                with zf.ZipFile(self.zip_file) as zfp:
+                    with zfp.open(xml_file) as fp:
+                        tree = rqet.parse(fp)
+                        root = tree.getroot()
             else:
-               indent = (level * 3) * ' '
-            print(indent,
-                  head.item_type,
-                  ':',
-                  head.number_of_items,
-                  'items at',
-                  head.bytes_per_item,
-                  'bytes per item',
-                  end = '')
-            if head.item_type == 'C':
-               s = RawData(fp, head.data_place, 'C', head.number_of_items, head.max_items)
-               if s is None or s.c is None:
-                  print(': ?', end = '')
-               else:
-                  print(': "' + s.c + '"', end = '')
-            if head.first_fragment != null_uint32:
-               print(' with fragment(s)')
+                assert os.path.exists(xml_file), 'could not find vdb main xml file: ' + xml_file
+                with open(xml_file, 'r') as fp:
+                    tree = rqet.parse(fp)
+                    root = tree.getroot()
+            caselist = rqet.list_of_tag(rqet.find_tag(root, 'CASELIST'), 'CASE')
+            self.case_list = []
+            for case in caselist:
+                self.case_list.append(str(case.attrib['Name']).strip())
+            if self.use_case is None and len(self.case_list):
+                self.use_case = self.case_list[0]
+        except Exception:
+            log.exception('failed to extract case list')
+        return self.case_list
+
+    def set_use_case(self, case):
+        """Sets the simulation case to use in other functions."""
+
+        try:
+            assert case in self.cases(), 'failed to find case ' + case + ' in list of vdb cases'
+            self.use_case = case
+        except Exception:
+            log.exception('failed to set use case')
+
+    def print_header_tree(self, relative_path):
+        """Low level: prints out the raw header tree found in the vdb file (for debugging)."""
+
+        visited = []
+
+        def print_tree(fp, place = 4, level = 0, dots = False, file_size = None):
+            try:
+                if file_size is None:
+                    fp.seek(0, 2)
+                    file_size = int(fp.tell())
+                assert 0 <= int(place) < file_size, f'place {place} not within bounds of file of size {file_size}'
+                assert place not in visited, 'circular pointers in vdb file header structure'
+                visited.append(place)
+                head = Header(fp, place = place)
+                if head is None:
+                    raise ValueError()
+                if dots:
+                    indent = ((level - 1) * 3) * ' ' + ' ..'
+                else:
+                    indent = (level * 3) * ' '
+                print(indent,
+                      head.item_type,
+                      ':',
+                      head.number_of_items,
+                      'items at',
+                      head.bytes_per_item,
+                      'bytes per item',
+                      end = '')
+                if head.item_type == 'C':
+                    s = RawData(fp, head.data_place, 'C', head.number_of_items, head.max_items)
+                    if s is None or s.c is None:
+                        print(': ?', end = '')
+                    else:
+                        print(': "' + s.c + '"', end = '')
+                if head.first_fragment != null_uint32:
+                    print(' with fragment(s)')
+                else:
+                    print('')
+                if head.item_type == 'P':
+                    pointers = RawData(fp, head.data_place, 'P', head.number_of_items, head.max_items)
+                    assert (pointers is not None and pointers.a is not None)
+                    for p in pointers.a:
+                        if p in visited:
+                            log.warning('breaking at circular pointer to place ' + str(p))
+                            break
+                        if int(p) == 0:
+                            log.warning('pointer to place zero encountered')
+                        elif int(p) > file_size:
+                            log.warning('skipping pointer to place beyond end of file ' + str(p))
+                        else:
+                            print_tree(fp, place = p, level = level + 1, dots = True, file_size = file_size)
+                if head.next != null_uint32:
+                    if not 0 <= int(head.next) < file_size:
+                        log.warning(f'skipping next {head.next} outwith bounds of file of size {file_size}')
+                    else:
+                        print_tree(fp, place = head.next, level = level, file_size = file_size)
+            except Exception:
+                print('?')
+                log.exception('failed in print tree for headers')
+                raise
+
+        try:
+            path = os.path.join(self.path, self.use_case, relative_path)
+            assert os.path.exists(path), 'failed to find vdb file ' + path
+            print('Header tree for: ' + path)
+            with open(path, 'rb') as fp:
+                print_tree(fp)
+        except Exception:
+            log.exception('failed to print header tree for relative file ' + relative_path)
+
+    def print_key_tree(self, relative_path):
+        """Low level: prints out the keyword tree found in the vdb file."""
+
+        visited = []
+
+        def print_tree(fp, place = 4, level = 0):
+            try:
+                if int(place) == 0:
+                    log.warning('returning due to place zero in vdb file key structure')
+                    return
+                if place in visited:
+                    log.warning(f'returning at circular pointer at place {place} in vdb file key structure')
+                    return
+                visited.append(place)
+                kp = KP(fp, place = place)
+            except AssertionError:
+                return
+            except Exception as e:
+                log.error(str(e) + ' at place ' + str(place))
+                raise
+            key_list = kp.key_list()
+            for key in key_list:
+                print((level * 3) * ' ', key)
+                print_tree(fp, kp.header_place_for_key(key, search = False), level + 1)
+
+        try:
+            path = os.path.join(self.path, self.use_case, relative_path)
+            if self.zipped:
+                with zf.ZipFile(self.zip_file) as zfp:
+                    with zfp.open(path) as fp:
+                        print_tree(fp)
             else:
-               print('')
-            if head.item_type == 'P':
-               pointers = RawData(fp, head.data_place, 'P', head.number_of_items, head.max_items)
-               assert (pointers is not None and pointers.a is not None)
-               for p in pointers.a:
-                  if p in visited:
-                     log.warning('breaking at circular pointer to place ' + str(p))
-                     break
-                  if int(p) == 0:
-                     log.warning('pointer to place zero encountered')
-                  elif int(p) > file_size:
-                     log.warning('skipping pointer to place beyond end of file ' + str(p))
-                  else:
-                     print_tree(fp, place = p, level = level + 1, dots = True, file_size = file_size)
-            if head.next != null_uint32:
-               if not 0 <= int(head.next) < file_size:
-                  log.warning(f'skipping next {head.next} outwith bounds of file of size {file_size}')
-               else:
-                  print_tree(fp, place = head.next, level = level, file_size = file_size)
-         except Exception:
-            print('?')
-            log.exception('failed in print tree for headers')
-            raise
+                assert os.path.exists(path), 'failed to find vdb file ' + str(path)
+                with open(path, 'rb') as fp:
+                    print_tree(fp)
+        except Exception:
+            log.exception('failed to print keyword tree for relative file ' + relative_path)
 
-      try:
-         path = os.path.join(self.path, self.use_case, relative_path)
-         assert os.path.exists(path), 'failed to find vdb file ' + path
-         print('Header tree for: ' + path)
-         with open(path, 'rb') as fp:
-            print_tree(fp)
-      except Exception:
-         log.exception('failed to print header tree for relative file ' + relative_path)
+    def data_for_keyword(self, relative_path, keyword, search = True):
+        """Reads data associated with a keyword from a vdb binary file; returns a numpy array (or string)."""
 
-   def print_key_tree(self, relative_path):
-      """Low level: prints out the keyword tree found in the vdb file."""
+        try:
+            path = os.path.join(self.path, self.use_case, relative_path)
+            if self.zipped:
+                with zf.ZipFile(self.zip_file) as zfp:
+                    with zfp.open(path) as fp:
+                        assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
+                        kp = KP(fp)
+                        return kp.data_for_key(keyword, search = search)
+            else:
+                assert os.path.exists(path), 'failed to find vdb file ' + str(path)
+                with open(path, 'rb') as fp:
+                    assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
+                    kp = KP(fp)
+                    return kp.data_for_key(keyword, search = search)
+        except Exception:
+            log.exception('failed to read keyword data from vdb binary file: ' + path)
+        return None
 
-      visited = []
+    def data_for_keyword_chain(self, relative_path, keyword_chain):
+        """Follows a list of keywords down through hierarchy and returns the data as a numpy array (or string)."""
 
-      def print_tree(fp, place = 4, level = 0):
-         try:
-            if int(place) == 0:
-               log.warning('returning due to place zero in vdb file key structure')
-               return
-            if place in visited:
-               log.warning(f'returning at circular pointer at place {place} in vdb file key structure')
-               return
-            visited.append(place)
-            kp = KP(fp, place = place)
-         except AssertionError:
-            return
-         except Exception as e:
-            log.error(str(e) + ' at place ' + str(place))
-            raise
-         key_list = kp.key_list()
-         for key in key_list:
-            print((level * 3) * ' ', key)
-            print_tree(fp, kp.header_place_for_key(key, search = False), level + 1)
-
-      try:
-         path = os.path.join(self.path, self.use_case, relative_path)
-         if self.zipped:
-            with zf.ZipFile(self.zip_file) as zfp:
-               with zfp.open(path) as fp:
-                  print_tree(fp)
-         else:
-            assert os.path.exists(path), 'failed to find vdb file ' + str(path)
-            with open(path, 'rb') as fp:
-               print_tree(fp)
-      except Exception:
-         log.exception('failed to print keyword tree for relative file ' + relative_path)
-
-   def data_for_keyword(self, relative_path, keyword, search = True):
-      """Reads data associated with a keyword from a vdb binary file; returns a numpy array (or string)."""
-
-      try:
-         path = os.path.join(self.path, self.use_case, relative_path)
-         if self.zipped:
-            with zf.ZipFile(self.zip_file) as zfp:
-               with zfp.open(path) as fp:
-                  assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
-                  kp = KP(fp)
-                  return kp.data_for_key(keyword, search = search)
-         else:
-            assert os.path.exists(path), 'failed to find vdb file ' + str(path)
-            with open(path, 'rb') as fp:
-               assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
-               kp = KP(fp)
-               return kp.data_for_key(keyword, search = search)
-      except Exception:
-         log.exception('failed to read keyword data from vdb binary file: ' + path)
-      return None
-
-   def data_for_keyword_chain(self, relative_path, keyword_chain):
-      """Follows a list of keywords down through hierarchy and returns the data as a numpy array (or string)."""
-
-      def dfkc_fp(fp, path, keyword_chain):
-         assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
-         chain_list = list(keyword_chain)
-         assert len(chain_list) > 0, 'empty chained keyword list'
-         head_place = 4
-         while len(chain_list) > 1:
+        def dfkc_fp(fp, path, keyword_chain):
+            assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
+            chain_list = list(keyword_chain)
+            assert len(chain_list) > 0, 'empty chained keyword list'
+            head_place = 4
+            while len(chain_list) > 1:
+                kp = KP(fp, place = head_place)
+                head_place = kp.header_place_for_key(chain_list[0], search = False)
+                assert head_place is not None, 'failed to find chained keyword: ' + chain_list[0]
+                chain_list.pop(0)
             kp = KP(fp, place = head_place)
-            head_place = kp.header_place_for_key(chain_list[0], search = False)
-            assert head_place is not None, 'failed to find chained keyword: ' + chain_list[0]
-            chain_list.pop(0)
-         kp = KP(fp, place = head_place)
-         return kp.data_for_key(chain_list[0], search = False)
+            return kp.data_for_key(chain_list[0], search = False)
 
-      path = os.path.join(self.path, self.use_case, relative_path)
-      try:
-         if isinstance(keyword_chain, str):
-            return self.data_for_keyword(relative_path, keyword_chain)
-         if self.zipped:
-            with zf.ZipFile(self.zip_file) as zfp:
-               with zfp.open(path) as fp:
-                  return dfkc_fp(fp, path, keyword_chain)
-         else:
-            assert os.path.exists(path), 'failed to find vdb file ' + str(path)
-            with open(path, 'rb') as fp:
-               return dfkc_fp(fp, path, keyword_chain)
-      except Exception:
-         log.exception('failed to read chained keyword data from vdb binary file: ' + path)
-      return None
-
-   def set_extent_kji(self, extent_kji, use_case = None, grid_name = 'ROOT'):
-      """Sets extent for one use case (defaults to current use case) as alternative to processing corp data."""
-
-      assert len(extent_kji) == 3, 'triple integer required for extent_kji'
-      if use_case is None:
-         use_case = self.use_case
-      assert use_case is not None, 'no use case for extent setting'
-      self.grid_extents_kji[use_case, grid_name.upper()] = extent_kji
-
-   def fetch_corp_patch(self, relative_path):
-      """Loads one patch of grid corp data from one file in the vdb; returns (number of cells, 1D array)."""
-
-      a = self.data_for_keyword(relative_path, 'CORP').a
-      assert a is not None, 'failed to extract corp data from vdb relative path ' + relative_path
-      element_count = a.size
-      assert element_count > 0, 'corp data is empty (no numbers)'
-      cells, remainder = divmod(element_count, 24)
-      assert remainder == 0, 'number of numbers in corp data is not a multiple of 24'
-      if a.dtype == 'float32':
-         d = np.empty((element_count,), dtype = 'float')  # double precision
-         d[:] = a
-         del a
-         a = d
-      return cells, a
-
-   def list_of_grids(self):
-      """Returns a list of grid names for which corp data exists in the vdb for the current use case."""
-
-      if self.use_case is None:
-         self.cases()
-      if self.use_case in self.grid_lists:
-         return self.grid_lists[self.use_case]
-      glob_path = os.path.join(self.path, self.use_case, 'INIT', '*_corp.bin')
-      if self.zipped:
-         corp_list = self.zip_glob(glob_path)
-      else:
-         corp_list = glob.glob(glob_path)
-      grid_name_list = []
-      for corp_path in corp_list:
-         _, corp_file_name = os.path.split(corp_path)
-         grid_name = corp_file_name[:-9].upper()
-         if grid_name == 'ROOT':
-            grid_name_list.insert(0, 'ROOT')
-         else:
-            grid_name_list.append(grid_name)
-      self.grid_lists[self.use_case] = grid_name_list
-      return grid_name_list
-
-   def root_corp(self):
-      """Loads root grid corp data from vdb; returns pagoda style resequenced 7D numpy array of doubles."""
-
-      return self.grid_corp('ROOT')
-
-   def grid_corp(self, grid_name):
-      """Loads corp data for named grid from vdb; returns pagoda style resequenced 7D numpy array of doubles."""
-      try:
-         if self.use_case is None:
-            self.cases()
-         grid_name = grid_name.upper()
-         assert self.use_case is not None, 'no case found in vdb'
-         relative_path = os.path.join('INIT', str(grid_name) + '_corp.bin')
-         cells, a = self.fetch_corp_patch(relative_path)
-         # check for extra corp patch files (used for big grids)
-         glob_path = os.path.join(self.path, self.use_case, 'INIT', str(grid_name) + '_corp')
-         glob_path += '_*.bin'
-         if self.zipped:
-            corp_patch_list = self.zip_glob(glob_path)
-         else:
-            corp_patch_list = glob.glob(glob_path)
-         if len(corp_patch_list) > 0:
-            sort_list = []
-            for patch_name in corp_patch_list:
-               layer_number = int(patch_name[patch_name.rfind('_') + 1:-4])
-               sort_list.append((layer_number, patch_name))
-            sort_list.sort()
-            for _, patch_name in sort_list:
-               patch_relative_path = patch_name[patch_name.rfind('INIT'):]
-               patch_cells, patch = self.fetch_corp_patch(patch_relative_path)
-               a = np.append(a, patch)
-               cells += patch_cells
-         ap = a.reshape((1, 1, cells, 2, 2, 2, 3))
-         gf.resequence_nexus_corp(ap)  # move from Nexus corp ordering to Pagoda ordering
-         if (self.use_case, grid_name) in self.grid_extents_kji:
-            extent_kji = self.grid_extents_kji[self.use_case, grid_name]
-            assert cells == extent_kji[0] * extent_kji[1] * extent_kji[2], 'corp extent mismatch in vdb'
-         else:
-            extent_kji = gf.determine_corp_extent(ap)
-            if extent_kji is None:
-               log.warning('failed to determine extent of root grid from corp data')
-               extent_kji = (1, 1, cells)
+        path = os.path.join(self.path, self.use_case, relative_path)
+        try:
+            if isinstance(keyword_chain, str):
+                return self.data_for_keyword(relative_path, keyword_chain)
+            if self.zipped:
+                with zf.ZipFile(self.zip_file) as zfp:
+                    with zfp.open(path) as fp:
+                        return dfkc_fp(fp, path, keyword_chain)
             else:
-               self.grid_extents_kji[self.use_case, grid_name] = extent_kji
-         shape_7d = (extent_kji[0], extent_kji[1], extent_kji[2], 2, 2, 2, 3)
-         return ap.reshape(shape_7d)
-      except Exception:
-         log.exception('failed to extract root grid corp data from vdb')
-      return None
+                assert os.path.exists(path), 'failed to find vdb file ' + str(path)
+                with open(path, 'rb') as fp:
+                    return dfkc_fp(fp, path, keyword_chain)
+        except Exception:
+            log.exception('failed to read chained keyword data from vdb binary file: ' + path)
+        return None
 
-   def load_init_mapdata_array(self, file, keyword, dtype = None, unpack = False, grid_name = 'ROOT'):
-      """Loads an INIT MAPDATA array from vdb; returns 3D numpy array coerced to dtype (if not None)."""
+    def set_extent_kji(self, extent_kji, use_case = None, grid_name = 'ROOT'):
+        """Sets extent for one use case (defaults to current use case) as alternative to processing corp data."""
 
-      try:
-         if self.use_case is None:
+        assert len(extent_kji) == 3, 'triple integer required for extent_kji'
+        if use_case is None:
+            use_case = self.use_case
+        assert use_case is not None, 'no use case for extent setting'
+        self.grid_extents_kji[use_case, grid_name.upper()] = extent_kji
+
+    def fetch_corp_patch(self, relative_path):
+        """Loads one patch of grid corp data from one file in the vdb; returns (number of cells, 1D array)."""
+
+        a = self.data_for_keyword(relative_path, 'CORP').a
+        assert a is not None, 'failed to extract corp data from vdb relative path ' + relative_path
+        element_count = a.size
+        assert element_count > 0, 'corp data is empty (no numbers)'
+        cells, remainder = divmod(element_count, 24)
+        assert remainder == 0, 'number of numbers in corp data is not a multiple of 24'
+        if a.dtype == 'float32':
+            d = np.empty((element_count,), dtype = 'float')  # double precision
+            d[:] = a
+            del a
+            a = d
+        return cells, a
+
+    def list_of_grids(self):
+        """Returns a list of grid names for which corp data exists in the vdb for the current use case."""
+
+        if self.use_case is None:
             self.cases()
-         assert self.use_case is not None, 'no case found in vdb'
-         relative_path = os.path.join('INIT', 'MAPDATA', file)
-         a = self.data_for_keyword(relative_path, keyword, search = True).a
-         assert a is not None, 'failed to extract data for keyword ' + keyword + ' from vdb relative path ' + relative_path
-         if unpack:
-            un = self.grid_unpack(grid_name)
-            if un is not None:
-               null_start = np.zeros((a.size + 1,), dtype = a.dtype)  # better to use Nan for null value?
-               null_start[1:] = a
-               a = null_start[un]
-         a = self.grid_shaped(grid_name, coerce(a, dtype))
-         return a
-      except Exception:
-         log.exception('failed to extract data from vdb for grid ' + str(grid_name))
-      return None
+        if self.use_case in self.grid_lists:
+            return self.grid_lists[self.use_case]
+        glob_path = os.path.join(self.path, self.use_case, 'INIT', '*_corp.bin')
+        if self.zipped:
+            corp_list = self.zip_glob(glob_path)
+        else:
+            corp_list = glob.glob(glob_path)
+        grid_name_list = []
+        for corp_path in corp_list:
+            _, corp_file_name = os.path.split(corp_path)
+            grid_name = corp_file_name[:-9].upper()
+            if grid_name == 'ROOT':
+                grid_name_list.insert(0, 'ROOT')
+            else:
+                grid_name_list.append(grid_name)
+        self.grid_lists[self.use_case] = grid_name_list
+        return grid_name_list
 
-   def load_recurrent_mapdata_array(self, file, keyword, dtype = None, unpack = False, grid_name = 'ROOT'):
-      """Loads a RECUR MAPDATA array from vdb; returns 3D numpy array coerced to dtype (if not None)."""
+    def root_corp(self):
+        """Loads root grid corp data from vdb; returns pagoda style resequenced 7D numpy array of doubles."""
 
-      try:
-         if not keyword or not keyword.isalnum():
-            log.warning('ignoring attempt to load recurrent vdb mapdata for corrupt keyword')
+        return self.grid_corp('ROOT')
+
+    def grid_corp(self, grid_name):
+        """Loads corp data for named grid from vdb; returns pagoda style resequenced 7D numpy array of doubles."""
+        try:
+            if self.use_case is None:
+                self.cases()
+            grid_name = grid_name.upper()
+            assert self.use_case is not None, 'no case found in vdb'
+            relative_path = os.path.join('INIT', str(grid_name) + '_corp.bin')
+            cells, a = self.fetch_corp_patch(relative_path)
+            # check for extra corp patch files (used for big grids)
+            glob_path = os.path.join(self.path, self.use_case, 'INIT', str(grid_name) + '_corp')
+            glob_path += '_*.bin'
+            if self.zipped:
+                corp_patch_list = self.zip_glob(glob_path)
+            else:
+                corp_patch_list = glob.glob(glob_path)
+            if len(corp_patch_list) > 0:
+                sort_list = []
+                for patch_name in corp_patch_list:
+                    layer_number = int(patch_name[patch_name.rfind('_') + 1:-4])
+                    sort_list.append((layer_number, patch_name))
+                sort_list.sort()
+                for _, patch_name in sort_list:
+                    patch_relative_path = patch_name[patch_name.rfind('INIT'):]
+                    patch_cells, patch = self.fetch_corp_patch(patch_relative_path)
+                    a = np.append(a, patch)
+                    cells += patch_cells
+            ap = a.reshape((1, 1, cells, 2, 2, 2, 3))
+            gf.resequence_nexus_corp(ap)  # move from Nexus corp ordering to Pagoda ordering
+            if (self.use_case, grid_name) in self.grid_extents_kji:
+                extent_kji = self.grid_extents_kji[self.use_case, grid_name]
+                assert cells == extent_kji[0] * extent_kji[1] * extent_kji[2], 'corp extent mismatch in vdb'
+            else:
+                extent_kji = gf.determine_corp_extent(ap)
+                if extent_kji is None:
+                    log.warning('failed to determine extent of root grid from corp data')
+                    extent_kji = (1, 1, cells)
+                else:
+                    self.grid_extents_kji[self.use_case, grid_name] = extent_kji
+            shape_7d = (extent_kji[0], extent_kji[1], extent_kji[2], 2, 2, 2, 3)
+            return ap.reshape(shape_7d)
+        except Exception:
+            log.exception('failed to extract root grid corp data from vdb')
+        return None
+
+    def load_init_mapdata_array(self, file, keyword, dtype = None, unpack = False, grid_name = 'ROOT'):
+        """Loads an INIT MAPDATA array from vdb; returns 3D numpy array coerced to dtype (if not None)."""
+
+        try:
+            if self.use_case is None:
+                self.cases()
+            assert self.use_case is not None, 'no case found in vdb'
+            relative_path = os.path.join('INIT', 'MAPDATA', file)
+            a = self.data_for_keyword(relative_path, keyword, search = True).a
+            assert a is not None, 'failed to extract data for keyword ' + keyword + ' from vdb relative path ' + relative_path
+            if unpack:
+                un = self.grid_unpack(grid_name)
+                if un is not None:
+                    null_start = np.zeros((a.size + 1,), dtype = a.dtype)  # better to use Nan for null value?
+                    null_start[1:] = a
+                    a = null_start[un]
+            a = self.grid_shaped(grid_name, coerce(a, dtype))
+            return a
+        except Exception:
+            log.exception('failed to extract data from vdb for grid ' + str(grid_name))
+        return None
+
+    def load_recurrent_mapdata_array(self, file, keyword, dtype = None, unpack = False, grid_name = 'ROOT'):
+        """Loads a RECUR MAPDATA array from vdb; returns 3D numpy array coerced to dtype (if not None)."""
+
+        try:
+            if not keyword or not keyword.isalnum():
+                log.warning('ignoring attempt to load recurrent vdb mapdata for corrupt keyword')
+                return None
+            if self.use_case is None:
+                self.cases()
+            assert self.use_case is not None, 'no case found in vdb'
+            relative_path = os.path.join('RECUR', 'MAPDATA', file)
+            data = self.data_for_keyword(relative_path, keyword, search = True)
+            if not data:
+                return None
+            a = data.a
+            if a is None:
+                return None
+            if unpack:
+                un = self.grid_unpack(grid_name)
+                if un is not None:
+                    null_start = np.zeros((a.size + 1,), dtype = a.dtype)  # better to use Nan for null value?
+                    null_start[1:] = a
+                    a = null_start[un]
+            a = self.grid_shaped(grid_name, coerce(a, dtype))
+            return a
+        except Exception:
+            log.exception('failed to extract grid recurrent data from vdb for keyword: ' + keyword)
+        return None
+
+    def root_dad(self):
+        """Loads and returns the IROOTDAD array from vdb; returns 3D numpy int32 array."""
+
+        return self.grid_dad('ROOT')
+
+    def grid_dad(self, grid_name):
+        """Loads and returns the DAD array from vdb for the named grid; returns 3D numpy int32 array."""
+
+        # todo: check file naming and values for LGRs
+        grid_name = grid_name.upper
+        # DAD data appear to be unique cell ids, in usual sequence, starting at 1, same as UID
+        return self.load_init_mapdata_array(file = 'I' + grid_name + 'DAD.bin',
+                                            keyword = 'DAD',
+                                            dtype = 'int32',
+                                            unpack = False,
+                                            grid_name = grid_name)
+
+    def root_kid(self):
+        """Loads and returns the IROOTKID array from vdb; returns 3D numpy int32 array (can be inactive cell mask)."""
+
+        return self.grid_kid('ROOT')
+
+    def grid_kid(self, grid_name):
+        """Loads and returns the IROOTKID array from vdb; returns 3D numpy int32 array (can be inactive cell mask)."""
+
+        grid_name = grid_name.upper()
+        # see comments in grid_kid_inactive_mask() for KID values
+        return self.load_init_mapdata_array(file = 'I' + grid_name + 'KID.bin',
+                                            keyword = 'KID',
+                                            dtype = 'int32',
+                                            unpack = False,
+                                            grid_name = grid_name)
+
+    def root_kid_inactive_mask(self):
+        """Loads the IROOTKID array and returns boolean mask of cells inactive in ROOT grid."""
+
+        return self.grid_kid_inactive_mask('ROOT')
+
+    def grid_kid_inactive_mask(self, grid_name):
+        """Loads the KID array for the named grid and returns boolean mask of cells inactive in grid."""
+
+        # KID values:
+        # 0 - active in this grid
+        # >0 - (in ROOT grid) cell inactive in ROOT as assigned to an LGR (KID value is LGR number)
+        # -1 – inactive for normal reasons (zero pore volume or DEADCELL set)
+        # -2 - (in LGR grids) cell omitted from LGR (possibly omitted as inactive in parent grid?)
+        # -3 - inactive due to coarsening (coarsening repurposes one cell in parent grid for each coarsened cell)
+        i = self.grid_kid(grid_name)
+        if i is None:
             return None
-         if self.use_case is None:
-            self.cases()
-         assert self.use_case is not None, 'no case found in vdb'
-         relative_path = os.path.join('RECUR', 'MAPDATA', file)
-         data = self.data_for_keyword(relative_path, keyword, search = True)
-         if not data:
-            return None
-         a = data.a
-         if a is None:
-            return None
-         if unpack:
-            un = self.grid_unpack(grid_name)
-            if un is not None:
-               null_start = np.zeros((a.size + 1,), dtype = a.dtype)  # better to use Nan for null value?
-               null_start[1:] = a
-               a = null_start[un]
-         a = self.grid_shaped(grid_name, coerce(a, dtype))
-         return a
-      except Exception:
-         log.exception('failed to extract grid recurrent data from vdb for keyword: ' + keyword)
-      return None
+        b = np.empty(i.shape, dtype = 'bool')
+        b[:] = (i != 0)
+        return b
 
-   def root_dad(self):
-      """Loads and returns the IROOTDAD array from vdb; returns 3D numpy int32 array."""
+    def root_uid(self):
+        """Loads and returns the IROOTUID array from vdb; returns 3D numpy int32 array."""
 
-      return self.grid_dad('ROOT')
+        return self.grid_uid('ROOT')
 
-   def grid_dad(self, grid_name):
-      """Loads and returns the DAD array from vdb for the named grid; returns 3D numpy int32 array."""
+    def grid_uid(self, grid_name):
+        """Loads and returns the UID array from vdb for the named grid; returns 3D numpy int32 array."""
 
-      # todo: check file naming and values for LGRs
-      grid_name = grid_name.upper
-      # DAD data appear to be unique cell ids, in usual sequence, starting at 1, same as UID
-      return self.load_init_mapdata_array(file = 'I' + grid_name + 'DAD.bin',
-                                          keyword = 'DAD',
+        grid_name = grid_name.upper()
+        # UID data appear to be unique cell ids, in usual sequence, starting at 1, same as DAD
+        return self.load_init_mapdata_array(file = 'I' + grid_name + 'UID.bin',
+                                            keyword = 'UID',
+                                            dtype = 'int32',
+                                            unpack = False,
+                                            grid_name = grid_name)
+
+    def root_unpack(self):
+        """Loads and returns the IROOTUNPACK array from vdb; returns 3D numpy int32 array."""
+
+        return self.grid_unpack('ROOT')
+
+    def grid_unpack(self, grid_name):
+        """Loads and returns the IROOTUNPACK array from vdb; returns 3D numpy int32 array."""
+
+        grid_name = grid_name.upper()
+        if self.use_case is not None and (self.use_case, grid_name) in self.grid_packings.keys():
+            return self.grid_packings[self.use_case, grid_name]
+        # UNPACK data appear to be index into packed array for each cell, zero for inactive/absent
+        un = self.load_init_mapdata_array(file = 'I' + grid_name + 'UNPACK.bin',
+                                          keyword = 'UNPACK',
                                           dtype = 'int32',
                                           unpack = False,
                                           grid_name = grid_name)
+        if self.use_case is not None:
+            self.grid_packings[self.use_case,
+                               grid_name] = un  # cache unpack array for later packing & unpacking operations
+        return un
 
-   def root_kid(self):
-      """Loads and returns the IROOTKID array from vdb; returns 3D numpy int32 array (can be inactive cell mask)."""
+    def list_of_static_properties(self):
+        """Returns list of static property keywords present in the vdb for ROOT."""
 
-      return self.grid_kid('ROOT')
+        return self.grid_list_of_static_properties('ROOT')
 
-   def grid_kid(self, grid_name):
-      """Loads and returns the IROOTKID array from vdb; returns 3D numpy int32 array (can be inactive cell mask)."""
+    def grid_list_of_static_properties(self, grid_name):
+        """Returns list of static property keywords present in the vdb for named grid."""
 
-      grid_name = grid_name.upper()
-      # see comments in grid_kid_inactive_mask() for KID values
-      return self.load_init_mapdata_array(file = 'I' + grid_name + 'KID.bin',
-                                          keyword = 'KID',
-                                          dtype = 'int32',
-                                          unpack = False,
-                                          grid_name = grid_name)
+        grid_name = grid_name.upper()
+        glob_path = os.path.join(self.path, self.use_case, 'INIT', 'MAPDATA', 'I' + grid_name + '*.bin')
+        if self.zipped:
+            file_list = self.zip_glob(glob_path)
+        else:
+            file_list = glob.glob(glob_path)
+        keyword_list = []
+        for p in file_list:
+            _, f = os.path.split(p)
+            keyword = f[1 + len(grid_name):-4]
+            keyword_list.append(keyword)
+        return keyword_list
 
-   def root_kid_inactive_mask(self):
-      """Loads the IROOTKID array and returns boolean mask of cells inactive in ROOT grid."""
+    def root_static_property(self, keyword, dtype = None, unpack = None):
+        """Loads and returns a ROOT static property array."""
 
-      return self.grid_kid_inactive_mask('ROOT')
+        return self.grid_static_property('ROOT'.keyword, dtype = dtype, unpack = unpack)
 
-   def grid_kid_inactive_mask(self, grid_name):
-      """Loads the KID array for the named grid and returns boolean mask of cells inactive in grid."""
+    def grid_static_property(self, grid_name, keyword, dtype = None, unpack = None):
+        """Loads and returns a static property array for named grid."""
 
-      # KID values:
-      # 0 - active in this grid
-      # >0 - (in ROOT grid) cell inactive in ROOT as assigned to an LGR (KID value is LGR number)
-      # -1 – inactive for normal reasons (zero pore volume or DEADCELL set)
-      # -2 - (in LGR grids) cell omitted from LGR (possibly omitted as inactive in parent grid?)
-      # -3 - inactive due to coarsening (coarsening repurposes one cell in parent grid for each coarsened cell)
-      i = self.grid_kid(grid_name)
-      if i is None:
-         return None
-      b = np.empty(i.shape, dtype = 'bool')
-      b[:] = (i != 0)
-      return b
+        grid_name = grid_name.upper()
+        keyword = keyword.strip().upper()
+        if unpack is None:
+            unpack = (keyword not in init_not_packed)
+        return self.load_init_mapdata_array(file = 'I' + grid_name + keyword + '.bin',
+                                            keyword = keyword,
+                                            dtype = dtype,
+                                            unpack = unpack,
+                                            grid_name = grid_name)
 
-   def root_uid(self):
-      """Loads and returns the IROOTUID array from vdb; returns 3D numpy int32 array."""
+    def list_of_timesteps(self):
+        """Returns a list of integer timesteps for which a ROOT recurrent mapdata file exists."""
 
-      return self.grid_uid('ROOT')
+        return self.grid_list_of_timesteps('ROOT')
 
-   def grid_uid(self, grid_name):
-      """Loads and returns the UID array from vdb for the named grid; returns 3D numpy int32 array."""
+    def grid_list_of_timesteps(self, grid_name):
+        """Returns a list of integer timesteps for which a recurrent mapdata file for the named grid exists."""
 
-      grid_name = grid_name.upper()
-      # UID data appear to be unique cell ids, in usual sequence, starting at 1, same as DAD
-      return self.load_init_mapdata_array(file = 'I' + grid_name + 'UID.bin',
-                                          keyword = 'UID',
-                                          dtype = 'int32',
-                                          unpack = False,
-                                          grid_name = grid_name)
+        # todo: check file naming for LGR recurrent properties
+        grid_name = grid_name.upper()
+        glob_path = os.path.join(self.path, self.use_case, 'RECUR', 'MAPDATA', 'R' + grid_name + '_*.bin')
+        if self.zipped:
+            file_list = self.zip_glob(glob_path)
+        else:
+            file_list = glob.glob(glob_path)
+        timestep_list = []
+        for p in file_list:
+            timestep_list.append(int(p[p.rfind('_') + 1:-4]))
+        return sorted(timestep_list)
 
-   def root_unpack(self):
-      """Loads and returns the IROOTUNPACK array from vdb; returns 3D numpy int32 array."""
+    def list_of_recurrent_properties(self, timestep):
+        """Returns list of recurrent property keywords present in the vdb for given timestep."""
 
-      return self.grid_unpack('ROOT')
+        return self.grid_list_of_recurrent_properties('ROOT', timestep)
 
-   def grid_unpack(self, grid_name):
-      """Loads and returns the IROOTUNPACK array from vdb; returns 3D numpy int32 array."""
+    def grid_list_of_recurrent_properties(self, grid_name, timestep):
+        """Returns list of recurrent property keywords present in the vdb for named grid for given timestep."""
 
-      grid_name = grid_name.upper()
-      if self.use_case is not None and (self.use_case, grid_name) in self.grid_packings.keys():
-         return self.grid_packings[self.use_case, grid_name]
-      # UNPACK data appear to be index into packed array for each cell, zero for inactive/absent
-      un = self.load_init_mapdata_array(file = 'I' + grid_name + 'UNPACK.bin',
-                                        keyword = 'UNPACK',
-                                        dtype = 'int32',
-                                        unpack = False,
-                                        grid_name = grid_name)
-      if self.use_case is not None:
-         self.grid_packings[self.use_case,
-                            grid_name] = un  # cache unpack array for later packing & unpacking operations
-      return un
-
-   def list_of_static_properties(self):
-      """Returns list of static property keywords present in the vdb for ROOT."""
-
-      return self.grid_list_of_static_properties('ROOT')
-
-   def grid_list_of_static_properties(self, grid_name):
-      """Returns list of static property keywords present in the vdb for named grid."""
-
-      grid_name = grid_name.upper()
-      glob_path = os.path.join(self.path, self.use_case, 'INIT', 'MAPDATA', 'I' + grid_name + '*.bin')
-      if self.zipped:
-         file_list = self.zip_glob(glob_path)
-      else:
-         file_list = glob.glob(glob_path)
-      keyword_list = []
-      for p in file_list:
-         _, f = os.path.split(p)
-         keyword = f[1 + len(grid_name):-4]
-         keyword_list.append(keyword)
-      return keyword_list
-
-   def root_static_property(self, keyword, dtype = None, unpack = None):
-      """Loads and returns a ROOT static property array."""
-
-      return self.grid_static_property('ROOT'.keyword, dtype = dtype, unpack = unpack)
-
-   def grid_static_property(self, grid_name, keyword, dtype = None, unpack = None):
-      """Loads and returns a static property array for named grid."""
-
-      grid_name = grid_name.upper()
-      keyword = keyword.strip().upper()
-      if unpack is None:
-         unpack = (keyword not in init_not_packed)
-      return self.load_init_mapdata_array(file = 'I' + grid_name + keyword + '.bin',
-                                          keyword = keyword,
-                                          dtype = dtype,
-                                          unpack = unpack,
-                                          grid_name = grid_name)
-
-   def list_of_timesteps(self):
-      """Returns a list of integer timesteps for which a ROOT recurrent mapdata file exists."""
-
-      return self.grid_list_of_timesteps('ROOT')
-
-   def grid_list_of_timesteps(self, grid_name):
-      """Returns a list of integer timesteps for which a recurrent mapdata file for the named grid exists."""
-
-      # todo: check file naming for LGR recurrent properties
-      grid_name = grid_name.upper()
-      glob_path = os.path.join(self.path, self.use_case, 'RECUR', 'MAPDATA', 'R' + grid_name + '_*.bin')
-      if self.zipped:
-         file_list = self.zip_glob(glob_path)
-      else:
-         file_list = glob.glob(glob_path)
-      timestep_list = []
-      for p in file_list:
-         timestep_list.append(int(p[p.rfind('_') + 1:-4]))
-      return sorted(timestep_list)
-
-   def list_of_recurrent_properties(self, timestep):
-      """Returns list of recurrent property keywords present in the vdb for given timestep."""
-
-      return self.grid_list_of_recurrent_properties('ROOT', timestep)
-
-   def grid_list_of_recurrent_properties(self, grid_name, timestep):
-      """Returns list of recurrent property keywords present in the vdb for named grid for given timestep."""
-
-      def keyword_list_from_fp(fp, path):
-         assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
-         kp = KP(fp)
-         keyword_list = kp.sub_key_list('MAPDATA', filter = True)
-         try:
-            keyword_list.remove('LASTMOD')
-         except Exception:
-            pass
-         bad_key_indices = []
-         for i in range(len(keyword_list)):
-            key = keyword_list[i]
-            if not key or not key.isalnum():
-               bad_key_indices.append(i)
-         if len(bad_key_indices):
-            log.warning(str(len(bad_key_indices)) + ' non-ascii keywords ignored in recurrent file ' + path)
-            bad_key_indices.reverse()
-            for i in bad_key_indices:
-               keyword_list.pop(i)
-         return keyword_list
-
-      # todo: check file naming for LGR recurrent properties
-      grid_name = grid_name.upper()
-      try:
-         path = os.path.join(self.path, self.use_case, 'RECUR', 'MAPDATA',
-                             'R' + grid_name + '_' + str(timestep) + '.bin')
-         if self.zipped:
-            with zf.ZipFile(self.zip_file) as zfp:
-               with zfp.open(path) as fp:
-                  return keyword_list_from_fp(fp, path)
-         else:
-            assert os.path.exists(path), 'failed to find vdb file ' + str(path)
-            with open(path, 'rb') as fp:
-               return keyword_list_from_fp(fp, path)
-      except Exception:
-         log.exception('failed to read keyword data from vdb binary file: ' + path)
-      return None
-
-   def root_recurrent_property_for_timestep(self, keyword, timestep, dtype = None, unpack = True):
-      """Loads and returns a ROOT recurrent property array for one timestep."""
-
-      return self.grid_recurrent_property_for_timestep('ROOT', keyword, timestep, dtype = dtype, unpack = unpack)
-
-   def grid_recurrent_property_for_timestep(self, grid_name, keyword, timestep, dtype = None, unpack = True):
-      """Loads and returns a recurrent property array for named grid for one timestep."""
-
-      # todo: check file naming convention for LGRs
-      grid_name = grid_name.upper()
-      keyword = keyword.strip().upper()
-      return self.load_recurrent_mapdata_array(file = 'R' + grid_name + '_' + str(timestep) + '.bin',
-                                               keyword = keyword,
-                                               dtype = dtype,
-                                               unpack = unpack,
-                                               grid_name = grid_name)
-
-   def header_place_for_keyword(self, relative_path, keyword, search = True):
-      """Low level function to return file position for header relating to given keyword."""
-
-      try:
-         path = os.path.join(self.path, relative_path)
-         assert os.path.exists(path), 'failed to find vdb file ' + str(path)
-         with open(path, 'rb') as fp:
+        def keyword_list_from_fp(fp, path):
             assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
             kp = KP(fp)
-            return kp.header_place_for_key(keyword, search = search)
-      except Exception:
-         log.exception('failed to read keyword data from vdb binary file: ' + path)
-      return None
+            keyword_list = kp.sub_key_list('MAPDATA', filter = True)
+            try:
+                keyword_list.remove('LASTMOD')
+            except Exception:
+                pass
+            bad_key_indices = []
+            for i in range(len(keyword_list)):
+                key = keyword_list[i]
+                if not key or not key.isalnum():
+                    bad_key_indices.append(i)
+            if len(bad_key_indices):
+                log.warning(str(len(bad_key_indices)) + ' non-ascii keywords ignored in recurrent file ' + path)
+                bad_key_indices.reverse()
+                for i in bad_key_indices:
+                    keyword_list.pop(i)
+            return keyword_list
 
-   def root_shaped(self, a):
-      """Returns array reshaped to root grid extent for current use case, if known; otherwise unchanged."""
+        # todo: check file naming for LGR recurrent properties
+        grid_name = grid_name.upper()
+        try:
+            path = os.path.join(self.path, self.use_case, 'RECUR', 'MAPDATA',
+                                'R' + grid_name + '_' + str(timestep) + '.bin')
+            if self.zipped:
+                with zf.ZipFile(self.zip_file) as zfp:
+                    with zfp.open(path) as fp:
+                        return keyword_list_from_fp(fp, path)
+            else:
+                assert os.path.exists(path), 'failed to find vdb file ' + str(path)
+                with open(path, 'rb') as fp:
+                    return keyword_list_from_fp(fp, path)
+        except Exception:
+            log.exception('failed to read keyword data from vdb binary file: ' + path)
+        return None
 
-      return self.grid_shaped('ROOT', a)
+    def root_recurrent_property_for_timestep(self, keyword, timestep, dtype = None, unpack = True):
+        """Loads and returns a ROOT recurrent property array for one timestep."""
 
-   def grid_shaped(self, grid_name, a):
-      """Returns array reshaped to named grid extent for current use case, if known; otherwise unchanged."""
+        return self.grid_recurrent_property_for_timestep('ROOT', keyword, timestep, dtype = dtype, unpack = unpack)
 
-      grid_name = grid_name.upper()
-      if self.use_case is not None and (self.use_case, grid_name) in self.grid_extents_kji.keys():
-         cell_count = np.prod(self.grid_extents_kji[self.use_case, grid_name])
-         if a.size == cell_count:
-            return a.reshape(tuple(self.grid_extents_kji[self.use_case, grid_name]))
-      return a
+    def grid_recurrent_property_for_timestep(self, grid_name, keyword, timestep, dtype = None, unpack = True):
+        """Loads and returns a recurrent property array for named grid for one timestep."""
 
-   def zip_glob(self, path_with_asterisk):
-      """Performs glob.glob like function for zipped file, path must contain a single asterisk."""
+        # todo: check file naming convention for LGRs
+        grid_name = grid_name.upper()
+        keyword = keyword.strip().upper()
+        return self.load_recurrent_mapdata_array(file = 'R' + grid_name + '_' + str(timestep) + '.bin',
+                                                 keyword = keyword,
+                                                 dtype = dtype,
+                                                 unpack = unpack,
+                                                 grid_name = grid_name)
 
-      assert self.zipped
+    def header_place_for_keyword(self, relative_path, keyword, search = True):
+        """Low level function to return file position for header relating to given keyword."""
 
-      star = path_with_asterisk.find('*')
-      assert star >= 0, 'no asterisk in zip glob path'
-      no_tail = (star == len(path_with_asterisk) - 1)
-      match_list = []
-      with zf.ZipFile(self.zip_file) as zfp:
-         zip_list = zfp.namelist()
-         for name in zip_list:
-            if ((star == 0 or name.startswith(path_with_asterisk[:star])) and
-                (no_tail or name.endswith(path_with_asterisk[star + 1:]))):
-               match_list.append(name)
-      return match_list
+        try:
+            path = os.path.join(self.path, relative_path)
+            assert os.path.exists(path), 'failed to find vdb file ' + str(path)
+            with open(path, 'rb') as fp:
+                assert fp.read(4) == b'NT32', 'first 4 characters not NT32 in file ' + path
+                kp = KP(fp)
+                return kp.header_place_for_key(keyword, search = search)
+        except Exception:
+            log.exception('failed to read keyword data from vdb binary file: ' + path)
+        return None
+
+    def root_shaped(self, a):
+        """Returns array reshaped to root grid extent for current use case, if known; otherwise unchanged."""
+
+        return self.grid_shaped('ROOT', a)
+
+    def grid_shaped(self, grid_name, a):
+        """Returns array reshaped to named grid extent for current use case, if known; otherwise unchanged."""
+
+        grid_name = grid_name.upper()
+        if self.use_case is not None and (self.use_case, grid_name) in self.grid_extents_kji.keys():
+            cell_count = np.prod(self.grid_extents_kji[self.use_case, grid_name])
+            if a.size == cell_count:
+                return a.reshape(tuple(self.grid_extents_kji[self.use_case, grid_name]))
+        return a
+
+    def zip_glob(self, path_with_asterisk):
+        """Performs glob.glob like function for zipped file, path must contain a single asterisk."""
+
+        assert self.zipped
+
+        star = path_with_asterisk.find('*')
+        assert star >= 0, 'no asterisk in zip glob path'
+        no_tail = (star == len(path_with_asterisk) - 1)
+        match_list = []
+        with zf.ZipFile(self.zip_file) as zfp:
+            zip_list = zfp.namelist()
+            for name in zip_list:
+                if ((star == 0 or name.startswith(path_with_asterisk[:star])) and
+                    (no_tail or name.endswith(path_with_asterisk[star + 1:]))):
+                    match_list.append(name)
+        return match_list

--- a/resqpy/olio/vector_utilities.py
+++ b/resqpy/olio/vector_utilities.py
@@ -17,281 +17,281 @@ import numpy as np
 
 
 def radians_from_degrees(deg):
-   """Converts angle from degrees to radians."""
-   return np.radians(deg)
+    """Converts angle from degrees to radians."""
+    return np.radians(deg)
 
 
 def degrees_from_radians(rad):
-   """Converts angle from radians to degrees."""
-   return np.degrees(rad)
+    """Converts angle from radians to degrees."""
+    return np.degrees(rad)
 
 
 def zero_vector():
-   """Returns a zero vector [0.0, 0.0, 0.0]."""
-   return np.zeros(3)
+    """Returns a zero vector [0.0, 0.0, 0.0]."""
+    return np.zeros(3)
 
 
 def v_3d(v):
-   """Returns a 3D vector for a 2D or 3D vector."""
-   assert 2 <= len(v) <= 3
-   if len(v) == 3:
-      return v
-   v3 = np.zeros(3)
-   v3[:2] = v
-   return v3
+    """Returns a 3D vector for a 2D or 3D vector."""
+    assert 2 <= len(v) <= 3
+    if len(v) == 3:
+        return v
+    v3 = np.zeros(3)
+    v3[:2] = v
+    return v3
 
 
 def add(a, b):  # note: could just use numpy a + b facility
-   """Returns vector sum a+b."""
-   a = np.array(a)
-   b = np.array(b)
-   assert a.size == b.size
-   return a + b
+    """Returns vector sum a+b."""
+    a = np.array(a)
+    b = np.array(b)
+    assert a.size == b.size
+    return a + b
 
 
 def subtract(a, b):  # note: could just use numpy a - b facility
-   """Returns vector difference a-b."""
-   a = np.array(a)
-   b = np.array(b)
-   assert a.size == b.size
-   return a - b
+    """Returns vector difference a-b."""
+    a = np.array(a)
+    b = np.array(b)
+    assert a.size == b.size
+    return a - b
 
 
 def elemental_multiply(a, b):  # note: could just use numpy a * b facility
-   """Returns vector with products of corresponding elements of a and b."""
-   a = np.array(a)
-   b = np.array(b)
-   assert a.size == b.size
-   return a * b
+    """Returns vector with products of corresponding elements of a and b."""
+    a = np.array(a)
+    b = np.array(b)
+    assert a.size == b.size
+    return a * b
 
 
 def amplify(v, scaling):  # note: could just use numpy a * scalar facility
-   """Returns vector with direction of v, amplified by scaling."""
-   v = np.array(v)
-   return scaling * v
+    """Returns vector with direction of v, amplified by scaling."""
+    v = np.array(v)
+    return scaling * v
 
 
 def unit_vector(v):
-   """Returns vector with same direction as v but with unit length."""
-   assert 2 <= len(v) <= 3
-   v = np.array(v, dtype = float)
-   if np.all(v == 0.0):
-      return v
-   return v / maths.sqrt(np.sum(v * v))
+    """Returns vector with same direction as v but with unit length."""
+    assert 2 <= len(v) <= 3
+    v = np.array(v, dtype = float)
+    if np.all(v == 0.0):
+        return v
+    return v / maths.sqrt(np.sum(v * v))
 
 
 def unit_vectors(v):
-   """Returns vectors with same direction as those in v but with unit length."""
-   scaling = np.sqrt(np.sum(v * v, axis = -1))
-   zero_mask = np.zeros(v.shape, dtype = bool)
-   zero_mask[np.where(scaling == 0.0), :] = True
-   restore = np.seterr(all = 'ignore')
-   result = np.where(zero_mask, 0.0, v / np.expand_dims(scaling, -1))
-   np.seterr(**restore)
-   return result
+    """Returns vectors with same direction as those in v but with unit length."""
+    scaling = np.sqrt(np.sum(v * v, axis = -1))
+    zero_mask = np.zeros(v.shape, dtype = bool)
+    zero_mask[np.where(scaling == 0.0), :] = True
+    restore = np.seterr(all = 'ignore')
+    result = np.where(zero_mask, 0.0, v / np.expand_dims(scaling, -1))
+    np.seterr(**restore)
+    return result
 
 
 def unit_vector_from_azimuth(azimuth):
-   """Returns horizontal unit vector in compass bearing given by azimuth (x = East, y = North)."""
-   azimuth = azimuth % 360.0
-   azimuth_radians = radians_from_degrees(azimuth)
-   result = zero_vector()
-   result[0] = maths.sin(azimuth_radians)  # x (increasing to east)
-   result[1] = maths.cos(azimuth_radians)  # y (increasing to north)
-   return result  # leave z as zero
+    """Returns horizontal unit vector in compass bearing given by azimuth (x = East, y = North)."""
+    azimuth = azimuth % 360.0
+    azimuth_radians = radians_from_degrees(azimuth)
+    result = zero_vector()
+    result[0] = maths.sin(azimuth_radians)  # x (increasing to east)
+    result[1] = maths.cos(azimuth_radians)  # y (increasing to north)
+    return result  # leave z as zero
 
 
 def azimuth(v):  # 'azimuth' is synonymous with 'compass bearing'
-   """Returns the compass bearing in degrees of the direction of v (x = East, y = North), ignoring z."""
-   assert 2 <= v.size <= 3
-   z_zero_v = np.zeros(3)
-   z_zero_v[:2] = v[:2]
-   unit_v = unit_vector(z_zero_v)  # also checks that z_zero_v is not zero vector
-   x = unit_v[0]
-   y = unit_v[1]  # ignore z component
-   if x == 0.0 and y == 0.0:
-      return 0.0  # arbitrary azimuth of a vertical vector
-   if abs(x) >= abs(y):
-      radians = maths.pi / 2.0 - maths.atan(y / x)
-      if x < 0.0:
-         radians += maths.pi
-   else:
-      radians = maths.atan(x / y)
-      if y < 0.0:
-         radians += maths.pi
-   if radians < 0.0:
-      radians += 2.0 * maths.pi
-   return degrees_from_radians(radians)
+    """Returns the compass bearing in degrees of the direction of v (x = East, y = North), ignoring z."""
+    assert 2 <= v.size <= 3
+    z_zero_v = np.zeros(3)
+    z_zero_v[:2] = v[:2]
+    unit_v = unit_vector(z_zero_v)  # also checks that z_zero_v is not zero vector
+    x = unit_v[0]
+    y = unit_v[1]  # ignore z component
+    if x == 0.0 and y == 0.0:
+        return 0.0  # arbitrary azimuth of a vertical vector
+    if abs(x) >= abs(y):
+        radians = maths.pi / 2.0 - maths.atan(y / x)
+        if x < 0.0:
+            radians += maths.pi
+    else:
+        radians = maths.atan(x / y)
+        if y < 0.0:
+            radians += maths.pi
+    if radians < 0.0:
+        radians += 2.0 * maths.pi
+    return degrees_from_radians(radians)
 
 
 def azimuths(va):  # 'azimuth' is synonymous with 'compass bearing'
-   """Returns the compass bearings in degrees of the direction of each vector in va (x = East, y = North), ignoring z."""
-   assert va.ndim > 1 and 2 <= va.shape[-1] <= 3
-   shape = tuple(list(va.shape[:-1]) + [3])
-   z_zero_v = np.zeros(shape)
-   z_zero_v[..., :2] = va[..., :2]
-   unit_v = unit_vectors(z_zero_v)  # also checks that z_zero_v is not zero vector
-   x = unit_v[..., 0]
-   y = unit_v[..., 1]  # ignore z component
-   # todo: handle cases where x == y == 0
-   restore = np.seterr(all = 'ignore')
-   radians = np.where(
-      np.abs(x) >= np.abs(y),
-      np.where(x < 0.0, maths.pi * 3.0 / 2.0 - np.arctan(y / x), maths.pi / 2.0 - np.arctan(y / x)),
-      np.where(y < 0.0, maths.pi + np.arctan(x / y), np.arctan(x / y)))
-   np.seterr(**restore)
-   radians = radians % (2.0 * maths.pi)
-   return np.degrees(radians)
+    """Returns the compass bearings in degrees of the direction of each vector in va (x = East, y = North), ignoring z."""
+    assert va.ndim > 1 and 2 <= va.shape[-1] <= 3
+    shape = tuple(list(va.shape[:-1]) + [3])
+    z_zero_v = np.zeros(shape)
+    z_zero_v[..., :2] = va[..., :2]
+    unit_v = unit_vectors(z_zero_v)  # also checks that z_zero_v is not zero vector
+    x = unit_v[..., 0]
+    y = unit_v[..., 1]  # ignore z component
+    # todo: handle cases where x == y == 0
+    restore = np.seterr(all = 'ignore')
+    radians = np.where(
+        np.abs(x) >= np.abs(y),
+        np.where(x < 0.0, maths.pi * 3.0 / 2.0 - np.arctan(y / x), maths.pi / 2.0 - np.arctan(y / x)),
+        np.where(y < 0.0, maths.pi + np.arctan(x / y), np.arctan(x / y)))
+    np.seterr(**restore)
+    radians = radians % (2.0 * maths.pi)
+    return np.degrees(radians)
 
 
 def inclination(v):
-   """Returns the inclination in degrees of v (angle relative to +ve z axis)."""
-   assert 2 <= len(v) <= 3
-   unit_v = unit_vector(v)
-   radians = maths.acos(dot_product(unit_v, np.array((0.0, 0.0, 1.0))))
-   return degrees_from_radians(radians)
+    """Returns the inclination in degrees of v (angle relative to +ve z axis)."""
+    assert 2 <= len(v) <= 3
+    unit_v = unit_vector(v)
+    radians = maths.acos(dot_product(unit_v, np.array((0.0, 0.0, 1.0))))
+    return degrees_from_radians(radians)
 
 
 def points_direction_vector(a, axis):
-   """Returns an average direction vector based on first and last non-NaN points or slices in given axis."""
+    """Returns an average direction vector based on first and last non-NaN points or slices in given axis."""
 
-   assert a.ndim > 1 and 0 <= axis < a.ndim - 1 and a.shape[-1] > 1 and a.shape[axis] > 1
-   if np.all(np.isnan(a)):
-      return None
-   start = 0
-   start_slicing = [slice(None)] * a.ndim
-   while True:
-      start_slicing[axis] = slice(start)
-      if not np.all(np.isnan(a[tuple(start_slicing)])):
-         break
-      start += 1
-   finish = a.shape[axis] - 1
-   finish_slicing = [slice(None)] * a.ndim
-   while True:
-      finish_slicing[axis] = slice(finish)
-      if not np.all(np.isnan(a[tuple(finish_slicing)])):
-         break
-      finish += 1
-   if start >= finish:
-      return None
-   if a.ndim > 2:
-      mean_axes = tuple(range(a.ndim - 1))
-      start_p = np.nanmean(a[tuple(start_slicing)], axis = mean_axes)
-      finish_p = np.nanmean(a[tuple(finish_slicing)], axis = mean_axes)
-   else:
-      start_p = a[start]
-      finish_p = a[finish]
+    assert a.ndim > 1 and 0 <= axis < a.ndim - 1 and a.shape[-1] > 1 and a.shape[axis] > 1
+    if np.all(np.isnan(a)):
+        return None
+    start = 0
+    start_slicing = [slice(None)] * a.ndim
+    while True:
+        start_slicing[axis] = slice(start)
+        if not np.all(np.isnan(a[tuple(start_slicing)])):
+            break
+        start += 1
+    finish = a.shape[axis] - 1
+    finish_slicing = [slice(None)] * a.ndim
+    while True:
+        finish_slicing[axis] = slice(finish)
+        if not np.all(np.isnan(a[tuple(finish_slicing)])):
+            break
+        finish += 1
+    if start >= finish:
+        return None
+    if a.ndim > 2:
+        mean_axes = tuple(range(a.ndim - 1))
+        start_p = np.nanmean(a[tuple(start_slicing)], axis = mean_axes)
+        finish_p = np.nanmean(a[tuple(finish_slicing)], axis = mean_axes)
+    else:
+        start_p = a[start]
+        finish_p = a[finish]
 
-   return finish_p - start_p
+    return finish_p - start_p
 
 
 def dot_product(a, b):
-   """Returns the dot product (scalar product) of the two vectors."""
-   return np.dot(a, b)
+    """Returns the dot product (scalar product) of the two vectors."""
+    return np.dot(a, b)
 
 
 def dot_products(a, b):
-   """Returns the dot products of pairs of vectors; last axis covers element of a vector."""
-   return np.sum(a * b, axis = -1)
+    """Returns the dot products of pairs of vectors; last axis covers element of a vector."""
+    return np.sum(a * b, axis = -1)
 
 
 def cross_product(a, b):
-   """Returns the cross product (vector product) of the two vectors."""
-   return np.cross(a, b)
+    """Returns the cross product (vector product) of the two vectors."""
+    return np.cross(a, b)
 
 
 def naive_length(v):
-   """Returns the length of the vector assuming consistent units."""
-   return maths.sqrt(dot_product(v, v))
+    """Returns the length of the vector assuming consistent units."""
+    return maths.sqrt(dot_product(v, v))
 
 
 def naive_lengths(v):
-   """Returns the lengths of the vectors assuming consistent units."""
-   return np.sqrt(np.sum(v * v, axis = -1))
+    """Returns the lengths of the vectors assuming consistent units."""
+    return np.sqrt(np.sum(v * v, axis = -1))
 
 
 def naive_2d_length(v):
-   """Returns the length of the vector projected onto xy plane, assuming consistent units."""
-   return maths.sqrt(dot_product(v[0:2], v[0:2]))
+    """Returns the length of the vector projected onto xy plane, assuming consistent units."""
+    return maths.sqrt(dot_product(v[0:2], v[0:2]))
 
 
 def naive_2d_lengths(v):
-   """Returns the lengths of the vectors projected onto xy plane, assuming consistent units."""
-   v2d = v[..., :2]
-   return np.sqrt(np.sum(v2d * v2d, axis = -1))
+    """Returns the lengths of the vectors projected onto xy plane, assuming consistent units."""
+    v2d = v[..., :2]
+    return np.sqrt(np.sum(v2d * v2d, axis = -1))
 
 
 def unit_corrected_length(v, unit_conversion):
-   """Returns the length of the vector v after applying the unit_conversion factors."""
-   # unit_conversion might be [1.0, 1.0, 0.3048] to convert z from feet to metres, for example
-   # or [3.28084, 3.28084, 1.0] to convert x and y from metres to feet
-   converted = elemental_multiply(v, unit_conversion)
-   return naive_length(converted)
+    """Returns the length of the vector v after applying the unit_conversion factors."""
+    # unit_conversion might be [1.0, 1.0, 0.3048] to convert z from feet to metres, for example
+    # or [3.28084, 3.28084, 1.0] to convert x and y from metres to feet
+    converted = elemental_multiply(v, unit_conversion)
+    return naive_length(converted)
 
 
 def manhatten_distance(p1, p2):
-   """Returns the Manhattan distance between two points."""
-   return abs(p2[0] - p1[0]) + abs(p2[1] - p1[1]) + abs(p2[2] - p1[2])
+    """Returns the Manhattan distance between two points."""
+    return abs(p2[0] - p1[0]) + abs(p2[1] - p1[1]) + abs(p2[2] - p1[2])
 
 
 def manhattan_distance(p1, p2):  # alternative spelling to above
-   """Returns the Manhattan distance between two points."""
-   return abs(p2[0] - p1[0]) + abs(p2[1] - p1[1]) + abs(p2[2] - p1[2])
+    """Returns the Manhattan distance between two points."""
+    return abs(p2[0] - p1[0]) + abs(p2[1] - p1[1]) + abs(p2[2] - p1[2])
 
 
 def radians_difference(a, b):
-   """Returns the angle between two vectors, in radians."""
+    """Returns the angle between two vectors, in radians."""
 
-   return maths.acos(min(1.0, max(-1.0, dot_product(unit_vector(a), unit_vector(b)))))
+    return maths.acos(min(1.0, max(-1.0, dot_product(unit_vector(a), unit_vector(b)))))
 
 
 def degrees_difference(a, b):
-   """Returns the angle between two vectors, in degrees."""
+    """Returns the angle between two vectors, in degrees."""
 
-   return degrees_from_radians(radians_difference(a, b))
+    return degrees_from_radians(radians_difference(a, b))
 
 
 def rotation_matrix_3d_axial(axis, angle):
-   """Retuns a rotation matrix which will rotate points about axis (0, 1, or 2) by angle in degrees."""
+    """Retuns a rotation matrix which will rotate points about axis (0, 1, or 2) by angle in degrees."""
 
-   axis_a = (axis + 1) % 3
-   axis_b = (axis_a + 1) % 3
-   matrix = np.zeros((3, 3))
-   matrix[axis, axis] = 1.0
-   radians = radians_from_degrees(angle)
-   cosine = maths.cos(radians)
-   sine = maths.sin(radians)
-   matrix[axis_a, axis_a] = cosine
-   matrix[axis_b, axis_b] = cosine
-   matrix[axis_a, axis_b] = -sine  # left handed coordinate system, eg. UTM & depth
-   matrix[axis_b, axis_a] = sine
-   return matrix
+    axis_a = (axis + 1) % 3
+    axis_b = (axis_a + 1) % 3
+    matrix = np.zeros((3, 3))
+    matrix[axis, axis] = 1.0
+    radians = radians_from_degrees(angle)
+    cosine = maths.cos(radians)
+    sine = maths.sin(radians)
+    matrix[axis_a, axis_a] = cosine
+    matrix[axis_b, axis_b] = cosine
+    matrix[axis_a, axis_b] = -sine  # left handed coordinate system, eg. UTM & depth
+    matrix[axis_b, axis_a] = sine
+    return matrix
 
 
 def rotation_3d_matrix(xzy_axis_angles):
-   matrix = np.zeros((3, 3))
-   for axis in range(3):
-      matrix[axis, axis] = 1.0
-   for axis in range(3):
-      matrix = np.dot(matrix, rotation_matrix_3d_axial(axis, xzy_axis_angles[axis]))
-   return matrix
+    matrix = np.zeros((3, 3))
+    for axis in range(3):
+        matrix[axis, axis] = 1.0
+    for axis in range(3):
+        matrix = np.dot(matrix, rotation_matrix_3d_axial(axis, xzy_axis_angles[axis]))
+    return matrix
 
 
 def rotate_vector(rotation_matrix, vector):
-   """Returns the rotated vector."""
+    """Returns the rotated vector."""
 
-   return np.dot(rotation_matrix, vector)
+    return np.dot(rotation_matrix, vector)
 
 
 def rotate_array(rotation_matrix, a):
-   """Returns a copy of array a with each vector rotated by the rotation matrix."""
+    """Returns a copy of array a with each vector rotated by the rotation matrix."""
 
-   s = a.shape
-   return np.matmul(rotation_matrix, a.reshape(-1, 3).T).T.reshape(s)
+    s = a.shape
+    return np.matmul(rotation_matrix, a.reshape(-1, 3).T).T.reshape(s)
 
 
 def rotate_xyz_array_around_z_axis(a, target_xy_vector):
-   """Returns a copy of array a suitable for presenting a cross-section using the resulting x,z values.
+    """Returns a copy of array a suitable for presenting a cross-section using the resulting x,z values.
 
    arguments:
       a (numpy float array of shape (..., 3)): the xyz points to be rotated
@@ -307,203 +307,203 @@ def rotate_xyz_array_around_z_axis(a, target_xy_vector):
       y values will indicate distance 'into the page' for non-planar or unaligned data
    """
 
-   target_v = np.zeros(3)
-   target_v[:2] = target_xy_vector[:2]
-   rotation_angle = azimuth(target_v) - 90.0
-   rotation_matrix = rotation_matrix_3d_axial(2, rotation_angle)  # todo: check sign of rotation angle
-   return rotate_array(rotation_matrix, a)
+    target_v = np.zeros(3)
+    target_v[:2] = target_xy_vector[:2]
+    rotation_angle = azimuth(target_v) - 90.0
+    rotation_matrix = rotation_matrix_3d_axial(2, rotation_angle)  # todo: check sign of rotation angle
+    return rotate_array(rotation_matrix, a)
 
 
 def unit_vector_from_azimuth_and_inclination(azimuth, inclination):
-   """Returns unit vector with compass bearing of azimuth and inclination off +z axis."""
+    """Returns unit vector with compass bearing of azimuth and inclination off +z axis."""
 
-   matrix = rotation_3d_matrix((inclination, azimuth, 0.0))
-   return rotate_vector(matrix, np.array((0.0, 0.0, 1.0)))
+    matrix = rotation_3d_matrix((inclination, azimuth, 0.0))
+    return rotate_vector(matrix, np.array((0.0, 0.0, 1.0)))
 
 
 def tilt_3d_matrix(azimuth, dip):
-   """Returns a 3D rotation matrix for applying a dip in a certain azimuth.
+    """Returns a 3D rotation matrix for applying a dip in a certain azimuth.
 
    note:
       if azimuth is compass bearing in degrees, and dip is in degrees, the resulting matrix can be used
       to rotate xyz points where x values are eastings, y values are northings and z increases downwards
    """
 
-   matrix = rotation_matrix_3d_axial(2, -azimuth)  # will yield rotation around z axis so azimuth goes north
-   matrix = np.dot(matrix, rotation_matrix_3d_axial(0, dip))  # adjust for dip
-   matrix = np.dot(matrix, rotation_matrix_3d_axial(2, azimuth))  # rotate azimuth back to original
-   return matrix
+    matrix = rotation_matrix_3d_axial(2, -azimuth)  # will yield rotation around z axis so azimuth goes north
+    matrix = np.dot(matrix, rotation_matrix_3d_axial(0, dip))  # adjust for dip
+    matrix = np.dot(matrix, rotation_matrix_3d_axial(2, azimuth))  # rotate azimuth back to original
+    return matrix
 
 
 def tilt_points(pivot_xyz, azimuth, dip, points):
-   """Modifies array of xyz points in situ to apply dip in direction of azimuth, about pivot point."""
+    """Modifies array of xyz points in situ to apply dip in direction of azimuth, about pivot point."""
 
-   #   log.debug('pivot xyz: ' + str(pivot_xyz))
-   matrix = tilt_3d_matrix(azimuth, dip)
-   points_shape = points.shape
-   points[:] -= pivot_xyz
-   #   log.debug('points shape: ' + str(points.shape))
-   points[:] = np.matmul(matrix, points.reshape((-1, 3)).transpose()).transpose().reshape(points_shape)
-   points[:] += pivot_xyz
+    #   log.debug('pivot xyz: ' + str(pivot_xyz))
+    matrix = tilt_3d_matrix(azimuth, dip)
+    points_shape = points.shape
+    points[:] -= pivot_xyz
+    #   log.debug('points shape: ' + str(points.shape))
+    points[:] = np.matmul(matrix, points.reshape((-1, 3)).transpose()).transpose().reshape(points_shape)
+    points[:] += pivot_xyz
 
 
 def project_points_onto_plane(plane_xyz, normal_vector, points):
-   """Modifies array of xyz points in situ to project onto a plane defined by a point and normal vector."""
+    """Modifies array of xyz points in situ to project onto a plane defined by a point and normal vector."""
 
-   az = azimuth(normal_vector)
-   incl = inclination(normal_vector)
-   tilt_points(plane_xyz, az, -incl, points)
-   points[..., 2] = plane_xyz[2]
-   tilt_points(plane_xyz, az, incl, points)
+    az = azimuth(normal_vector)
+    incl = inclination(normal_vector)
+    tilt_points(plane_xyz, az, -incl, points)
+    points[..., 2] = plane_xyz[2]
+    tilt_points(plane_xyz, az, incl, points)
 
 
 def perspective_vector(xyz_box, view_axis, vanishing_distance, vector):
-   mid_points = np.zeros(3)
-   xyz_ranges = np.zeros(3)
-   result = np.zeros(3)
-   for axis in range(3):
-      mid_points[axis] = 0.5 * (xyz_box[0, axis] + xyz_box[1, axis])
-      xyz_ranges[axis] = xyz_box[1, axis] - xyz_box[0, axis]
-   factor = 1.0 - (vector[view_axis] - xyz_box[0, view_axis]) / (vanishing_distance * (xyz_ranges[view_axis]))
-   result[view_axis] = vector[view_axis]
-   for axis in range(3):
-      if axis == view_axis:
-         continue
-      result[axis] = mid_points[axis] + factor * (vector[axis] - mid_points[axis])
-   return result
+    mid_points = np.zeros(3)
+    xyz_ranges = np.zeros(3)
+    result = np.zeros(3)
+    for axis in range(3):
+        mid_points[axis] = 0.5 * (xyz_box[0, axis] + xyz_box[1, axis])
+        xyz_ranges[axis] = xyz_box[1, axis] - xyz_box[0, axis]
+    factor = 1.0 - (vector[view_axis] - xyz_box[0, view_axis]) / (vanishing_distance * (xyz_ranges[view_axis]))
+    result[view_axis] = vector[view_axis]
+    for axis in range(3):
+        if axis == view_axis:
+            continue
+        result[axis] = mid_points[axis] + factor * (vector[axis] - mid_points[axis])
+    return result
 
 
 def determinant(a, b, c):
-   """Returns the determinant of the 3 x 3 matrix comprised of the 3 vectors."""
+    """Returns the determinant of the 3 x 3 matrix comprised of the 3 vectors."""
 
-   return (a[0] * b[1] * c[2] + a[1] * b[2] * c[0] + a[2] * b[0] * c[1] - a[2] * b[1] * c[0] - a[1] * b[0] * c[2] -
-           a[0] * b[2] * c[1])
+    return (a[0] * b[1] * c[2] + a[1] * b[2] * c[0] + a[2] * b[0] * c[1] - a[2] * b[1] * c[0] - a[1] * b[0] * c[2] -
+            a[0] * b[2] * c[1])
 
 
 def determinant_3x3(a):
-   """Returns the determinant of the 3 x 3 matrix."""
+    """Returns the determinant of the 3 x 3 matrix."""
 
-   return determinant(a[0], a[1], a[2])
+    return determinant(a[0], a[1], a[2])
 
 
 def clockwise(a, b, c):
-   """Returns a +ve value if 2D points a,b,c are in clockwise order, 0.0 if in line, -ve for ccw.
+    """Returns a +ve value if 2D points a,b,c are in clockwise order, 0.0 if in line, -ve for ccw.
 
    note:
       assumes positive y-axis is anticlockwise from positive x-axis
    """
 
-   return (c[0] - a[0]) * (b[1] - a[1]) - ((c[1] - a[1]) * (b[0] - a[0]))
+    return (c[0] - a[0]) * (b[1] - a[1]) - ((c[1] - a[1]) * (b[0] - a[0]))
 
 
 def in_triangle(a, b, c, d):
-   """Returns True if point d lies wholly within the triangle pf ccw points a, b, c, projected onto xy plane.
+    """Returns True if point d lies wholly within the triangle pf ccw points a, b, c, projected onto xy plane.
 
    note:
       a, b & c must be sorted into anti-clockwise order before calling this function
    """
 
-   return clockwise(a, b, d) < 0.0 and clockwise(b, c, d) < 0.0 and clockwise(c, a, d) < 0.0
+    return clockwise(a, b, d) < 0.0 and clockwise(b, c, d) < 0.0 and clockwise(c, a, d) < 0.0
 
 
 def in_triangle_edged(a, b, c, d):
-   """Returns True if d lies within or on the boudnary of triangle of ccw points a,b,c projected onto xy plane.
+    """Returns True if d lies within or on the boudnary of triangle of ccw points a,b,c projected onto xy plane.
 
    note:
       a, b & c must be sorted into anti-clockwise order before calling this function
    """
 
-   return clockwise(a, b, d) <= 0.0 and clockwise(b, c, d) <= 0.0 and clockwise(c, a, d) <= 0.0
+    return clockwise(a, b, d) <= 0.0 and clockwise(b, c, d) <= 0.0 and clockwise(c, a, d) <= 0.0
 
 
 def in_circumcircle(a, b, c, d):
-   """Returns True if point d lies within the circumcircle pf ccw points a, b, c, projected onto xy plane.
+    """Returns True if point d lies within the circumcircle pf ccw points a, b, c, projected onto xy plane.
 
    note:
       a, b & c must be sorted into anti-clockwise order before calling this function
    """
 
-   m = np.empty((3, 3))
-   m[0, :2] = a[:2] - d[:2]
-   m[1, :2] = b[:2] - d[:2]
-   m[2, :2] = c[:2] - d[:2]
-   m[:, 2] = (m[:, 0] * m[:, 0]) + (m[:, 1] * m[:, 1])
-   return determinant_3x3(m) > 0.0
+    m = np.empty((3, 3))
+    m[0, :2] = a[:2] - d[:2]
+    m[1, :2] = b[:2] - d[:2]
+    m[2, :2] = c[:2] - d[:2]
+    m[:, 2] = (m[:, 0] * m[:, 0]) + (m[:, 1] * m[:, 1])
+    return determinant_3x3(m) > 0.0
 
 
 def point_distance_to_line_2d(p, l1, l2):
-   """Ignoring any z values, returns the xy distance of point p from line passing through l1 and l2."""
+    """Ignoring any z values, returns the xy distance of point p from line passing through l1 and l2."""
 
-   return (abs(p[0] * (l1[1] - l2[1]) + l1[0] * (l2[1] - p[1]) + l2[0] * (p[1] - l1[1])) / naive_2d_length(l2 - l1))
+    return (abs(p[0] * (l1[1] - l2[1]) + l1[0] * (l2[1] - p[1]) + l2[0] * (p[1] - l1[1])) / naive_2d_length(l2 - l1))
 
 
 def isclose(a, b, tolerance = 1.0e-6):
-   """Returns True if the two points are extremely close to one another (ie. the same point)."""
+    """Returns True if the two points are extremely close to one another (ie. the same point)."""
 
-   #   return np.all(np.isclose(a, b, atol = tolerance))
-   # cheap and cheerful alternative to thorough numpy version commented out above
-   return np.max(np.abs(a - b)) <= tolerance
+    #   return np.all(np.isclose(a, b, atol = tolerance))
+    # cheap and cheerful alternative to thorough numpy version commented out above
+    return np.max(np.abs(a - b)) <= tolerance
 
 
 def is_close(a, b, tolerance = 1.0e-6):
-   """Returns True if the two points are extremely close to one another (ie. the same point)."""
+    """Returns True if the two points are extremely close to one another (ie. the same point)."""
 
-   return isclose(a, b, tolerance = tolerance)
+    return isclose(a, b, tolerance = tolerance)
 
 
 def point_distance_sqr_to_points_projected(p, points, projection):
-   """Returns an array of projected distances squared between p and points; projection is 'xy', 'xz' or 'yz'."""
+    """Returns an array of projected distances squared between p and points; projection is 'xy', 'xz' or 'yz'."""
 
-   if projection == 'xy':
-      d = points[..., :2] - p[:2]
-   elif projection == 'xz':
-      d = points[..., 0:3:2] - p[0:3:2]
-   elif projection == 'yz':
-      d = points[..., 1:] - p[1:]
-   else:
-      raise ValueError("projection must be 'xy', 'xz' or 'yz'")
-   return np.sum(d * d, axis = -1)
+    if projection == 'xy':
+        d = points[..., :2] - p[:2]
+    elif projection == 'xz':
+        d = points[..., 0:3:2] - p[0:3:2]
+    elif projection == 'yz':
+        d = points[..., 1:] - p[1:]
+    else:
+        raise ValueError("projection must be 'xy', 'xz' or 'yz'")
+    return np.sum(d * d, axis = -1)
 
 
 def nearest_point_projected(p, points, projection):
-   """Returns the index into points array closest to point p; projection is 'xy', 'xz' or 'yz'."""
+    """Returns the index into points array closest to point p; projection is 'xy', 'xz' or 'yz'."""
 
-   # note: in the case of equidistant points, the index of the 'first' point is returned
+    # note: in the case of equidistant points, the index of the 'first' point is returned
 
-   d2 = point_distance_sqr_to_points_projected(p, points, projection)
-   return np.unravel_index(np.nanargmin(d2), d2.shape)
+    d2 = point_distance_sqr_to_points_projected(p, points, projection)
+    return np.unravel_index(np.nanargmin(d2), d2.shape)
 
 
 def area_of_triangle(a, b, c):
-   """Returns the area of the triangle defined by three vertices."""
+    """Returns the area of the triangle defined by three vertices."""
 
-   # uses Heron's formula
-   la = naive_length(a - b)
-   lb = naive_length(b - c)
-   lc = naive_length(c - a)
-   s = 0.5 * (la + lb + lc)
-   return maths.sqrt(s * (s - la) * (s - lb) * (s - lc))
+    # uses Heron's formula
+    la = naive_length(a - b)
+    lb = naive_length(b - c)
+    lc = naive_length(c - a)
+    s = 0.5 * (la + lb + lc)
+    return maths.sqrt(s * (s - la) * (s - lb) * (s - lc))
 
 
 def area_of_triangles(p, t, xy_projection = False):
-   """Returns numpy array of areas of triangles, optionally when projected onto xy plane."""
+    """Returns numpy array of areas of triangles, optionally when projected onto xy plane."""
 
-   # uses Heron's formula
-   pt = p[t]
-   if xy_projection:
-      la = naive_2d_lengths(pt[:, 0, :] - pt[:, 1, :])
-      lb = naive_2d_lengths(pt[:, 1, :] - pt[:, 2, :])
-      lc = naive_2d_lengths(pt[:, 2, :] - pt[:, 0, :])
-   else:
-      la = naive_lengths(pt[:, 0, :] - pt[:, 1, :])
-      lb = naive_lengths(pt[:, 1, :] - pt[:, 2, :])
-      lc = naive_lengths(pt[:, 2, :] - pt[:, 0, :])
-   s = 0.5 * (la + lb + lc)
-   return np.sqrt(s * (s - la) * (s - lb) * (s - lc))
+    # uses Heron's formula
+    pt = p[t]
+    if xy_projection:
+        la = naive_2d_lengths(pt[:, 0, :] - pt[:, 1, :])
+        lb = naive_2d_lengths(pt[:, 1, :] - pt[:, 2, :])
+        lc = naive_2d_lengths(pt[:, 2, :] - pt[:, 0, :])
+    else:
+        la = naive_lengths(pt[:, 0, :] - pt[:, 1, :])
+        lb = naive_lengths(pt[:, 1, :] - pt[:, 2, :])
+        lc = naive_lengths(pt[:, 2, :] - pt[:, 0, :])
+    s = 0.5 * (la + lb + lc)
+    return np.sqrt(s * (s - la) * (s - lb) * (s - lc))
 
 
 def clockwise_sorted_indices(p, b):
-   """Returns a clockwise sorted numpy list of indices b into the points p.
+    """Returns a clockwise sorted numpy list of indices b into the points p.
 
    note:
       this function is designed for preparing a list of points defining a convex polygon when projected in
@@ -511,15 +511,15 @@ def clockwise_sorted_indices(p, b):
       mean of p (over axis 0) lies within the polygon and the clockwise ordering is relative to that mean point
    """
 
-   # note: this function currently assumes that the mean of points bp lies within the hull of bp
-   # and that the points form a convex polygon from the perspective of the mean point
-   assert p.ndim == 2 and len(p) >= 3
-   centre = np.mean(p, axis = 0)
-   hull_list = []  # list of azimuths and indices into p (axis 0)
-   for i in b:
-      azi = azimuth(p[i] - centre)
-      hull_list.append((azi, i))
-   return np.array([i for (_, i) in sorted(hull_list)], dtype = int)
+    # note: this function currently assumes that the mean of points bp lies within the hull of bp
+    # and that the points form a convex polygon from the perspective of the mean point
+    assert p.ndim == 2 and len(p) >= 3
+    centre = np.mean(p, axis = 0)
+    hull_list = []  # list of azimuths and indices into p (axis 0)
+    for i in b:
+        azi = azimuth(p[i] - centre)
+        hull_list.append((azi, i))
+    return np.array([i for (_, i) in sorted(hull_list)], dtype = int)
 
 
 # end of vector_utilities module

--- a/resqpy/olio/volume.py
+++ b/resqpy/olio/volume.py
@@ -6,11 +6,11 @@ import numpy as np
 
 
 def _pyr(ra, ab, ac, ad, db):  # returns 6 * volume of one quad pyramid, defined by specific vectors
-   return np.dot(ra, np.cross(db, ac)) + 0.5 * np.dot(ac, np.cross(ad, ab))
+    return np.dot(ra, np.cross(db, ac)) + 0.5 * np.dot(ac, np.cross(ad, ab))
 
 
 def pyramid_volume(apex, a, b, c, d, crs_is_right_handed = False):
-   """Returns volume of a quadrilateral pyramid.
+    """Returns volume of a quadrilateral pyramid.
 
    arguments:
       apex (triple float): location of the apex of the pyramid
@@ -22,19 +22,19 @@ def pyramid_volume(apex, a, b, c, d, crs_is_right_handed = False):
       float, being the volume of the pyramid; units are implied by crs units in use by the vertices
    """
 
-   apex = np.array(apex)
-   a = np.array(a)
-   b = np.array(b)
-   c = np.array(c)
-   d = np.array(d)
-   v = _pyr(a - apex, b - a, c - a, d - a, b - d) / 6.0
-   if not crs_is_right_handed:
-      v = -v
-   return v
+    apex = np.array(apex)
+    a = np.array(a)
+    b = np.array(b)
+    c = np.array(c)
+    d = np.array(d)
+    v = _pyr(a - apex, b - a, c - a, d - a, b - d) / 6.0
+    if not crs_is_right_handed:
+        v = -v
+    return v
 
 
 def tetrahedron_volume(a, b, c, d):
-   """Returns volume of a tetrahedron.
+    """Returns volume of a tetrahedron.
 
    arguments:
       a, b, c, d (each triple float): locations of corners of tetrahedron
@@ -44,63 +44,63 @@ def tetrahedron_volume(a, b, c, d):
       float, being the volume of the tetrahedron; units are implied by crs units in use by the vertices
    """
 
-   a = np.array(a)
-   b = np.array(b)
-   c = np.array(c)
-   d = np.array(d)
+    a = np.array(a)
+    b = np.array(b)
+    c = np.array(c)
+    d = np.array(d)
 
-   return np.abs(np.dot(a - d, np.cross(b - d, c - d))) / 6.0
+    return np.abs(np.dot(a - d, np.cross(b - d, c - d))) / 6.0
 
 
 def tetra_cell_volume(cp, centre = None, off_hand = False):
-   """Returns volume of single hexahedral cell with corner points cp of shape (2, 2, 2, 3); assumes bilinear faces."""
+    """Returns volume of single hexahedral cell with corner points cp of shape (2, 2, 2, 3); assumes bilinear faces."""
 
-   if centre is None:
-      centre = np.mean(cp.reshape((8, 3)), axis = 0)
-   r0 = cp[0, 0, 0] - centre
-   r1 = cp[1, 1, 1] - centre
-   v = 0.0
-   v += _pyr(r0, cp[0, 0, 1] - cp[0, 0, 0], cp[0, 1, 1] - cp[0, 0, 0], cp[0, 1, 0] - cp[0, 0, 0],
-             cp[0, 1, 0] - cp[0, 0, 1])
-   v += _pyr(r0, cp[1, 0, 0] - cp[0, 0, 0], cp[1, 0, 1] - cp[0, 0, 0], cp[0, 0, 1] - cp[0, 0, 0],
-             cp[0, 0, 1] - cp[1, 0, 0])
-   v += _pyr(r0, cp[0, 1, 0] - cp[0, 0, 0], cp[1, 1, 0] - cp[0, 0, 0], cp[1, 0, 0] - cp[0, 0, 0],
-             cp[1, 0, 0] - cp[0, 1, 0])
-   v += _pyr(r1, cp[1, 0, 1] - cp[1, 1, 1], cp[1, 0, 0] - cp[1, 1, 1], cp[1, 1, 0] - cp[1, 1, 1],
-             cp[1, 1, 0] - cp[1, 0, 1])
-   v += _pyr(r1, cp[1, 1, 0] - cp[1, 1, 1], cp[0, 1, 0] - cp[1, 1, 1], cp[0, 1, 1] - cp[1, 1, 1],
-             cp[0, 1, 1] - cp[1, 1, 0])
-   v += _pyr(r1, cp[0, 1, 1] - cp[1, 1, 1], cp[0, 0, 1] - cp[1, 1, 1], cp[1, 0, 1] - cp[1, 1, 1],
-             cp[1, 0, 1] - cp[0, 1, 1])
+    if centre is None:
+        centre = np.mean(cp.reshape((8, 3)), axis = 0)
+    r0 = cp[0, 0, 0] - centre
+    r1 = cp[1, 1, 1] - centre
+    v = 0.0
+    v += _pyr(r0, cp[0, 0, 1] - cp[0, 0, 0], cp[0, 1, 1] - cp[0, 0, 0], cp[0, 1, 0] - cp[0, 0, 0],
+              cp[0, 1, 0] - cp[0, 0, 1])
+    v += _pyr(r0, cp[1, 0, 0] - cp[0, 0, 0], cp[1, 0, 1] - cp[0, 0, 0], cp[0, 0, 1] - cp[0, 0, 0],
+              cp[0, 0, 1] - cp[1, 0, 0])
+    v += _pyr(r0, cp[0, 1, 0] - cp[0, 0, 0], cp[1, 1, 0] - cp[0, 0, 0], cp[1, 0, 0] - cp[0, 0, 0],
+              cp[1, 0, 0] - cp[0, 1, 0])
+    v += _pyr(r1, cp[1, 0, 1] - cp[1, 1, 1], cp[1, 0, 0] - cp[1, 1, 1], cp[1, 1, 0] - cp[1, 1, 1],
+              cp[1, 1, 0] - cp[1, 0, 1])
+    v += _pyr(r1, cp[1, 1, 0] - cp[1, 1, 1], cp[0, 1, 0] - cp[1, 1, 1], cp[0, 1, 1] - cp[1, 1, 1],
+              cp[0, 1, 1] - cp[1, 1, 0])
+    v += _pyr(r1, cp[0, 1, 1] - cp[1, 1, 1], cp[0, 0, 1] - cp[1, 1, 1], cp[1, 0, 1] - cp[1, 1, 1],
+              cp[1, 0, 1] - cp[0, 1, 1])
 
-   if off_hand:
-      v = -v
+    if off_hand:
+        v = -v
 
-   return v / 6.0
+    return v / 6.0
 
 
 def tetra_volumes_slow(cp, centres = None, off_hand = False):
-   """Returns volume array for all hexahedral cells assuming bilinear faces, using loop over cells."""
+    """Returns volume array for all hexahedral cells assuming bilinear faces, using loop over cells."""
 
-   # NB: deprecated, superceded by much faster function below
-   # todo: handle NaNs
-   # Pagoda style corner point data
-   assert cp.ndim == 7
+    # NB: deprecated, superceded by much faster function below
+    # todo: handle NaNs
+    # Pagoda style corner point data
+    assert cp.ndim == 7
 
-   flat = cp.reshape(-1, 2, 2, 2, 3)
-   cells = flat.shape[0]
-   if centres is None:
-      centres = np.mean(flat, axis = (1, 2, 3))
-   else:
-      centres = centres.reshape((-1, 3))
-   volumes = np.zeros(cells)
-   for cell in range(cells):
-      volumes[cell] = tetra_cell_volume(flat[cell], centre = centres[cell], off_hand = off_hand)
-   return volumes.reshape(cp.shape[0:3])
+    flat = cp.reshape(-1, 2, 2, 2, 3)
+    cells = flat.shape[0]
+    if centres is None:
+        centres = np.mean(flat, axis = (1, 2, 3))
+    else:
+        centres = centres.reshape((-1, 3))
+    volumes = np.zeros(cells)
+    for cell in range(cells):
+        volumes[cell] = tetra_cell_volume(flat[cell], centre = centres[cell], off_hand = off_hand)
+    return volumes.reshape(cp.shape[0:3])
 
 
 def tetra_volumes(cp, centres = None, off_hand = False):
-   """Returns volume array for all hexahedral cells assuming bilinear faces, using numpy operations.
+    """Returns volume array for all hexahedral cells assuming bilinear faces, using numpy operations.
 
    arguments:
       cp (7D numpy array of floats): cell corner point data in Pagoda 7D format [nk, nj, ni, kp, jp, ip, xyz]
@@ -116,39 +116,39 @@ def tetra_volumes(cp, centres = None, off_hand = False):
       those length units cubed
    """
 
-   def pyrs(ra, ab, ac, ad, db):  # returns 6 * volume of one quad pyramid (for each cell)
-      return np.sum(ra * np.cross(db, ac), axis = -1) + 0.5 * np.sum(ac * np.cross(ad, ab), axis = -1)
+    def pyrs(ra, ab, ac, ad, db):  # returns 6 * volume of one quad pyramid (for each cell)
+        return np.sum(ra * np.cross(db, ac), axis = -1) + 0.5 * np.sum(ac * np.cross(ad, ab), axis = -1)
 
-   # Pagoda style corner point data
-   assert cp.ndim == 7
+    # Pagoda style corner point data
+    assert cp.ndim == 7
 
-   flat = cp.reshape(-1, 2, 2, 2, 3)
-   cells = flat.shape[0]
-   if centres is None:
-      centres = np.mean(flat, axis = (1, 2, 3))
-   else:
-      centres = centres.reshape((-1, 3))
-   v = np.zeros(cells)
-   # todo: numpy array operation covering all cells in grid
+    flat = cp.reshape(-1, 2, 2, 2, 3)
+    cells = flat.shape[0]
+    if centres is None:
+        centres = np.mean(flat, axis = (1, 2, 3))
+    else:
+        centres = centres.reshape((-1, 3))
+    v = np.zeros(cells)
+    # todo: numpy array operation covering all cells in grid
 
-   r0 = flat[:, 0, 0, 0] - centres
-   r1 = flat[:, 1, 1, 1] - centres
+    r0 = flat[:, 0, 0, 0] - centres
+    r1 = flat[:, 1, 1, 1] - centres
 
-   v += pyrs(r0, flat[:, 0, 0, 1] - flat[:, 0, 0, 0], flat[:, 0, 1, 1] - flat[:, 0, 0, 0],
-             flat[:, 0, 1, 0] - flat[:, 0, 0, 0], flat[:, 0, 1, 0] - flat[:, 0, 0, 1])
-   v += pyrs(r0, flat[:, 1, 0, 0] - flat[:, 0, 0, 0], flat[:, 1, 0, 1] - flat[:, 0, 0, 0],
-             flat[:, 0, 0, 1] - flat[:, 0, 0, 0], flat[:, 0, 0, 1] - flat[:, 1, 0, 0])
-   v += pyrs(r0, flat[:, 0, 1, 0] - flat[:, 0, 0, 0], flat[:, 1, 1, 0] - flat[:, 0, 0, 0],
-             flat[:, 1, 0, 0] - flat[:, 0, 0, 0], flat[:, 1, 0, 0] - flat[:, 0, 1, 0])
-   v += pyrs(r1, flat[:, 1, 0, 1] - flat[:, 1, 1, 1], flat[:, 1, 0, 0] - flat[:, 1, 1, 1],
-             flat[:, 1, 1, 0] - flat[:, 1, 1, 1], flat[:, 1, 1, 0] - flat[:, 1, 0, 1])
-   v += pyrs(r1, flat[:, 1, 1, 0] - flat[:, 1, 1, 1], flat[:, 0, 1, 0] - flat[:, 1, 1, 1],
-             flat[:, 0, 1, 1] - flat[:, 1, 1, 1], flat[:, 0, 1, 1] - flat[:, 1, 1, 0])
-   v += pyrs(r1, flat[:, 0, 1, 1] - flat[:, 1, 1, 1], flat[:, 0, 0, 1] - flat[:, 1, 1, 1],
-             flat[:, 1, 0, 1] - flat[:, 1, 1, 1], flat[:, 1, 0, 1] - flat[:, 0, 1, 1])
+    v += pyrs(r0, flat[:, 0, 0, 1] - flat[:, 0, 0, 0], flat[:, 0, 1, 1] - flat[:, 0, 0, 0],
+              flat[:, 0, 1, 0] - flat[:, 0, 0, 0], flat[:, 0, 1, 0] - flat[:, 0, 0, 1])
+    v += pyrs(r0, flat[:, 1, 0, 0] - flat[:, 0, 0, 0], flat[:, 1, 0, 1] - flat[:, 0, 0, 0],
+              flat[:, 0, 0, 1] - flat[:, 0, 0, 0], flat[:, 0, 0, 1] - flat[:, 1, 0, 0])
+    v += pyrs(r0, flat[:, 0, 1, 0] - flat[:, 0, 0, 0], flat[:, 1, 1, 0] - flat[:, 0, 0, 0],
+              flat[:, 1, 0, 0] - flat[:, 0, 0, 0], flat[:, 1, 0, 0] - flat[:, 0, 1, 0])
+    v += pyrs(r1, flat[:, 1, 0, 1] - flat[:, 1, 1, 1], flat[:, 1, 0, 0] - flat[:, 1, 1, 1],
+              flat[:, 1, 1, 0] - flat[:, 1, 1, 1], flat[:, 1, 1, 0] - flat[:, 1, 0, 1])
+    v += pyrs(r1, flat[:, 1, 1, 0] - flat[:, 1, 1, 1], flat[:, 0, 1, 0] - flat[:, 1, 1, 1],
+              flat[:, 0, 1, 1] - flat[:, 1, 1, 1], flat[:, 0, 1, 1] - flat[:, 1, 1, 0])
+    v += pyrs(r1, flat[:, 0, 1, 1] - flat[:, 1, 1, 1], flat[:, 0, 0, 1] - flat[:, 1, 1, 1],
+              flat[:, 1, 0, 1] - flat[:, 1, 1, 1], flat[:, 1, 0, 1] - flat[:, 0, 1, 1])
 
-   v /= 6.0
+    v /= 6.0
 
-   if off_hand:
-      v = np.negative(v)
-   return v.reshape(cp.shape[0:3])
+    if off_hand:
+        v = np.negative(v)
+    return v.reshape(cp.shape[0:3])

--- a/resqpy/olio/weights_and_measures.py
+++ b/resqpy/olio/weights_and_measures.py
@@ -4,5 +4,5 @@ import warnings
 from resqpy.weights_and_measures import *  # noqa
 
 warnings.warn(
-   "resqpy.olio.weights_and_measures is Deprecated and will be removed. Please update your code to use resqpy.weights_and_measures"
+    "resqpy.olio.weights_and_measures is Deprecated and will be removed. Please update your code to use resqpy.weights_and_measures"
 )

--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -127,79 +127,79 @@ wellspec_dtype['DZ']       = float
 
 
 def increment_complaints(keyword):
-   global wellspec_dict
-   assert (keyword.upper() in wellspec_dict.keys())
-   old_entry = wellspec_dict[keyword.upper()]
-   wellspec_dict[keyword.upper()] = (old_entry[0] + 1, old_entry[1], old_entry[2], old_entry[3], old_entry[4])
+    global wellspec_dict
+    assert (keyword.upper() in wellspec_dict.keys())
+    old_entry = wellspec_dict[keyword.upper()]
+    wellspec_dict[keyword.upper()] = (old_entry[0] + 1, old_entry[1], old_entry[2], old_entry[3], old_entry[4])
 
 
 def known_keyword(keyword):
-   return keyword.upper() in wellspec_dict.keys()
+    return keyword.upper() in wellspec_dict.keys()
 
 
 def add_unknown_keyword(keyword):
-   global wellspec_dict
-   assert (not known_keyword(keyword))
-   wellspec_dict[keyword.upper()] = (1, wk_unknown, wk_banned, None, False)  # assumes warning or error already given
+    global wellspec_dict
+    assert (not known_keyword(keyword))
+    wellspec_dict[keyword.upper()] = (1, wk_unknown, wk_banned, None, False)  # assumes warning or error already given
 
 
 def default_value(keyword):
-   assert (known_keyword(keyword))
-   return wellspec_dict[keyword][3]
+    assert (known_keyword(keyword))
+    return wellspec_dict[keyword][3]
 
 
 def complaints(keyword):
-   assert (known_keyword(keyword))
-   return wellspec_dict[keyword][0]
+    assert (known_keyword(keyword))
+    return wellspec_dict[keyword][0]
 
 
 def check_value(keyword, value):
-   try:
-      key = keyword.upper()
-      if not known_keyword(key):
-         return False
-      if key in ['IW', 'JW', 'L', 'LAYER', 'IRELPM', 'CELL', 'SECT', 'FLOWSECT', 'ZONE', 'IPTN']:
-         return int(value) > 0
-      elif key == 'GRID':
-         return len(str(value)) > 0
-      elif key == 'STAT':
-         return (str(value)).upper() in ['ON', 'OFF']
-      elif key == 'ANGLA':
-         return -360.0 <= float(value) and float(value) <= 360.0
-      elif key == 'ANGLV':
-         return 0.0 <= float(value) and float(value) <= 180.0
-      elif key in ['RADW', 'RADB', 'RADWP', 'RADBP']:
-         return float(value) > 0.0
-      elif key in ['WI', 'LENGTH', 'KH', 'KHMULT', 'K', 'DZ']:
-         return float(value) >= 0.0
-      elif key == 'PPERF':
-         return 0.0 <= float(value) and float(value) <= 1.0
-      elif key == 'ANGLE':
-         return 0.0 <= float(value) and float(value) <= 360.0
-      elif key in ['SKIN', 'DEPTH', 'X', 'Y', 'TEMP']:
-         float(value)
-         return True
-      else:
-         return True
-   except Exception:
-      return False
+    try:
+        key = keyword.upper()
+        if not known_keyword(key):
+            return False
+        if key in ['IW', 'JW', 'L', 'LAYER', 'IRELPM', 'CELL', 'SECT', 'FLOWSECT', 'ZONE', 'IPTN']:
+            return int(value) > 0
+        elif key == 'GRID':
+            return len(str(value)) > 0
+        elif key == 'STAT':
+            return (str(value)).upper() in ['ON', 'OFF']
+        elif key == 'ANGLA':
+            return -360.0 <= float(value) and float(value) <= 360.0
+        elif key == 'ANGLV':
+            return 0.0 <= float(value) and float(value) <= 180.0
+        elif key in ['RADW', 'RADB', 'RADWP', 'RADBP']:
+            return float(value) > 0.0
+        elif key in ['WI', 'LENGTH', 'KH', 'KHMULT', 'K', 'DZ']:
+            return float(value) >= 0.0
+        elif key == 'PPERF':
+            return 0.0 <= float(value) and float(value) <= 1.0
+        elif key == 'ANGLE':
+            return 0.0 <= float(value) and float(value) <= 360.0
+        elif key in ['SKIN', 'DEPTH', 'X', 'Y', 'TEMP']:
+            float(value)
+            return True
+        else:
+            return True
+    except Exception:
+        return False
 
 
 def required_out_list():
-   list = []
-   for key in wellspec_dict.keys():
-      if wellspec_dict[key][2] == wk_required:
-         list.append(key)
-   return list
+    list = []
+    for key in wellspec_dict.keys():
+        if wellspec_dict[key][2] == wk_required:
+            list.append(key)
+    return list
 
 
 def length_unit_conversion_applicable(keyword):
-   assert (known_keyword(keyword))
-   return wellspec_dict[keyword][4]
+    assert (known_keyword(keyword))
+    return wellspec_dict[keyword][4]
 
 
 def load_wellspecs(wellspec_file, well = None, column_list = []):
-   """Reads the Nexus wellspec file returning a dictionary of well name to pandas dataframe.
+    """Reads the Nexus wellspec file returning a dictionary of well name to pandas dataframe.
 
    args:
       wellspec_file (string): file path of ascii input file containing wellspec keywords
@@ -216,83 +216,84 @@ def load_wellspecs(wellspec_file, well = None, column_list = []):
          to a dataframe containing the wellspec data
    """
 
-   assert wellspec_file, 'no wellspec file specified'
+    assert wellspec_file, 'no wellspec file specified'
 
-   if column_list is not None:
-      for column in column_list:
-         assert column.upper() in wellspec_dict, 'unrecognized wellspec column name ' + str(column)
-   selecting = bool(column_list)
+    if column_list is not None:
+        for column in column_list:
+            assert column.upper() in wellspec_dict, 'unrecognized wellspec column name ' + str(column)
+    selecting = bool(column_list)
 
-   well_dict = {}  # maps from well name to pandas data frame with column_list as columns
+    well_dict = {}  # maps from well name to pandas data frame with column_list as columns
 
-   with open(wellspec_file, 'r') as fp:
-      while True:
-         found = kf.find_keyword(fp, 'WELLSPEC')
-         if not found:
-            break
-         line = fp.readline()
-         words = line.split()
-         assert len(words) >= 2, 'missing well name after WELLSPEC keyword'
-         well_name = words[1]
-         if well and well_name.upper() != well.upper():
-            continue
-         if column_list is None:
-            well_dict[well_name] = None
-            continue
-         kf.skip_blank_lines_and_comments(fp)
-         line = kf.strip_trailing_comment(fp.readline()).upper()
-         columns_present = line.split()
-         if selecting:
-            column_map = np.full((len(column_list),), -1, dtype = int)
-            for i in range(len(column_list)):
-               column = column_list[i].upper()
-               if column in columns_present:
-                  column_map[i] = columns_present.index(column)
-            df = pd.DataFrame(columns = column_list)
-         else:
-            df = pd.DataFrame(columns = columns_present)
-         while True:
-            kf.skip_comments(fp)
-            if kf.blank_line(fp):
-               break  # unclear from Nexus doc what marks end of table
-            if kf.specific_keyword_next(fp, 'WELLSPEC') or kf.specific_keyword_next(fp, 'WELLMOD'):
-               break
-            line = kf.strip_trailing_comment(fp.readline())
+    with open(wellspec_file, 'r') as fp:
+        while True:
+            found = kf.find_keyword(fp, 'WELLSPEC')
+            if not found:
+                break
+            line = fp.readline()
             words = line.split()
-            assert len(words) >= len(columns_present), f'insufficient data in line of wellspec table {well} [{line}]'
-            row_dict = {}
+            assert len(words) >= 2, 'missing well name after WELLSPEC keyword'
+            well_name = words[1]
+            if well and well_name.upper() != well.upper():
+                continue
+            if column_list is None:
+                well_dict[well_name] = None
+                continue
+            kf.skip_blank_lines_and_comments(fp)
+            line = kf.strip_trailing_comment(fp.readline()).upper()
+            columns_present = line.split()
             if selecting:
-               for col_index in range(len(column_list)):
-                  column = column_list[col_index]
-                  if column_map[col_index] < 0:
-                     if column_list[col_index].upper() == 'GRID':
-                        row_dict[column] = 'ROOT'
-                     else:
-                        row_dict[column] = np.NaN
-                  else:
-                     v = words[column_map[col_index]]
-                     if v == 'NA':
-                        row_dict[column] = np.NaN
-                     elif v == '#':
-                        row_dict[column] = v
-                     else:
-                        row_dict[column] = wellspec_dtype[column.upper()](v)
+                column_map = np.full((len(column_list),), -1, dtype = int)
+                for i in range(len(column_list)):
+                    column = column_list[i].upper()
+                    if column in columns_present:
+                        column_map[i] = columns_present.index(column)
+                df = pd.DataFrame(columns = column_list)
             else:
-               for column, v in zip(columns_present, words[:len(columns_present)]):
-                  if v == 'NA':
-                     row_dict[column] = np.NaN
-                  elif v == '#':
-                     row_dict[column] = v
-                  else:
-                     row_dict[column] = wellspec_dtype[column](v)
-            df = df.append(row_dict, ignore_index = True)
+                df = pd.DataFrame(columns = columns_present)
+            while True:
+                kf.skip_comments(fp)
+                if kf.blank_line(fp):
+                    break  # unclear from Nexus doc what marks end of table
+                if kf.specific_keyword_next(fp, 'WELLSPEC') or kf.specific_keyword_next(fp, 'WELLMOD'):
+                    break
+                line = kf.strip_trailing_comment(fp.readline())
+                words = line.split()
+                assert len(words) >= len(
+                    columns_present), f'insufficient data in line of wellspec table {well} [{line}]'
+                row_dict = {}
+                if selecting:
+                    for col_index in range(len(column_list)):
+                        column = column_list[col_index]
+                        if column_map[col_index] < 0:
+                            if column_list[col_index].upper() == 'GRID':
+                                row_dict[column] = 'ROOT'
+                            else:
+                                row_dict[column] = np.NaN
+                        else:
+                            v = words[column_map[col_index]]
+                            if v == 'NA':
+                                row_dict[column] = np.NaN
+                            elif v == '#':
+                                row_dict[column] = v
+                            else:
+                                row_dict[column] = wellspec_dtype[column.upper()](v)
+                else:
+                    for column, v in zip(columns_present, words[:len(columns_present)]):
+                        if v == 'NA':
+                            row_dict[column] = np.NaN
+                        elif v == '#':
+                            row_dict[column] = v
+                        else:
+                            row_dict[column] = wellspec_dtype[column](v)
+                df = df.append(row_dict, ignore_index = True)
 
-         if well:
-            well_dict[well] = df
-            break  # NB. if more than one table for a well, this function returns first, Nexus uses last
-         well_dict[well_name] = df
+            if well:
+                well_dict[well] = df
+                break  # NB. if more than one table for a well, this function returns first, Nexus uses last
+            well_dict[well_name] = df
 
 
 #   log.debug(f'load-wellspecs returning:\n{well_dict}')
 
-   return well_dict
+    return well_dict

--- a/resqpy/olio/write_data.py
+++ b/resqpy/olio/write_data.py
@@ -27,9 +27,9 @@ import resqpy.olio.ab_toolbox as abt
 
 
 def write_pure_binary_data(binary_file_name, numpy_array):
-   with open(binary_file_name, 'wb') as binary_file_out:
-      numpy_array.tofile(binary_file_out)
-   log.info('Binary data file %s created', binary_file_name)
+    with open(binary_file_name, 'wb') as binary_file_out:
+        numpy_array.tofile(binary_file_out)
+    log.info('Binary data file %s created', binary_file_name)
 
 
 ##########################################################################################
@@ -54,88 +54,88 @@ def write_array_to_ascii_file(file_name,
                               use_binary = False,
                               binary_only = False,
                               nan_substitute_value = None):
-   """Writes a 3D array of data to an ascii file."""
+    """Writes a 3D array of data to an ascii file."""
 
-   assert columns > 0 and decimals >= 0  # todo: test behaviour when decimals = 0
-   assert target_simulator == 'nexus'  # no other simulator formats supported at the moment
+    assert columns > 0 and decimals >= 0  # todo: test behaviour when decimals = 0
+    assert target_simulator == 'nexus'  # no other simulator formats supported at the moment
 
-   if not (use_binary and binary_only):
+    if not (use_binary and binary_only):
 
-      format_str = ''
-      if data_type == 'real' or data_type == 'float':
-         format_str = '{0:.' + str(decimals) + 'f}'
+        format_str = ''
+        if data_type == 'real' or data_type == 'float':
+            format_str = '{0:.' + str(decimals) + 'f}'
 
-      try:
+        try:
 
-         if append:
-            file_mode = 'a'
-         else:
-            file_mode = 'w'
+            if append:
+                file_mode = 'a'
+            else:
+                file_mode = 'w'
 
-         with open(file_name, file_mode) as new_file:
+            with open(file_name, file_mode) as new_file:
 
-            if headers:  # write 3 comment lines at start of file
-               new_file.write('! Data written by write_array_to_ascii_file() python function\n')
-               new_file.write('! Extent of array is: [' + str(extent_kji[2]) + ', ' + str(extent_kji[1]) + ', ' +
-                              str(extent_kji[0]) + ']\n')
-               new_file.write('! Maximum ' + str(columns) + ' data items per line\n')
+                if headers:  # write 3 comment lines at start of file
+                    new_file.write('! Data written by write_array_to_ascii_file() python function\n')
+                    new_file.write('! Extent of array is: [' + str(extent_kji[2]) + ', ' + str(extent_kji[1]) + ', ' +
+                                   str(extent_kji[0]) + ']\n')
+                    new_file.write('! Maximum ' + str(columns) + ' data items per line\n')
 
-            if keyword is not None:
-               new_file.write(keyword + '\n')
+                if keyword is not None:
+                    new_file.write(keyword + '\n')
 
-            for k in range(extent_kji[0]):
-               for j in range(extent_kji[1]):
-                  for i in range(extent_kji[2]):
-                     if (i % columns == 0):
+                for k in range(extent_kji[0]):
+                    for j in range(extent_kji[1]):
+                        for i in range(extent_kji[2]):
+                            if (i % columns == 0):
+                                new_file.write('\n')
+                            elif space_separated:
+                                new_file.write(' ')
+                            else:
+                                new_file.write('\t')
+                            if data_type == 'real' or data_type == 'float':  # todo: speed up by using common write, different format
+                                v = a[k, j, i]
+                                if nan_substitute_value is not None and maths.isnan(v):
+                                    v = nan_substitute_value
+                                new_file.write(format_str.format(v))
+                            elif data_type == 'bool' or data_type == 'boolean':
+                                if a[k, j, i]:
+                                    new_file.write('1')
+                                else:
+                                    new_file.write('0')
+                            else:
+                                new_file.write(str(a[k, j, i]))  # todo: other formatting
+                        if blank_line_after_i_block:
+                            new_file.write('\n')
+                    if blank_line_after_j_block:
                         new_file.write('\n')
-                     elif space_separated:
-                        new_file.write(' ')
-                     else:
-                        new_file.write('\t')
-                     if data_type == 'real' or data_type == 'float':  # todo: speed up by using common write, different format
-                        v = a[k, j, i]
-                        if nan_substitute_value is not None and maths.isnan(v):
-                           v = nan_substitute_value
-                        new_file.write(format_str.format(v))
-                     elif data_type == 'bool' or data_type == 'boolean':
-                        if a[k, j, i]:
-                           new_file.write('1')
-                        else:
-                           new_file.write('0')
-                     else:
-                        new_file.write(str(a[k, j, i]))  # todo: other formatting
-                  if blank_line_after_i_block:
-                     new_file.write('\n')
-               if blank_line_after_j_block:
-                  new_file.write('\n')
 
-            if not (blank_line_after_i_block or blank_line_after_j_block):
-               new_file.write('\n')
+                if not (blank_line_after_i_block or blank_line_after_j_block):
+                    new_file.write('\n')
 
-         log.info('Ascii data file %s created', file_name)
+            log.info('Ascii data file %s created', file_name)
 
-      except Exception:
-         log.error('Failed to write data to ascii file %s', file_name)
-         # could abort at this point, or raise
+        except Exception:
+            log.error('Failed to write data to ascii file %s', file_name)
+            # could abort at this point, or raise
 
-   if use_binary:
-      (extension, _) = abt.binary_file_extension_and_np_type_for_data_type(data_type)
-      binary_file_name = file_name + extension
-      if append and (keyword is not None):
-         key = keyword.split()[0].lower()
-         if key != 'corp':
-            binary_file_name = file_name + '_' + key + extension
-      if nan_substitute_value is None:
-         ap = a
-      else:
-         ap = np.where(np.isnan(a), nan_substitute_value, a)
-      try:
-         with open(binary_file_name, 'wb') as binary_file_out:
-            ap.tofile(binary_file_out)
-         log.info('Binary data file %s created', binary_file_name)
-      except Exception:
-         log.warn('Failed to write data to binary file %s', binary_file_name)
-         # todo: could delete the binary file in case a corrupt file is left for use next time
+    if use_binary:
+        (extension, _) = abt.binary_file_extension_and_np_type_for_data_type(data_type)
+        binary_file_name = file_name + extension
+        if append and (keyword is not None):
+            key = keyword.split()[0].lower()
+            if key != 'corp':
+                binary_file_name = file_name + '_' + key + extension
+        if nan_substitute_value is None:
+            ap = a
+        else:
+            ap = np.where(np.isnan(a), nan_substitute_value, a)
+        try:
+            with open(binary_file_name, 'wb') as binary_file_out:
+                ap.tofile(binary_file_out)
+            log.info('Binary data file %s created', binary_file_name)
+        except Exception:
+            log.warn('Failed to write data to binary file %s', binary_file_name)
+            # todo: could delete the binary file in case a corrupt file is left for use next time
 
 
 # end of def write_array_to_ascii_file()

--- a/resqpy/olio/write_faults.py
+++ b/resqpy/olio/write_faults.py
@@ -21,36 +21,35 @@ import resqpy.olio.trademark as tm
 
 
 def write_faults_nexus(filename, df, grid_name = 'ROOT'):
-   """Creates a Nexus include file holding MULT keywords with FNAME and face data, from pandas dataframe."""
+    """Creates a Nexus include file holding MULT keywords with FNAME and face data, from pandas dataframe."""
 
-   def write_header_lines(fp, T, grid_name, fault_name):
-      fp.write('\nMULT\t' + T + '\tALL\tPLUS\tMULT\n')
-      fp.write('\tGRID\t' + grid_name + '\n')
-      fp.write('\tFNAME\t' + fault_name + '\n')
-      if len(fault_name) > 256:
-         log.warning('exported fault name longer than Nexus limit of 256 characters: ' + fault_name)
-         tm.log_nexus_tm('warning')
+    def write_header_lines(fp, T, grid_name, fault_name):
+        fp.write('\nMULT\t' + T + '\tALL\tPLUS\tMULT\n')
+        fp.write('\tGRID\t' + grid_name + '\n')
+        fp.write('\tFNAME\t' + fault_name + '\n')
+        if len(fault_name) > 256:
+            log.warning('exported fault name longer than Nexus limit of 256 characters: ' + fault_name)
+            tm.log_nexus_tm('warning')
 
-   def write_rows(fp, df):
-      for row in range(len(df)):
-         fp.write('\t{0:1d}\t{1:1d}\t{2:1d}\t{3:1d}\t{4:1d}\t{5:1d}\t1.0\n'.format(df.iloc[row, 1], df.iloc[row, 2],
-                                                                                   df.iloc[row, 3], df.iloc[row, 4],
-                                                                                   df.iloc[row, 5], df.iloc[row, 6]))
+    def write_rows(fp, df):
+        for row in range(len(df)):
+            fp.write('\t{0:1d}\t{1:1d}\t{2:1d}\t{3:1d}\t{4:1d}\t{5:1d}\t1.0\n'.format(
+                df.iloc[row, 1], df.iloc[row, 2], df.iloc[row, 3], df.iloc[row, 4], df.iloc[row, 5], df.iloc[row, 6]))
 
-   log.info('writing FNAME data in Nexus format to file: ' + filename)
-   tm.log_nexus_tm('info')
-   assert df is not None and len(df) > 0, 'no data in faults dataframe'
+    log.info('writing FNAME data in Nexus format to file: ' + filename)
+    tm.log_nexus_tm('info')
+    assert df is not None and len(df) > 0, 'no data in faults dataframe'
 
-   with open(filename, 'w') as fp:
-      fp.write('! Exported from Bifrost resqml_baffle notebook\n\n')
-      fault_names = pd.unique(df.name)
-      for fault_name in fault_names:
-         fdf = df[df.name == fault_name]
-         fdfi = fdf[fdf.face == 'I+']
-         fdfj = fdf[fdf.face == 'J+']
-         if len(fdfi):
-            write_header_lines(fp, 'TX', grid_name, fault_name)
-            write_rows(fp, fdfi)
-         if len(fdfj):
-            write_header_lines(fp, 'TY', grid_name, fault_name)
-            write_rows(fp, fdfj)
+    with open(filename, 'w') as fp:
+        fp.write('! Exported from Bifrost resqml_baffle notebook\n\n')
+        fault_names = pd.unique(df.name)
+        for fault_name in fault_names:
+            fdf = df[df.name == fault_name]
+            fdfi = fdf[fdf.face == 'I+']
+            fdfj = fdf[fdf.face == 'J+']
+            if len(fdfi):
+                write_header_lines(fp, 'TX', grid_name, fault_name)
+                write_rows(fp, fdfi)
+            if len(fdfj):
+                write_header_lines(fp, 'TY', grid_name, fault_name)
+                write_rows(fp, fdfj)

--- a/resqpy/olio/write_hdf5.py
+++ b/resqpy/olio/write_hdf5.py
@@ -24,17 +24,17 @@ write_int_as_int32 = True  # only applies if registered dtype is None
 
 
 class H5Register():
-   """Class for registering arrays and then writing to an hdf5 file."""
+    """Class for registering arrays and then writing to an hdf5 file."""
 
-   def __init__(self, model):
-      """Create a new, empty register of arrays to be written to an hdf5 file."""
+    def __init__(self, model):
+        """Create a new, empty register of arrays to be written to an hdf5 file."""
 
-      self.dataset_dict = {}  # dictionary mapping from (object_uuid, group_tail) to (numpy_array, dtype)
-      self.hdf5_path_dict = {}  # dictionary optionally mapping from (object_uuid, group_tail) to hdf5 internal path
-      self.model = model
+        self.dataset_dict = {}  # dictionary mapping from (object_uuid, group_tail) to (numpy_array, dtype)
+        self.hdf5_path_dict = {}  # dictionary optionally mapping from (object_uuid, group_tail) to hdf5 internal path
+        self.model = model
 
-   def register_dataset(self, object_uuid, group_tail, a, dtype = None, hdf5_path = None):
-      """Register an array to be included as a dataset in the hdf5 file.
+    def register_dataset(self, object_uuid, group_tail, a, dtype = None, hdf5_path = None):
+        """Register an array to be included as a dataset in the hdf5 file.
 
       arguments:
          object_uuid (uuid.UUID): the uuid of the object (part) that this array is for
@@ -52,22 +52,22 @@ class H5Register():
          several arrays might belong to the same object
       """
 
-      #     print('registering dataset with uuid ' + str(object_uuid) + ' and group tail ' + group_tail)
-      assert (len(group_tail) > 0)
-      assert a is not None
-      assert isinstance(a, np.ndarray)
-      if group_tail[0] == '/':
-         group_tail = group_tail[1:]
-      if group_tail[-1] == '/':
-         group_tail = group_tail[:-1]
-      if (object_uuid, group_tail) in self.dataset_dict.keys():
-         pass  # todo: warn of re-registration?
-      self.dataset_dict[(object_uuid, group_tail)] = (a, dtype)
-      if hdf5_path:
-         self.hdf5_path_dict[(object_uuid, group_tail)] = hdf5_path
+        #     print('registering dataset with uuid ' + str(object_uuid) + ' and group tail ' + group_tail)
+        assert (len(group_tail) > 0)
+        assert a is not None
+        assert isinstance(a, np.ndarray)
+        if group_tail[0] == '/':
+            group_tail = group_tail[1:]
+        if group_tail[-1] == '/':
+            group_tail = group_tail[:-1]
+        if (object_uuid, group_tail) in self.dataset_dict.keys():
+            pass  # todo: warn of re-registration?
+        self.dataset_dict[(object_uuid, group_tail)] = (a, dtype)
+        if hdf5_path:
+            self.hdf5_path_dict[(object_uuid, group_tail)] = hdf5_path
 
-   def write_fp(self, fp):
-      """Write or append to an hdf5 file, writing the pre-registered datasets (arrays).
+    def write_fp(self, fp):
+        """Write or append to an hdf5 file, writing the pre-registered datasets (arrays).
 
       arguments:
          fp: an already open h5py._hl.files.File object
@@ -79,26 +79,26 @@ class H5Register():
          the file handle fp must have been opened with mode 'w' or 'a'
       """
 
-      # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
-      #       this function allows appending to any hdf5 file; calling code should set a new uuid when needed
-      assert (fp is not None)
-      for (object_uuid, group_tail) in self.dataset_dict.keys():
-         if (object_uuid, group_tail) in self.hdf5_path_dict.keys():
-            hdf5_path = self.hdf5_path_dict[(object_uuid, group_tail)]
-         else:
-            hdf5_path = resqml_path_head + str(object_uuid) + '/' + group_tail
-         (a, dtype) = self.dataset_dict[(object_uuid, group_tail)]
-         if dtype is None:
-            dtype = a.dtype
-            if write_int_as_int32 and str(dtype) == 'int64':
-               dtype = 'int32'
-         if write_bool_as_int8 and str(dtype).lower().startswith('bool'):
-            dtype = 'int8'
-         log.debug('Writing hdf5 dataset ' + hdf5_path + ' of size ' + str(a.size) + ' type ' + str(dtype))
-         fp.create_dataset(hdf5_path, data = a, dtype = dtype)
+        # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
+        #       this function allows appending to any hdf5 file; calling code should set a new uuid when needed
+        assert (fp is not None)
+        for (object_uuid, group_tail) in self.dataset_dict.keys():
+            if (object_uuid, group_tail) in self.hdf5_path_dict.keys():
+                hdf5_path = self.hdf5_path_dict[(object_uuid, group_tail)]
+            else:
+                hdf5_path = resqml_path_head + str(object_uuid) + '/' + group_tail
+            (a, dtype) = self.dataset_dict[(object_uuid, group_tail)]
+            if dtype is None:
+                dtype = a.dtype
+                if write_int_as_int32 and str(dtype) == 'int64':
+                    dtype = 'int32'
+            if write_bool_as_int8 and str(dtype).lower().startswith('bool'):
+                dtype = 'int8'
+            log.debug('Writing hdf5 dataset ' + hdf5_path + ' of size ' + str(a.size) + ' type ' + str(dtype))
+            fp.create_dataset(hdf5_path, data = a, dtype = dtype)
 
-   def write(self, file = None, mode = 'w', release_after = True):
-      """Create or append to an hdf5 file, writing the pre-registered datasets (arrays).
+    def write(self, file = None, mode = 'w', release_after = True):
+        """Create or append to an hdf5 file, writing the pre-registered datasets (arrays).
 
       arguments:
          file: either a string being the file path, or an already open h5py._hl.files.File object;
@@ -111,25 +111,25 @@ class H5Register():
          None
       """
 
-      # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
-      #       this function allows appending to any hdf5 file;
-      #       strictly, calling code should set a new uuid when needed, in practice not essential
-      if len(self.dataset_dict) == 0:
-         return
-      if file is None:
-         file = self.model.h5_access(mode = mode)
-      elif isinstance(file, str):
-         file = self.model.h5_access(mode = mode, file_path = file)
-      if mode == 'a' and isinstance(file, str) and not os.path.exists(file):
-         mode = 'w'
-      assert isinstance(file, h5py._hl.files.File)
-      self.write_fp(file)
-      if release_after:
-         self.model.h5_release()
+        # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
+        #       this function allows appending to any hdf5 file;
+        #       strictly, calling code should set a new uuid when needed, in practice not essential
+        if len(self.dataset_dict) == 0:
+            return
+        if file is None:
+            file = self.model.h5_access(mode = mode)
+        elif isinstance(file, str):
+            file = self.model.h5_access(mode = mode, file_path = file)
+        if mode == 'a' and isinstance(file, str) and not os.path.exists(file):
+            mode = 'w'
+        assert isinstance(file, h5py._hl.files.File)
+        self.write_fp(file)
+        if release_after:
+            self.model.h5_release()
 
 
 def copy_h5(file_in, file_out, uuid_inclusion_list = None, uuid_exclusion_list = None, mode = 'w'):
-   """Create a copy of an hdf5, optionally including or excluding arrays with specified uuids.
+    """Create a copy of an hdf5, optionally including or excluding arrays with specified uuids.
 
    arguments:
       file_in (string): path of existing hdf5 file to be duplicated
@@ -150,53 +150,57 @@ def copy_h5(file_in, file_out, uuid_inclusion_list = None, uuid_exclusion_list =
       output file
    """
 
-   #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
-   assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
-   assert uuid_inclusion_list is None or uuid_exclusion_list is None,  \
-      'inclusion and exclusion lists both specified for hdf5 copy; at most one allowed'
-   checking_uuid = uuid_inclusion_list is not None or uuid_exclusion_list is not None
-   assert mode in ['w', 'a']
-   copy_count = 0
-   with h5py.File(file_out, mode) as fp_out:
-      assert fp_out is not None, 'failed to open output hdf5 file: ' + file_out
-      with h5py.File(file_in, 'r') as fp_in:
-         assert fp_in is not None, 'failed to open input hdf5 file: ' + file_in
-         main_group_in = fp_in['RESQML']
-         assert main_group_in is not None, 'failed to find RESQML group in hdf5 file: ' + file_in
-         if mode == 'w':
-            main_group_out = fp_out.create_group('RESQML')
-         elif mode == 'a':
-            try:
-               main_group_out = fp_out['RESQML']
-            except Exception:
-               main_group_out = fp_out.create_group('RESQML')
-         else:
-            main_group_out = fp_out['RESQML']
-         for group in main_group_in:
-            if checking_uuid:
-               uuid = bu.uuid_from_string(group)
-               if uuid_inclusion_list is not None:
-                  if uuid not in uuid_inclusion_list:
-                     if uuid is None:
-                        log.warning('RESQML group name in hdf5 file does not start with a uuid, skipping: ' +
-                                    str(group))
-                     continue
-               else:  # uuid_exclusion_list is not None
-                  if uuid in uuid_exclusion_list:
-                     continue
-                  if uuid is None:  # will still be copied
-                     log.warning('RESQML group name in hdf5 file does not start with a uuid: ' + str(group))
-            if group in main_group_out:
-               log.warning('not copying hdf5 data due to pre-existence for: ' + str(group))
-               continue
-            log.debug('copying hdf5 data for uuid: ' + group)
-            main_group_in.copy(group, main_group_out, expand_soft = True, expand_external = True, expand_refs = True)
-            copy_count += 1
-   return copy_count
+    #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
+    assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
+    assert uuid_inclusion_list is None or uuid_exclusion_list is None,  \
+       'inclusion and exclusion lists both specified for hdf5 copy; at most one allowed'
+    checking_uuid = uuid_inclusion_list is not None or uuid_exclusion_list is not None
+    assert mode in ['w', 'a']
+    copy_count = 0
+    with h5py.File(file_out, mode) as fp_out:
+        assert fp_out is not None, 'failed to open output hdf5 file: ' + file_out
+        with h5py.File(file_in, 'r') as fp_in:
+            assert fp_in is not None, 'failed to open input hdf5 file: ' + file_in
+            main_group_in = fp_in['RESQML']
+            assert main_group_in is not None, 'failed to find RESQML group in hdf5 file: ' + file_in
+            if mode == 'w':
+                main_group_out = fp_out.create_group('RESQML')
+            elif mode == 'a':
+                try:
+                    main_group_out = fp_out['RESQML']
+                except Exception:
+                    main_group_out = fp_out.create_group('RESQML')
+            else:
+                main_group_out = fp_out['RESQML']
+            for group in main_group_in:
+                if checking_uuid:
+                    uuid = bu.uuid_from_string(group)
+                    if uuid_inclusion_list is not None:
+                        if uuid not in uuid_inclusion_list:
+                            if uuid is None:
+                                log.warning('RESQML group name in hdf5 file does not start with a uuid, skipping: ' +
+                                            str(group))
+                            continue
+                    else:  # uuid_exclusion_list is not None
+                        if uuid in uuid_exclusion_list:
+                            continue
+                        if uuid is None:  # will still be copied
+                            log.warning('RESQML group name in hdf5 file does not start with a uuid: ' + str(group))
+                if group in main_group_out:
+                    log.warning('not copying hdf5 data due to pre-existence for: ' + str(group))
+                    continue
+                log.debug('copying hdf5 data for uuid: ' + group)
+                main_group_in.copy(group,
+                                   main_group_out,
+                                   expand_soft = True,
+                                   expand_external = True,
+                                   expand_refs = True)
+                copy_count += 1
+    return copy_count
 
 
 def copy_h5_path_list(file_in, file_out, hdf5_path_list, mode = 'w'):
-   """Create a copy of some hdf5 datasets (or groups), identified as a list of hdf5 internal paths.
+    """Create a copy of some hdf5 datasets (or groups), identified as a list of hdf5 internal paths.
 
    arguments:
       file_in (string): path of existing hdf5 file to be copied from
@@ -209,38 +213,38 @@ def copy_h5_path_list(file_in, file_out, hdf5_path_list, mode = 'w'):
       number of hdf5 datasets (or groups) copied
    """
 
-   #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
-   assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
-   assert hdf5_path_list is not None
-   assert mode in ['w', 'a']
-   copy_count = 0
-   with h5py.File(file_out, mode) as fp_out:
-      assert fp_out is not None, f'failed to open output hdf5 file: {file_out}'
-      with h5py.File(file_in, 'r') as fp_in:
-         assert fp_in is not None, f'failed to open input hdf5 file: {file_in}'
-         for path in hdf5_path_list:
-            if path in fp_out:
-               log.warning(f'not copying hdf5 data due to pre-existence for: {path}')
-               continue
-            assert path in fp_in, f'internal path {path} not found in hdf5 file {file_in}'
-            log.debug(f'copying hdf5 data for: {path}')
-            build = ''
-            group_list = list(path.split(sep = '/'))
-            assert len(group_list) > 1, f'no hdf5 group(s) in internal path {path}'
-            for w in group_list[:-1]:
-               if w:
-                  build += '/' + w
-                  if build not in fp_out:
-                     fp_out.create_group(build)
-            build += '/' + group_list[-1]
-            fp_out.create_dataset(build, data = fp_in[path])
-            #            fp_in.copy(path, fp_out[path], expand_soft = True, expand_external = True, expand_refs = True)
-            copy_count += 1
-   return copy_count
+    #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
+    assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
+    assert hdf5_path_list is not None
+    assert mode in ['w', 'a']
+    copy_count = 0
+    with h5py.File(file_out, mode) as fp_out:
+        assert fp_out is not None, f'failed to open output hdf5 file: {file_out}'
+        with h5py.File(file_in, 'r') as fp_in:
+            assert fp_in is not None, f'failed to open input hdf5 file: {file_in}'
+            for path in hdf5_path_list:
+                if path in fp_out:
+                    log.warning(f'not copying hdf5 data due to pre-existence for: {path}')
+                    continue
+                assert path in fp_in, f'internal path {path} not found in hdf5 file {file_in}'
+                log.debug(f'copying hdf5 data for: {path}')
+                build = ''
+                group_list = list(path.split(sep = '/'))
+                assert len(group_list) > 1, f'no hdf5 group(s) in internal path {path}'
+                for w in group_list[:-1]:
+                    if w:
+                        build += '/' + w
+                        if build not in fp_out:
+                            fp_out.create_group(build)
+                build += '/' + group_list[-1]
+                fp_out.create_dataset(build, data = fp_in[path])
+                #            fp_in.copy(path, fp_out[path], expand_soft = True, expand_external = True, expand_refs = True)
+                copy_count += 1
+    return copy_count
 
 
 def change_uuid(file, old_uuid, new_uuid):
-   """Changes hdf5 internal path (group name) for part, switching from old to new uuid.
+    """Changes hdf5 internal path (group name) for part, switching from old to new uuid.
 
    notes:
       this is low level functionality not usually called directly;
@@ -248,18 +252,18 @@ def change_uuid(file, old_uuid, new_uuid):
       when writing data, namely /RESQML/uuid/tail...
    """
 
-   assert file, 'hdf5 file name missing'
-   assert old_uuid is not None and new_uuid is not None, 'missing uuid'
+    assert file, 'hdf5 file name missing'
+    assert old_uuid is not None and new_uuid is not None, 'missing uuid'
 
-   def change_uuid_fp(fp, old_uuid, new_uuid):
-      main_group = fp[resqml_path_head.strip('/')]
-      old_group = main_group[str(old_uuid)]
-      main_group[str(new_uuid)] = old_group
-      del main_group[str(old_uuid)]
+    def change_uuid_fp(fp, old_uuid, new_uuid):
+        main_group = fp[resqml_path_head.strip('/')]
+        old_group = main_group[str(old_uuid)]
+        main_group[str(new_uuid)] = old_group
+        del main_group[str(old_uuid)]
 
-   if isinstance(file, h5py._hl.files.File):
-      change_uuid_fp(file, old_uuid, new_uuid)
-   else:
-      assert isinstance(file, str)
-      with h5py.File(file, 'r+') as fp:
-         change_uuid_fp(fp, old_uuid, new_uuid)
+    if isinstance(file, h5py._hl.files.File):
+        change_uuid_fp(file, old_uuid, new_uuid)
+    else:
+        assert isinstance(file, str)
+        with h5py.File(file, 'r+') as fp:
+            change_uuid_fp(fp, old_uuid, new_uuid)

--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -22,285 +22,285 @@ use_fesapi_quirks = True
 use_tabs = False
 
 if use_fesapi_quirks:
-   null_xml_text = '\n'
+    null_xml_text = '\n'
 else:
-   null_xml_text = ''
+    null_xml_text = ''
 
 
 def strip_path(full_path):
-   """Returns the filename part of full_path with any directory path removed.
+    """Returns the filename part of full_path with any directory path removed.
 
       :meta private:
    """
 
-   return os.path.basename(full_path)
+    return os.path.basename(full_path)
 
 
 def stripped_of_prefix(prefixed):
-   """Returns a simplified version of an xml tag or other element with any {xsd defining prefix} stripped off."""
+    """Returns a simplified version of an xml tag or other element with any {xsd defining prefix} stripped off."""
 
-   if prefixed is None:
-      return None
-   if '}' in prefixed:
-      return prefixed[prefixed.rfind('}') + 1:]
-   return prefixed[prefixed.rfind(':') + 1:]
+    if prefixed is None:
+        return None
+    if '}' in prefixed:
+        return prefixed[prefixed.rfind('}') + 1:]
+    return prefixed[prefixed.rfind(':') + 1:]
 
 
 def colon_prefixed(curly_prefixed):
-   """Returns a version of an xml tag with {url} prefix replaced with nsi: equivalent; also returns the nsi prefix."""
+    """Returns a version of an xml tag with {url} prefix replaced with nsi: equivalent; also returns the nsi prefix."""
 
-   if not curly_prefixed:
-      return None, None
-   if curly_prefixed[0] != '{':
-      colon = curly_prefixed.find(':')
-      if colon < 0:
-         return curly_prefixed, None
-      return curly_prefixed, curly_prefixed[:colon]
-   pre_end = curly_prefixed.rfind('}')
-   try:
-      pre_colon = inv_ns[curly_prefixed[1:pre_end]]
-   except Exception:
-      return curly_prefixed, None
-   return pre_colon + ':' + curly_prefixed[pre_end + 1:], pre_colon
+    if not curly_prefixed:
+        return None, None
+    if curly_prefixed[0] != '{':
+        colon = curly_prefixed.find(':')
+        if colon < 0:
+            return curly_prefixed, None
+        return curly_prefixed, curly_prefixed[:colon]
+    pre_end = curly_prefixed.rfind('}')
+    try:
+        pre_colon = inv_ns[curly_prefixed[1:pre_end]]
+    except Exception:
+        return curly_prefixed, None
+    return pre_colon + ':' + curly_prefixed[pre_end + 1:], pre_colon
 
 
 def find_tag(root, tag_name, must_exist = False):
-   """Finds the first child in xml node with a (prefix-stripped) tag matching given tag name."""
+    """Finds the first child in xml node with a (prefix-stripped) tag matching given tag name."""
 
-   if root is None:
-      return None
-   for child in root:
-      if stripped_of_prefix(child.tag) == tag_name:
-         return child
-   if must_exist:
-      raise ValueError(f"Expected tag {tag_name} not found in root {root}")
-   return None
+    if root is None:
+        return None
+    for child in root:
+        if stripped_of_prefix(child.tag) == tag_name:
+            return child
+    if must_exist:
+        raise ValueError(f"Expected tag {tag_name} not found in root {root}")
+    return None
 
 
 def find_tag_text(root, tag_name, must_exist = False):
-   """Finds the first child in xml node with a tag matching given tag name; returns stripped text field."""
+    """Finds the first child in xml node with a tag matching given tag name; returns stripped text field."""
 
-   if root is None:
-      return None
-   for child in root:
-      if stripped_of_prefix(child.tag) == tag_name:
-         return node_text(child)
-   if must_exist:
-      raise ValueError(f"Expected tag {tag_name} not found in root {root}")
-   return None
+    if root is None:
+        return None
+    for child in root:
+        if stripped_of_prefix(child.tag) == tag_name:
+            return node_text(child)
+    if must_exist:
+        raise ValueError(f"Expected tag {tag_name} not found in root {root}")
+    return None
 
 
 def find_tag_bool(root, tag_name, must_exist = False):
-   """Finds the first child in xml node with a tag matching given tag name; returns stripped text field as bool."""
+    """Finds the first child in xml node with a tag matching given tag name; returns stripped text field as bool."""
 
-   if root is None:
-      return None
-   for child in root:
-      if stripped_of_prefix(child.tag) == tag_name:
-         return node_bool(child)
-   if must_exist:
-      raise ValueError(f"Expected tag {tag_name} not found in root {root}")
-   return None
+    if root is None:
+        return None
+    for child in root:
+        if stripped_of_prefix(child.tag) == tag_name:
+            return node_bool(child)
+    if must_exist:
+        raise ValueError(f"Expected tag {tag_name} not found in root {root}")
+    return None
 
 
 def find_tag_int(root, tag_name, must_exist = False):
-   """Finds the first child in xml node with a tag matching given tag name; returns stripped text field as int."""
+    """Finds the first child in xml node with a tag matching given tag name; returns stripped text field as int."""
 
-   if root is None:
-      return None
-   for child in root:
-      if stripped_of_prefix(child.tag) == tag_name:
-         return node_int(child)
-   if must_exist:
-      raise ValueError(f"Expected tag {tag_name} not found in root {root}")
-   return None
+    if root is None:
+        return None
+    for child in root:
+        if stripped_of_prefix(child.tag) == tag_name:
+            return node_int(child)
+    if must_exist:
+        raise ValueError(f"Expected tag {tag_name} not found in root {root}")
+    return None
 
 
 def find_tag_float(root, tag_name, must_exist = False):
-   """Finds the first child in xml node with a tag matching given tag name; returns stripped text field as float."""
+    """Finds the first child in xml node with a tag matching given tag name; returns stripped text field as float."""
 
-   if root is None:
-      return None
-   for child in root:
-      if stripped_of_prefix(child.tag) == tag_name:
-         return node_float(child)
-   if must_exist:
-      raise ValueError(f"Expected tag {tag_name} not found in root {root}")
-   return None
+    if root is None:
+        return None
+    for child in root:
+        if stripped_of_prefix(child.tag) == tag_name:
+            return node_float(child)
+    if must_exist:
+        raise ValueError(f"Expected tag {tag_name} not found in root {root}")
+    return None
 
 
 def find_nested_tags(root, tag_list):
-   """Follows a list of tags in a nested xml hierarchy, returning the node at the deepest level."""
+    """Follows a list of tags in a nested xml hierarchy, returning the node at the deepest level."""
 
-   if not tag_list:
-      return None
-   head = find_tag(root, tag_list[0])
-   if head is None:
-      return None
-   if len(tag_list) == 1:
-      return head
-   return find_nested_tags(head, tag_list[1:])
+    if not tag_list:
+        return None
+    head = find_tag(root, tag_list[0])
+    if head is None:
+        return None
+    if len(tag_list) == 1:
+        return head
+    return find_nested_tags(head, tag_list[1:])
 
 
 def find_nested_tags_cast(root, tag_list, dtype = None):
-   """Return value of nested tags as desired dtype.
+    """Return value of nested tags as desired dtype.
    
    Follows a list of tags in a nested xml hierarchy, returning the stripped text
    of the node at the deepest level.
    """
 
-   cast_func = {
-      int: node_int,
-      float: node_float,
-      bool: node_bool,
-      str: node_text,
-      None: lambda x: x,
-   }[dtype]
+    cast_func = {
+        int: node_int,
+        float: node_float,
+        bool: node_bool,
+        str: node_text,
+        None: lambda x: x,
+    }[dtype]
 
-   node = find_nested_tags(root, tag_list)
-   return cast_func(node)
+    node = find_nested_tags(root, tag_list)
+    return cast_func(node)
 
 
 def find_nested_tags_text(root, tag_list):
-   """Follows a list of tags in a nested xml hierarchy, returning the stripped text of the node at the deepest level."""
+    """Follows a list of tags in a nested xml hierarchy, returning the stripped text of the node at the deepest level."""
 
-   node = find_nested_tags(root, tag_list)
-   return node_text(node)
+    node = find_nested_tags(root, tag_list)
+    return node_text(node)
 
 
 def find_nested_tags_bool(root, tag_list):
-   """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as bool."""
+    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as bool."""
 
-   node = find_nested_tags(root, tag_list)
-   return node_bool(node)
+    node = find_nested_tags(root, tag_list)
+    return node_bool(node)
 
 
 def find_nested_tags_int(root, tag_list):
-   """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as int."""
+    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as int."""
 
-   node = find_nested_tags(root, tag_list)
-   return node_int(node)
+    node = find_nested_tags(root, tag_list)
+    return node_int(node)
 
 
 def find_nested_tags_float(root, tag_list):
-   """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as float."""
+    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as float."""
 
-   node = find_nested_tags(root, tag_list)
-   return node_float(node)
+    node = find_nested_tags(root, tag_list)
+    return node_float(node)
 
 
 def count_tag(root, tag_name):
-   """Returns the number of children in xml node with a (prefix-stripped) tag matching given tag name."""
+    """Returns the number of children in xml node with a (prefix-stripped) tag matching given tag name."""
 
-   if root is None:
-      return None
-   count = 0
-   for child in root:
-      if stripped_of_prefix(child.tag) == tag_name:
-         count += 1
-   return count
+    if root is None:
+        return None
+    count = 0
+    for child in root:
+        if stripped_of_prefix(child.tag) == tag_name:
+            count += 1
+    return count
 
 
 def list_of_tag(root, tag_name):
-   """Returns a list of children in xml node with a (prefix-stripped) tag matching given tag name."""
+    """Returns a list of children in xml node with a (prefix-stripped) tag matching given tag name."""
 
-   if root is None:
-      return None
-   results = []
-   for child in root:
-      if stripped_of_prefix(child.tag) == tag_name:
-         results.append(child)
-   return results
+    if root is None:
+        return None
+    results = []
+    for child in root:
+        if stripped_of_prefix(child.tag) == tag_name:
+            results.append(child)
+    return results
 
 
 def list_of_descendant_tag(root, tag_name):
-   """Returns a list of descendants in xml node tree with a (prefix-stripped) tag matching given tag name."""
+    """Returns a list of descendants in xml node tree with a (prefix-stripped) tag matching given tag name."""
 
-   if root is None:
-      return None
-   results = []
-   for child in root.iterdescendants():
-      if stripped_of_prefix(child.tag) == tag_name:
-         results.append(child)
-   return results
+    if root is None:
+        return None
+    results = []
+    for child in root.iterdescendants():
+        if stripped_of_prefix(child.tag) == tag_name:
+            results.append(child)
+    return results
 
 
 def list_obj_references(root, skip_hdf5 = True):
-   """Returns list of nodes of type DataObjectReference."""
+    """Returns list of nodes of type DataObjectReference."""
 
-   if root is None:
-      return None
-   results = []
-   if node_type(root) == 'DataObjectReference' and not (skip_hdf5 and stripped_of_prefix(root.tag) == 'HdfProxy'):
-      results.append(root)
-   for child in root:
-      results += list_obj_references(child, skip_hdf5 = skip_hdf5)
-   return results
+    if root is None:
+        return None
+    results = []
+    if node_type(root) == 'DataObjectReference' and not (skip_hdf5 and stripped_of_prefix(root.tag) == 'HdfProxy'):
+        results.append(root)
+    for child in root:
+        results += list_obj_references(child, skip_hdf5 = skip_hdf5)
+    return results
 
 
 def cut_obj_references(root, uuids_to_be_cut):
-   """Deletes any object reference nodes to uuids in given list."""
+    """Deletes any object reference nodes to uuids in given list."""
 
-   if root is None or not uuids_to_be_cut:
-      return
-   for child in root:
-      if node_type(child) == 'DataObjectReference':
-         referred_uuid = bu.uuid_from_string(find_tag_text(child, 'UUID', must_exist = True))
-         for cut_uuid in uuids_to_be_cut:
-            if bu.matching_uuids(referred_uuid, cut_uuid):
-               root.remove(child)
-               break
-      else:
-         cut_obj_references(child, uuids_to_be_cut)
+    if root is None or not uuids_to_be_cut:
+        return
+    for child in root:
+        if node_type(child) == 'DataObjectReference':
+            referred_uuid = bu.uuid_from_string(find_tag_text(child, 'UUID', must_exist = True))
+            for cut_uuid in uuids_to_be_cut:
+                if bu.matching_uuids(referred_uuid, cut_uuid):
+                    root.remove(child)
+                    break
+        else:
+            cut_obj_references(child, uuids_to_be_cut)
 
 
 def cut_nodes_of_types(root, types_to_be_cut):
-   """Deletes any nodes of a type matching one in the given list."""
+    """Deletes any nodes of a type matching one in the given list."""
 
-   if root is None or not types_to_be_cut:
-      return
-   for child in root:
-      if node_type(child) in types_to_be_cut:
-         root.remove(child)  # hope this doesn't mess up the iteration
-      else:
-         cut_nodes_of_types(child, types_to_be_cut)
+    if root is None or not types_to_be_cut:
+        return
+    for child in root:
+        if node_type(child) in types_to_be_cut:
+            root.remove(child)  # hope this doesn't mess up the iteration
+        else:
+            cut_nodes_of_types(child, types_to_be_cut)
 
 
 def content_type(content_type_str):
-   """Returns the actual type, as embedded in an xml ContentType attribute; application and version are disregarded."""
+    """Returns the actual type, as embedded in an xml ContentType attribute; application and version are disregarded."""
 
-   if content_type_str is None:
-      return None
-   if 'type=' in content_type_str:
-      return content_type_str[content_type_str.rfind('type=') + 5:]
+    if content_type_str is None:
+        return None
+    if 'type=' in content_type_str:
+        return content_type_str[content_type_str.rfind('type=') + 5:]
 
 
 #   if ':' in content_type_str:
 #      return content_type_str[content_type_str.rfind(':') + 1:]
-   return content_type_str
+    return content_type_str
 
 
 def node_type(node, is_rels = False, strip_obj = False):
-   """Returns the type as held in attributes of xml node; defining authority is stripped out."""
+    """Returns the type as held in attributes of xml node; defining authority is stripped out."""
 
-   result = None
-   if node is None:
-      return None
-   if is_rels:
-      if 'Type' not in node.attrib.keys():
-         return None
-      type_str = node.attrib['Type']
-      result = type_str[type_str.rfind('/') + 1:]
-   else:
-      for key in node.attrib.keys():
-         if stripped_of_prefix(key) == 'type':
-            #           type_str = node.attrib[key]
-            #           return type_str[type_str.rfind(':') + 1:]
-            type_str = stripped_of_prefix(node.attrib[key])
-            result = type_str
-   if result and strip_obj and result.startswith('obj_'):
-      result = result[4:]
-   return result
+    result = None
+    if node is None:
+        return None
+    if is_rels:
+        if 'Type' not in node.attrib.keys():
+            return None
+        type_str = node.attrib['Type']
+        result = type_str[type_str.rfind('/') + 1:]
+    else:
+        for key in node.attrib.keys():
+            if stripped_of_prefix(key) == 'type':
+                #           type_str = node.attrib[key]
+                #           return type_str[type_str.rfind(':') + 1:]
+                type_str = stripped_of_prefix(node.attrib[key])
+                result = type_str
+    if result and strip_obj and result.startswith('obj_'):
+        result = result[4:]
+    return result
 
 
 def print_xml_tree(root,
@@ -311,466 +311,466 @@ def print_xml_tree(root,
                    log_level = None,
                    max_lines = 0,
                    line_count = 0):
-   """Print an xml tree in an indented semi-readable format; return accumulated number of lines."""
+    """Print an xml tree in an indented semi-readable format; return accumulated number of lines."""
 
-   if root is None or (max_level is not None and level > max_level):
-      return line_count
-   if log_level is not None:
-      to_log = True
-   if log_level is None or log_level == 'info':
-      print_fn = log.info
-   elif log_level == 'debug':
-      print_fn = log.debug
-   elif log_level in ['warn', 'warning']:
-      print_fn = log.warning
-   elif log_level == 'error':
-      print_fn = log.error
-   else:
-      print_fn = log.critical
-   if max_lines and line_count >= max_lines:
-      if line_count == max_lines:
-         message = '(...xml tree output truncated after ' + str(max_lines) + ' lines)'
-         if to_log:
-            print_fn(message)
-         else:
-            print(message)
-         line_count += 1
-      return line_count
+    if root is None or (max_level is not None and level > max_level):
+        return line_count
+    if log_level is not None:
+        to_log = True
+    if log_level is None or log_level == 'info':
+        print_fn = log.info
+    elif log_level == 'debug':
+        print_fn = log.debug
+    elif log_level in ['warn', 'warning']:
+        print_fn = log.warning
+    elif log_level == 'error':
+        print_fn = log.error
+    else:
+        print_fn = log.critical
+    if max_lines and line_count >= max_lines:
+        if line_count == max_lines:
+            message = '(...xml tree output truncated after ' + str(max_lines) + ' lines)'
+            if to_log:
+                print_fn(message)
+            else:
+                print(message)
+            line_count += 1
+        return line_count
 
-   value = root.text
-   type_attr = None
-   if strip_tag_refs:
-      tag = stripped_of_prefix(root.tag)
-      attrib_dict = {}
-      for key in root.attrib.keys():
-         stripped_key = stripped_of_prefix(key)
-         attrib_dict[stripped_key] = root.attrib[key]
-         if stripped_key == 'type':
-            type_attr = stripped_of_prefix(root.attrib[key])
-   else:
-      tag = root.tag
-      attrib_dict = root.attrib
-      for key in root.attrib.keys():
-         if stripped_of_prefix(key) == 'type':
-            type_attr = root.attrib[key]
-   if to_log:
-      message = (3 * level * ' ') + tag + ' # ' + str(attrib_dict)
-      if type_attr is not None:
-         message += ' ## ' + type_attr
-      if value is not None:
-         message += ' ### ' + root.text.replace('\n', '\\n')
-      print_fn(message)
-   else:
-      print((3 * level * ' ') + tag, '#', attrib_dict, end = ' ')
-      if type_attr is not None:
-         print('##', type_attr, end = ' ')
-      if value is not None:
-         print('###', root.text.replace('\n', '\\n'), end = '')
-      print('')
-   line_count += 1
-   for child in root:
-      line_count = print_xml_tree(child,
-                                  level = level + 1,
-                                  max_level = max_level,
-                                  strip_tag_refs = strip_tag_refs,
-                                  to_log = to_log,
-                                  log_level = log_level,
-                                  max_lines = max_lines,
-                                  line_count = line_count)
-      if line_count > max_lines:
-         break
-   return line_count
+    value = root.text
+    type_attr = None
+    if strip_tag_refs:
+        tag = stripped_of_prefix(root.tag)
+        attrib_dict = {}
+        for key in root.attrib.keys():
+            stripped_key = stripped_of_prefix(key)
+            attrib_dict[stripped_key] = root.attrib[key]
+            if stripped_key == 'type':
+                type_attr = stripped_of_prefix(root.attrib[key])
+    else:
+        tag = root.tag
+        attrib_dict = root.attrib
+        for key in root.attrib.keys():
+            if stripped_of_prefix(key) == 'type':
+                type_attr = root.attrib[key]
+    if to_log:
+        message = (3 * level * ' ') + tag + ' # ' + str(attrib_dict)
+        if type_attr is not None:
+            message += ' ## ' + type_attr
+        if value is not None:
+            message += ' ### ' + root.text.replace('\n', '\\n')
+        print_fn(message)
+    else:
+        print((3 * level * ' ') + tag, '#', attrib_dict, end = ' ')
+        if type_attr is not None:
+            print('##', type_attr, end = ' ')
+        if value is not None:
+            print('###', root.text.replace('\n', '\\n'), end = '')
+        print('')
+    line_count += 1
+    for child in root:
+        line_count = print_xml_tree(child,
+                                    level = level + 1,
+                                    max_level = max_level,
+                                    strip_tag_refs = strip_tag_refs,
+                                    to_log = to_log,
+                                    log_level = log_level,
+                                    max_lines = max_lines,
+                                    line_count = line_count)
+        if line_count > max_lines:
+            break
+    return line_count
 
 
 def uuid_in_part_name(part_name):
-   """Returns uuid as embedded in part name."""
+    """Returns uuid as embedded in part name."""
 
-   # This might not always work
-   if part_name is None:
-      return None
-   if part_name.endswith('.xml') and len(part_name) >= 40:
-      return bu.uuid_from_string(part_name[-40:-4])
-   elif part_name.endswith('.xml.rels') and len(part_name) >= 45:
-      return bu.uuid_from_string(part_name[-45:-9])
-   return None
+    # This might not always work
+    if part_name is None:
+        return None
+    if part_name.endswith('.xml') and len(part_name) >= 40:
+        return bu.uuid_from_string(part_name[-40:-4])
+    elif part_name.endswith('.xml.rels') and len(part_name) >= 45:
+        return bu.uuid_from_string(part_name[-45:-9])
+    return None
 
 
 def part_name_for_object(obj_type, uuid, prefixed = False, epc_subdir = None):
-   """Returns the standard part name comprised of the object type, uuid and .xml extension."""
+    """Returns the standard part name comprised of the object type, uuid and .xml extension."""
 
-   if prefixed and (pretend_to_be_fesapi or use_fesapi_quirks) and obj_type[0] != '/':
-      prefix = '/'
-   else:
-      prefix = ''
-   if not obj_type.startswith('obj_'):
-      prefix += 'obj_'
-   if epc_subdir:
-      if not epc_subdir.endswith('/'):
-         epc_subdir += '/'
-      prefix = epc_subdir + prefix
-   return prefix + obj_type + '_' + str(uuid) + '.xml'
+    if prefixed and (pretend_to_be_fesapi or use_fesapi_quirks) and obj_type[0] != '/':
+        prefix = '/'
+    else:
+        prefix = ''
+    if not obj_type.startswith('obj_'):
+        prefix += 'obj_'
+    if epc_subdir:
+        if not epc_subdir.endswith('/'):
+            epc_subdir += '/'
+        prefix = epc_subdir + prefix
+    return prefix + obj_type + '_' + str(uuid) + '.xml'
 
 
 def rels_part_name_for_part(part_name):
-   """Returns the paired relationships part name for the given part name."""
+    """Returns the paired relationships part name for the given part name."""
 
-   pn = stripped_of_prefix(part_name)
-   if pn is None or len(pn) == 0:
-      return None
-   dir_place = pn.rfind('/')
-   if dir_place == -1:
-      return '_rels/' + pn + '.rels'
-   if dir_place == 0:
-      return '_rels' + pn + '.rels'
-   if dir_place == len(pn) - 1:
-      return None
-   return pn[:dir_place + 1] + '_rels' + pn[dir_place:] + '.rels'
+    pn = stripped_of_prefix(part_name)
+    if pn is None or len(pn) == 0:
+        return None
+    dir_place = pn.rfind('/')
+    if dir_place == -1:
+        return '_rels/' + pn + '.rels'
+    if dir_place == 0:
+        return '_rels' + pn + '.rels'
+    if dir_place == len(pn) - 1:
+        return None
+    return pn[:dir_place + 1] + '_rels' + pn[dir_place:] + '.rels'
 
 
 def uuid_for_part_root(root):
-   """Returns uuid as stored in xml attribs for root."""
+    """Returns uuid as stored in xml attribs for root."""
 
-   if root is None:
-      return None
-   if 'uuid' not in root.attrib.keys():
-      return None
-   return bu.uuid_from_string(root.attrib['uuid'])
+    if root is None:
+        return None
+    if 'uuid' not in root.attrib.keys():
+        return None
+    return bu.uuid_from_string(root.attrib['uuid'])
 
 
 def patch_uuid_in_part_root(root, uuid):
-   """Returns modified part name with uuid swapped to uuid argument; root attrib is also changed."""
+    """Returns modified part name with uuid swapped to uuid argument; root attrib is also changed."""
 
-   if root is None or uuid is None:
-      return None
-   # This might not always work
-   root.attrib['uuid'] = str(uuid)
-   return part_name_for_part_root(root)
+    if root is None or uuid is None:
+        return None
+    # This might not always work
+    root.attrib['uuid'] = str(uuid)
+    return part_name_for_part_root(root)
 
 
 def part_name_for_part_root(root, is_rels = False, epc_subdir = None):
-   """Returns the part name given the root node for the part's xml."""
+    """Returns the part name given the root node for the part's xml."""
 
-   if root is None:
-      return None
-   obj_type = node_type(root, is_rels = is_rels)
-   uuid = uuid_for_part_root(root)
-   if obj_type is None or uuid is None:
-      return None
-   return part_name_for_object(obj_type, uuid, epc_subdir = epc_subdir)
+    if root is None:
+        return None
+    obj_type = node_type(root, is_rels = is_rels)
+    uuid = uuid_for_part_root(root)
+    if obj_type is None or uuid is None:
+        return None
+    return part_name_for_object(obj_type, uuid, epc_subdir = epc_subdir)
 
 
 # the next two functions aren't really much to do with the xml element tree
 
 
 def find_in_ordered_data(value, array_1d):
-   """Returns the index in the ordered list-like array of value; or None if not present."""
+    """Returns the index in the ordered list-like array of value; or None if not present."""
 
-   def find_in_subset(value, array_1d, start, end):
-      # recursive binary split
-      if start >= end:
-         return None
-      mid = start + (end - start) // 2
-      sample = array_1d[mid]
-      if sample == value:
-         while mid > 0 and array_1d[mid - 1] == value:
-            mid -= 1
-         return mid
-      if sample > value:
-         return find_in_subset(value, array_1d, start, mid)
-      if mid == start:
-         mid += 1
-      return find_in_subset(value, array_1d, mid, end)
+    def find_in_subset(value, array_1d, start, end):
+        # recursive binary split
+        if start >= end:
+            return None
+        mid = start + (end - start) // 2
+        sample = array_1d[mid]
+        if sample == value:
+            while mid > 0 and array_1d[mid - 1] == value:
+                mid -= 1
+            return mid
+        if sample > value:
+            return find_in_subset(value, array_1d, start, mid)
+        if mid == start:
+            mid += 1
+        return find_in_subset(value, array_1d, mid, end)
 
-   return find_in_subset(value, array_1d, 0, len(array_1d))
+    return find_in_subset(value, array_1d, 0, len(array_1d))
 
 
 def simplified_data_type(array_dtype):
-   """Returns a simplified string version of the elemental data type (typically for a numpy or hdf5 array)."""
+    """Returns a simplified string version of the elemental data type (typically for a numpy or hdf5 array)."""
 
-   str_dtype = str(array_dtype)
-   if str_dtype.startswith('int'):
-      return 'int'
-   if str_dtype.startswith('float') or str_dtype.startswith('real'):
-      return 'float'
-   if str_dtype.startswith('bool'):
-      return 'bool'
-   return str_dtype
+    str_dtype = str(array_dtype)
+    if str_dtype.startswith('int'):
+        return 'int'
+    if str_dtype.startswith('float') or str_dtype.startswith('real'):
+        return 'float'
+    if str_dtype.startswith('bool'):
+        return 'bool'
+    return str_dtype
 
 
 # following functions mostly previously in resqml_print.py
 
 
 def bool_from_text(text):
-   """Returns boolean value for string 'true' or 'false'; anything else results in None."""
+    """Returns boolean value for string 'true' or 'false'; anything else results in None."""
 
-   if text is None:
-      return None
-   if text.strip().lower() == 'true':
-      return True
-   if text.strip().lower() == 'false':
-      return False
-   return None
+    if text is None:
+        return None
+    if text.strip().lower() == 'true':
+        return True
+    if text.strip().lower() == 'false':
+        return False
+    return None
 
 
 def node_text(node, unknown_if_none = False):
-   """Returns stripped node text or 'unknown' if node is None or text is blank or newline."""
+    """Returns stripped node text or 'unknown' if node is None or text is blank or newline."""
 
-   if node is None or node.text is None:
-      return 'unknown' if unknown_if_none else None
-   text = node.text.strip()
-   if len(text):
-      return text
-   return 'unknown' if unknown_if_none else None
+    if node is None or node.text is None:
+        return 'unknown' if unknown_if_none else None
+    text = node.text.strip()
+    if len(text):
+        return text
+    return 'unknown' if unknown_if_none else None
 
 
 def node_bool(node):
-   """Returns stripped node text as bool, or None."""
+    """Returns stripped node text as bool, or None."""
 
-   if node is None:
-      return None
-   return bool_from_text(node.text)
+    if node is None:
+        return None
+    return bool_from_text(node.text)
 
 
 def node_int(node):
-   """Returns stripped node text as int, or None."""
+    """Returns stripped node text as int, or None."""
 
-   if node is None:
-      return None
-   text = node.text.strip()
-   if text.lower() == 'none':
-      return None
-   if len(text):
-      return int(text)
-   return None
+    if node is None:
+        return None
+    text = node.text.strip()
+    if text.lower() == 'none':
+        return None
+    if len(text):
+        return int(text)
+    return None
 
 
 def node_float(node):
-   """Returns stripped node text as float, or None."""
+    """Returns stripped node text as float, or None."""
 
-   if node is None:
-      return None
-   text = node.text.strip()
-   if text.lower() == 'none':
-      return None
-   if len(text):
-      return float(text)
-   return None
+    if node is None:
+        return None
+    text = node.text.strip()
+    if text.lower() == 'none':
+        return None
+    if len(text):
+        return float(text)
+    return None
 
 
 def length_units_from_node(node):
-   """Returns standard length units string based on node text, or 'unknown'."""
+    """Returns standard length units string based on node text, or 'unknown'."""
 
-   if node is None or node.text == '' or node.text == '\n':
-      return 'unknown'
-   else:
-      return node.text.strip()
+    if node is None or node.text == '' or node.text == '\n':
+        return 'unknown'
+    else:
+        return node.text.strip()
 
 
 def time_units_from_node(node):
-   """Returns standard time units string based on node text, or 'unknown'."""
+    """Returns standard time units string based on node text, or 'unknown'."""
 
-   if node is None or node.text == '' or node.text == '\n':
-      return 'unknown'
-   else:
-      return node.text.strip()
+    if node is None or node.text == '' or node.text == '\n':
+        return 'unknown'
+    else:
+        return node.text.strip()
 
 
 def xyz_handedness(xy_axes, z_inc_down):
-   """Returns xyz true handedness as 'left', 'right' or 'unknown', based on xy_axes (string) and z_inc_down (boolean)."""
+    """Returns xyz true handedness as 'left', 'right' or 'unknown', based on xy_axes (string) and z_inc_down (boolean)."""
 
-   if xy_axes is None or z_inc_down is None:
-      return 'unknown'
-   xy_axes_split = xy_axes.lower().split()
-   if len(xy_axes_split) != 2:
-      return 'unknown'
-   if xy_axes_split not in [
-      ['easting', 'northing'],
-      ['northing', 'easting'],  # only these 6 options allowed in resqml
-      ['westing', 'southing'],
-      ['southing', 'westing'],
-      ['northing', 'westing'],
-      ['westing', 'northing']
-   ]:
-      return 'unknown'
-   right_handed = z_inc_down
-   if xy_axes_split in [['easting', 'northing'], ['westing', 'southing'], ['northing', 'westing']]:
-      right_handed = not right_handed
-   if right_handed:
-      return 'right'
-   else:
-      return 'left'
+    if xy_axes is None or z_inc_down is None:
+        return 'unknown'
+    xy_axes_split = xy_axes.lower().split()
+    if len(xy_axes_split) != 2:
+        return 'unknown'
+    if xy_axes_split not in [
+        ['easting', 'northing'],
+        ['northing', 'easting'],  # only these 6 options allowed in resqml
+        ['westing', 'southing'],
+        ['southing', 'westing'],
+        ['northing', 'westing'],
+        ['westing', 'northing']
+    ]:
+        return 'unknown'
+    right_handed = z_inc_down
+    if xy_axes_split in [['easting', 'northing'], ['westing', 'southing'], ['northing', 'westing']]:
+        right_handed = not right_handed
+    if right_handed:
+        return 'right'
+    else:
+        return 'left'
 
 
 def ijk_handedness(geom_node):
-   """Returns ijk true handedness as 'left', 'right' or 'unknown', based on GridIsRightHanded node in grid geometry node."""
+    """Returns ijk true handedness as 'left', 'right' or 'unknown', based on GridIsRightHanded node in grid geometry node."""
 
-   if geom_node is None:
-      return 'unknown'
-   right_handed = bool_from_text(node_text(find_tag(geom_node, 'GridIsRighthanded')))
-   if right_handed is None:
-      return 'unknown'
-   if right_handed:
-      return 'right'
-   return 'left'
+    if geom_node is None:
+        return 'unknown'
+    right_handed = bool_from_text(node_text(find_tag(geom_node, 'GridIsRighthanded')))
+    if right_handed is None:
+        return 'unknown'
+    if right_handed:
+        return 'right'
+    return 'left'
 
 
 def citation_title_for_node(node):
-   """Looks for a citation node as a child of node and returns the title text."""
+    """Looks for a citation node as a child of node and returns the title text."""
 
-   return find_nested_tags_text(node, ['Citation', 'Title'])
+    return find_nested_tags_text(node, ['Citation', 'Title'])
 
 
 def creation_date_for_node(node):
-   """Looks for a citation node as a child of node and returns the creation (date-time) text."""
+    """Looks for a citation node as a child of node and returns the creation (date-time) text."""
 
-   return find_nested_tags_text(node, ['Citation', 'Creation'])
+    return find_nested_tags_text(node, ['Citation', 'Creation'])
 
 
 def write_xml_node(xml_fp, root, level = 0, namespace_keys = []):
-   """Recursively write an xml node to an open file; return number of nodes written."""
+    """Recursively write an xml node to an open file; return number of nodes written."""
 
-   if root is None:
-      return 0
+    if root is None:
+        return 0
 
-   ns_keys = namespace_keys.copy()
+    ns_keys = namespace_keys.copy()
 
-   type_attr = None
-   tag, pre_colon = colon_prefixed(root.tag)
+    type_attr = None
+    tag, pre_colon = colon_prefixed(root.tag)
 
-   if pre_colon in ['content_types', 'rels']:
-      tag = tag[len(pre_colon) + 1:]
-      ct_special = True
-   else:
-      ct_special = False
+    if pre_colon in ['content_types', 'rels']:
+        tag = tag[len(pre_colon) + 1:]
+        ct_special = True
+    else:
+        ct_special = False
 
-   if use_tabs:
-      line = (level * '\t')
-   else:
-      line = (3 * level * ' ')
-   line += '<' + tag
-   if pre_colon and pre_colon not in ns_keys:
-      line += ' xmlns'
-      if not ct_special:
-         line += ':' + pre_colon
-      line += '="' + ns[pre_colon] + '"'
-      ns_keys.append(pre_colon)
+    if use_tabs:
+        line = (level * '\t')
+    else:
+        line = (3 * level * ' ')
+    line += '<' + tag
+    if pre_colon and pre_colon not in ns_keys:
+        line += ' xmlns'
+        if not ct_special:
+            line += ':' + pre_colon
+        line += '="' + ns[pre_colon] + '"'
+        ns_keys.append(pre_colon)
 
-   attrib_ns_list = []
-   attrib_list = []
-   type_pre_colon = None
-   for key in root.attrib.keys():
-      colon_attrib_key, pre_colon_attrib = colon_prefixed(key)
-      if pre_colon_attrib and pre_colon_attrib not in ns_keys:
-         attrib_ns_list.append(pre_colon_attrib)
-      if stripped_of_prefix(key) == 'type':
-         type_attr, type_pre_colon = colon_prefixed(root.attrib[key])
-         attrib_list.append(colon_attrib_key + '="' + type_attr + '"')
-      elif ct_special and colon_attrib_key == 'PartName' and root.attrib[key].startswith('obj_'):
-         attrib_list.append(colon_attrib_key + '="/' + root.attrib[key] + '"')
-      else:
-         attrib_list.append(colon_attrib_key + '="' + root.attrib[key] + '"')
+    attrib_ns_list = []
+    attrib_list = []
+    type_pre_colon = None
+    for key in root.attrib.keys():
+        colon_attrib_key, pre_colon_attrib = colon_prefixed(key)
+        if pre_colon_attrib and pre_colon_attrib not in ns_keys:
+            attrib_ns_list.append(pre_colon_attrib)
+        if stripped_of_prefix(key) == 'type':
+            type_attr, type_pre_colon = colon_prefixed(root.attrib[key])
+            attrib_list.append(colon_attrib_key + '="' + type_attr + '"')
+        elif ct_special and colon_attrib_key == 'PartName' and root.attrib[key].startswith('obj_'):
+            attrib_list.append(colon_attrib_key + '="/' + root.attrib[key] + '"')
+        else:
+            attrib_list.append(colon_attrib_key + '="' + root.attrib[key] + '"')
 
-   for attrib_ns in attrib_ns_list:
-      line += ' xmlns:' + attrib_ns + '="' + ns[attrib_ns] + '"'
-      ns_keys.append(attrib_ns)
-   if type_pre_colon and type_pre_colon not in ns_keys:  # must be included in the local xml line?
-      line += ' xmlns:' + type_pre_colon + '="' + ns[type_pre_colon] + '"'
-      ns_keys.append(type_pre_colon)
+    for attrib_ns in attrib_ns_list:
+        line += ' xmlns:' + attrib_ns + '="' + ns[attrib_ns] + '"'
+        ns_keys.append(attrib_ns)
+    if type_pre_colon and type_pre_colon not in ns_keys:  # must be included in the local xml line?
+        line += ' xmlns:' + type_pre_colon + '="' + ns[type_pre_colon] + '"'
+        ns_keys.append(type_pre_colon)
 
-   for attrib in attrib_list:
-      line += ' ' + attrib
+    for attrib in attrib_list:
+        line += ' ' + attrib
 
-   node_count = 1
+    node_count = 1
 
-   if ct_special and len(root) == 0:
+    if ct_special and len(root) == 0:
 
-      line += '/>\n'
-      xml_fp.write(line.encode())
+        line += '/>\n'
+        xml_fp.write(line.encode())
 #      print(line, end = '') # debug
 
-   else:
+    else:
 
-      line += '>'
+        line += '>'
 
-      if root.text and not root.text.isspace():
-         line += root.text
+        if root.text and not root.text.isspace():
+            line += root.text
 
-      xml_fp.write(line.encode())
-      #      print(line, end = '') # debug
-      indentation = ''
+        xml_fp.write(line.encode())
+        #      print(line, end = '') # debug
+        indentation = ''
 
-      if len(root):
-         xml_fp.write(b'\n')
-         #         print()  # debug
-         if use_tabs:
-            indentation = (level * '\t')
-         else:
-            indentation = (3 * level * ' ')
-         for child in root:
-            node_count += write_xml_node(xml_fp, child, level = level + 1, namespace_keys = ns_keys)
+        if len(root):
+            xml_fp.write(b'\n')
+            #         print()  # debug
+            if use_tabs:
+                indentation = (level * '\t')
+            else:
+                indentation = (3 * level * ' ')
+            for child in root:
+                node_count += write_xml_node(xml_fp, child, level = level + 1, namespace_keys = ns_keys)
 
-      line = indentation + '</' + tag + '>\n'
-      xml_fp.write(line.encode())
+        line = indentation + '</' + tag + '>\n'
+        xml_fp.write(line.encode())
 
 
 #      print(line, end = '') # debug
 
-   return node_count
+    return node_count
 
 
 def write_xml(xml_fp, tree, standalone = None):
-   """Write an xml tree to file in an indented format; gSOAP/FESAPI compatible; return number of nodes written."""
+    """Write an xml tree to file in an indented format; gSOAP/FESAPI compatible; return number of nodes written."""
 
-   #   print('-------------------------------------------------------------------------------------') # debug
-   line = '<?xml version="1.0" encoding="UTF-8"'
-   if standalone is not None:
-      line += ' standalone="' + standalone + '"'
-   line += '?>\n'
-   xml_fp.write(line.encode())
-   #   print(line, end = '')  # debug
-   nodes = write_xml_node(xml_fp, tree.getroot())
+    #   print('-------------------------------------------------------------------------------------') # debug
+    line = '<?xml version="1.0" encoding="UTF-8"'
+    if standalone is not None:
+        line += ' standalone="' + standalone + '"'
+    line += '?>\n'
+    xml_fp.write(line.encode())
+    #   print(line, end = '')  # debug
+    nodes = write_xml_node(xml_fp, tree.getroot())
 
-   return nodes
+    return nodes
 
 
 def load_metadata_from_xml(node):
-   """Loads the ExtraMetaData stored in a RESQML part as a dictionary"""
+    """Loads the ExtraMetaData stored in a RESQML part as a dictionary"""
 
-   if node is None:
-      return None
-   extra_metadata = {}
-   meta_nodes = list_of_tag(node, 'ExtraMetadata')
-   for meta in meta_nodes:
-      name = find_tag_text(meta, 'Name')
-      value = find_tag_text(meta, 'Value')
-      extra_metadata[name] = value
-   return extra_metadata
+    if node is None:
+        return None
+    extra_metadata = {}
+    meta_nodes = list_of_tag(node, 'ExtraMetadata')
+    for meta in meta_nodes:
+        name = find_tag_text(meta, 'Name')
+        value = find_tag_text(meta, 'Value')
+        extra_metadata[name] = value
+    return extra_metadata
 
 
 def create_metadata_xml(node, extra_metadata):
-   """Writes the xml for the given metadata dictionary"""
+    """Writes the xml for the given metadata dictionary"""
 
-   if extra_metadata:
-      for data in extra_metadata.keys():
+    if extra_metadata:
+        for data in extra_metadata.keys():
 
-         metadata = SubElement(node, cns['resqml2'] + 'ExtraMetadata')
-         metadata.set(cns['xsi'] + 'type', cns['resqml2'] + 'NameValuePair')
-         metadata.text = null_xml_text
+            metadata = SubElement(node, cns['resqml2'] + 'ExtraMetadata')
+            metadata.set(cns['xsi'] + 'type', cns['resqml2'] + 'NameValuePair')
+            metadata.text = null_xml_text
 
-         name = SubElement(metadata, cns['resqml2'] + 'Name')
-         name.set(cns['xsi'] + 'type', cns['xsd'] + 'string')
-         name.text = str(data)
+            name = SubElement(metadata, cns['resqml2'] + 'Name')
+            name.set(cns['xsi'] + 'type', cns['xsd'] + 'string')
+            name.text = str(data)
 
-         value = SubElement(metadata, cns['resqml2'] + 'Value')
-         value.set(cns['xsi'] + 'type', cns['xsd'] + 'string')
-         value.text = str(extra_metadata[data])
+            value = SubElement(metadata, cns['resqml2'] + 'Value')
+            value.set(cns['xsi'] + 'type', cns['xsd'] + 'string')
+            value.text = str(extra_metadata[data])
 
-   return node
+    return node
 
 
 def is_node(obj):
-   """Returns True if type of object is element tree node; False otherwise."""
+    """Returns True if type of object is element tree node; False otherwise."""
 
-   # note: only tested for lxml
+    # note: only tested for lxml
 
-   return type(obj) is _Element or type(obj) is Element
+    return type(obj) is _Element or type(obj) is Element

--- a/resqpy/olio/xml_namespaces.py
+++ b/resqpy/olio/xml_namespaces.py
@@ -30,15 +30,15 @@ namespace['dc'] = 'http://purl.org/dc/elements/1.1/'
 
 curly_namespace = {}
 for key, url in namespace.items():
-   curly_namespace[key] = '{' + url + '}'
+    curly_namespace[key] = '{' + url + '}'
 
 inverse_namespace = {}
 for key, url in namespace.items():
-   if url not in inverse_namespace:
-      inverse_namespace[url] = key
+    if url not in inverse_namespace:
+        inverse_namespace[url] = key
 
 
 def colon_namespace(url):
-   if url[0] == '{':
-      return inverse_namespace[url[1:-1]] + ':'
-   return inverse_namespace[url] + ':'
+    if url[0] == '{':
+        return inverse_namespace[url[1:-1]] + ':'
+    return inverse_namespace[url] + ':'

--- a/resqpy/olio/zmap_reader.py
+++ b/resqpy/olio/zmap_reader.py
@@ -14,53 +14,53 @@ import numpy as np
 
 def read_zmap_header(inputfile):
 
-   # read header, read until second '@', record header lines and content
-   with open(inputfile, 'r') as infile:
-      comments = []
-      head = []
-      a = 0  # count '@'s
-      headers = 0  # count header+comment lines
-      while a < 2:
-         line = infile.readline()
-         headers += 1
-         if line[:1] == '@':
-            a += 1
-         if line[:1] == '!':
-            comments.append(line.strip())
-         elif a == 1 or (line[:1] == '@'):
-            row = line.strip().strip('@').split(',')
-            head.append(row)
-         else:
-            log.error("Header section does not seem to be defined by 2 @s")
-            return None, None, None
-      line = infile.readline()
-      if line[0] == '+':
-         headers = headers + 1  # add extra line for the + symbol..
+    # read header, read until second '@', record header lines and content
+    with open(inputfile, 'r') as infile:
+        comments = []
+        head = []
+        a = 0  # count '@'s
+        headers = 0  # count header+comment lines
+        while a < 2:
+            line = infile.readline()
+            headers += 1
+            if line[:1] == '@':
+                a += 1
+            if line[:1] == '!':
+                comments.append(line.strip())
+            elif a == 1 or (line[:1] == '@'):
+                row = line.strip().strip('@').split(',')
+                head.append(row)
+            else:
+                log.error("Header section does not seem to be defined by 2 @s")
+                return None, None, None
+        line = infile.readline()
+        if line[0] == '+':
+            headers = headers + 1  # add extra line for the + symbol..
 
-   for c in comments:
-      log.debug(c)
+    for c in comments:
+        log.debug(c)
 
-   # ok now process the header
+    # ok now process the header
 #  nodes_per_line                          = int(head[0][2])
 #  field_w                                 = head[1][0]
-   null_value = head[1][1].strip()
-   null_value2 = head[1][2].strip()
-   #  dec_places                              = head[1][3]
-   #  strt_c                                  = head[1][4]
-   no_rows = int(head[2][0])
-   no_cols = int(head[2][1])
-   minx = np.float64(head[2][2])
-   maxx = np.float64(head[2][3])
-   miny = np.float64(head[2][4])
-   maxy = np.float64(head[2][5])
+    null_value = head[1][1].strip()
+    null_value2 = head[1][2].strip()
+    #  dec_places                              = head[1][3]
+    #  strt_c                                  = head[1][4]
+    no_rows = int(head[2][0])
+    no_cols = int(head[2][1])
+    minx = np.float64(head[2][2])
+    maxx = np.float64(head[2][3])
+    miny = np.float64(head[2][4])
+    maxy = np.float64(head[2][5])
 
-   # decide on the null value
-   if not null_value:
-      null_value = null_value2
-   log.debug("Read {} header lines, we have {} rows, {} cols, and data from {} to {} and {} to {}".format(
-      headers, no_rows, no_cols, minx, maxx, miny, maxy))
+    # decide on the null value
+    if not null_value:
+        null_value = null_value2
+    log.debug("Read {} header lines, we have {} rows, {} cols, and data from {} to {} and {} to {}".format(
+        headers, no_rows, no_cols, minx, maxx, miny, maxy))
 
-   return headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value
+    return headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value
 
 
 # note: the RMS text format was previously known as the Roxar format
@@ -68,95 +68,95 @@ def read_zmap_header(inputfile):
 
 def read_roxar_header(inputfile):
 
-   with open(inputfile, 'r') as fp:
-      words = fp.readline().split()
-      assert words[0] == '-996', 'RMS text format indicator -996 not found'
-      no_rows = int(words[1])
-      # dx = float(words[2])
-      # dy = float(words[3])
-      words = fp.readline().split()
-      minx = float(words[0])
-      maxx = float(words[1])
-      miny = float(words[2])
-      maxy = float(words[3])
-      words = fp.readline().split()
-      no_cols = int(words[0])
-   headers = 4
-   null_value = '9999900.0000'
-   return headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value
+    with open(inputfile, 'r') as fp:
+        words = fp.readline().split()
+        assert words[0] == '-996', 'RMS text format indicator -996 not found'
+        no_rows = int(words[1])
+        # dx = float(words[2])
+        # dy = float(words[3])
+        words = fp.readline().split()
+        minx = float(words[0])
+        maxx = float(words[1])
+        miny = float(words[2])
+        maxy = float(words[3])
+        words = fp.readline().split()
+        no_cols = int(words[0])
+    headers = 4
+    null_value = '9999900.0000'
+    return headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value
 
 
 def read_mesh(inputfile, dtype = np.float64, format = None):
 
-   if format == 'zmap':
-      headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value = read_zmap_header(inputfile)
-   elif format in ['rms', 'roxar']:
-      headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value = read_roxar_header(inputfile)
-   else:
-      raise ValueError('format not recognised for read_mesh: ' + str(format))
-   # load the values in, converting null value to NaN's
+    if format == 'zmap':
+        headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value = read_zmap_header(inputfile)
+    elif format in ['rms', 'roxar']:
+        headers, no_rows, no_cols, minx, maxx, miny, maxy, null_value = read_roxar_header(inputfile)
+    else:
+        raise ValueError('format not recognised for read_mesh: ' + str(format))
+    # load the values in, converting null value to NaN's
 
-   infile = open(inputfile, 'r')
-   indata = infile.readlines()
-   infile.close()
-   c = 0
-   f = np.zeros(no_cols * no_rows, dtype = dtype)
-   n = 0
-   for line in indata:
-      c += 1
-      if c <= headers:
-         continue
-      else:
-         for x in line.split():
-            if (x == null_value) or (dtype(x) == dtype(null_value)):
-               f[n] = np.nan
-            else:
-               f[n] = dtype(x)
-            n += 1
-      if (n % 10000 == 0) and (n > 10000):
-         log.debug("Read node {} of {}".format(n, no_cols * no_rows))
+    infile = open(inputfile, 'r')
+    indata = infile.readlines()
+    infile.close()
+    c = 0
+    f = np.zeros(no_cols * no_rows, dtype = dtype)
+    n = 0
+    for line in indata:
+        c += 1
+        if c <= headers:
+            continue
+        else:
+            for x in line.split():
+                if (x == null_value) or (dtype(x) == dtype(null_value)):
+                    f[n] = np.nan
+                else:
+                    f[n] = dtype(x)
+                n += 1
+        if (n % 10000 == 0) and (n > 10000):
+            log.debug("Read node {} of {}".format(n, no_cols * no_rows))
 
-   log.debug("Read {} nodes".format(len(f)))
+    log.debug("Read {} nodes".format(len(f)))
 
-   if format == 'zmap':
-      # reshape it, and swap axis. Beacuse columns major order from fortran.
-      f = f.reshape((no_cols, no_rows)).swapaxes(0, 1)
-   else:  # format in ['rms', 'roxar']
-      f = f.reshape((no_rows, no_cols))
+    if format == 'zmap':
+        # reshape it, and swap axis. Beacuse columns major order from fortran.
+        f = f.reshape((no_cols, no_rows)).swapaxes(0, 1)
+    else:  # format in ['rms', 'roxar']
+        f = f.reshape((no_rows, no_cols))
 
-   # now generate x and y coords
-   x = np.linspace(minx, maxx, no_cols)  # get x axis coords
-   if format == 'zmap':
-      y = np.linspace(maxy, miny, no_rows)
-   else:  # format in ['rms', 'roxar']
-      y = np.linspace(miny, maxy, no_rows)
-   x, y = np.meshgrid(x, y)  # get x and y of every node
-   assert x.shape == y.shape == f.shape
+    # now generate x and y coords
+    x = np.linspace(minx, maxx, no_cols)  # get x axis coords
+    if format == 'zmap':
+        y = np.linspace(maxy, miny, no_rows)
+    else:  # format in ['rms', 'roxar']
+        y = np.linspace(miny, maxy, no_rows)
+    x, y = np.meshgrid(x, y)  # get x and y of every node
+    assert x.shape == y.shape == f.shape
 
-   return x, y, f
+    return x, y, f
 
 
 def read_zmapplusgrid(inputfile, dtype = np.float64):
-   """Read zmapplus grid (surface mesh); returns triple (x, y, z) 2D arrays."""
+    """Read zmapplus grid (surface mesh); returns triple (x, y, z) 2D arrays."""
 
-   return read_mesh(inputfile, dtype = dtype, format = 'zmap')
+    return read_mesh(inputfile, dtype = dtype, format = 'zmap')
 
 
 def read_roxar_mesh(inputfile, dtype = np.float64):
-   """Read RMS text format surface mesh; returns triple (x, y, z) 2D arrays.
+    """Read RMS text format surface mesh; returns triple (x, y, z) 2D arrays.
 
    note:
       the RMS text format was previously known as the Roxar format
    """
 
-   return read_mesh(inputfile, dtype = dtype, format = 'rms')
+    return read_mesh(inputfile, dtype = dtype, format = 'rms')
 
 
 def read_rms_text_mesh(inputfile, dtype = np.float64):
-   """Read RMS text format surface mesh; returns triple (x, y, z) 2D arrays.
+    """Read RMS text format surface mesh; returns triple (x, y, z) 2D arrays.
 
    note:
       the RMS text format was previously known as the Roxar format
    """
 
-   return read_roxar_mesh(inputfile, dtype = dtype)
+    return read_roxar_mesh(inputfile, dtype = dtype)

--- a/resqpy/organize.py
+++ b/resqpy/organize.py
@@ -23,599 +23,599 @@ from resqpy.olio.base import BaseResqpy
 
 
 def extract_has_occurred_during(parent_node, tag = 'HasOccuredDuring'):  # RESQML Occured (stet)
-   """Extracts UUIDs of chrono bottom and top from xml for has occurred during sub-node, or (None, None)."""
-   hod_node = rqet.find_tag(parent_node, tag)
-   if hod_node is None:
-      return (None, None)
-   else:
-      return (rqet.find_nested_tags_text(hod_node, ['ChronoBottom', 'UUID']),
-              rqet.find_nested_tags_text(hod_node, ['ChronoTop', 'UUID']))
+    """Extracts UUIDs of chrono bottom and top from xml for has occurred during sub-node, or (None, None)."""
+    hod_node = rqet.find_tag(parent_node, tag)
+    if hod_node is None:
+        return (None, None)
+    else:
+        return (rqet.find_nested_tags_text(hod_node, ['ChronoBottom', 'UUID']),
+                rqet.find_nested_tags_text(hod_node, ['ChronoTop', 'UUID']))
 
 
 def equivalent_chrono_pairs(pair_a, pair_b, model = None):
-   if pair_a == pair_b:
-      return True
-   if pair_a is None or pair_b is None:
-      return False
-   if pair_a == (None, None) or pair_b == (None, None):
-      return False
-   if model is not None:
-      # todo: compare chrono info by looking up xml based on the uuids
-      pass
-   return False  # cautious
+    if pair_a == pair_b:
+        return True
+    if pair_a is None or pair_b is None:
+        return False
+    if pair_a == (None, None) or pair_b == (None, None):
+        return False
+    if model is not None:
+        # todo: compare chrono info by looking up xml based on the uuids
+        pass
+    return False  # cautious
 
 
 def equivalent_extra_metadata(a, b):
-   a_has = hasattr(a, 'extra_metadata')
-   b_has = hasattr(b, 'extra_metadata')
-   if a_has:
-      a_em = a.extra_metadata
-      a_has = len(a_em) > 0
-   else:
-      a_em = rqet.load_metadata_from_xml(a.root)
-      a_has = a_em is not None and len(a_em) > 0
-   if b_has:
-      b_em = b.extra_metadata
-      b_has = len(b_em) > 0
-   else:
-      b_em = rqet.load_metadata_from_xml(b.root)
-      b_has = b_em is not None and len(b_em) > 0
-   if a_has != b_has:
-      return False
-   if not a_has:
-      return True
-   return a_em == b_em
+    a_has = hasattr(a, 'extra_metadata')
+    b_has = hasattr(b, 'extra_metadata')
+    if a_has:
+        a_em = a.extra_metadata
+        a_has = len(a_em) > 0
+    else:
+        a_em = rqet.load_metadata_from_xml(a.root)
+        a_has = a_em is not None and len(a_em) > 0
+    if b_has:
+        b_em = b.extra_metadata
+        b_has = len(b_em) > 0
+    else:
+        b_em = rqet.load_metadata_from_xml(b.root)
+        b_has = b_em is not None and len(b_em) > 0
+    if a_has != b_has:
+        return False
+    if not a_has:
+        return True
+    return a_em == b_em
 
 
 def create_xml_has_occurred_during(model, parent_node, hod_pair, tag = 'HasOccuredDuring'):
-   if hod_pair is None:
-      return
-   base_chrono_uuid, top_chrono_uuid = hod_pair
-   if base_chrono_uuid is None or top_chrono_uuid is None:
-      return
-   hod_node = rqet.SubElement(parent_node, tag)
-   hod_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeInterval')
-   hod_node.text = rqet.null_xml_text
-   chrono_base_root = model.root_for_uuid(base_chrono_uuid)
-   chrono_top_root = model.root_for_uuid(top_chrono_uuid)
-   model.create_ref_node('ChronoBottom', model.title_for_root(chrono_base_root), base_chrono_uuid, root = hod_node)
-   model.create_ref_node('ChronoTop', model.title_for_root(chrono_top_root), top_chrono_uuid, root = hod_node)
+    if hod_pair is None:
+        return
+    base_chrono_uuid, top_chrono_uuid = hod_pair
+    if base_chrono_uuid is None or top_chrono_uuid is None:
+        return
+    hod_node = rqet.SubElement(parent_node, tag)
+    hod_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeInterval')
+    hod_node.text = rqet.null_xml_text
+    chrono_base_root = model.root_for_uuid(base_chrono_uuid)
+    chrono_top_root = model.root_for_uuid(top_chrono_uuid)
+    model.create_ref_node('ChronoBottom', model.title_for_root(chrono_base_root), base_chrono_uuid, root = hod_node)
+    model.create_ref_node('ChronoTop', model.title_for_root(chrono_top_root), top_chrono_uuid, root = hod_node)
 
 
 def _alias_for_attribute(attribute_name):
-   """Return an attribute that is a direct alias for an existing attribute"""
+    """Return an attribute that is a direct alias for an existing attribute"""
 
-   def fget(self):
-      return getattr(self, attribute_name)
+    def fget(self):
+        return getattr(self, attribute_name)
 
-   def fset(self, value):
-      return setattr(self, attribute_name, value)
+    def fset(self, value):
+        return setattr(self, attribute_name, value)
 
-   return property(fget, fset, doc = f"Alias for {attribute_name}")
+    return property(fget, fset, doc = f"Alias for {attribute_name}")
 
 
 class OrganizationFeature(BaseResqpy):
-   """Class for generic RESQML Organization Feature objects."""
+    """Class for generic RESQML Organization Feature objects."""
 
-   resqml_type = "OrganizationFeature"
-   feature_name = _alias_for_attribute("title")
+    resqml_type = "OrganizationFeature"
+    feature_name = _alias_for_attribute("title")
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                feature_name = None,
-                organization_kind = None,
-                originator = None,
-                extra_metadata = None):
-      """Initialises an organization feature object."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 feature_name = None,
+                 organization_kind = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Initialises an organization feature object."""
 
-      self.organization_kind = organization_kind
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        self.organization_kind = organization_kind
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if not isinstance(other, OrganizationFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      return (self.feature_name == other.feature_name and self.organization_kind == other.organization_kind and
-              ((not check_extra_metadata) or equivalent_extra_metadata(self, other)))
+        if not isinstance(other, OrganizationFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        return (self.feature_name == other.feature_name and self.organization_kind == other.organization_kind and
+                ((not check_extra_metadata) or equivalent_extra_metadata(self, other)))
 
-   def _load_from_xml(self):
-      self.organization_kind = rqet.find_tag_text(self.root, 'OrganizationKind')
+    def _load_from_xml(self):
+        self.organization_kind = rqet.find_tag_text(self.root, 'OrganizationKind')
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates an organization feature xml node from this organization feature object."""
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates an organization feature xml node from this organization feature object."""
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      # create node with citation block
-      ofn = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        # create node with citation block
+        ofn = super().create_xml(add_as_part = False, originator = originator)
 
-      # Extra element for organization_kind
-      if self.organization_kind not in ['earth model', 'fluid', 'stratigraphic', 'structural']:
-         raise ValueError(self.organization_kind)
-      kind_node = rqet.SubElement(ofn, ns['resqml2'] + 'OrganizationKind')
-      kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'OrganizationKind')
-      kind_node.text = self.organization_kind
+        # Extra element for organization_kind
+        if self.organization_kind not in ['earth model', 'fluid', 'stratigraphic', 'structural']:
+            raise ValueError(self.organization_kind)
+        kind_node = rqet.SubElement(ofn, ns['resqml2'] + 'OrganizationKind')
+        kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'OrganizationKind')
+        kind_node.text = self.organization_kind
 
-      if add_as_part:
-         self.model.add_part('obj_OrganizationFeature', self.uuid, ofn)
+        if add_as_part:
+            self.model.add_part('obj_OrganizationFeature', self.uuid, ofn)
 
-      return ofn
+        return ofn
 
 
 class GeobodyFeature(BaseResqpy):
-   """Class for RESQML Geobody Feature objects (note: definition may be incomplete in RESQML 2.0.1)."""
+    """Class for RESQML Geobody Feature objects (note: definition may be incomplete in RESQML 2.0.1)."""
 
-   resqml_type = "GeobodyFeature"
-   feature_name = _alias_for_attribute("title")
+    resqml_type = "GeobodyFeature"
+    feature_name = _alias_for_attribute("title")
 
-   def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
-      """Initialises a geobody feature object."""
+    def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
+        """Initialises a geobody feature object."""
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, self.__class__):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name
+        if other is None or not isinstance(other, self.__class__):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a geobody feature xml node from this geobody feature object."""
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      return super().create_xml(add_as_part = add_as_part, originator = originator)
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a geobody feature xml node from this geobody feature object."""
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        return super().create_xml(add_as_part = add_as_part, originator = originator)
 
 
 class BoundaryFeature(BaseResqpy):
-   """Class for RESQML Boudary Feature organizational objects."""
+    """Class for RESQML Boudary Feature organizational objects."""
 
-   resqml_type = "BoundaryFeature"
-   feature_name = _alias_for_attribute("title")
+    resqml_type = "BoundaryFeature"
+    feature_name = _alias_for_attribute("title")
 
-   def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
-      """Initialises a boundary feature organisational object."""
+    def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
+        """Initialises a boundary feature organisational object."""
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, BoundaryFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name
+        if other is None or not isinstance(other, BoundaryFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a geobody feature xml node from this geobody feature object."""
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      return super().create_xml(add_as_part = add_as_part, originator = originator)
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a geobody feature xml node from this geobody feature object."""
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        return super().create_xml(add_as_part = add_as_part, originator = originator)
 
 
 class FrontierFeature(BaseResqpy):
-   """Class for RESQML Frontier Feature organizational objects."""
+    """Class for RESQML Frontier Feature organizational objects."""
 
-   resqml_type = "FrontierFeature"
-   feature_name = _alias_for_attribute("title")
+    resqml_type = "FrontierFeature"
+    feature_name = _alias_for_attribute("title")
 
-   def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
-      """Initialises a frontier feature organisational object."""
+    def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
+        """Initialises a frontier feature organisational object."""
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, FrontierFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name
+        if other is None or not isinstance(other, FrontierFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a frontier feature organisational xml node from this frontier feature object."""
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      return super().create_xml(add_as_part = add_as_part, originator = originator)
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a frontier feature organisational xml node from this frontier feature object."""
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        return super().create_xml(add_as_part = add_as_part, originator = originator)
 
 
 class GeologicUnitFeature(BaseResqpy):
-   """Class for RESQML Geologic Unit Feature organizational objects."""
+    """Class for RESQML Geologic Unit Feature organizational objects."""
 
-   resqml_type = "GeologicUnitFeature"
-   feature_name = _alias_for_attribute("title")
+    resqml_type = "GeologicUnitFeature"
+    feature_name = _alias_for_attribute("title")
 
-   def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
-      """Initialises a geologic unit feature organisational object."""
+    def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
+        """Initialises a geologic unit feature organisational object."""
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, GeologicUnitFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name
+        if other is None or not isinstance(other, GeologicUnitFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a geologic unit feature organisational xml node from this geologic unit feature object."""
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      return super().create_xml(add_as_part = add_as_part, originator = originator)
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a geologic unit feature organisational xml node from this geologic unit feature object."""
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        return super().create_xml(add_as_part = add_as_part, originator = originator)
 
 
 class FluidBoundaryFeature(BaseResqpy):
-   """Class for RESQML Fluid Boundary Feature (contact) organizational objects."""
+    """Class for RESQML Fluid Boundary Feature (contact) organizational objects."""
 
-   resqml_type = "FluidBoundaryFeature"
-   feature_name = _alias_for_attribute("title")
-   valid_kinds = ('free water contact', 'gas oil contact', 'gas water contact', 'seal', 'water oil contact')
+    resqml_type = "FluidBoundaryFeature"
+    feature_name = _alias_for_attribute("title")
+    valid_kinds = ('free water contact', 'gas oil contact', 'gas water contact', 'seal', 'water oil contact')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                kind = None,
-                feature_name = None,
-                extra_metadata = None):
-      """Initialises a fluid boundary feature (contact) organisational object."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 kind = None,
+                 feature_name = None,
+                 extra_metadata = None):
+        """Initialises a fluid boundary feature (contact) organisational object."""
 
-      self.kind = kind
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        self.kind = kind
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, FluidBoundaryFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name and self.kind == other.kind
+        if other is None or not isinstance(other, FluidBoundaryFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name and self.kind == other.kind
 
-   def _load_from_xml(self):
-      self.kind = rqet.find_tag_text(self.root, 'FluidContact')
+    def _load_from_xml(self):
+        self.kind = rqet.find_tag_text(self.root, 'FluidContact')
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a fluid boundary feature organisational xml node from this fluid boundary feature object."""
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a fluid boundary feature organisational xml node from this fluid boundary feature object."""
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      # create node with citation block
-      fbf = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        # create node with citation block
+        fbf = super().create_xml(add_as_part = False, originator = originator)
 
-      # Extra element for kind
-      if self.kind not in self.valid_kinds:
-         raise ValueError(f"fluid boundary feature kind '{self.kind}' not recognized")
+        # Extra element for kind
+        if self.kind not in self.valid_kinds:
+            raise ValueError(f"fluid boundary feature kind '{self.kind}' not recognized")
 
-      kind_node = rqet.SubElement(fbf, ns['resqml2'] + 'FluidContact')
-      kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'FluidContact')
-      kind_node.text = self.kind
+        kind_node = rqet.SubElement(fbf, ns['resqml2'] + 'FluidContact')
+        kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'FluidContact')
+        kind_node.text = self.kind
 
-      if add_as_part:
-         self.model.add_part('obj_FluidBoundaryFeature', self.uuid, fbf)
+        if add_as_part:
+            self.model.add_part('obj_FluidBoundaryFeature', self.uuid, fbf)
 
-      return fbf
+        return fbf
 
 
 class RockFluidUnitFeature(BaseResqpy):
-   """Class for RESQML Rock Fluid Unit Feature organizational objects."""
+    """Class for RESQML Rock Fluid Unit Feature organizational objects."""
 
-   resqml_type = "RockFluidUnitFeature"
-   feature_name = _alias_for_attribute("title")
-   valid_phases = ('aquifer', 'gas cap', 'oil column', 'seal')
+    resqml_type = "RockFluidUnitFeature"
+    feature_name = _alias_for_attribute("title")
+    valid_phases = ('aquifer', 'gas cap', 'oil column', 'seal')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                phase = None,
-                feature_name = None,
-                top_boundary_feature = None,
-                base_boundary_feature = None,
-                extra_metadata = None):
-      """Initialises a rock fluid unit feature organisational object."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 phase = None,
+                 feature_name = None,
+                 top_boundary_feature = None,
+                 base_boundary_feature = None,
+                 extra_metadata = None):
+        """Initialises a rock fluid unit feature organisational object."""
 
-      self.phase = phase
-      self.top_boundary_feature = top_boundary_feature
-      self.base_boundary_feature = base_boundary_feature
+        self.phase = phase
+        self.top_boundary_feature = top_boundary_feature
+        self.base_boundary_feature = base_boundary_feature
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, RockFluidUnitFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.feature_name != other.feature_name or self.phase != other.phase:
-         return False
-      if self.top_boundary_feature is not None:
-         if not self.top_boundary_feature.is_equivalent(other.top_boundary_feature):
+        if other is None or not isinstance(other, RockFluidUnitFeature):
             return False
-      elif other.top_boundary_feature is not None:
-         return False
-      if self.base_boundary_feature is not None:
-         if not self.base_boundary_feature.is_equivalent(other.base_boundary_feature):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.feature_name != other.feature_name or self.phase != other.phase:
             return False
-      elif other.base_boundary_feature is not None:
-         return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return True
+        if self.top_boundary_feature is not None:
+            if not self.top_boundary_feature.is_equivalent(other.top_boundary_feature):
+                return False
+        elif other.top_boundary_feature is not None:
+            return False
+        if self.base_boundary_feature is not None:
+            if not self.base_boundary_feature.is_equivalent(other.base_boundary_feature):
+                return False
+        elif other.base_boundary_feature is not None:
+            return False
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return True
 
-   def _load_from_xml(self):
+    def _load_from_xml(self):
 
-      self.phase = rqet.find_tag_text(self.root, 'Phase')
+        self.phase = rqet.find_tag_text(self.root, 'Phase')
 
-      feature_ref_node = rqet.find_tag(self.root, 'FluidBoundaryTop')
-      assert feature_ref_node is not None
-      feature_root = self.model.referenced_node(feature_ref_node)
-      feature_uuid = rqet.uuid_for_part_root(feature_root)
-      assert feature_uuid is not None, 'rock fluid top boundary feature missing from model'
-      self.top_boundary_feature = BoundaryFeature(self.model, uuid = feature_uuid)
+        feature_ref_node = rqet.find_tag(self.root, 'FluidBoundaryTop')
+        assert feature_ref_node is not None
+        feature_root = self.model.referenced_node(feature_ref_node)
+        feature_uuid = rqet.uuid_for_part_root(feature_root)
+        assert feature_uuid is not None, 'rock fluid top boundary feature missing from model'
+        self.top_boundary_feature = BoundaryFeature(self.model, uuid = feature_uuid)
 
-      feature_ref_node = rqet.find_tag(self.root, 'FluidBoundaryBottom')
-      assert feature_ref_node is not None
-      feature_root = self.model.referenced_node(feature_ref_node)
-      feature_uuid = rqet.uuid_for_part_root(feature_root)
-      assert feature_uuid is not None, 'rock fluid bottom boundary feature missing from model'
-      self.base_boundary_feature = BoundaryFeature(self.model, uuid = feature_uuid)
+        feature_ref_node = rqet.find_tag(self.root, 'FluidBoundaryBottom')
+        assert feature_ref_node is not None
+        feature_root = self.model.referenced_node(feature_ref_node)
+        feature_uuid = rqet.uuid_for_part_root(feature_root)
+        assert feature_uuid is not None, 'rock fluid bottom boundary feature missing from model'
+        self.base_boundary_feature = BoundaryFeature(self.model, uuid = feature_uuid)
 
-   def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
-      """Creates a rock fluid unit feature organisational xml node from this rock fluid unit feature object."""
+    def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
+        """Creates a rock fluid unit feature organisational xml node from this rock fluid unit feature object."""
 
-      assert self.feature_name and self.phase and self.top_boundary_feature and self.base_boundary_feature
-      if self.phase not in self.valid_phases:
-         raise ValueError(f"Phase '{self.phase}' not recognized")
+        assert self.feature_name and self.phase and self.top_boundary_feature and self.base_boundary_feature
+        if self.phase not in self.valid_phases:
+            raise ValueError(f"Phase '{self.phase}' not recognized")
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      # create node with citation block
-      rfuf = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        # create node with citation block
+        rfuf = super().create_xml(add_as_part = False, originator = originator)
 
-      phase_node = rqet.SubElement(rfuf, ns['resqml2'] + 'Phase')
-      phase_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Phase')
-      phase_node.text = self.phase
+        phase_node = rqet.SubElement(rfuf, ns['resqml2'] + 'Phase')
+        phase_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Phase')
+        phase_node.text = self.phase
 
-      top_boundary_root = self.top_boundary_feature.root
-      assert top_boundary_root is not None
-      self.model.create_ref_node('FluidBoundaryTop',
-                                 self.model.title_for_root(top_boundary_root),
-                                 top_boundary_root.attrib['uuid'],
-                                 content_type = 'obj_BoundaryFeature',
-                                 root = rfuf)
+        top_boundary_root = self.top_boundary_feature.root
+        assert top_boundary_root is not None
+        self.model.create_ref_node('FluidBoundaryTop',
+                                   self.model.title_for_root(top_boundary_root),
+                                   top_boundary_root.attrib['uuid'],
+                                   content_type = 'obj_BoundaryFeature',
+                                   root = rfuf)
 
-      base_boundary_root = self.base_boundary_feature.root
-      assert base_boundary_root is not None
-      self.model.create_ref_node('FluidBoundaryBottom',
-                                 self.model.title_for_root(base_boundary_root),
-                                 base_boundary_root.attrib['uuid'],
-                                 content_type = 'obj_BoundaryFeature',
-                                 root = rfuf)
+        base_boundary_root = self.base_boundary_feature.root
+        assert base_boundary_root is not None
+        self.model.create_ref_node('FluidBoundaryBottom',
+                                   self.model.title_for_root(base_boundary_root),
+                                   base_boundary_root.attrib['uuid'],
+                                   content_type = 'obj_BoundaryFeature',
+                                   root = rfuf)
 
-      if add_as_part:
-         self.model.add_part('obj_RockFluidUnitFeature', self.uuid, rfuf)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(rfuf, 'destinationObject', top_boundary_root, 'sourceObject')
-            self.model.create_reciprocal_relationship(rfuf, 'destinationObject', base_boundary_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_RockFluidUnitFeature', self.uuid, rfuf)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(rfuf, 'destinationObject', top_boundary_root, 'sourceObject')
+                self.model.create_reciprocal_relationship(rfuf, 'destinationObject', base_boundary_root, 'sourceObject')
 
-      return rfuf
+        return rfuf
 
 
 class TectonicBoundaryFeature(BaseResqpy):
-   """Class for RESQML Tectonic Boundary Feature (fault) organizational objects."""
+    """Class for RESQML Tectonic Boundary Feature (fault) organizational objects."""
 
-   resqml_type = "TectonicBoundaryFeature"
-   feature_name = _alias_for_attribute("title")
-   valid_kinds = ('fault', 'fracture')
+    resqml_type = "TectonicBoundaryFeature"
+    feature_name = _alias_for_attribute("title")
+    valid_kinds = ('fault', 'fracture')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                kind = None,
-                feature_name = None,
-                extra_metadata = None):
-      """Initialises a tectonic boundary feature (fault or fracture) organisational object."""
-      self.kind = kind
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 kind = None,
+                 feature_name = None,
+                 extra_metadata = None):
+        """Initialises a tectonic boundary feature (fault or fracture) organisational object."""
+        self.kind = kind
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      self.kind = rqet.find_tag_text(self.root, 'TectonicBoundaryKind')
-      if not self.kind:
-         self.kind = 'fault'
+    def _load_from_xml(self):
+        self.kind = rqet.find_tag_text(self.root, 'TectonicBoundaryKind')
+        if not self.kind:
+            self.kind = 'fault'
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
-      if other is None or not isinstance(other, TectonicBoundaryFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name and self.kind == other.kind
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
+        if other is None or not isinstance(other, TectonicBoundaryFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name and self.kind == other.kind
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a tectonic boundary feature organisational xml node from this tectonic boundary feature object."""
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a tectonic boundary feature organisational xml node from this tectonic boundary feature object."""
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      # create node with citation block
-      tbf = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        # create node with citation block
+        tbf = super().create_xml(add_as_part = False, originator = originator)
 
-      assert self.kind in self.valid_kinds
-      kind_node = rqet.SubElement(tbf, ns['resqml2'] + 'TectonicBoundaryKind')
-      kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TectonicBoundaryKind')
-      kind_node.text = self.kind
+        assert self.kind in self.valid_kinds
+        kind_node = rqet.SubElement(tbf, ns['resqml2'] + 'TectonicBoundaryKind')
+        kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TectonicBoundaryKind')
+        kind_node.text = self.kind
 
-      if add_as_part:
-         self.model.add_part('obj_TectonicBoundaryFeature', self.uuid, tbf)
+        if add_as_part:
+            self.model.add_part('obj_TectonicBoundaryFeature', self.uuid, tbf)
 
-      return tbf
+        return tbf
 
 
 class GeneticBoundaryFeature(BaseResqpy):
-   """Class for RESQML Genetic Boundary Feature (horizon) organizational objects."""
+    """Class for RESQML Genetic Boundary Feature (horizon) organizational objects."""
 
-   resqml_type = "GeneticBoundaryFeature"
-   feature_name = _alias_for_attribute("title")
-   valid_kinds = ('horizon', 'geobody boundary')
+    resqml_type = "GeneticBoundaryFeature"
+    feature_name = _alias_for_attribute("title")
+    valid_kinds = ('horizon', 'geobody boundary')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                kind = None,
-                feature_name = None,
-                extra_metadata = None):
-      """Initialises a genetic boundary feature (horizon or geobody boundary) organisational object."""
-      self.kind = kind
-      self.absolute_age = None  # (timestamp, year offset) pair, or None; todo: support setting from args
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 kind = None,
+                 feature_name = None,
+                 extra_metadata = None):
+        """Initialises a genetic boundary feature (horizon or geobody boundary) organisational object."""
+        self.kind = kind
+        self.absolute_age = None  # (timestamp, year offset) pair, or None; todo: support setting from args
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      self.kind = rqet.find_tag_text(self.root, 'GeneticBoundaryKind')
-      age_node = rqet.find_tag(self.root, 'AbsoluteAge')
-      if age_node:
-         self.absolute_age = (rqet.find_tag_text(age_node, 'DateTime'), rqet.find_tag_int(age_node, 'YearOffset')
-                             )  # year offset may be None
+    def _load_from_xml(self):
+        self.kind = rqet.find_tag_text(self.root, 'GeneticBoundaryKind')
+        age_node = rqet.find_tag(self.root, 'AbsoluteAge')
+        if age_node:
+            self.absolute_age = (rqet.find_tag_text(age_node, 'DateTime'), rqet.find_tag_int(age_node, 'YearOffset')
+                                )  # year offset may be None
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
-      if other is None or not isinstance(other, GeneticBoundaryFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name and self.kind == other.kind and self.absolute_age == other.absolute_age
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
+        if other is None or not isinstance(other, GeneticBoundaryFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name and self.kind == other.kind and self.absolute_age == other.absolute_age
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a genetic boundary feature organisational xml node from this genetic boundary feature object."""
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a genetic boundary feature organisational xml node from this genetic boundary feature object."""
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      # create node with citation block
-      gbf = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        # create node with citation block
+        gbf = super().create_xml(add_as_part = False, originator = originator)
 
-      assert self.kind in self.valid_kinds
-      kind_node = rqet.SubElement(gbf, ns['resqml2'] + 'GeneticBoundaryKind')
-      kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeneticBoundaryKind')
-      kind_node.text = self.kind
+        assert self.kind in self.valid_kinds
+        kind_node = rqet.SubElement(gbf, ns['resqml2'] + 'GeneticBoundaryKind')
+        kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeneticBoundaryKind')
+        kind_node.text = self.kind
 
-      if self.absolute_age is not None:
-         date_time, year_offset = self.absolute_age
-         age_node = rqet.SubElement(gbf, ns['resqml2'] + 'AbsoluteAge')
-         age_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Timestamp')
-         age_node.text = rqet.null_xml_text
-         dt_node = rqet.SubElement(age_node, ns['resqml2'] + 'DateTime')
-         dt_node.set(ns['xsi'] + 'type', ns['xsd'] + 'dateTime')
-         dt_node.text = str(date_time)
-         if year_offset is not None:
-            yo_node = rqet.SubElement(age_node, ns['resqml2'] + 'YearOffset')
-            yo_node.set(ns['xsi'] + 'type', ns['xsd'] + 'long')
-            yo_node.text = str(year_offset)
+        if self.absolute_age is not None:
+            date_time, year_offset = self.absolute_age
+            age_node = rqet.SubElement(gbf, ns['resqml2'] + 'AbsoluteAge')
+            age_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Timestamp')
+            age_node.text = rqet.null_xml_text
+            dt_node = rqet.SubElement(age_node, ns['resqml2'] + 'DateTime')
+            dt_node.set(ns['xsi'] + 'type', ns['xsd'] + 'dateTime')
+            dt_node.text = str(date_time)
+            if year_offset is not None:
+                yo_node = rqet.SubElement(age_node, ns['resqml2'] + 'YearOffset')
+                yo_node.set(ns['xsi'] + 'type', ns['xsd'] + 'long')
+                yo_node.text = str(year_offset)
 
-      if add_as_part:
-         self.model.add_part('obj_GeneticBoundaryFeature', self.uuid, gbf)
+        if add_as_part:
+            self.model.add_part('obj_GeneticBoundaryFeature', self.uuid, gbf)
 
-      return gbf
+        return gbf
 
 
 class WellboreFeature(BaseResqpy):
-   """Class for RESQML Wellbore Feature organizational objects."""
+    """Class for RESQML Wellbore Feature organizational objects."""
 
-   # note: optional WITSML link not supported
+    # note: optional WITSML link not supported
 
-   resqml_type = "WellboreFeature"
-   feature_name = _alias_for_attribute("title")
+    resqml_type = "WellboreFeature"
+    feature_name = _alias_for_attribute("title")
 
-   def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
-      """Initialises a wellbore feature organisational object."""
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = feature_name,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+    def __init__(self, parent_model, root_node = None, uuid = None, feature_name = None, extra_metadata = None):
+        """Initialises a wellbore feature organisational object."""
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = feature_name,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False."""
-      if other is None or not isinstance(other, WellboreFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.feature_name == other.feature_name
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False."""
+        if other is None or not isinstance(other, WellboreFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.feature_name == other.feature_name
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Creates a wellbore feature organisational xml node from this wellbore feature object."""
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      return super().create_xml(add_as_part = add_as_part, originator = originator)
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Creates a wellbore feature organisational xml node from this wellbore feature object."""
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        return super().create_xml(add_as_part = add_as_part, originator = originator)
 
 
 class FaultInterpretation(BaseResqpy):
-   """Class for RESQML Fault Interpretation organizational objects.
+    """Class for RESQML Fault Interpretation organizational objects.
 
    RESQML documentation:
 
@@ -624,779 +624,781 @@ class FaultInterpretation(BaseResqpy):
 
    """
 
-   resqml_type = "FaultInterpretation"
-   valid_domains = ('depth', 'time', 'mixed')
+    resqml_type = "FaultInterpretation"
+    valid_domains = ('depth', 'time', 'mixed')
 
-   # note: many of the attributes could be deduced from geometry
+    # note: many of the attributes could be deduced from geometry
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                title = None,
-                tectonic_boundary_feature = None,
-                domain = 'depth',
-                is_normal = None,
-                is_listric = None,
-                maximum_throw = None,
-                mean_azimuth = None,
-                mean_dip = None,
-                extra_metadata = None):
-      """Initialises a Fault interpretation organisational object."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 title = None,
+                 tectonic_boundary_feature = None,
+                 domain = 'depth',
+                 is_normal = None,
+                 is_listric = None,
+                 maximum_throw = None,
+                 mean_azimuth = None,
+                 mean_dip = None,
+                 extra_metadata = None):
+        """Initialises a Fault interpretation organisational object."""
 
-      # note: will create a paired TectonicBoundaryFeature object when loading from xml
-      # if not extracting from xml,:
-      # tectonic_boundary_feature is required and must be a TectonicBoundaryFeature object
-      # domain is required and must be one of 'depth', 'time' or 'mixed'
-      # is_listric is required if the fault is not normal (and must be None if normal)
-      # max throw, azimuth & dip are all optional
-      # the throw interpretation list is not supported for direct initialisation
+        # note: will create a paired TectonicBoundaryFeature object when loading from xml
+        # if not extracting from xml,:
+        # tectonic_boundary_feature is required and must be a TectonicBoundaryFeature object
+        # domain is required and must be one of 'depth', 'time' or 'mixed'
+        # is_listric is required if the fault is not normal (and must be None if normal)
+        # max throw, azimuth & dip are all optional
+        # the throw interpretation list is not supported for direct initialisation
 
-      self.tectonic_boundary_feature = tectonic_boundary_feature  # InterpretedFeature RESQML field, when not loading from xml
-      self.feature_root = None if self.tectonic_boundary_feature is None else self.tectonic_boundary_feature.root
-      if (not title) and self.tectonic_boundary_feature is not None:
-         title = self.tectonic_boundary_feature.feature_name
-      self.main_has_occurred_during = (None, None)
-      self.is_normal = is_normal  # extra field, not explicitly in RESQML
-      self.domain = domain
-      # RESQML xml business rule: IsListric must be present if the fault is normal; must not be present if the fault is not normal
-      self.is_listric = is_listric
-      self.maximum_throw = maximum_throw
-      self.mean_azimuth = mean_azimuth
-      self.mean_dip = mean_dip
-      self.throw_interpretation_list = None  # list of (list of throw kind, (base chrono uuid, top chrono uuid)))
+        self.tectonic_boundary_feature = tectonic_boundary_feature  # InterpretedFeature RESQML field, when not loading from xml
+        self.feature_root = None if self.tectonic_boundary_feature is None else self.tectonic_boundary_feature.root
+        if (not title) and self.tectonic_boundary_feature is not None:
+            title = self.tectonic_boundary_feature.feature_name
+        self.main_has_occurred_during = (None, None)
+        self.is_normal = is_normal  # extra field, not explicitly in RESQML
+        self.domain = domain
+        # RESQML xml business rule: IsListric must be present if the fault is normal; must not be present if the fault is not normal
+        self.is_listric = is_listric
+        self.maximum_throw = maximum_throw
+        self.mean_azimuth = mean_azimuth
+        self.mean_dip = mean_dip
+        self.throw_interpretation_list = None  # list of (list of throw kind, (base chrono uuid, top chrono uuid)))
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   @property
-   def feature_uuid(self):
-      # TODO: rewrite using uuid as primary key
-      return rqet.uuid_for_part_root(self.feature_root)
+    @property
+    def feature_uuid(self):
+        # TODO: rewrite using uuid as primary key
+        return rqet.uuid_for_part_root(self.feature_root)
 
-   def _load_from_xml(self):
-      root_node = self.root
-      self.domain = rqet.find_tag_text(root_node, 'Domain')
-      interp_feature_ref_node = rqet.find_tag(root_node, 'InterpretedFeature')
-      assert interp_feature_ref_node is not None
-      self.feature_root = self.model.referenced_node(interp_feature_ref_node)
-      if self.feature_root is not None:
-         self.tectonic_boundary_feature = TectonicBoundaryFeature(self.model,
-                                                                  uuid = self.feature_root.attrib['uuid'],
-                                                                  feature_name = self.model.title_for_root(
-                                                                     self.feature_root))
-         self.main_has_occurred_during = extract_has_occurred_during(root_node)
-         self.is_listric = rqet.find_tag_bool(root_node, 'IsListric')
-         self.is_normal = (self.is_listric is None)
-         self.maximum_throw = rqet.find_tag_float(root_node, 'MaximumThrow')
-         # todo: check that type="eml:LengthMeasure" is simple float
-         self.mean_azimuth = rqet.find_tag_float(root_node, 'MeanAzimuth')
-         self.mean_dip = rqet.find_tag_float(root_node, 'MeanDip')
-         throw_interpretation_nodes = rqet.list_of_tag(root_node, 'ThrowInterpretation')
-         if throw_interpretation_nodes is not None and len(throw_interpretation_nodes):
-            self.throw_interpretation_list = []
-            for ti_node in throw_interpretation_nodes:
-               hod_pair = extract_has_occurred_during(ti_node)
-               throw_kind_list = rqet.list_of_tag(ti_node, 'Throw')
-               for tk_node in throw_kind_list:
-                  self.throw_interpretation_list.append((tk_node.text, hod_pair))
+    def _load_from_xml(self):
+        root_node = self.root
+        self.domain = rqet.find_tag_text(root_node, 'Domain')
+        interp_feature_ref_node = rqet.find_tag(root_node, 'InterpretedFeature')
+        assert interp_feature_ref_node is not None
+        self.feature_root = self.model.referenced_node(interp_feature_ref_node)
+        if self.feature_root is not None:
+            self.tectonic_boundary_feature = TectonicBoundaryFeature(self.model,
+                                                                     uuid = self.feature_root.attrib['uuid'],
+                                                                     feature_name = self.model.title_for_root(
+                                                                         self.feature_root))
+            self.main_has_occurred_during = extract_has_occurred_during(root_node)
+            self.is_listric = rqet.find_tag_bool(root_node, 'IsListric')
+            self.is_normal = (self.is_listric is None)
+            self.maximum_throw = rqet.find_tag_float(root_node, 'MaximumThrow')
+            # todo: check that type="eml:LengthMeasure" is simple float
+            self.mean_azimuth = rqet.find_tag_float(root_node, 'MeanAzimuth')
+            self.mean_dip = rqet.find_tag_float(root_node, 'MeanDip')
+            throw_interpretation_nodes = rqet.list_of_tag(root_node, 'ThrowInterpretation')
+            if throw_interpretation_nodes is not None and len(throw_interpretation_nodes):
+                self.throw_interpretation_list = []
+                for ti_node in throw_interpretation_nodes:
+                    hod_pair = extract_has_occurred_during(ti_node)
+                    throw_kind_list = rqet.list_of_tag(ti_node, 'Throw')
+                    for tk_node in throw_kind_list:
+                        self.throw_interpretation_list.append((tk_node.text, hod_pair))
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, FaultInterpretation):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.tectonic_boundary_feature is not None:
-         if not self.tectonic_boundary_feature.is_equivalent(other.tectonic_boundary_feature):
+        if other is None or not isinstance(other, FaultInterpretation):
             return False
-      elif other.tectonic_boundary_feature is not None:
-         return False
-      if self.root is not None and other.root is not None:
-         if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.tectonic_boundary_feature is not None:
+            if not self.tectonic_boundary_feature.is_equivalent(other.tectonic_boundary_feature):
+                return False
+        elif other.tectonic_boundary_feature is not None:
             return False
-      if (not equivalent_chrono_pairs(self.main_has_occurred_during, other.main_has_occurred_during) or
-          self.is_normal != other.is_normal or self.domain != other.domain or self.is_listric != other.is_listric):
-         return False
-      if ((self.maximum_throw is None) != (other.maximum_throw is None) or (self.mean_azimuth is None) !=
-          (other.mean_azimuth is None) or (self.mean_dip is None) != (other.mean_dip is None)):
-         return False
-      if self.maximum_throw is not None and not maths.isclose(self.maximum_throw, other.maximum_throw, rel_tol = 1e-3):
-         return False
-      if self.mean_azimuth is not None and not maths.isclose(self.mean_azimuth, other.mean_azimuth, abs_tol = 0.5):
-         return False
-      if self.mean_dip is not None and not maths.isclose(self.mean_dip, other.mean_dip, abs_tol = 0.5):
-         return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      if not self.throw_interpretation_list and not other.throw_interpretation_list:
-         return True
-      if not self.throw_interpretation_list or not other.throw_interpretation_list:
-         return False
-      if len(self.throw_interpretation_list) != len(other.throw_interpretation_list):
-         return False
-      for this_ti, other_ti in zip(self.throw_interpretation_list, other.throw_interpretation_list):
-         if this_ti[0] != other_ti[0]:
-            return False  # throw kind
-         if not equivalent_chrono_pairs(this_ti[1], other_ti[1]):
+        if self.root is not None and other.root is not None:
+            if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+                return False
+        if (not equivalent_chrono_pairs(self.main_has_occurred_during, other.main_has_occurred_during) or
+                self.is_normal != other.is_normal or self.domain != other.domain or
+                self.is_listric != other.is_listric):
             return False
-      return True
+        if ((self.maximum_throw is None) != (other.maximum_throw is None) or (self.mean_azimuth is None) !=
+            (other.mean_azimuth is None) or (self.mean_dip is None) != (other.mean_dip is None)):
+            return False
+        if self.maximum_throw is not None and not maths.isclose(self.maximum_throw, other.maximum_throw,
+                                                                rel_tol = 1e-3):
+            return False
+        if self.mean_azimuth is not None and not maths.isclose(self.mean_azimuth, other.mean_azimuth, abs_tol = 0.5):
+            return False
+        if self.mean_dip is not None and not maths.isclose(self.mean_dip, other.mean_dip, abs_tol = 0.5):
+            return False
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        if not self.throw_interpretation_list and not other.throw_interpretation_list:
+            return True
+        if not self.throw_interpretation_list or not other.throw_interpretation_list:
+            return False
+        if len(self.throw_interpretation_list) != len(other.throw_interpretation_list):
+            return False
+        for this_ti, other_ti in zip(self.throw_interpretation_list, other.throw_interpretation_list):
+            if this_ti[0] != other_ti[0]:
+                return False  # throw kind
+            if not equivalent_chrono_pairs(this_ti[1], other_ti[1]):
+                return False
+        return True
 
-   def create_xml(self,
-                  tectonic_boundary_feature_root = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  originator = None,
-                  title_suffix = None,
-                  reuse = True):
-      """Creates a fault interpretation organisational xml node from a fault interpretation object."""
+    def create_xml(self,
+                   tectonic_boundary_feature_root = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   originator = None,
+                   title_suffix = None,
+                   reuse = True):
+        """Creates a fault interpretation organisational xml node from a fault interpretation object."""
 
-      # note: related tectonic boundary feature node should be created first and referenced here
+        # note: related tectonic boundary feature node should be created first and referenced here
 
-      assert self.is_normal == (self.is_listric is None)
-      if not self.title:
-         if tectonic_boundary_feature_root is not None:
-            title = rqet.find_nested_tags_text(tectonic_boundary_feature_root, ['Citation', 'Title'])
-         else:
-            title = 'fault interpretation'
-         if title_suffix:
-            title += ' ' + title_suffix
-
-      if reuse and self.try_reuse():
-         return self.root
-
-      fi = super().create_xml(add_as_part = False, originator = originator)
-
-      if self.tectonic_boundary_feature is not None:
-         tbf_root = self.tectonic_boundary_feature.root
-         if tbf_root is not None:
-            if tectonic_boundary_feature_root is None:
-               tectonic_boundary_feature_root = tbf_root
+        assert self.is_normal == (self.is_listric is None)
+        if not self.title:
+            if tectonic_boundary_feature_root is not None:
+                title = rqet.find_nested_tags_text(tectonic_boundary_feature_root, ['Citation', 'Title'])
             else:
-               assert tbf_root is tectonic_boundary_feature_root, 'tectonic boundary feature mismatch'
-      assert tectonic_boundary_feature_root is not None
+                title = 'fault interpretation'
+            if title_suffix:
+                title += ' ' + title_suffix
 
-      assert self.domain in self.valid_domains, 'illegal domain value for fault interpretation'
-      dom_node = rqet.SubElement(fi, ns['resqml2'] + 'Domain')
-      dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      dom_node.text = self.domain
+        if reuse and self.try_reuse():
+            return self.root
 
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.model.title_for_root(tectonic_boundary_feature_root),
-                                 tectonic_boundary_feature_root.attrib['uuid'],
-                                 content_type = 'obj_TectonicBoundaryFeature',
-                                 root = fi)
+        fi = super().create_xml(add_as_part = False, originator = originator)
 
-      create_xml_has_occurred_during(self.model, fi, self.main_has_occurred_during)
+        if self.tectonic_boundary_feature is not None:
+            tbf_root = self.tectonic_boundary_feature.root
+            if tbf_root is not None:
+                if tectonic_boundary_feature_root is None:
+                    tectonic_boundary_feature_root = tbf_root
+                else:
+                    assert tbf_root is tectonic_boundary_feature_root, 'tectonic boundary feature mismatch'
+        assert tectonic_boundary_feature_root is not None
 
-      if self.is_listric is not None:
-         listric = rqet.SubElement(fi, ns['resqml2'] + 'IsListric')
-         listric.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-         listric.text = str(self.is_listric).lower()
+        assert self.domain in self.valid_domains, 'illegal domain value for fault interpretation'
+        dom_node = rqet.SubElement(fi, ns['resqml2'] + 'Domain')
+        dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        dom_node.text = self.domain
 
-      # todo: check eml:LengthMeasure and PlaneAngleMeasure structures: uom?
-      if self.maximum_throw is not None:
-         max_throw = rqet.SubElement(fi, ns['resqml2'] + 'MaximumThrow')
-         max_throw.set(ns['xsi'] + 'type', ns['eml'] + 'LengthMeasure')
-         max_throw.text = str(self.maximum_throw)
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.model.title_for_root(tectonic_boundary_feature_root),
+                                   tectonic_boundary_feature_root.attrib['uuid'],
+                                   content_type = 'obj_TectonicBoundaryFeature',
+                                   root = fi)
 
-      if self.mean_azimuth is not None:
-         azimuth = rqet.SubElement(fi, ns['resqml2'] + 'MeanAzimuth')
-         azimuth.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleMeasure')
-         azimuth.text = str(self.mean_azimuth)
+        create_xml_has_occurred_during(self.model, fi, self.main_has_occurred_during)
 
-      if self.mean_dip is not None:
-         dip = rqet.SubElement(fi, ns['resqml2'] + 'MeanDip')
-         dip.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleMeasure')
-         dip.text = str(self.mean_azimuth)
+        if self.is_listric is not None:
+            listric = rqet.SubElement(fi, ns['resqml2'] + 'IsListric')
+            listric.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+            listric.text = str(self.is_listric).lower()
 
-      if self.throw_interpretation_list is not None and len(self.throw_interpretation_list):
-         previous_has_occurred_during = ('never', 'never')
-         ti_node = None
-         for (throw_kind, (base_chrono_uuid, top_chrono_uuid)) in self.throw_interpretation_list:
-            if (str(base_chrono_uuid), str(top_chrono_uuid)) != previous_has_occurred_during:
-               previous_has_occurred_during = (str(base_chrono_uuid), str(top_chrono_uuid))
-               ti_node = rqet.SubElement(fi, 'ThrowInterpretation')
-               ti_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'FaultThrow')
-               ti_node.text = rqet.null_xml_text
-               create_xml_has_occurred_during(self.model, ti_node, (base_chrono_uuid, top_chrono_uuid))
-            tk_node = rqet.SubElement(ti_node, 'Throw')
-            tk_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ThrowKind')
-            tk_node.text = throw_kind
+        # todo: check eml:LengthMeasure and PlaneAngleMeasure structures: uom?
+        if self.maximum_throw is not None:
+            max_throw = rqet.SubElement(fi, ns['resqml2'] + 'MaximumThrow')
+            max_throw.set(ns['xsi'] + 'type', ns['eml'] + 'LengthMeasure')
+            max_throw.text = str(self.maximum_throw)
 
-      if add_as_part:
-         self.model.add_part('obj_FaultInterpretation', self.uuid, fi)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(fi, 'destinationObject', tectonic_boundary_feature_root,
-                                                      'sourceObject')
+        if self.mean_azimuth is not None:
+            azimuth = rqet.SubElement(fi, ns['resqml2'] + 'MeanAzimuth')
+            azimuth.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleMeasure')
+            azimuth.text = str(self.mean_azimuth)
 
-      return fi
+        if self.mean_dip is not None:
+            dip = rqet.SubElement(fi, ns['resqml2'] + 'MeanDip')
+            dip.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleMeasure')
+            dip.text = str(self.mean_azimuth)
+
+        if self.throw_interpretation_list is not None and len(self.throw_interpretation_list):
+            previous_has_occurred_during = ('never', 'never')
+            ti_node = None
+            for (throw_kind, (base_chrono_uuid, top_chrono_uuid)) in self.throw_interpretation_list:
+                if (str(base_chrono_uuid), str(top_chrono_uuid)) != previous_has_occurred_during:
+                    previous_has_occurred_during = (str(base_chrono_uuid), str(top_chrono_uuid))
+                    ti_node = rqet.SubElement(fi, 'ThrowInterpretation')
+                    ti_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'FaultThrow')
+                    ti_node.text = rqet.null_xml_text
+                    create_xml_has_occurred_during(self.model, ti_node, (base_chrono_uuid, top_chrono_uuid))
+                tk_node = rqet.SubElement(ti_node, 'Throw')
+                tk_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ThrowKind')
+                tk_node.text = throw_kind
+
+        if add_as_part:
+            self.model.add_part('obj_FaultInterpretation', self.uuid, fi)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(fi, 'destinationObject', tectonic_boundary_feature_root,
+                                                          'sourceObject')
+
+        return fi
 
 
 class EarthModelInterpretation(BaseResqpy):
-   """Class for RESQML Earth Model Interpretation organizational objects."""
+    """Class for RESQML Earth Model Interpretation organizational objects."""
 
-   # TODO: add support for StratigraphicColumn reference and other optional references
+    # TODO: add support for StratigraphicColumn reference and other optional references
 
-   resqml_type = 'EarthModelInterpretation'
-   valid_domains = ('depth', 'time', 'mixed')
+    resqml_type = 'EarthModelInterpretation'
+    valid_domains = ('depth', 'time', 'mixed')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                title = None,
-                organization_feature = None,
-                domain = 'depth',
-                extra_metadata = None):
-      """Initialises an earth model interpretation organisational object."""
-      self.domain = domain
-      self.organization_feature = organization_feature  # InterpretedFeature RESQML field
-      self.feature_root = None if self.organization_feature is None else self.organization_feature.root
-      self.has_occurred_during = (None, None)
-      if (not title) and organization_feature is not None:
-         title = organization_feature.feature_name
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 title = None,
+                 organization_feature = None,
+                 domain = 'depth',
+                 extra_metadata = None):
+        """Initialises an earth model interpretation organisational object."""
+        self.domain = domain
+        self.organization_feature = organization_feature  # InterpretedFeature RESQML field
+        self.feature_root = None if self.organization_feature is None else self.organization_feature.root
+        self.has_occurred_during = (None, None)
+        if (not title) and organization_feature is not None:
+            title = organization_feature.feature_name
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      self.domain = rqet.find_tag_text(self.root, 'Domain')
-      interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
-      assert interp_feature_ref_node is not None
-      self.feature_root = self.model.referenced_node(interp_feature_ref_node)
-      if self.feature_root is not None:
-         self.organization_feature = OrganizationFeature(self.model,
-                                                         uuid = self.feature_root.attrib['uuid'],
-                                                         feature_name = self.model.title_for_root(self.feature_root))
-      self.has_occurred_during = extract_has_occurred_during(self.root)
+    def _load_from_xml(self):
+        self.domain = rqet.find_tag_text(self.root, 'Domain')
+        interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
+        assert interp_feature_ref_node is not None
+        self.feature_root = self.model.referenced_node(interp_feature_ref_node)
+        if self.feature_root is not None:
+            self.organization_feature = OrganizationFeature(self.model,
+                                                            uuid = self.feature_root.attrib['uuid'],
+                                                            feature_name = self.model.title_for_root(self.feature_root))
+        self.has_occurred_during = extract_has_occurred_during(self.root)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False."""
-      if other is None or not isinstance(other, EarthModelInterpretation):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.organization_feature is not None:
-         if not self.organization_feature.is_equivalent(other.organization_feature):
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False."""
+        if other is None or not isinstance(other, EarthModelInterpretation):
             return False
-      elif other.organization_feature is not None:
-         return False
-      if self.root is not None and other.root is not None:
-         if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.organization_feature is not None:
+            if not self.organization_feature.is_equivalent(other.organization_feature):
+                return False
+        elif other.organization_feature is not None:
             return False
-      elif self.root is not None or other.root is not None:
-         return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return self.domain == other.domain and equivalent_chrono_pairs(self.has_occurred_during,
-                                                                     other.has_occurred_during)
+        if self.root is not None and other.root is not None:
+            if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+                return False
+        elif self.root is not None or other.root is not None:
+            return False
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return self.domain == other.domain and equivalent_chrono_pairs(self.has_occurred_during,
+                                                                       other.has_occurred_during)
 
-   def create_xml(self,
-                  organization_feature_root = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  originator = None,
-                  title_suffix = None,
-                  reuse = True):
-      """Creates an earth model interpretation organisational xml node from an earth model interpretation object."""
+    def create_xml(self,
+                   organization_feature_root = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   originator = None,
+                   title_suffix = None,
+                   reuse = True):
+        """Creates an earth model interpretation organisational xml node from an earth model interpretation object."""
 
-      # note: related organization feature node should be created first and referenced here
+        # note: related organization feature node should be created first and referenced here
 
-      if not self.title:
-         self.title = self.organization_feature.feature_name
-      if title_suffix:
-         self.title += ' ' + title_suffix
+        if not self.title:
+            self.title = self.organization_feature.feature_name
+        if title_suffix:
+            self.title += ' ' + title_suffix
 
-      if reuse and self.try_reuse():
-         return self.root
-      emi = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root
+        emi = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.organization_feature is not None:
-         of_root = self.organization_feature.root
-         if of_root is not None:
-            if organization_feature_root is None:
-               organization_feature_root = of_root
-            else:
-               assert of_root is organization_feature_root, 'organization feature mismatch'
+        if self.organization_feature is not None:
+            of_root = self.organization_feature.root
+            if of_root is not None:
+                if organization_feature_root is None:
+                    organization_feature_root = of_root
+                else:
+                    assert of_root is organization_feature_root, 'organization feature mismatch'
 
-      assert organization_feature_root is not None, 'interpreted feature not established for model interpretation'
+        assert organization_feature_root is not None, 'interpreted feature not established for model interpretation'
 
-      assert self.domain in self.valid_domains, 'illegal domain value for earth model interpretation'
-      dom_node = rqet.SubElement(emi, ns['resqml2'] + 'Domain')
-      dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      dom_node.text = self.domain
+        assert self.domain in self.valid_domains, 'illegal domain value for earth model interpretation'
+        dom_node = rqet.SubElement(emi, ns['resqml2'] + 'Domain')
+        dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        dom_node.text = self.domain
 
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.model.title_for_root(organization_feature_root),
-                                 organization_feature_root.attrib['uuid'],
-                                 content_type = 'obj_OrganizationFeature',
-                                 root = emi)
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.model.title_for_root(organization_feature_root),
+                                   organization_feature_root.attrib['uuid'],
+                                   content_type = 'obj_OrganizationFeature',
+                                   root = emi)
 
-      create_xml_has_occurred_during(self.model, emi, self.has_occurred_during)
+        create_xml_has_occurred_during(self.model, emi, self.has_occurred_during)
 
-      if add_as_part:
-         self.model.add_part('obj_EarthModelInterpretation', self.uuid, emi)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(emi, 'destinationObject', organization_feature_root,
-                                                      'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_EarthModelInterpretation', self.uuid, emi)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(emi, 'destinationObject', organization_feature_root,
+                                                          'sourceObject')
 
-      return emi
+        return emi
 
 
 class HorizonInterpretation(BaseResqpy):
-   """Class for RESQML Horizon Interpretation organizational objects."""
+    """Class for RESQML Horizon Interpretation organizational objects."""
 
-   resqml_type = 'HorizonInterpretation'
-   valid_domains = ('depth', 'time', 'mixed')
-   valid_sequence_stratigraphy_surfaces = ('flooding', 'ravinement', 'maximum flooding', 'transgressive')
-   valid_boundary_relations = ('conformable', 'unconformable below and above', 'unconformable above',
-                               'unconformable below')
+    resqml_type = 'HorizonInterpretation'
+    valid_domains = ('depth', 'time', 'mixed')
+    valid_sequence_stratigraphy_surfaces = ('flooding', 'ravinement', 'maximum flooding', 'transgressive')
+    valid_boundary_relations = ('conformable', 'unconformable below and above', 'unconformable above',
+                                'unconformable below')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                title = None,
-                genetic_boundary_feature = None,
-                domain = 'depth',
-                boundary_relation_list = None,
-                sequence_stratigraphy_surface = None,
-                extra_metadata = None):
-      """Initialises a horizon interpretation organisational object."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 title = None,
+                 genetic_boundary_feature = None,
+                 domain = 'depth',
+                 boundary_relation_list = None,
+                 sequence_stratigraphy_surface = None,
+                 extra_metadata = None):
+        """Initialises a horizon interpretation organisational object."""
 
-      # note: will create a paired GeneticBoundaryFeature object when loading from xml (and possibly a Surface object)
+        # note: will create a paired GeneticBoundaryFeature object when loading from xml (and possibly a Surface object)
 
-      self.domain = domain
-      self.genetic_boundary_feature = genetic_boundary_feature  # InterpretedFeature RESQML field, when not loading from xml
-      self.feature_root = None if self.genetic_boundary_feature is None else self.genetic_boundary_feature.root
-      if (not title) and self.genetic_boundary_feature is not None:
-         title = self.genetic_boundary_feature.feature_name
-      self.has_occurred_during = (None, None)
-      self.boundary_relation_list = None if not boundary_relation_list else boundary_relation_list.copy()
-      self.sequence_stratigraphy_surface = sequence_stratigraphy_surface
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        self.domain = domain
+        self.genetic_boundary_feature = genetic_boundary_feature  # InterpretedFeature RESQML field, when not loading from xml
+        self.feature_root = None if self.genetic_boundary_feature is None else self.genetic_boundary_feature.root
+        if (not title) and self.genetic_boundary_feature is not None:
+            title = self.genetic_boundary_feature.feature_name
+        self.has_occurred_during = (None, None)
+        self.boundary_relation_list = None if not boundary_relation_list else boundary_relation_list.copy()
+        self.sequence_stratigraphy_surface = sequence_stratigraphy_surface
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      self.domain = rqet.find_tag_text(self.root, 'Domain')
-      interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
-      assert interp_feature_ref_node is not None
-      self.feature_root = self.model.referenced_node(interp_feature_ref_node)
-      if self.feature_root is not None:
-         self.genetic_boundary_feature = GeneticBoundaryFeature(self.model,
-                                                                kind = 'horizon',
-                                                                uuid = self.feature_root.attrib['uuid'],
-                                                                feature_name = self.model.title_for_root(
-                                                                   self.feature_root))
-      self.has_occurred_during = extract_has_occurred_during(self.root)
-      br_node_list = rqet.list_of_tag(self.root, 'BoundaryRelation')
-      if br_node_list is not None and len(br_node_list) > 0:
-         self.boundary_relation_list = []
-         for br_node in br_node_list:
-            self.boundary_relation_list.append(br_node.text)
-      self.sequence_stratigraphy_surface = rqet.find_tag_text(self.root, 'SequenceStratigraphySurface')
+    def _load_from_xml(self):
+        self.domain = rqet.find_tag_text(self.root, 'Domain')
+        interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
+        assert interp_feature_ref_node is not None
+        self.feature_root = self.model.referenced_node(interp_feature_ref_node)
+        if self.feature_root is not None:
+            self.genetic_boundary_feature = GeneticBoundaryFeature(self.model,
+                                                                   kind = 'horizon',
+                                                                   uuid = self.feature_root.attrib['uuid'],
+                                                                   feature_name = self.model.title_for_root(
+                                                                       self.feature_root))
+        self.has_occurred_during = extract_has_occurred_during(self.root)
+        br_node_list = rqet.list_of_tag(self.root, 'BoundaryRelation')
+        if br_node_list is not None and len(br_node_list) > 0:
+            self.boundary_relation_list = []
+            for br_node in br_node_list:
+                self.boundary_relation_list.append(br_node.text)
+        self.sequence_stratigraphy_surface = rqet.find_tag_text(self.root, 'SequenceStratigraphySurface')
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, HorizonInterpretation):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.genetic_boundary_feature is not None:
-         if not self.genetic_boundary_feature.is_equivalent(other.genetic_boundary_feature):
+        if other is None or not isinstance(other, HorizonInterpretation):
             return False
-      elif other.genetic_boundary_feature is not None:
-         return False
-      if self.root is not None and other.root is not None:
-         if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.genetic_boundary_feature is not None:
+            if not self.genetic_boundary_feature.is_equivalent(other.genetic_boundary_feature):
+                return False
+        elif other.genetic_boundary_feature is not None:
             return False
-      elif self.root is not None or other.root is not None:
-         return False
-      if (self.domain != other.domain or
-          not equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during) or
-          self.sequence_stratigraphy_surface != other.sequence_stratigraphy_surface):
-         return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      if not self.boundary_relation_list and not other.boundary_relation_list:
-         return True
-      if not self.boundary_relation_list or not other.boundary_relation_list:
-         return False
-      return set(self.boundary_relation_list) == set(other.boundary_relation_list)
+        if self.root is not None and other.root is not None:
+            if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+                return False
+        elif self.root is not None or other.root is not None:
+            return False
+        if (self.domain != other.domain or
+                not equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during) or
+                self.sequence_stratigraphy_surface != other.sequence_stratigraphy_surface):
+            return False
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        if not self.boundary_relation_list and not other.boundary_relation_list:
+            return True
+        if not self.boundary_relation_list or not other.boundary_relation_list:
+            return False
+        return set(self.boundary_relation_list) == set(other.boundary_relation_list)
 
-   def create_xml(self,
-                  genetic_boundary_feature_root = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  originator = None,
-                  title_suffix = None,
-                  reuse = True):
-      """Creates a horizon interpretation organisational xml node from a horizon interpretation object."""
+    def create_xml(self,
+                   genetic_boundary_feature_root = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   originator = None,
+                   title_suffix = None,
+                   reuse = True):
+        """Creates a horizon interpretation organisational xml node from a horizon interpretation object."""
 
-      # note: related genetic boundary feature node should be created first and referenced here
+        # note: related genetic boundary feature node should be created first and referenced here
 
-      if not self.title:
-         self.title = self.genetic_boundary_feature.feature_name
-      if title_suffix:
-         self.title += ' ' + title_suffix
+        if not self.title:
+            self.title = self.genetic_boundary_feature.feature_name
+        if title_suffix:
+            self.title += ' ' + title_suffix
 
-      if reuse and self.try_reuse():
-         return self.root
-      hi = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root
+        hi = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.genetic_boundary_feature is not None:
-         gbf_root = self.genetic_boundary_feature.root
-         if gbf_root is not None:
-            if genetic_boundary_feature_root is None:
-               genetic_boundary_feature_root = gbf_root
-            else:
-               assert gbf_root is genetic_boundary_feature_root, 'genetic boundary feature mismatch'
+        if self.genetic_boundary_feature is not None:
+            gbf_root = self.genetic_boundary_feature.root
+            if gbf_root is not None:
+                if genetic_boundary_feature_root is None:
+                    genetic_boundary_feature_root = gbf_root
+                else:
+                    assert gbf_root is genetic_boundary_feature_root, 'genetic boundary feature mismatch'
 
-      assert self.domain in self.valid_domains, 'illegal domain value for horizon interpretation'
-      dom_node = rqet.SubElement(hi, ns['resqml2'] + 'Domain')
-      dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      dom_node.text = self.domain
+        assert self.domain in self.valid_domains, 'illegal domain value for horizon interpretation'
+        dom_node = rqet.SubElement(hi, ns['resqml2'] + 'Domain')
+        dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        dom_node.text = self.domain
 
-      create_xml_has_occurred_during(self.model, hi, self.has_occurred_during)
+        create_xml_has_occurred_during(self.model, hi, self.has_occurred_during)
 
-      if self.boundary_relation_list is not None:
-         for boundary_relation in self.boundary_relation_list:
-            assert boundary_relation in self.valid_boundary_relations
-            br_node = rqet.SubElement(hi, ns['resqml2'] + 'BoundaryRelation')
-            br_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BoundaryRelation')
-            br_node.text = boundary_relation
+        if self.boundary_relation_list is not None:
+            for boundary_relation in self.boundary_relation_list:
+                assert boundary_relation in self.valid_boundary_relations
+                br_node = rqet.SubElement(hi, ns['resqml2'] + 'BoundaryRelation')
+                br_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BoundaryRelation')
+                br_node.text = boundary_relation
 
-      if self.sequence_stratigraphy_surface is not None:
-         assert self.sequence_stratigraphy_surface in self.valid_sequence_stratigraphy_surfaces
-         sss_node = rqet.SubElement(hi, ns['resqml2'] + 'SequenceStratigraphySurface')
-         sss_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'SequenceStratigraphySurface')
-         sss_node.text = self.sequence_stratigraphy_surface
+        if self.sequence_stratigraphy_surface is not None:
+            assert self.sequence_stratigraphy_surface in self.valid_sequence_stratigraphy_surfaces
+            sss_node = rqet.SubElement(hi, ns['resqml2'] + 'SequenceStratigraphySurface')
+            sss_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'SequenceStratigraphySurface')
+            sss_node.text = self.sequence_stratigraphy_surface
 
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.model.title_for_root(genetic_boundary_feature_root),
-                                 genetic_boundary_feature_root.attrib['uuid'],
-                                 content_type = 'obj_GeneticBoundaryFeature',
-                                 root = hi)
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.model.title_for_root(genetic_boundary_feature_root),
+                                   genetic_boundary_feature_root.attrib['uuid'],
+                                   content_type = 'obj_GeneticBoundaryFeature',
+                                   root = hi)
 
-      if add_as_part:
-         self.model.add_part('obj_HorizonInterpretation', self.uuid, hi)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(hi, 'destinationObject', genetic_boundary_feature_root,
-                                                      'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_HorizonInterpretation', self.uuid, hi)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(hi, 'destinationObject', genetic_boundary_feature_root,
+                                                          'sourceObject')
 
-      return hi
+        return hi
 
 
 class GeobodyBoundaryInterpretation(BaseResqpy):
-   """Class for RESQML Geobody Boudary Interpretation organizational objects."""
+    """Class for RESQML Geobody Boudary Interpretation organizational objects."""
 
-   resqml_type = 'GeobodyBoundaryInterpretation'
-   valid_domains = ('depth', 'time', 'mixed')
-   valid_boundary_relations = ('conformable', 'unconformable below and above', 'unconformable above',
-                               'unconformable below')
+    resqml_type = 'GeobodyBoundaryInterpretation'
+    valid_domains = ('depth', 'time', 'mixed')
+    valid_boundary_relations = ('conformable', 'unconformable below and above', 'unconformable above',
+                                'unconformable below')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                title = None,
-                genetic_boundary_feature = None,
-                domain = 'depth',
-                boundary_relation_list = None,
-                extra_metadata = None):
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 title = None,
+                 genetic_boundary_feature = None,
+                 domain = 'depth',
+                 boundary_relation_list = None,
+                 extra_metadata = None):
 
-      self.domain = domain
-      self.boundary_relation_list = None if not boundary_relation_list else boundary_relation_list.copy()
-      self.genetic_boundary_feature = genetic_boundary_feature  # InterpretedFeature RESQML field, when not loading from xml
-      self.feature_root = None if self.genetic_boundary_feature is None else self.genetic_boundary_feature.root
-      if (not title) and self.genetic_boundary_feature is not None:
-         title = self.genetic_boundary_feature.feature_name
-      self.has_occurred_during = (None, None)
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        self.domain = domain
+        self.boundary_relation_list = None if not boundary_relation_list else boundary_relation_list.copy()
+        self.genetic_boundary_feature = genetic_boundary_feature  # InterpretedFeature RESQML field, when not loading from xml
+        self.feature_root = None if self.genetic_boundary_feature is None else self.genetic_boundary_feature.root
+        if (not title) and self.genetic_boundary_feature is not None:
+            title = self.genetic_boundary_feature.feature_name
+        self.has_occurred_during = (None, None)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      self.domain = rqet.find_tag_text(self.root, 'Domain')
-      interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
-      assert interp_feature_ref_node is not None
-      self.feature_root = self.model.referenced_node(interp_feature_ref_node)
-      if self.feature_root is not None:
-         self.genetic_boundary_feature = GeneticBoundaryFeature(self.model,
-                                                                kind = 'geobody boundary',
-                                                                uuid = self.feature_root.attrib['uuid'],
-                                                                feature_name = self.model.title_for_root(
-                                                                   self.feature_root))
-      self.has_occurred_during = extract_has_occurred_during(self.root)
-      br_node_list = rqet.list_of_tag(self.root, 'BoundaryRelation')
-      if br_node_list is not None and len(br_node_list) > 0:
-         self.boundary_relation_list = []
-         for br_node in br_node_list:
-            self.boundary_relation_list.append(br_node.text)
+    def _load_from_xml(self):
+        self.domain = rqet.find_tag_text(self.root, 'Domain')
+        interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
+        assert interp_feature_ref_node is not None
+        self.feature_root = self.model.referenced_node(interp_feature_ref_node)
+        if self.feature_root is not None:
+            self.genetic_boundary_feature = GeneticBoundaryFeature(self.model,
+                                                                   kind = 'geobody boundary',
+                                                                   uuid = self.feature_root.attrib['uuid'],
+                                                                   feature_name = self.model.title_for_root(
+                                                                       self.feature_root))
+        self.has_occurred_during = extract_has_occurred_during(self.root)
+        br_node_list = rqet.list_of_tag(self.root, 'BoundaryRelation')
+        if br_node_list is not None and len(br_node_list) > 0:
+            self.boundary_relation_list = []
+            for br_node in br_node_list:
+                self.boundary_relation_list.append(br_node.text)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, GeobodyBoundaryInterpretation):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.genetic_boundary_feature is not None:
-         if not self.genetic_boundary_feature.is_equivalent(other.genetic_boundary_feature):
+        if other is None or not isinstance(other, GeobodyBoundaryInterpretation):
             return False
-      elif other.genetic_boundary_feature is not None:
-         return False
-      if self.root is not None and other.root is not None:
-         if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.genetic_boundary_feature is not None:
+            if not self.genetic_boundary_feature.is_equivalent(other.genetic_boundary_feature):
+                return False
+        elif other.genetic_boundary_feature is not None:
             return False
-      elif self.root is not None or other.root is not None:
-         return False
-      if (self.domain != other.domain or
-          not equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during)):
-         return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      if not self.boundary_relation_list and not other.boundary_relation_list:
-         return True
-      if not self.boundary_relation_list or not other.boundary_relation_list:
-         return False
-      return set(self.boundary_relation_list) == set(other.boundary_relation_list)
+        if self.root is not None and other.root is not None:
+            if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+                return False
+        elif self.root is not None or other.root is not None:
+            return False
+        if (self.domain != other.domain or
+                not equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during)):
+            return False
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        if not self.boundary_relation_list and not other.boundary_relation_list:
+            return True
+        if not self.boundary_relation_list or not other.boundary_relation_list:
+            return False
+        return set(self.boundary_relation_list) == set(other.boundary_relation_list)
 
-   def create_xml(self,
-                  genetic_boundary_feature_root = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  originator = None,
-                  title_suffix = None,
-                  reuse = True):
-      """Creates a geobody boundary interpretation organisational xml node from a geobody boundary interpretation object."""
+    def create_xml(self,
+                   genetic_boundary_feature_root = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   originator = None,
+                   title_suffix = None,
+                   reuse = True):
+        """Creates a geobody boundary interpretation organisational xml node from a geobody boundary interpretation object."""
 
-      if not self.title:
-         self.title = self.genetic_boundary_feature.feature_name
-      if title_suffix:
-         self.title += ' ' + title_suffix
+        if not self.title:
+            self.title = self.genetic_boundary_feature.feature_name
+        if title_suffix:
+            self.title += ' ' + title_suffix
 
-      if reuse and self.try_reuse():
-         return self.root
-      gbi = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root
+        gbi = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.genetic_boundary_feature is not None:
-         gbf_root = self.genetic_boundary_feature.root
-         if gbf_root is not None:
+        if self.genetic_boundary_feature is not None:
+            gbf_root = self.genetic_boundary_feature.root
+            if gbf_root is not None:
+                if genetic_boundary_feature_root is None:
+                    genetic_boundary_feature_root = gbf_root
+                else:
+                    assert gbf_root is genetic_boundary_feature_root, 'genetic boundary feature mismatch'
+        else:
             if genetic_boundary_feature_root is None:
-               genetic_boundary_feature_root = gbf_root
-            else:
-               assert gbf_root is genetic_boundary_feature_root, 'genetic boundary feature mismatch'
-      else:
-         if genetic_boundary_feature_root is None:
-            genetic_boundary_feature_root = self.feature_root
-         assert genetic_boundary_feature_root is not None
-         self.genetic_boundary_feature = GeneticBoundaryFeature(self.model,
-                                                                uuid = genetic_boundary_feature_root.attrib['uuid'])
-      self.feature_root = genetic_boundary_feature_root
+                genetic_boundary_feature_root = self.feature_root
+            assert genetic_boundary_feature_root is not None
+            self.genetic_boundary_feature = GeneticBoundaryFeature(self.model,
+                                                                   uuid = genetic_boundary_feature_root.attrib['uuid'])
+        self.feature_root = genetic_boundary_feature_root
 
-      assert self.domain in self.valid_domains, 'illegal domain value for geobody boundary interpretation'
-      dom_node = rqet.SubElement(gbi, ns['resqml2'] + 'Domain')
-      dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      dom_node.text = self.domain
+        assert self.domain in self.valid_domains, 'illegal domain value for geobody boundary interpretation'
+        dom_node = rqet.SubElement(gbi, ns['resqml2'] + 'Domain')
+        dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        dom_node.text = self.domain
 
-      create_xml_has_occurred_during(self.model, gbi, self.has_occurred_during)
+        create_xml_has_occurred_during(self.model, gbi, self.has_occurred_during)
 
-      if self.boundary_relation_list is not None:
-         for boundary_relation in self.boundary_relation_list:
-            assert boundary_relation in self.valid_boundary_relations
-            br_node = rqet.SubElement(gbi, ns['resqml2'] + 'BoundaryRelation')
-            br_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BoundaryRelation')
-            br_node.text = str(boundary_relation)
+        if self.boundary_relation_list is not None:
+            for boundary_relation in self.boundary_relation_list:
+                assert boundary_relation in self.valid_boundary_relations
+                br_node = rqet.SubElement(gbi, ns['resqml2'] + 'BoundaryRelation')
+                br_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BoundaryRelation')
+                br_node.text = str(boundary_relation)
 
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.model.title_for_root(genetic_boundary_feature_root),
-                                 genetic_boundary_feature_root.attrib['uuid'],
-                                 content_type = 'obj_GeneticBoundaryFeature',
-                                 root = gbi)
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.model.title_for_root(genetic_boundary_feature_root),
+                                   genetic_boundary_feature_root.attrib['uuid'],
+                                   content_type = 'obj_GeneticBoundaryFeature',
+                                   root = gbi)
 
-      if add_as_part:
-         self.model.add_part('obj_GeobodyBoundaryInterpretation', self.uuid, gbi)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(gbi, 'destinationObject', genetic_boundary_feature_root,
-                                                      'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_GeobodyBoundaryInterpretation', self.uuid, gbi)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(gbi, 'destinationObject', genetic_boundary_feature_root,
+                                                          'sourceObject')
 
-      return gbi
+        return gbi
 
 
 class GeobodyInterpretation(BaseResqpy):
-   """Class for RESQML Geobody Interpretation objects."""
+    """Class for RESQML Geobody Interpretation objects."""
 
-   resqml_type = 'GeobodyInterpretation'
-   valid_domains = ('depth', 'time', 'mixed')
-   valid_compositions = (
-      'intrusive clay',
-      'organic',
-      'intrusive mud',
-      'evaporite salt',
-      'evaporite non salt',
-      'sedimentary siliclastic',
-      'carbonate',
-      'magmatic intrusive granitoid',
-      'magmatic intrusive pyroclastic',
-      'magmatic extrusive lava flow',
-      'other chemichal rock',  # chemichal (stet: from xsd)
-      'other chemical rock',
-      'sedimentary turbidite')
-   valid_implacements = ('autochtonous', 'allochtonous')
-   valid_geobody_shapes = ('dyke', 'silt', 'sill', 'dome', 'sheeth', 'sheet', 'diapir', 'batholith', 'channel', 'delta',
-                           'dune', 'fan', 'reef', 'wedge')
+    resqml_type = 'GeobodyInterpretation'
+    valid_domains = ('depth', 'time', 'mixed')
+    valid_compositions = (
+        'intrusive clay',
+        'organic',
+        'intrusive mud',
+        'evaporite salt',
+        'evaporite non salt',
+        'sedimentary siliclastic',
+        'carbonate',
+        'magmatic intrusive granitoid',
+        'magmatic intrusive pyroclastic',
+        'magmatic extrusive lava flow',
+        'other chemichal rock',  # chemichal (stet: from xsd)
+        'other chemical rock',
+        'sedimentary turbidite')
+    valid_implacements = ('autochtonous', 'allochtonous')
+    valid_geobody_shapes = ('dyke', 'silt', 'sill', 'dome', 'sheeth', 'sheet', 'diapir', 'batholith', 'channel',
+                            'delta', 'dune', 'fan', 'reef', 'wedge')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                title = None,
-                geobody_feature = None,
-                domain = 'depth',
-                composition = None,
-                material_implacement = None,
-                geobody_shape = None,
-                extra_metadata = None):
-      """Initialise a new geobody interpretation object, either from xml or explicitly."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 title = None,
+                 geobody_feature = None,
+                 domain = 'depth',
+                 composition = None,
+                 material_implacement = None,
+                 geobody_shape = None,
+                 extra_metadata = None):
+        """Initialise a new geobody interpretation object, either from xml or explicitly."""
 
-      self.domain = domain
-      self.geobody_feature = geobody_feature  # InterpretedFeature RESQML field, when not loading from xml
-      self.feature_root = None if self.geobody_feature is None else self.geobody_feature.root
-      self.has_occurred_during = (None, None)
-      self.composition = composition
-      self.implacement = material_implacement
-      self.geobody_shape = geobody_shape
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        self.domain = domain
+        self.geobody_feature = geobody_feature  # InterpretedFeature RESQML field, when not loading from xml
+        self.feature_root = None if self.geobody_feature is None else self.geobody_feature.root
+        self.has_occurred_during = (None, None)
+        self.composition = composition
+        self.implacement = material_implacement
+        self.geobody_shape = geobody_shape
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
-      assert interp_feature_ref_node is not None
-      self.feature_root = self.model.referenced_node(interp_feature_ref_node)
-      if self.feature_root is not None:
-         self.geobody_feature = GeobodyFeature(self.model,
-                                               uuid = self.feature_root.attrib['uuid'],
-                                               feature_name = self.model.title_for_root(self.feature_root))
-      self.has_occurred_during = extract_has_occurred_during(self.root)
-      self.composition = rqet.find_tag_text(self.root, 'GeologicUnitComposition')
-      self.implacement = rqet.find_tag_text(self.root, 'GeologicUnitMaterialImplacement')
-      self.geobody_shape = rqet.find_tag_text(self.root, 'Geobody3dShape')
+    def _load_from_xml(self):
+        interp_feature_ref_node = rqet.find_tag(self.root, 'InterpretedFeature')
+        assert interp_feature_ref_node is not None
+        self.feature_root = self.model.referenced_node(interp_feature_ref_node)
+        if self.feature_root is not None:
+            self.geobody_feature = GeobodyFeature(self.model,
+                                                  uuid = self.feature_root.attrib['uuid'],
+                                                  feature_name = self.model.title_for_root(self.feature_root))
+        self.has_occurred_during = extract_has_occurred_during(self.root)
+        self.composition = rqet.find_tag_text(self.root, 'GeologicUnitComposition')
+        self.implacement = rqet.find_tag_text(self.root, 'GeologicUnitMaterialImplacement')
+        self.geobody_shape = rqet.find_tag_text(self.root, 'Geobody3dShape')
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, GeobodyInterpretation):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.geobody_feature is not None:
-         if not self.geobody_feature.is_equivalent(other.geobody_feature):
+        if other is None or not isinstance(other, GeobodyInterpretation):
             return False
-      elif other.geobody_feature is not None:
-         return False
-      if self.root is not None and other.root is not None:
-         if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.geobody_feature is not None:
+            if not self.geobody_feature.is_equivalent(other.geobody_feature):
+                return False
+        elif other.geobody_feature is not None:
             return False
-      elif self.root is not None or other.root is not None:
-         return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return (self.domain == other.domain and
-              equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during) and
-              self.composition == other.composition and self.implacement == other.implacement and
-              self.geobody_shape == other.geobody_shape)
+        if self.root is not None and other.root is not None:
+            if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+                return False
+        elif self.root is not None or other.root is not None:
+            return False
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return (self.domain == other.domain and
+                equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during) and
+                self.composition == other.composition and self.implacement == other.implacement and
+                self.geobody_shape == other.geobody_shape)
 
-   def create_xml(self,
-                  geobody_feature_root = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  originator = None,
-                  title_suffix = None,
-                  reuse = True):
+    def create_xml(self,
+                   geobody_feature_root = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   originator = None,
+                   title_suffix = None,
+                   reuse = True):
 
-      if not self.title:
-         self.title = self.geobody_feature.feature_name
-      if title_suffix:
-         self.title += ' ' + title_suffix
+        if not self.title:
+            self.title = self.geobody_feature.feature_name
+        if title_suffix:
+            self.title += ' ' + title_suffix
 
-      if reuse and self.try_reuse():
-         return self.root
-      gi = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root
+        gi = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.geobody_feature is not None:
-         gbf_root = self.geobody_feature.root
-         if gbf_root is not None:
+        if self.geobody_feature is not None:
+            gbf_root = self.geobody_feature.root
+            if gbf_root is not None:
+                if geobody_feature_root is None:
+                    geobody_feature_root = gbf_root
+                else:
+                    assert gbf_root is geobody_feature_root, 'geobody feature mismatch'
+        else:
             if geobody_feature_root is None:
-               geobody_feature_root = gbf_root
-            else:
-               assert gbf_root is geobody_feature_root, 'geobody feature mismatch'
-      else:
-         if geobody_feature_root is None:
-            geobody_feature_root = self.feature_root
-         assert geobody_feature_root is not None
-         self.geobody_feature = GeobodyFeature(self.model, uuid = geobody_feature_root.attrib['uuid'])
-      self.feature_root = geobody_feature_root
+                geobody_feature_root = self.feature_root
+            assert geobody_feature_root is not None
+            self.geobody_feature = GeobodyFeature(self.model, uuid = geobody_feature_root.attrib['uuid'])
+        self.feature_root = geobody_feature_root
 
-      assert self.domain in self.valid_domains, 'illegal domain value for geobody interpretation'
-      dom_node = rqet.SubElement(gi, ns['resqml2'] + 'Domain')
-      dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      dom_node.text = self.domain
+        assert self.domain in self.valid_domains, 'illegal domain value for geobody interpretation'
+        dom_node = rqet.SubElement(gi, ns['resqml2'] + 'Domain')
+        dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        dom_node.text = self.domain
 
-      create_xml_has_occurred_during(self.model, gi, self.has_occurred_during)
+        create_xml_has_occurred_during(self.model, gi, self.has_occurred_during)
 
-      if self.composition:
-         assert self.composition in self.valid_compositions
-         guc_node = rqet.SubElement(gi, ns['resqml2'] + 'GeologicUnitComposition')
-         guc_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitComposition')
-         guc_node.text = self.composition
-         # if self.composition.startswith('intrusive'): guc_node.text += ' '
+        if self.composition:
+            assert self.composition in self.valid_compositions
+            guc_node = rqet.SubElement(gi, ns['resqml2'] + 'GeologicUnitComposition')
+            guc_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitComposition')
+            guc_node.text = self.composition
+            # if self.composition.startswith('intrusive'): guc_node.text += ' '
 
-      if self.implacement:
-         assert self.implacement in self.valid_implacements
-         gumi_node = rqet.SubElement(gi, ns['resqml2'] + 'GeologicUnitMaterialImplacement')
-         gumi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitMaterialImplacement')
-         gumi_node.text = self.implacement
+        if self.implacement:
+            assert self.implacement in self.valid_implacements
+            gumi_node = rqet.SubElement(gi, ns['resqml2'] + 'GeologicUnitMaterialImplacement')
+            gumi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitMaterialImplacement')
+            gumi_node.text = self.implacement
 
-      if self.geobody_shape:
-         # note: 'silt' & 'sheeth' believed erroneous, so 'sill' and 'sheet' added
-         assert self.geobody_shape in self.valid_geobody_shapes
-         gs_node = rqet.SubElement(gi, ns['resqml2'] + 'Geobody3dShape')
-         gs_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Geobody3dShape')
-         gs_node.text = self.geobody_shape
+        if self.geobody_shape:
+            # note: 'silt' & 'sheeth' believed erroneous, so 'sill' and 'sheet' added
+            assert self.geobody_shape in self.valid_geobody_shapes
+            gs_node = rqet.SubElement(gi, ns['resqml2'] + 'Geobody3dShape')
+            gs_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Geobody3dShape')
+            gs_node.text = self.geobody_shape
 
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.model.title_for_root(geobody_feature_root),
-                                 geobody_feature_root.attrib['uuid'],
-                                 content_type = 'obj_GeobodyFeature',
-                                 root = gi)
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.model.title_for_root(geobody_feature_root),
+                                   geobody_feature_root.attrib['uuid'],
+                                   content_type = 'obj_GeobodyFeature',
+                                   root = gi)
 
-      if add_as_part:
-         self.model.add_part('obj_GeobodyInterpretation', self.uuid, gi)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(gi, 'destinationObject', geobody_feature_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_GeobodyInterpretation', self.uuid, gi)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(gi, 'destinationObject', geobody_feature_root, 'sourceObject')
 
-      return gi
+        return gi
 
 
 class WellboreInterpretation(BaseResqpy):
-   """Class for RESQML Wellbore Interpretation organizational objects.
+    """Class for RESQML Wellbore Interpretation organizational objects.
 
    RESQML documentation:
 
@@ -1412,127 +1414,128 @@ class WellboreInterpretation(BaseResqpy):
 
    """
 
-   resqml_type = 'WellboreInterpretation'
-   valid_domains = ('depth', 'time', 'mixed')
+    resqml_type = 'WellboreInterpretation'
+    valid_domains = ('depth', 'time', 'mixed')
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                title = None,
-                is_drilled = None,
-                wellbore_feature = None,
-                domain = 'depth',
-                extra_metadata = None):
-      """Initialises a wellbore interpretation organisational object."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 title = None,
+                 is_drilled = None,
+                 wellbore_feature = None,
+                 domain = 'depth',
+                 extra_metadata = None):
+        """Initialises a wellbore interpretation organisational object."""
 
-      # note: will create a paired WellboreFeature object when loading from xml
+        # note: will create a paired WellboreFeature object when loading from xml
 
-      self.is_drilled = is_drilled
-      self.wellbore_feature = wellbore_feature
-      self.feature_root = None if self.wellbore_feature is None else self.wellbore_feature.root
-      if (not title) and self.wellbore_feature is not None:
-         title = self.wellbore_feature.feature_name
-      self.domain = domain
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        self.is_drilled = is_drilled
+        self.wellbore_feature = wellbore_feature
+        self.feature_root = None if self.wellbore_feature is None else self.wellbore_feature.root
+        if (not title) and self.wellbore_feature is not None:
+            title = self.wellbore_feature.feature_name
+        self.domain = domain
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      root_node = self.root
-      self.is_drilled = rqet.find_tag_bool(root_node, 'IsDrilled')
-      self.domain = rqet.find_tag_text(root_node, 'Domain')
-      interp_feature_ref_node = rqet.find_tag(root_node, 'InterpretedFeature')
-      if interp_feature_ref_node is not None:
-         self.feature_root = self.model.referenced_node(interp_feature_ref_node)
-         if self.feature_root is not None:
-            self.wellbore_feature = WellboreFeature(self.model,
-                                                    uuid = self.feature_root.attrib['uuid'],
-                                                    feature_name = self.model.title_for_root(self.feature_root))
+    def _load_from_xml(self):
+        root_node = self.root
+        self.is_drilled = rqet.find_tag_bool(root_node, 'IsDrilled')
+        self.domain = rqet.find_tag_text(root_node, 'Domain')
+        interp_feature_ref_node = rqet.find_tag(root_node, 'InterpretedFeature')
+        if interp_feature_ref_node is not None:
+            self.feature_root = self.model.referenced_node(interp_feature_ref_node)
+            if self.feature_root is not None:
+                self.wellbore_feature = WellboreFeature(self.model,
+                                                        uuid = self.feature_root.attrib['uuid'],
+                                                        feature_name = self.model.title_for_root(self.feature_root))
 
-   def iter_trajectories(self):
-      """ Iterable of associated trajectories """
+    def iter_trajectories(self):
+        """ Iterable of associated trajectories """
 
-      import resqpy.well
+        import resqpy.well
 
-      uuids = self.model.uuids(obj_type = "WellboreTrajectoryRepresentation", related_uuid = self.uuid)
-      for uuid in uuids:
-         yield resqpy.well.Trajectory(self.model, uuid = uuid)
+        uuids = self.model.uuids(obj_type = "WellboreTrajectoryRepresentation", related_uuid = self.uuid)
+        for uuid in uuids:
+            yield resqpy.well.Trajectory(self.model, uuid = uuid)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False."""
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False."""
 
-      if other is None or not isinstance(other, WellboreInterpretation):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.wellbore_feature is not None:
-         if not self.wellbore_feature.is_equivalent(other.wellbore_feature):
+        if other is None or not isinstance(other, WellboreInterpretation):
             return False
-      elif other.wellbore_feature is not None:
-         return False
-      if self.root is not None and other.root is not None:
-         if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.wellbore_feature is not None:
+            if not self.wellbore_feature.is_equivalent(other.wellbore_feature):
+                return False
+        elif other.wellbore_feature is not None:
             return False
-         if self.domain != other.domain:
+        if self.root is not None and other.root is not None:
+            if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+                return False
+            if self.domain != other.domain:
+                return False
+        elif self.root is not None or other.root is not None:
             return False
-      elif self.root is not None or other.root is not None:
-         return False
-      if check_extra_metadata and not equivalent_extra_metadata(self, other):
-         return False
-      return (self.title == other.title and self.is_drilled == other.is_drilled)
+        if check_extra_metadata and not equivalent_extra_metadata(self, other):
+            return False
+        return (self.title == other.title and self.is_drilled == other.is_drilled)
 
-   def create_xml(self,
-                  wellbore_feature_root = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  originator = None,
-                  title_suffix = None,
-                  reuse = True):
-      """Creates a wellbore interpretation organisational xml node from a wellbore interpretation object."""
+    def create_xml(self,
+                   wellbore_feature_root = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   originator = None,
+                   title_suffix = None,
+                   reuse = True):
+        """Creates a wellbore interpretation organisational xml node from a wellbore interpretation object."""
 
-      # note: related wellbore feature node should be created first and referenced here
+        # note: related wellbore feature node should be created first and referenced here
 
-      if not self.title:
-         self.title = self.wellbore_feature.feature_name
-      if title_suffix:
-         self.title += ' ' + title_suffix
+        if not self.title:
+            self.title = self.wellbore_feature.feature_name
+        if title_suffix:
+            self.title += ' ' + title_suffix
 
-      if reuse and self.try_reuse():
-         return self.root
-      wi = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root
+        wi = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.wellbore_feature is not None:
-         wbf_root = self.wellbore_feature.root
-         if wbf_root is not None:
-            if wellbore_feature_root is None:
-               wellbore_feature_root = wbf_root
-            else:
-               assert wbf_root is wellbore_feature_root, 'wellbore feature mismatch'
+        if self.wellbore_feature is not None:
+            wbf_root = self.wellbore_feature.root
+            if wbf_root is not None:
+                if wellbore_feature_root is None:
+                    wellbore_feature_root = wbf_root
+                else:
+                    assert wbf_root is wellbore_feature_root, 'wellbore feature mismatch'
 
-      if self.is_drilled is None:
-         self.is_drilled = False
+        if self.is_drilled is None:
+            self.is_drilled = False
 
-      id_node = rqet.SubElement(wi, ns['resqml2'] + 'IsDrilled')
-      id_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-      id_node.text = str(self.is_drilled).lower()
+        id_node = rqet.SubElement(wi, ns['resqml2'] + 'IsDrilled')
+        id_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+        id_node.text = str(self.is_drilled).lower()
 
-      assert self.domain in self.valid_domains, 'illegal domain value for wellbore interpretation'
-      domain_node = rqet.SubElement(wi, ns['resqml2'] + 'Domain')
-      domain_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      domain_node.text = str(self.domain).lower()
+        assert self.domain in self.valid_domains, 'illegal domain value for wellbore interpretation'
+        domain_node = rqet.SubElement(wi, ns['resqml2'] + 'Domain')
+        domain_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        domain_node.text = str(self.domain).lower()
 
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.model.title_for_root(wellbore_feature_root),
-                                 wellbore_feature_root.attrib['uuid'],
-                                 content_type = 'obj_WellboreFeature',
-                                 root = wi)
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.model.title_for_root(wellbore_feature_root),
+                                   wellbore_feature_root.attrib['uuid'],
+                                   content_type = 'obj_WellboreFeature',
+                                   root = wi)
 
-      if add_as_part:
-         self.model.add_part('obj_WellboreInterpretation', self.uuid, wi)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(wi, 'destinationObject', wellbore_feature_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_WellboreInterpretation', self.uuid, wi)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(wi, 'destinationObject', wellbore_feature_root,
+                                                          'sourceObject')
 
-      return wi
+        return wi

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -44,14 +44,14 @@ import resqpy.time_series as rts
 # see property_kind_and_facet_from_keyword() for simulator keyword to property kind and facet mapping
 
 supported_property_kind_list = [
-   'code', 'index', 'depth', 'rock volume', 'pore volume', 'volume', 'thickness', 'length', 'cell length',
-   'net to gross ratio', 'porosity', 'permeability thickness', 'permeability length', 'permeability rock',
-   'rock permeability', 'fluid volume', 'transmissibility', 'pressure', 'saturation', 'solution gas-oil ratio',
-   'vapor oil-gas ratio', 'property multiplier', 'thermodynamic temperature', 'continuous', 'discrete', 'categorical'
+    'code', 'index', 'depth', 'rock volume', 'pore volume', 'volume', 'thickness', 'length', 'cell length',
+    'net to gross ratio', 'porosity', 'permeability thickness', 'permeability length', 'permeability rock',
+    'rock permeability', 'fluid volume', 'transmissibility', 'pressure', 'saturation', 'solution gas-oil ratio',
+    'vapor oil-gas ratio', 'property multiplier', 'thermodynamic temperature', 'continuous', 'discrete', 'categorical'
 ]
 
 supported_local_property_kind_list = [
-   'active', 'transmissibility multiplier', 'fault transmissibility', 'mat transmissibility'
+    'active', 'transmissibility multiplier', 'fault transmissibility', 'mat transmissibility'
 ]
 
 supported_facet_type_list = ['direction', 'netgross', 'what']
@@ -62,58 +62,58 @@ supported_facet_type_list = ['direction', 'netgross', 'what']
 # use of the following in code is DEPRECATED; it remains here to give a hint of facet types and facets in use
 
 expected_facet_type_dict = {
-   'depth': ('what', ['cell centre', 'cell top']),  # made up
-   'rock volume': ('netgross', ['net', 'gross']),  # resqml standard
-   'thickness': ('netgross', ['net', 'gross']),
-   'length': ('direction', ['X', 'Y', 'Z']),  # facet values made up
-   'cell length': ('direction', ['I', 'J', 'K']),  # facet values made up
-   'permeability rock': ('direction', ['I', 'J', 'K']),  # todo: allow IJ and IJK
-   'rock permeability': ('direction', ['I', 'J', 'K']),  # todo: allow IJ and IJK
-   'transmissibility': ('direction', ['I', 'J', 'K']),
-   'transmissibility multiplier': (
-      'direction',  # local property kind
-      ['I', 'J', 'K']),
-   'fault transmissibility': ('direction', ['I', 'J']),  # local property kind; K faces also permitted
-   'mat transmissibility': ('direction', ['K']),  # local property kind; I & J faces also permitted
-   'saturation': (
-      'what',
-      [
-         'water',
-         'oil',
-         'gas',  # made up but probably good
-         'water minimum',
-         'gas minimum',
-         'oil minimum',  # made up for end-points
-         'water residual',
-         'gas residual',
-         'oil residual',
-         'water residual to oil',
-         'gas residual to oil'
-      ]),
-   'fluid volume': (
-      'what',
-      [
-         'water',
-         'oil',
-         'gas',  # made up but probably good
-         'water (mobile)',
-         'oil (mobile)',
-         'gas (mobile)'
-      ]),  # made up
-   'property multiplier': (
-      'what',
-      [
-         'rock volume',  # made up; todo: add rock permeability?
-         'pore volume',
-         'transmissibility'
-      ]),
-   'code': ('what', ['inactive', 'active']),  # NB: user defined keywords also accepted
-   'index': ('what', ['uid', 'pixel map'])
+    'depth': ('what', ['cell centre', 'cell top']),  # made up
+    'rock volume': ('netgross', ['net', 'gross']),  # resqml standard
+    'thickness': ('netgross', ['net', 'gross']),
+    'length': ('direction', ['X', 'Y', 'Z']),  # facet values made up
+    'cell length': ('direction', ['I', 'J', 'K']),  # facet values made up
+    'permeability rock': ('direction', ['I', 'J', 'K']),  # todo: allow IJ and IJK
+    'rock permeability': ('direction', ['I', 'J', 'K']),  # todo: allow IJ and IJK
+    'transmissibility': ('direction', ['I', 'J', 'K']),
+    'transmissibility multiplier': (
+        'direction',  # local property kind
+        ['I', 'J', 'K']),
+    'fault transmissibility': ('direction', ['I', 'J']),  # local property kind; K faces also permitted
+    'mat transmissibility': ('direction', ['K']),  # local property kind; I & J faces also permitted
+    'saturation': (
+        'what',
+        [
+            'water',
+            'oil',
+            'gas',  # made up but probably good
+            'water minimum',
+            'gas minimum',
+            'oil minimum',  # made up for end-points
+            'water residual',
+            'gas residual',
+            'oil residual',
+            'water residual to oil',
+            'gas residual to oil'
+        ]),
+    'fluid volume': (
+        'what',
+        [
+            'water',
+            'oil',
+            'gas',  # made up but probably good
+            'water (mobile)',
+            'oil (mobile)',
+            'gas (mobile)'
+        ]),  # made up
+    'property multiplier': (
+        'what',
+        [
+            'rock volume',  # made up; todo: add rock permeability?
+            'pore volume',
+            'transmissibility'
+        ]),
+    'code': ('what', ['inactive', 'active']),  # NB: user defined keywords also accepted
+    'index': ('what', ['uid', 'pixel map'])
 }
 
 
 class PropertyCollection():
-   """Class for RESQML Property collection for any supporting representation (or mix of supporting representations).
+    """Class for RESQML Property collection for any supporting representation (or mix of supporting representations).
 
    notes:
       this is a base class inherited by GridPropertyCollection and WellLogCollection (and others to follow), application
@@ -124,8 +124,8 @@ class PropertyCollection():
       support Comment properties
    """
 
-   def __init__(self, support = None, property_set_root = None, realization = None):
-      """Initialise an empty Property Collection; if support is not None, populate with properties for that representation.
+    def __init__(self, support = None, property_set_root = None, realization = None):
+        """Initialise an empty Property Collection; if support is not None, populate with properties for that representation.
 
       arguments:
          support (optional): a grid.Grid object or a well.WellboreFrame object which belongs to a resqpy.Model which includes
@@ -147,59 +147,61 @@ class PropertyCollection():
       :meta common:
       """
 
-      assert property_set_root is None or support is not None,  \
-         'support (grid, wellbore frame, blocked well, mesh, or grid connection set) must be specified when populating property collection from property set'
+        assert property_set_root is None or support is not None,  \
+           'support (grid, wellbore frame, blocked well, mesh, or grid connection set) must be specified when populating property collection from property set'
 
-      self.dict = {}  # main dictionary of model property parts which are members of the collection
-      # above is mapping from part_name to:
-      # (realization, support, uuid, xml_node, continuous, count, indexable, prop_kind, facet_type, facet, citation_title,
-      #   time_series_uuid, time_index, min, max, uom, string_lookup_uuid, property_kind_uuid, extra_metadata, null_value,
-      #     const_value, points)
-      #  0            1        2     3         4           5      6          7          8           9      10
-      #   11                12          13   14   15   16                  17                  18              19
-      #     20           21
-      # note: grid is included to allow for super-collections covering more than one grid
-      # todo: replace items 8 & 9 with a facet dictionary (to allow for multiple facets)
-      self.model = None
-      self.support = None
-      self.support_root = None
-      self.support_uuid = None
-      self.property_set_root = None
-      self.time_set_kind_attr = None
-      self.has_single_property_kind_flag = None
-      self.has_single_uom_flag = None
-      self.has_single_indexable_element_flag = None
-      self.has_multiple_realizations_flag = None
-      self.parent_set_root = None
-      self.realization = realization  # model realization number within an ensemble
-      self.imported_list = []  # list of (uuid, file_name, keyword, cached_name, discrete, uom, time_index, null_value,
-      #                                   min_value, max_value, property_kind, facet_type, facet, realization,
-      #                                   indexable_element, count, local_property_kind_uuid, const_value, points)
-      if support is not None:
-         self.model = support.model
-         self.set_support(support = support)
-         assert self.model is not None
-         # assert self.support_root is not None
-         assert self.support_uuid is not None
-         if property_set_root is None:
-            # todo: make more rigorous by looking up supporting representation node uuids
-            props_list = self.model.parts_list_of_type(type_of_interest = 'obj_DiscreteProperty')
-            discrete_props_list = self.model.parts_list_filtered_by_supporting_uuid(props_list, self.support_uuid)
-            self.add_parts_list_to_dict(discrete_props_list)
-            props_list = self.model.parts_list_of_type(type_of_interest = 'obj_CategoricalProperty')
-            categorical_props_list = self.model.parts_list_filtered_by_supporting_uuid(props_list, self.support_uuid)
-            self.add_parts_list_to_dict(categorical_props_list)
-            props_list = self.model.parts_list_of_type(type_of_interest = 'obj_ContinuousProperty')
-            continuous_props_list = self.model.parts_list_filtered_by_supporting_uuid(props_list, self.support_uuid)
-            self.add_parts_list_to_dict(continuous_props_list)
-            props_list = self.model.parts_list_of_type(type_of_interest = 'obj_PointsProperty')
-            points_props_list = self.model.parts_list_filtered_by_supporting_uuid(props_list, self.support_uuid)
-            self.add_parts_list_to_dict(points_props_list)
-         else:
-            self.populate_from_property_set(property_set_root)
+        self.dict = {}  # main dictionary of model property parts which are members of the collection
+        # above is mapping from part_name to:
+        # (realization, support, uuid, xml_node, continuous, count, indexable, prop_kind, facet_type, facet, citation_title,
+        #   time_series_uuid, time_index, min, max, uom, string_lookup_uuid, property_kind_uuid, extra_metadata, null_value,
+        #     const_value, points)
+        #  0            1        2     3         4           5      6          7          8           9      10
+        #   11                12          13   14   15   16                  17                  18              19
+        #     20           21
+        # note: grid is included to allow for super-collections covering more than one grid
+        # todo: replace items 8 & 9 with a facet dictionary (to allow for multiple facets)
+        self.model = None
+        self.support = None
+        self.support_root = None
+        self.support_uuid = None
+        self.property_set_root = None
+        self.time_set_kind_attr = None
+        self.has_single_property_kind_flag = None
+        self.has_single_uom_flag = None
+        self.has_single_indexable_element_flag = None
+        self.has_multiple_realizations_flag = None
+        self.parent_set_root = None
+        self.realization = realization  # model realization number within an ensemble
+        self.imported_list = [
+        ]  # list of (uuid, file_name, keyword, cached_name, discrete, uom, time_index, null_value,
+        #                                   min_value, max_value, property_kind, facet_type, facet, realization,
+        #                                   indexable_element, count, local_property_kind_uuid, const_value, points)
+        if support is not None:
+            self.model = support.model
+            self.set_support(support = support)
+            assert self.model is not None
+            # assert self.support_root is not None
+            assert self.support_uuid is not None
+            if property_set_root is None:
+                # todo: make more rigorous by looking up supporting representation node uuids
+                props_list = self.model.parts_list_of_type(type_of_interest = 'obj_DiscreteProperty')
+                discrete_props_list = self.model.parts_list_filtered_by_supporting_uuid(props_list, self.support_uuid)
+                self.add_parts_list_to_dict(discrete_props_list)
+                props_list = self.model.parts_list_of_type(type_of_interest = 'obj_CategoricalProperty')
+                categorical_props_list = self.model.parts_list_filtered_by_supporting_uuid(
+                    props_list, self.support_uuid)
+                self.add_parts_list_to_dict(categorical_props_list)
+                props_list = self.model.parts_list_of_type(type_of_interest = 'obj_ContinuousProperty')
+                continuous_props_list = self.model.parts_list_filtered_by_supporting_uuid(props_list, self.support_uuid)
+                self.add_parts_list_to_dict(continuous_props_list)
+                props_list = self.model.parts_list_of_type(type_of_interest = 'obj_PointsProperty')
+                points_props_list = self.model.parts_list_filtered_by_supporting_uuid(props_list, self.support_uuid)
+                self.add_parts_list_to_dict(points_props_list)
+            else:
+                self.populate_from_property_set(property_set_root)
 
-   def set_support(self, support_uuid = None, support = None, model = None, modify_parts = True):
-      """Sets the supporting object associated with this collection, without loading props, if not done so at initialisation.
+    def set_support(self, support_uuid = None, support = None, model = None, modify_parts = True):
+        """Sets the supporting object associated with this collection, without loading props, if not done so at initialisation.
 
       Arguments:
          support_uuid: the uuid of the supporting representation which the properties in this collection are for
@@ -211,80 +213,80 @@ class PropertyCollection():
             support_uuid set
       """
 
-      # when at global level was causing circular reference loading issues as grid imports this module
-      import resqpy.grid as grr
-      import resqpy.unstructured as rug
-      import resqpy.well as rqw
-      import resqpy.surface as rqs
-      import resqpy.fault as rqf
+        # when at global level was causing circular reference loading issues as grid imports this module
+        import resqpy.grid as grr
+        import resqpy.unstructured as rug
+        import resqpy.well as rqw
+        import resqpy.surface as rqs
+        import resqpy.fault as rqf
 
-      # todo: check uuid's of individual parts' supports match that of support being set for whole collection
+        # todo: check uuid's of individual parts' supports match that of support being set for whole collection
 
-      if model is None and support is not None:
-         model = support.model
-      if model is None:
-         model = self.model
-      else:
-         self.model = model
+        if model is None and support is not None:
+            model = support.model
+        if model is None:
+            model = self.model
+        else:
+            self.model = model
 
-      if support_uuid is None and support is not None:
-         support_uuid = support.uuid
+        if support_uuid is None and support is not None:
+            support_uuid = support.uuid
 
-      if support_uuid is None:
-         if self.support_uuid is not None:
-            log.warning('clearing supporting representation for property collection')
-#         self.model = None
-         self.support = None
-         self.support_root = None
-         self.support_uuid = None
+        if support_uuid is None:
+            if self.support_uuid is not None:
+                log.warning('clearing supporting representation for property collection')
+            # self.model = None
+            self.support = None
+            self.support_root = None
+            self.support_uuid = None
 
-      else:
-         assert model is not None, 'model not established when setting support for property collection'
-         if self.support_uuid is not None and not bu.matching_uuids(support_uuid, self.support_uuid):
-            log.warning('changing supporting representation for property collection')
-         self.support_uuid = support_uuid
-         self.support = support
-         if self.support is None:
-            support_part = model.part_for_uuid(support_uuid)
-            assert support_part is not None, 'supporting representation part missing in model'
-            self.support_root = model.root_for_part(support_part)
-            support_type = model.type_of_part(support_part)
-            assert support_type is not None
-            if support_type == 'obj_IjkGridRepresentation':
-               self.support = grr.any_grid(model, uuid = self.support_uuid, find_properties = False)
-            elif support_type == 'obj_WellboreFrameRepresentation':
-               self.support = rqw.WellboreFrame(model, uuid = self.support_uuid)
-            elif support_type == 'obj_BlockedWellboreRepresentation':
-               self.support = rqw.BlockedWell(model, uuid = self.support_uuid)
-            elif support_type == 'obj_Grid2dRepresentation':
-               self.support = rqs.Mesh(model, uuid = self.support_uuid)
-            elif support_type == 'obj_GridConnectionSetRepresentation':
-               self.support = rqf.GridConnectionSet(model, uuid = self.support_uuid)
-            elif support_type == 'obj_UnstructuredGridRepresentation':
-               self.support = rug.UnstructuredGrid(model,
-                                                   uuid = self.support_uuid,
-                                                   geometry_required = False,
-                                                   find_properties = False)
+        else:
+            assert model is not None, 'model not established when setting support for property collection'
+            if self.support_uuid is not None and not bu.matching_uuids(support_uuid, self.support_uuid):
+                log.warning('changing supporting representation for property collection')
+            self.support_uuid = support_uuid
+            self.support = support
+            if self.support is None:
+                support_part = model.part_for_uuid(support_uuid)
+                assert support_part is not None, 'supporting representation part missing in model'
+                self.support_root = model.root_for_part(support_part)
+                support_type = model.type_of_part(support_part)
+                assert support_type is not None
+                if support_type == 'obj_IjkGridRepresentation':
+                    self.support = grr.any_grid(model, uuid = self.support_uuid, find_properties = False)
+                elif support_type == 'obj_WellboreFrameRepresentation':
+                    self.support = rqw.WellboreFrame(model, uuid = self.support_uuid)
+                elif support_type == 'obj_BlockedWellboreRepresentation':
+                    self.support = rqw.BlockedWell(model, uuid = self.support_uuid)
+                elif support_type == 'obj_Grid2dRepresentation':
+                    self.support = rqs.Mesh(model, uuid = self.support_uuid)
+                elif support_type == 'obj_GridConnectionSetRepresentation':
+                    self.support = rqf.GridConnectionSet(model, uuid = self.support_uuid)
+                elif support_type == 'obj_UnstructuredGridRepresentation':
+                    self.support = rug.UnstructuredGrid(model,
+                                                        uuid = self.support_uuid,
+                                                        geometry_required = False,
+                                                        find_properties = False)
+                else:
+                    raise TypeError('unsupported property supporting representation class: ' + str(support_type))
             else:
-               raise TypeError('unsupported property supporting representation class: ' + str(support_type))
-         else:
-            if type(self.support) in [
-                  grr.Grid, grr.RegularGrid, rqw.WellboreFrame, rqw.BlockedWell, rqs.Mesh, rqf.GridConnectionSet,
-                  rug.UnstructuredGrid, rug.HexaGrid, rug.TetraGrid, rug.PrismGrid, rug.VerticalPrismGrid,
-                  rug.PyramidGrid
-            ]:
-               self.support_root = self.support.root
-            else:
-               raise TypeError('unsupported property supporting representation class: ' + str(type(self.support)))
-         if modify_parts:
-            for (part, info) in self.dict.items():
-               if info[1] is not None:
-                  modified = list(info)
-                  modified[1] = support_uuid
-                  self.dict[part] = tuple(modified)
+                if type(self.support) in [
+                        grr.Grid, grr.RegularGrid, rqw.WellboreFrame, rqw.BlockedWell, rqs.Mesh, rqf.GridConnectionSet,
+                        rug.UnstructuredGrid, rug.HexaGrid, rug.TetraGrid, rug.PrismGrid, rug.VerticalPrismGrid,
+                        rug.PyramidGrid
+                ]:
+                    self.support_root = self.support.root
+                else:
+                    raise TypeError('unsupported property supporting representation class: ' + str(type(self.support)))
+            if modify_parts:
+                for (part, info) in self.dict.items():
+                    if info[1] is not None:
+                        modified = list(info)
+                        modified[1] = support_uuid
+                        self.dict[part] = tuple(modified)
 
-   def supporting_shape(self, indexable_element = None, direction = None):
-      """Returns the shape of the supporting representation with respect to the given indexable element, as a list of ints.
+    def supporting_shape(self, indexable_element = None, direction = None):
+        """Returns the shape of the supporting representation with respect to the given indexable element, as a list of ints.
 
       arguments:
          indexable_element (string, optional): if None, a hard-coded default depending on the supporting representation class
@@ -299,113 +301,113 @@ class PropertyCollection():
          individual property arrays will only match this shape if they have the same indexable element and a count of one
       """
 
-      # when at global level was causing circular reference loading issues as grid imports this module
-      import resqpy.grid as grr
-      import resqpy.unstructured as rug
-      import resqpy.well as rqw
-      import resqpy.surface as rqs
-      import resqpy.fault as rqf
+        # when at global level was causing circular reference loading issues as grid imports this module
+        import resqpy.grid as grr
+        import resqpy.unstructured as rug
+        import resqpy.well as rqw
+        import resqpy.surface as rqs
+        import resqpy.fault as rqf
 
-      shape_list = None
-      support = self.support
+        shape_list = None
+        support = self.support
 
-      if isinstance(support, grr.Grid):
-         if indexable_element is None or indexable_element == 'cells':
-            shape_list = [support.nk, support.nj, support.ni]
-         elif indexable_element == 'columns':
-            shape_list = [support.nj, support.ni]
-         elif indexable_element == 'layers':
-            shape_list = [support.nk]
-         elif indexable_element == 'faces':
-            assert direction is not None and direction.upper() in 'IJK'
-            axis = 'KJI'.index(direction.upper())
-            shape_list = [support.nk, support.nj, support.ni]
-            shape_list[axis] += 1  # note: properties for grid faces include outer faces
-         elif indexable_element == 'column edges':
-            shape_list = [(support.nj * (support.ni + 1)) + ((support.nj + 1) * support.ni)
-                         ]  # I edges first; include outer edges
-         elif indexable_element == 'edges per column':
-            shape_list = [support.nj, support.ni, 4]  # assume I-, J+, I+, J- ordering
-         elif indexable_element == 'faces per cell':
-            shape_list = [support.nk, support.nj, support.ni, 6]  # assume K-, K+, J-, I+, J+, I- ordering
-            # TODO: resolve ordering of edges and make consistent with maps code (edges per column) and fault module (gcs faces)
-         elif indexable_element == 'nodes per cell':
-            shape_list = [support.nk, support.nj, support.ni, 2, 2,
-                          2]  # kp, jp, ip within each cell; todo: check RESQML shaping
-         elif indexable_element == 'nodes':
-            assert not support.k_gaps, 'indexable element of nodes not currently supported for grids with K gaps'
-            if support.has_split_coordinate_lines:
-               pillar_count = (support.nj + 1) * (support.ni + 1) + support.split_pillars_count
-               shape_list = [support.nk + 1, pillar_count]
-            else:
-               shape_list = [support.nk + 1, support.nj + 1, support.ni + 1]
+        if isinstance(support, grr.Grid):
+            if indexable_element is None or indexable_element == 'cells':
+                shape_list = [support.nk, support.nj, support.ni]
+            elif indexable_element == 'columns':
+                shape_list = [support.nj, support.ni]
+            elif indexable_element == 'layers':
+                shape_list = [support.nk]
+            elif indexable_element == 'faces':
+                assert direction is not None and direction.upper() in 'IJK'
+                axis = 'KJI'.index(direction.upper())
+                shape_list = [support.nk, support.nj, support.ni]
+                shape_list[axis] += 1  # note: properties for grid faces include outer faces
+            elif indexable_element == 'column edges':
+                shape_list = [(support.nj * (support.ni + 1)) + ((support.nj + 1) * support.ni)
+                             ]  # I edges first; include outer edges
+            elif indexable_element == 'edges per column':
+                shape_list = [support.nj, support.ni, 4]  # assume I-, J+, I+, J- ordering
+            elif indexable_element == 'faces per cell':
+                shape_list = [support.nk, support.nj, support.ni, 6]  # assume K-, K+, J-, I+, J+, I- ordering
+                # TODO: resolve ordering of edges and make consistent with maps code (edges per column) and fault module (gcs faces)
+            elif indexable_element == 'nodes per cell':
+                shape_list = [support.nk, support.nj, support.ni, 2, 2,
+                              2]  # kp, jp, ip within each cell; todo: check RESQML shaping
+            elif indexable_element == 'nodes':
+                assert not support.k_gaps, 'indexable element of nodes not currently supported for grids with K gaps'
+                if support.has_split_coordinate_lines:
+                    pillar_count = (support.nj + 1) * (support.ni + 1) + support.split_pillars_count
+                    shape_list = [support.nk + 1, pillar_count]
+                else:
+                    shape_list = [support.nk + 1, support.nj + 1, support.ni + 1]
 
-      elif isinstance(support, rqw.WellboreFrame):
-         if indexable_element is None or indexable_element == 'nodes':
-            shape_list = [support.node_count]
-         elif indexable_element == 'intervals':
-            shape_list = [support.node_count - 1]
+        elif isinstance(support, rqw.WellboreFrame):
+            if indexable_element is None or indexable_element == 'nodes':
+                shape_list = [support.node_count]
+            elif indexable_element == 'intervals':
+                shape_list = [support.node_count - 1]
 
-      elif isinstance(support, rqw.BlockedWell):
-         if indexable_element is None or indexable_element == 'intervals':
-            shape_list = [support.node_count - 1]  # all intervals, including unblocked
+        elif isinstance(support, rqw.BlockedWell):
+            if indexable_element is None or indexable_element == 'intervals':
+                shape_list = [support.node_count - 1]  # all intervals, including unblocked
 
 
 #            shape_list = [support.cell_count]  # for blocked intervals only – use 'cells' as indexable element
-         elif indexable_element == 'nodes':
-            shape_list = [support.node_count]
-         elif indexable_element == 'cells':
-            shape_list = [support.cell_count]  # ie. blocked intervals only
+            elif indexable_element == 'nodes':
+                shape_list = [support.node_count]
+            elif indexable_element == 'cells':
+                shape_list = [support.cell_count]  # ie. blocked intervals only
 
-      elif isinstance(support, rqs.Mesh):
-         if indexable_element is None or indexable_element == 'cells' or indexable_element == 'columns':
-            shape_list = [support.nj - 1, support.ni - 1]
-         elif indexable_element == 'nodes':
-            shape_list = [support.nj, support.ni]
+        elif isinstance(support, rqs.Mesh):
+            if indexable_element is None or indexable_element == 'cells' or indexable_element == 'columns':
+                shape_list = [support.nj - 1, support.ni - 1]
+            elif indexable_element == 'nodes':
+                shape_list = [support.nj, support.ni]
 
-      elif isinstance(support, rqf.GridConnectionSet):
-         if indexable_element is None or indexable_element == 'faces':
-            shape_list = [support.count]
+        elif isinstance(support, rqf.GridConnectionSet):
+            if indexable_element is None or indexable_element == 'faces':
+                shape_list = [support.count]
 
-      elif type(support) in [
-            rug.UnstructuredGrid, rug.HexaGrid, rug.TetraGrid, rug.PrismGrid, rug.VerticalPrismGrid, rug.PyramidGrid
-      ]:
-         if indexable_element is None or indexable_element == 'cells':
-            shape_list = [support.cell_count]
-         elif indexable_element == 'faces per cell':
-            support.cache_all_geometry_arrays()
-            shape_list = [len(support.faces_per_cell)]
+        elif type(support) in [
+                rug.UnstructuredGrid, rug.HexaGrid, rug.TetraGrid, rug.PrismGrid, rug.VerticalPrismGrid, rug.PyramidGrid
+        ]:
+            if indexable_element is None or indexable_element == 'cells':
+                shape_list = [support.cell_count]
+            elif indexable_element == 'faces per cell':
+                support.cache_all_geometry_arrays()
+                shape_list = [len(support.faces_per_cell)]
 
-      else:
-         raise Exception(f'unsupported support class {type(support)} for property')
+        else:
+            raise Exception(f'unsupported support class {type(support)} for property')
 
-      return shape_list
+        return shape_list
 
-   def populate_from_property_set(self, property_set_root):
-      """Populates this (newly created) collection based on xml members of property set."""
+    def populate_from_property_set(self, property_set_root):
+        """Populates this (newly created) collection based on xml members of property set."""
 
-      assert property_set_root is not None, 'missing property set xml root'
-      assert self.model is not None and self.support is not None, 'set support for collection before populating from property set'
+        assert property_set_root is not None, 'missing property set xml root'
+        assert self.model is not None and self.support is not None, 'set support for collection before populating from property set'
 
-      self.property_set_root = property_set_root
-      self.time_set_kind_attr = rqet.find_tag_text(property_set_root, 'TimeSetKind')
-      self.has_single_property_kind_flag = rqet.find_tag_bool(property_set_root, 'HasSinglePropertyKind')
-      self.has_multiple_realizations_flag = rqet.find_tag_bool(property_set_root, 'HasMultipleRealizations')
-      parent_set_ref_root = rqet.find_tag(property_set_root, 'ParentSet')  # at most one parent set handled here
-      if parent_set_ref_root is not None:
-         self.parent_set_root = self.model.referenced_node(parent_set_ref_root)
-      # loop over properties in property set xml, adding parts to main dictionary
-      for child in property_set_root:
-         if rqet.stripped_of_prefix(child.tag) != 'Properties':
-            continue
-         property_root = self.model.referenced_node(child)
-         if property_root is None:
-            log.warning('property set member missing from resqml dataset')
-            continue
-         self.add_part_to_dict(rqet.part_name_for_part_root(property_root))
+        self.property_set_root = property_set_root
+        self.time_set_kind_attr = rqet.find_tag_text(property_set_root, 'TimeSetKind')
+        self.has_single_property_kind_flag = rqet.find_tag_bool(property_set_root, 'HasSinglePropertyKind')
+        self.has_multiple_realizations_flag = rqet.find_tag_bool(property_set_root, 'HasMultipleRealizations')
+        parent_set_ref_root = rqet.find_tag(property_set_root, 'ParentSet')  # at most one parent set handled here
+        if parent_set_ref_root is not None:
+            self.parent_set_root = self.model.referenced_node(parent_set_ref_root)
+        # loop over properties in property set xml, adding parts to main dictionary
+        for child in property_set_root:
+            if rqet.stripped_of_prefix(child.tag) != 'Properties':
+                continue
+            property_root = self.model.referenced_node(child)
+            if property_root is None:
+                log.warning('property set member missing from resqml dataset')
+                continue
+            self.add_part_to_dict(rqet.part_name_for_part_root(property_root))
 
-   def set_realization(self, realization):
-      """Sets the model realization number (within an ensemble) for this collection.
+    def set_realization(self, realization):
+        """Sets the model realization number (within an ensemble) for this collection.
 
          argument:
             realization (non-negative integer): the realization number of the whole collection within an ensemble of
@@ -419,12 +421,12 @@ class PropertyCollection():
             provided
       """
 
-      # the following assertion might need to be downgraded to a warning, to allow for reassignment of realization numbers
-      assert self.realization is None
-      self.realization = realization
+        # the following assertion might need to be downgraded to a warning, to allow for reassignment of realization numbers
+        assert self.realization is None
+        self.realization = realization
 
-   def add_part_to_dict(self, part, continuous = None, realization = None, trust_uom = True):
-      """Add the named part to the dictionary for this collection.
+    def add_part_to_dict(self, part, continuous = None, realization = None, trust_uom = True):
+        """Add the named part to the dictionary for this collection.
 
          arguments:
             part (string): the name of a part (which exists in the support's parent model) to be added to this collection
@@ -441,121 +443,124 @@ class PropertyCollection():
                      note that this guessed value is not used to overwrite the value in the xml
       """
 
-      if part is None:
-         return
-      assert part not in self.dict
-      if realization is not None and self.realization is not None:
-         assert (realization == self.realization)
-      if realization is None:
-         realization = self.realization
-      uuid = self.model.uuid_for_part(part, is_rels = False)
-      assert uuid is not None
-      xml_node = self.model.root_for_part(part, is_rels = False)
-      assert xml_node is not None
-      type = self.model.type_of_part(part)
-      #      log.debug('adding part ' + part + ' of type ' + type)
-      assert type in ['obj_ContinuousProperty', 'obj_DiscreteProperty', 'obj_CategoricalProperty', 'obj_PointsProperty']
-      if continuous is None:
-         continuous = (type in ['obj_ContinuousProperty', 'obj_PointsProperty'])
-      else:
-         assert continuous == (type in ['obj_ContinuousProperty', 'obj_PointsProperty'])
-      points = (type == 'obj_PointsProperty')
-      string_lookup_uuid = None
-      if type == 'obj_CategoricalProperty':
-         sl_ref_node = rqet.find_tag(xml_node, 'Lookup')
-         string_lookup_uuid = bu.uuid_from_string(rqet.find_tag_text(sl_ref_node, 'UUID'))
-      extra_metadata = rqet.load_metadata_from_xml(xml_node)
-      count_node = rqet.find_tag(xml_node, 'Count')
-      assert count_node is not None
-      count = int(count_node.text)
-      realization_node = rqet.find_tag(xml_node, 'RealizationIndex')  # optional; if present use to populate realization
-      if realization_node is not None:
-         realization = int(realization_node.text)
-      indexable_node = rqet.find_tag(xml_node, 'IndexableElement')
-      assert indexable_node is not None
-      indexable = indexable_node.text
-      citation_title = rqet.find_tag(rqet.find_tag(xml_node, 'Citation'), 'Title').text
-      (p_kind_from_keyword, facet_type, facet) = property_kind_and_facet_from_keyword(citation_title)
-      prop_kind_node = rqet.find_tag(xml_node, 'PropertyKind')
-      assert (prop_kind_node is not None)
-      kind_node = rqet.find_tag(prop_kind_node, 'Kind')
-      property_kind_uuid = None  # only used for bespoke (local) property kinds
-      if kind_node is not None:
-         property_kind = kind_node.text  # could check for consistency with that derived from citation title
-      else:
-         lpk_node = rqet.find_tag(prop_kind_node, 'LocalPropertyKind')
-         if lpk_node is not None:
-            property_kind = rqet.find_tag_text(lpk_node, 'Title')
-            property_kind_uuid = rqet.find_tag_text(lpk_node, 'UUID')
-      assert property_kind is not None and len(property_kind) > 0
-      if (p_kind_from_keyword and p_kind_from_keyword != property_kind and
-          (p_kind_from_keyword not in ['cell length', 'length', 'thickness'] or
-           property_kind not in ['cell length', 'length', 'thickness'])):
-         log.warning(
-            f'property kind {property_kind} not the expected {p_kind_from_keyword} for keyword {citation_title}')
-      facet_type = None
-      facet = None
-      facet_node = rqet.find_tag(xml_node, 'Facet')  # todo: handle more than one facet for a property
-      if facet_node is not None:
-         facet_type = rqet.find_tag(facet_node, 'Facet').text
-         facet = rqet.find_tag(facet_node, 'Value').text
-         if facet_type is not None and facet_type == '':
-            facet_type = None
-         if facet is not None and facet == '':
-            facet = None
-      time_series_uuid = None
-      time_index = None
-      time_node = rqet.find_tag(xml_node, 'TimeIndex')
-      if time_node is not None:
-         time_index = int(rqet.find_tag(time_node, 'Index').text)
-         time_series_uuid = bu.uuid_from_string(rqet.find_tag(rqet.find_tag(time_node, 'TimeSeries'), 'UUID').text)
-      minimum = None
-      min_node = rqet.find_tag(xml_node, 'MinimumValue')
-      if min_node is not None:
-         minimum = min_node.text  # NB: left as text
-      maximum = None
-      max_node = rqet.find_tag(xml_node, 'MaximumValue')
-      if max_node is not None:
-         maximum = max_node.text  # NB: left as text
-      uom = None
-      support_uuid = self.model.supporting_representation_for_part(part)
-      if support_uuid is None:
-         support_uuid = self.support_uuid
-      elif self.support_uuid is None:
-         self.set_support(support_uuid)
-      elif not bu.matching_uuids(support_uuid, self.support.uuid):  # multi-support collection
-         self.set_support(None)
-      if isinstance(support_uuid, str):
-         support_uuid = bu.uuid_from_string(support_uuid)
-      if continuous:
-         uom_node = rqet.find_tag(xml_node, 'UOM')
-         if uom_node is not None and (trust_uom or uom_node.text not in ['', 'Euc']):
-            uom = uom_node.text
-         else:
-            uom = guess_uom(property_kind, minimum, maximum, self.support, facet_type = facet_type, facet = facet)
-      null_value = None
-      if not continuous:
-         null_value = rqet.find_nested_tags_int(xml_node, ['PatchOfValues', 'Values', 'NullValue'])
-      const_value = None
-      if points:
-         values_node = rqet.find_nested_tags(xml_node, ['PatchOfPoints', 'Points'])
-      else:
-         values_node = rqet.find_nested_tags(xml_node, ['PatchOfValues', 'Values'])
-      values_type = rqet.node_type(values_node)
-      assert values_type is not None
-      if values_type.endswith('ConstantArray'):
-         if continuous:
-            const_value = rqet.find_tag_float(values_node, 'Value')
-         elif values_type.startswith('Bool'):
-            const_value = rqet.find_tag_bool(values_node, 'Value')
-         else:
-            const_value = rqet.find_tag_int(values_node, 'Value')
-      self.dict[part] = (realization, support_uuid, uuid, xml_node, continuous, count, indexable, property_kind,
-                         facet_type, facet, citation_title, time_series_uuid, time_index, minimum, maximum, uom,
-                         string_lookup_uuid, property_kind_uuid, extra_metadata, null_value, const_value, points)
+        if part is None:
+            return
+        assert part not in self.dict
+        if realization is not None and self.realization is not None:
+            assert (realization == self.realization)
+        if realization is None:
+            realization = self.realization
+        uuid = self.model.uuid_for_part(part, is_rels = False)
+        assert uuid is not None
+        xml_node = self.model.root_for_part(part, is_rels = False)
+        assert xml_node is not None
+        type = self.model.type_of_part(part)
+        #      log.debug('adding part ' + part + ' of type ' + type)
+        assert type in [
+            'obj_ContinuousProperty', 'obj_DiscreteProperty', 'obj_CategoricalProperty', 'obj_PointsProperty'
+        ]
+        if continuous is None:
+            continuous = (type in ['obj_ContinuousProperty', 'obj_PointsProperty'])
+        else:
+            assert continuous == (type in ['obj_ContinuousProperty', 'obj_PointsProperty'])
+        points = (type == 'obj_PointsProperty')
+        string_lookup_uuid = None
+        if type == 'obj_CategoricalProperty':
+            sl_ref_node = rqet.find_tag(xml_node, 'Lookup')
+            string_lookup_uuid = bu.uuid_from_string(rqet.find_tag_text(sl_ref_node, 'UUID'))
+        extra_metadata = rqet.load_metadata_from_xml(xml_node)
+        count_node = rqet.find_tag(xml_node, 'Count')
+        assert count_node is not None
+        count = int(count_node.text)
+        realization_node = rqet.find_tag(xml_node,
+                                         'RealizationIndex')  # optional; if present use to populate realization
+        if realization_node is not None:
+            realization = int(realization_node.text)
+        indexable_node = rqet.find_tag(xml_node, 'IndexableElement')
+        assert indexable_node is not None
+        indexable = indexable_node.text
+        citation_title = rqet.find_tag(rqet.find_tag(xml_node, 'Citation'), 'Title').text
+        (p_kind_from_keyword, facet_type, facet) = property_kind_and_facet_from_keyword(citation_title)
+        prop_kind_node = rqet.find_tag(xml_node, 'PropertyKind')
+        assert (prop_kind_node is not None)
+        kind_node = rqet.find_tag(prop_kind_node, 'Kind')
+        property_kind_uuid = None  # only used for bespoke (local) property kinds
+        if kind_node is not None:
+            property_kind = kind_node.text  # could check for consistency with that derived from citation title
+        else:
+            lpk_node = rqet.find_tag(prop_kind_node, 'LocalPropertyKind')
+            if lpk_node is not None:
+                property_kind = rqet.find_tag_text(lpk_node, 'Title')
+                property_kind_uuid = rqet.find_tag_text(lpk_node, 'UUID')
+        assert property_kind is not None and len(property_kind) > 0
+        if (p_kind_from_keyword and p_kind_from_keyword != property_kind and
+            (p_kind_from_keyword not in ['cell length', 'length', 'thickness'] or
+             property_kind not in ['cell length', 'length', 'thickness'])):
+            log.warning(
+                f'property kind {property_kind} not the expected {p_kind_from_keyword} for keyword {citation_title}')
+        facet_type = None
+        facet = None
+        facet_node = rqet.find_tag(xml_node, 'Facet')  # todo: handle more than one facet for a property
+        if facet_node is not None:
+            facet_type = rqet.find_tag(facet_node, 'Facet').text
+            facet = rqet.find_tag(facet_node, 'Value').text
+            if facet_type is not None and facet_type == '':
+                facet_type = None
+            if facet is not None and facet == '':
+                facet = None
+        time_series_uuid = None
+        time_index = None
+        time_node = rqet.find_tag(xml_node, 'TimeIndex')
+        if time_node is not None:
+            time_index = int(rqet.find_tag(time_node, 'Index').text)
+            time_series_uuid = bu.uuid_from_string(rqet.find_tag(rqet.find_tag(time_node, 'TimeSeries'), 'UUID').text)
+        minimum = None
+        min_node = rqet.find_tag(xml_node, 'MinimumValue')
+        if min_node is not None:
+            minimum = min_node.text  # NB: left as text
+        maximum = None
+        max_node = rqet.find_tag(xml_node, 'MaximumValue')
+        if max_node is not None:
+            maximum = max_node.text  # NB: left as text
+        uom = None
+        support_uuid = self.model.supporting_representation_for_part(part)
+        if support_uuid is None:
+            support_uuid = self.support_uuid
+        elif self.support_uuid is None:
+            self.set_support(support_uuid)
+        elif not bu.matching_uuids(support_uuid, self.support.uuid):  # multi-support collection
+            self.set_support(None)
+        if isinstance(support_uuid, str):
+            support_uuid = bu.uuid_from_string(support_uuid)
+        if continuous:
+            uom_node = rqet.find_tag(xml_node, 'UOM')
+            if uom_node is not None and (trust_uom or uom_node.text not in ['', 'Euc']):
+                uom = uom_node.text
+            else:
+                uom = guess_uom(property_kind, minimum, maximum, self.support, facet_type = facet_type, facet = facet)
+        null_value = None
+        if not continuous:
+            null_value = rqet.find_nested_tags_int(xml_node, ['PatchOfValues', 'Values', 'NullValue'])
+        const_value = None
+        if points:
+            values_node = rqet.find_nested_tags(xml_node, ['PatchOfPoints', 'Points'])
+        else:
+            values_node = rqet.find_nested_tags(xml_node, ['PatchOfValues', 'Values'])
+        values_type = rqet.node_type(values_node)
+        assert values_type is not None
+        if values_type.endswith('ConstantArray'):
+            if continuous:
+                const_value = rqet.find_tag_float(values_node, 'Value')
+            elif values_type.startswith('Bool'):
+                const_value = rqet.find_tag_bool(values_node, 'Value')
+            else:
+                const_value = rqet.find_tag_int(values_node, 'Value')
+        self.dict[part] = (realization, support_uuid, uuid, xml_node, continuous, count, indexable, property_kind,
+                           facet_type, facet, citation_title, time_series_uuid, time_index, minimum, maximum, uom,
+                           string_lookup_uuid, property_kind_uuid, extra_metadata, null_value, const_value, points)
 
-   def add_parts_list_to_dict(self, parts_list):
-      """Add all the parts named in the parts list to the dictionary for this collection.
+    def add_parts_list_to_dict(self, parts_list):
+        """Add all the parts named in the parts list to the dictionary for this collection.
 
       argument:
          parts_list: a list of strings, each being the name of a part in the support's parent model
@@ -564,11 +569,11 @@ class PropertyCollection():
          the add_part_to_dict() function is called for each part in the list
       """
 
-      for part in parts_list:
-         self.add_part_to_dict(part)
+        for part in parts_list:
+            self.add_part_to_dict(part)
 
-   def remove_part_from_dict(self, part):
-      """Remove the named part from the dictionary for this collection.
+    def remove_part_from_dict(self, part):
+        """Remove the named part from the dictionary for this collection.
 
       argument:
          part (string): the name of a part which might be in this collection, to be removed
@@ -577,14 +582,14 @@ class PropertyCollection():
          if the part is not in the collection, no action is taken and no exception is raised
       """
 
-      if part is None:
-         return
-      if part not in self.dict:
-         return
-      del self.dict[part]
+        if part is None:
+            return
+        if part not in self.dict:
+            return
+        del self.dict[part]
 
-   def remove_parts_list_from_dict(self, parts_list):
-      """Remove all the parts named in the parts list from the dictionary for this collection.
+    def remove_parts_list_from_dict(self, parts_list):
+        """Remove all the parts named in the parts list from the dictionary for this collection.
 
       argument:
          parts_list: a list of strings, each being the name of a part which might be in the collection
@@ -593,11 +598,11 @@ class PropertyCollection():
          the remove_part_from_dict() function is called for each part in the list
       """
 
-      for part in parts_list:
-         self.remove_part_from_dict(part)
+        for part in parts_list:
+            self.remove_part_from_dict(part)
 
-   def inherit_imported_list_from_other_collection(self, other, copy_cached_arrays = True, exclude_inactive = False):
-      """Extends this collection's imported list with items from other's imported list.
+    def inherit_imported_list_from_other_collection(self, other, copy_cached_arrays = True, exclude_inactive = False):
+        """Extends this collection's imported list with items from other's imported list.
 
       arguments:
          other: another PropertyCollection object with some imported arrays
@@ -612,24 +617,24 @@ class PropertyCollection():
          of the support's parent model and writing the arrays to the hdf5 file
       """
 
-      # note: does not inherit parts
-      if exclude_inactive:
-         other_list = []
-         for imp in other.imported_list:
-            if imp[2].upper() not in ['INACTIVE', 'ACTIVE']:
-               other_list.append(imp)
-      else:
-         other_list = other.imported_list
-      self.imported_list += other_list
-      if copy_cached_arrays:
-         for imp in other_list:
-            if imp[17] is not None:
-               continue  # constant array
-            cached_name = imp[3]
-            self.__dict__[cached_name] = other.__dict__[cached_name].copy()
+        # note: does not inherit parts
+        if exclude_inactive:
+            other_list = []
+            for imp in other.imported_list:
+                if imp[2].upper() not in ['INACTIVE', 'ACTIVE']:
+                    other_list.append(imp)
+        else:
+            other_list = other.imported_list
+        self.imported_list += other_list
+        if copy_cached_arrays:
+            for imp in other_list:
+                if imp[17] is not None:
+                    continue  # constant array
+                cached_name = imp[3]
+                self.__dict__[cached_name] = other.__dict__[cached_name].copy()
 
-   def inherit_parts_from_other_collection(self, other, ignore_clashes = False):
-      """Adds all the parts in the other PropertyCollection to this one.
+    def inherit_parts_from_other_collection(self, other, ignore_clashes = False):
+        """Adds all the parts in the other PropertyCollection to this one.
 
       Arguments:
          other: another PropertyCollection object related to the same support as this collection
@@ -638,21 +643,21 @@ class PropertyCollection():
             simply skipped without modifying the existing part in this collection
       """
 
-      assert self.support_uuid is None or other.support_uuid is None or bu.matching_uuids(
-         self.support_uuid, other.support_uuid)
-      if self.support_uuid is None and self.number_of_parts() == 0 and other.support_uuid is not None:
-         self.set_support(support_uuid = other.support_uuid, support = other.support)
-      if self.realization is not None and other.realization is not None:
-         assert self.realization == other.realization
-      for (part, info) in other.dict.items():
-         if part in self.dict.keys():
-            if ignore_clashes:
-               continue
-            assert False, 'attempt to inherit a part which already exists in property collection: ' + part
-         self.dict[part] = info
+        assert self.support_uuid is None or other.support_uuid is None or bu.matching_uuids(
+            self.support_uuid, other.support_uuid)
+        if self.support_uuid is None and self.number_of_parts() == 0 and other.support_uuid is not None:
+            self.set_support(support_uuid = other.support_uuid, support = other.support)
+        if self.realization is not None and other.realization is not None:
+            assert self.realization == other.realization
+        for (part, info) in other.dict.items():
+            if part in self.dict.keys():
+                if ignore_clashes:
+                    continue
+                assert False, 'attempt to inherit a part which already exists in property collection: ' + part
+            self.dict[part] = info
 
-   def add_to_imported_list_sampling_other_collection(self, other, flattened_indices):
-      """Makes cut down copies of parts from other collection, using indices, and adds to imported list.
+    def add_to_imported_list_sampling_other_collection(self, other, flattened_indices):
+        """Makes cut down copies of parts from other collection, using indices, and adds to imported list.
 
       arguments:
         other (PropertyCollection): the source collection whose arrays will be sampled
@@ -668,54 +673,54 @@ class PropertyCollection():
         of the imported list
       """
 
-      source = 'sampled'
-      if other.support is not None:
-         source += ' from property for ' + str(other.support.title)
-      for (part, info) in other.dict.items():
-         target_shape = self.supporting_shape(indexable_element = other.indexable_for_part(part),
-                                              direction = other._part_direction(part))
-         assert np.prod(target_shape) == flattened_indices.size
-         a = other.cached_part_array_ref(part).flatten()[flattened_indices].reshape(target_shape)
-         self.add_cached_array_to_imported_list(a,
-                                                source,
-                                                info[10],
-                                                discrete = not info[4],
-                                                uom = info[15],
-                                                time_index = info[12],
-                                                null_value = info[19],
-                                                property_kind = info[7],
-                                                local_property_kind_uuid = info[17],
-                                                facet_type = info[8],
-                                                facet = info[9],
-                                                realization = info[0],
-                                                indexable_element = info[6],
-                                                count = info[5],
-                                                const_value = info[20],
-                                                points = info[21])
+        source = 'sampled'
+        if other.support is not None:
+            source += ' from property for ' + str(other.support.title)
+        for (part, info) in other.dict.items():
+            target_shape = self.supporting_shape(indexable_element = other.indexable_for_part(part),
+                                                 direction = other._part_direction(part))
+            assert np.prod(target_shape) == flattened_indices.size
+            a = other.cached_part_array_ref(part).flatten()[flattened_indices].reshape(target_shape)
+            self.add_cached_array_to_imported_list(a,
+                                                   source,
+                                                   info[10],
+                                                   discrete = not info[4],
+                                                   uom = info[15],
+                                                   time_index = info[12],
+                                                   null_value = info[19],
+                                                   property_kind = info[7],
+                                                   local_property_kind_uuid = info[17],
+                                                   facet_type = info[8],
+                                                   facet = info[9],
+                                                   realization = info[0],
+                                                   indexable_element = info[6],
+                                                   count = info[5],
+                                                   const_value = info[20],
+                                                   points = info[21])
 
-   def inherit_parts_selectively_from_other_collection(
-         self,
-         other,
-         realization = None,
-         support_uuid = None,
-         grid = None,  # for backward compatibility
-         uuid = None,
-         continuous = None,
-         count = None,
-         points = None,
-         indexable = None,
-         property_kind = None,
-         facet_type = None,
-         facet = None,
-         citation_title = None,
-         citation_title_match_starts_with = False,
-         time_series_uuid = None,
-         time_index = None,
-         uom = None,
-         string_lookup_uuid = None,
-         categorical = None,
-         ignore_clashes = False):
-      """Adds those parts from the other PropertyCollection which match all arguments that are not None.
+    def inherit_parts_selectively_from_other_collection(
+            self,
+            other,
+            realization = None,
+            support_uuid = None,
+            grid = None,  # for backward compatibility
+            uuid = None,
+            continuous = None,
+            count = None,
+            points = None,
+            indexable = None,
+            property_kind = None,
+            facet_type = None,
+            facet = None,
+            citation_title = None,
+            citation_title_match_starts_with = False,
+            time_series_uuid = None,
+            time_index = None,
+            uom = None,
+            string_lookup_uuid = None,
+            categorical = None,
+            ignore_clashes = False):
+        """Adds those parts from the other PropertyCollection which match all arguments that are not None.
 
       arguments:
          other: another PropertyCollection object related to the same support as this collection
@@ -741,79 +746,79 @@ class PropertyCollection():
 
       """
 
-      #      log.debug('inheriting parts selectively')
-      if support_uuid is None and grid is not None:
-         support_uuid = grid.uuid
-      if support_uuid is not None and self.support_uuid is not None:
-         assert bu.matching_uuids(support_uuid, self.support_uuid)
-      assert other is not None
-      if self.model is None:
-         self.model = other.model
-      else:
-         assert self.model is other.model
-      assert self.support_uuid is None or other.support_uuid is None or bu.matching_uuids(
-         self.support_uuid, other.support_uuid)
-      if self.support_uuid is None and self.number_of_parts() == 0:
-         self.set_support(support_uuid = other.support_uuid, support = other.support)
-      if self.realization is not None and other.realization is not None:
-         assert self.realization == other.realization
-      if time_index is not None:
-         assert time_index >= 0
-      for (part, info) in other.dict.items():
-         if realization is not None and other.realization_for_part(part) != realization:
-            continue
-         if support_uuid is not None and not bu.matching_uuids(support_uuid, other.support_uuid_for_part(part)):
-            continue
-         if uuid is not None and not bu.matching_uuids(uuid, other.uuid_for_part(part)):
-            continue
-         if continuous is not None and other.continuous_for_part(part) != continuous:
-            continue
-         if categorical is not None:
-            if categorical:
-               if other.continuous_for_part(part) or (other.string_lookup_uuid_for_part(part) is None):
-                  continue
-            else:
-               if not (other.continuous_for_part(part) or (other.string_lookup_uuid_for_part(part) is None)):
-                  continue
-         if count is not None and other.count_for_part(part) != count:
-            continue
-         if points is not None and other.points_for_part(part) != points:
-            continue
-         if indexable is not None and other.indexable_for_part(part) != indexable:
-            continue
-         if property_kind is not None and not same_property_kind(other.property_kind_for_part(part), property_kind):
-            continue
-         if facet_type is not None and other.facet_type_for_part(part) != facet_type:
-            continue
-         if facet is not None and other.facet_for_part(part) != facet:
-            continue
-         if citation_title is not None:
-            if citation_title_match_starts_with:
-               if not other.citation_title_for_part(part).startswith():
-                  continue
-            else:
-               if other.citation_title_for_part(part) != citation_title:
-                  continue
-         if time_series_uuid is not None and not bu.matching_uuids(time_series_uuid,
-                                                                   other.time_series_uuid_for_part(part)):
-            continue
-         if time_index is not None and other.time_index_for_part(part) != time_index:
-            continue
-         if string_lookup_uuid is not None and not bu.matching_uuids(string_lookup_uuid,
-                                                                     other.string_lookup_uuid_for_part(part)):
-            continue
-         if part in self.dict.keys():
-            if ignore_clashes:
-               continue
-            assert (False)
-         self.dict[part] = other.dict[part]
+        #      log.debug('inheriting parts selectively')
+        if support_uuid is None and grid is not None:
+            support_uuid = grid.uuid
+        if support_uuid is not None and self.support_uuid is not None:
+            assert bu.matching_uuids(support_uuid, self.support_uuid)
+        assert other is not None
+        if self.model is None:
+            self.model = other.model
+        else:
+            assert self.model is other.model
+        assert self.support_uuid is None or other.support_uuid is None or bu.matching_uuids(
+            self.support_uuid, other.support_uuid)
+        if self.support_uuid is None and self.number_of_parts() == 0:
+            self.set_support(support_uuid = other.support_uuid, support = other.support)
+        if self.realization is not None and other.realization is not None:
+            assert self.realization == other.realization
+        if time_index is not None:
+            assert time_index >= 0
+        for (part, info) in other.dict.items():
+            if realization is not None and other.realization_for_part(part) != realization:
+                continue
+            if support_uuid is not None and not bu.matching_uuids(support_uuid, other.support_uuid_for_part(part)):
+                continue
+            if uuid is not None and not bu.matching_uuids(uuid, other.uuid_for_part(part)):
+                continue
+            if continuous is not None and other.continuous_for_part(part) != continuous:
+                continue
+            if categorical is not None:
+                if categorical:
+                    if other.continuous_for_part(part) or (other.string_lookup_uuid_for_part(part) is None):
+                        continue
+                else:
+                    if not (other.continuous_for_part(part) or (other.string_lookup_uuid_for_part(part) is None)):
+                        continue
+            if count is not None and other.count_for_part(part) != count:
+                continue
+            if points is not None and other.points_for_part(part) != points:
+                continue
+            if indexable is not None and other.indexable_for_part(part) != indexable:
+                continue
+            if property_kind is not None and not same_property_kind(other.property_kind_for_part(part), property_kind):
+                continue
+            if facet_type is not None and other.facet_type_for_part(part) != facet_type:
+                continue
+            if facet is not None and other.facet_for_part(part) != facet:
+                continue
+            if citation_title is not None:
+                if citation_title_match_starts_with:
+                    if not other.citation_title_for_part(part).startswith():
+                        continue
+                else:
+                    if other.citation_title_for_part(part) != citation_title:
+                        continue
+            if time_series_uuid is not None and not bu.matching_uuids(time_series_uuid,
+                                                                      other.time_series_uuid_for_part(part)):
+                continue
+            if time_index is not None and other.time_index_for_part(part) != time_index:
+                continue
+            if string_lookup_uuid is not None and not bu.matching_uuids(string_lookup_uuid,
+                                                                        other.string_lookup_uuid_for_part(part)):
+                continue
+            if part in self.dict.keys():
+                if ignore_clashes:
+                    continue
+                assert (False)
+            self.dict[part] = other.dict[part]
 
-   def inherit_similar_parts_for_time_series_from_other_collection(self,
-                                                                   other,
-                                                                   example_part,
-                                                                   citation_title_match_starts_with = False,
-                                                                   ignore_clashes = False):
-      """Adds the example part from other collection and any other parts for the same property at different times.
+    def inherit_similar_parts_for_time_series_from_other_collection(self,
+                                                                    other,
+                                                                    example_part,
+                                                                    citation_title_match_starts_with = False,
+                                                                    ignore_clashes = False):
+        """Adds the example part from other collection and any other parts for the same property at different times.
 
       arguments:
          other: another PropertyCollection object related to the same grid as this collection, from which to inherit
@@ -829,35 +834,35 @@ class PropertyCollection():
          inherited
       """
 
-      assert other is not None
-      assert other.part_in_collection(example_part)
-      time_series_uuid = other.time_series_uuid_for_part(example_part)
-      assert time_series_uuid is not None
-      title = other.citation_title_for_part(example_part)
-      if citation_title_match_starts_with:
-         while title and title[-1].isdigit():
-            title = title[:-1]
-      self.inherit_parts_selectively_from_other_collection(
-         other,
-         realization = other.realization_for_part(example_part),
-         support_uuid = other.support_uuid_for_part(example_part),
-         continuous = other.continuous_for_part(example_part),
-         points = other.points_for_part(example_part),
-         indexable = other.indexable_for_part(example_part),
-         property_kind = other.property_kind_for_part(example_part),
-         facet_type = other.facet_type_for_part(example_part),
-         facet = other.facet_for_part(example_part),
-         citation_title = title,
-         citation_title_match_starts_with = citation_title_match_starts_with,
-         time_series_uuid = time_series_uuid,
-         ignore_clashes = ignore_clashes)
+        assert other is not None
+        assert other.part_in_collection(example_part)
+        time_series_uuid = other.time_series_uuid_for_part(example_part)
+        assert time_series_uuid is not None
+        title = other.citation_title_for_part(example_part)
+        if citation_title_match_starts_with:
+            while title and title[-1].isdigit():
+                title = title[:-1]
+        self.inherit_parts_selectively_from_other_collection(
+            other,
+            realization = other.realization_for_part(example_part),
+            support_uuid = other.support_uuid_for_part(example_part),
+            continuous = other.continuous_for_part(example_part),
+            points = other.points_for_part(example_part),
+            indexable = other.indexable_for_part(example_part),
+            property_kind = other.property_kind_for_part(example_part),
+            facet_type = other.facet_type_for_part(example_part),
+            facet = other.facet_for_part(example_part),
+            citation_title = title,
+            citation_title_match_starts_with = citation_title_match_starts_with,
+            time_series_uuid = time_series_uuid,
+            ignore_clashes = ignore_clashes)
 
-   def inherit_similar_parts_for_facets_from_other_collection(self,
-                                                              other,
-                                                              example_part,
-                                                              citation_title_match_starts_with = False,
-                                                              ignore_clashes = False):
-      """Adds the example part from other collection and any other parts for same property with different facets.
+    def inherit_similar_parts_for_facets_from_other_collection(self,
+                                                               other,
+                                                               example_part,
+                                                               citation_title_match_starts_with = False,
+                                                               ignore_clashes = False):
+        """Adds the example part from other collection and any other parts for same property with different facets.
 
       arguments:
          other: another PropertyCollection object related to the same grid as this collection, from which to inherit
@@ -873,33 +878,33 @@ class PropertyCollection():
          inherited
       """
 
-      # the following RESQML limitation could be reported as a warning here, instead of an assertion
-      assert not other.points_for_part(example_part), 'facets not allowed for RESQML Points properties'
-      assert other is not None
-      assert other.part_in_collection(example_part)
-      title = other.citation_title_for_part(example_part)
-      if citation_title_match_starts_with:
-         while title and title[-1].isdigit():
-            title = title[:-1]
-      self.inherit_parts_selectively_from_other_collection(
-         other,
-         realization = other.realization_for_part(example_part),
-         support_uuid = other.support_uuid_for_part(example_part),
-         continuous = other.continuous_for_part(example_part),
-         points = False,
-         indexable = other.indexable_for_part(example_part),
-         property_kind = other.property_kind_for_part(example_part),
-         citation_title = title,
-         time_series_uuid = other.time_series_uuid_for_part(example_part),
-         time_index = other.time_index_for_part(example_part),
-         ignore_clashes = ignore_clashes)
+        # the following RESQML limitation could be reported as a warning here, instead of an assertion
+        assert not other.points_for_part(example_part), 'facets not allowed for RESQML Points properties'
+        assert other is not None
+        assert other.part_in_collection(example_part)
+        title = other.citation_title_for_part(example_part)
+        if citation_title_match_starts_with:
+            while title and title[-1].isdigit():
+                title = title[:-1]
+        self.inherit_parts_selectively_from_other_collection(
+            other,
+            realization = other.realization_for_part(example_part),
+            support_uuid = other.support_uuid_for_part(example_part),
+            continuous = other.continuous_for_part(example_part),
+            points = False,
+            indexable = other.indexable_for_part(example_part),
+            property_kind = other.property_kind_for_part(example_part),
+            citation_title = title,
+            time_series_uuid = other.time_series_uuid_for_part(example_part),
+            time_index = other.time_index_for_part(example_part),
+            ignore_clashes = ignore_clashes)
 
-   def inherit_similar_parts_for_realizations_from_other_collection(self,
-                                                                    other,
-                                                                    example_part,
-                                                                    citation_title_match_starts_with = False,
-                                                                    ignore_clashes = False):
-      """Adds the example part from other collection and any other parts for same property with different realizations.
+    def inherit_similar_parts_for_realizations_from_other_collection(self,
+                                                                     other,
+                                                                     example_part,
+                                                                     citation_title_match_starts_with = False,
+                                                                     ignore_clashes = False):
+        """Adds the example part from other collection and any other parts for same property with different realizations.
 
       arguments:
          other: another PropertyCollection object related to the same support as this collection, from which to inherit
@@ -915,30 +920,30 @@ class PropertyCollection():
          inherited
       """
 
-      assert other is not None
-      assert other.part_in_collection(example_part)
-      title = other.citation_title_for_part(example_part)
-      if citation_title_match_starts_with:
-         while title and title[-1].isdigit():
-            title = title[:-1]
-      self.inherit_parts_selectively_from_other_collection(
-         other,
-         realization = None,
-         support_uuid = other.support_uuid_for_part(example_part),
-         continuous = other.continuous_for_part(example_part),
-         points = other.points_for_part(example_part),
-         indexable = other.indexable_for_part(example_part),
-         property_kind = other.property_kind_for_part(example_part),
-         facet_type = other.facet_type_for_part(example_part),
-         facet = other.facet_for_part(example_part),
-         citation_title = title,
-         citation_title_match_starts_with = citation_title_match_starts_with,
-         time_series_uuid = other.time_series_uuid_for_part(example_part),
-         time_index = other.time_index_for_part(example_part),
-         ignore_clashes = ignore_clashes)
+        assert other is not None
+        assert other.part_in_collection(example_part)
+        title = other.citation_title_for_part(example_part)
+        if citation_title_match_starts_with:
+            while title and title[-1].isdigit():
+                title = title[:-1]
+        self.inherit_parts_selectively_from_other_collection(
+            other,
+            realization = None,
+            support_uuid = other.support_uuid_for_part(example_part),
+            continuous = other.continuous_for_part(example_part),
+            points = other.points_for_part(example_part),
+            indexable = other.indexable_for_part(example_part),
+            property_kind = other.property_kind_for_part(example_part),
+            facet_type = other.facet_type_for_part(example_part),
+            facet = other.facet_for_part(example_part),
+            citation_title = title,
+            citation_title_match_starts_with = citation_title_match_starts_with,
+            time_series_uuid = other.time_series_uuid_for_part(example_part),
+            time_index = other.time_index_for_part(example_part),
+            ignore_clashes = ignore_clashes)
 
-   def number_of_imports(self):
-      """Returns the number of property arrays in the imported list for this collection.
+    def number_of_imports(self):
+        """Returns the number of property arrays in the imported list for this collection.
 
       returns:
          count of number of cached property arrays in the imported list for this collection (non-negative integer)
@@ -948,10 +953,10 @@ class PropertyCollection():
          function will return zero at that point, until a new list of imports is built up
       """
 
-      return len(self.imported_list)
+        return len(self.imported_list)
 
-   def parts(self):
-      """Return list of parts in this collection.
+    def parts(self):
+        """Return list of parts in this collection.
 
       returns:
          list of part names (strings) being the members of this collection; there is one part per property array
@@ -959,38 +964,38 @@ class PropertyCollection():
       :meta common:
       """
 
-      return list(self.dict.keys())
+        return list(self.dict.keys())
 
-   def uuids(self):
-      """Return list of uuids in this collection.
+    def uuids(self):
+        """Return list of uuids in this collection.
 
       returns:
          list of uuids being the members of this collection; there is one uuid per property array
 
       :meta common:
       """
-      return [self.model.uuid_for_part(p) for p in self.dict.keys()]
+        return [self.model.uuid_for_part(p) for p in self.dict.keys()]
 
-   def selective_parts_list(
-         self,
-         realization = None,
-         support = None,  # maintained for backward compatibility
-         support_uuid = None,
-         grid = None,  # maintained for backward compatibility
-         continuous = None,
-         points = None,
-         count = None,
-         indexable = None,
-         property_kind = None,
-         facet_type = None,
-         facet = None,
-         citation_title = None,
-         time_series_uuid = None,
-         time_index = None,
-         uom = None,
-         string_lookup_uuid = None,
-         categorical = None):
-      """Returns a list of parts filtered by those arguments which are not None.
+    def selective_parts_list(
+            self,
+            realization = None,
+            support = None,  # maintained for backward compatibility
+            support_uuid = None,
+            grid = None,  # maintained for backward compatibility
+            continuous = None,
+            points = None,
+            count = None,
+            indexable = None,
+            property_kind = None,
+            facet_type = None,
+            facet = None,
+            citation_title = None,
+            time_series_uuid = None,
+            time_index = None,
+            uom = None,
+            string_lookup_uuid = None,
+            categorical = None):
+        """Returns a list of parts filtered by those arguments which are not None.
 
       All arguments are optional.
 
@@ -1009,51 +1014,51 @@ class PropertyCollection():
       :meta common:
       """
 
-      if support is None:
-         support = grid
-      if support_uuid is None and support is not None:
-         support_uuid = support.uuid
+        if support is None:
+            support = grid
+        if support_uuid is None and support is not None:
+            support_uuid = support.uuid
 
-      temp_collection = selective_version_of_collection(self,
-                                                        realization = realization,
-                                                        support_uuid = support_uuid,
-                                                        continuous = continuous,
-                                                        points = points,
-                                                        count = count,
-                                                        indexable = indexable,
-                                                        property_kind = property_kind,
-                                                        facet_type = facet_type,
-                                                        facet = facet,
-                                                        citation_title = citation_title,
-                                                        time_series_uuid = time_series_uuid,
-                                                        time_index = time_index,
-                                                        uom = uom,
-                                                        categorical = categorical,
-                                                        string_lookup_uuid = string_lookup_uuid)
-      parts_list = temp_collection.parts()
-      return parts_list
+        temp_collection = selective_version_of_collection(self,
+                                                          realization = realization,
+                                                          support_uuid = support_uuid,
+                                                          continuous = continuous,
+                                                          points = points,
+                                                          count = count,
+                                                          indexable = indexable,
+                                                          property_kind = property_kind,
+                                                          facet_type = facet_type,
+                                                          facet = facet,
+                                                          citation_title = citation_title,
+                                                          time_series_uuid = time_series_uuid,
+                                                          time_index = time_index,
+                                                          uom = uom,
+                                                          categorical = categorical,
+                                                          string_lookup_uuid = string_lookup_uuid)
+        parts_list = temp_collection.parts()
+        return parts_list
 
-   def singleton(
-         self,
-         realization = None,
-         support = None,  # for backward compatibility
-         support_uuid = None,
-         grid = None,  # for backward compatibility
-         uuid = None,
-         continuous = None,
-         points = None,
-         count = None,
-         indexable = None,
-         property_kind = None,
-         facet_type = None,
-         facet = None,
-         citation_title = None,
-         time_series_uuid = None,
-         time_index = None,
-         uom = None,
-         string_lookup_uuid = None,
-         categorical = None):
-      """Returns a single part selected by those arguments which are not None.
+    def singleton(
+            self,
+            realization = None,
+            support = None,  # for backward compatibility
+            support_uuid = None,
+            grid = None,  # for backward compatibility
+            uuid = None,
+            continuous = None,
+            points = None,
+            count = None,
+            indexable = None,
+            property_kind = None,
+            facet_type = None,
+            facet = None,
+            citation_title = None,
+            time_series_uuid = None,
+            time_index = None,
+            uom = None,
+            string_lookup_uuid = None,
+            categorical = None):
+        """Returns a single part selected by those arguments which are not None.
 
       For each argument: if None, then all members of collection pass this filter;
       if not None then only those members with the given value pass this filter;
@@ -1067,58 +1072,58 @@ class PropertyCollection():
       :meta common:
       """
 
-      if support is None:
-         support = grid
-      if support_uuid is None and support is not None:
-         support_uuid = support.uuid
+        if support is None:
+            support = grid
+        if support_uuid is None and support is not None:
+            support_uuid = support.uuid
 
-      temp_collection = selective_version_of_collection(self,
-                                                        realization = realization,
-                                                        support_uuid = support_uuid,
-                                                        uuid = uuid,
-                                                        continuous = continuous,
-                                                        points = points,
-                                                        count = count,
-                                                        indexable = indexable,
-                                                        property_kind = property_kind,
-                                                        facet_type = facet_type,
-                                                        facet = facet,
-                                                        citation_title = citation_title,
-                                                        time_series_uuid = time_series_uuid,
-                                                        time_index = time_index,
-                                                        uom = uom,
-                                                        string_lookup_uuid = string_lookup_uuid,
-                                                        categorical = categorical)
-      parts_list = temp_collection.parts()
-      if len(parts_list) == 0:
-         return None
-      assert len(parts_list) == 1, 'More than one property part matches selection criteria'
-      return parts_list[0]
+        temp_collection = selective_version_of_collection(self,
+                                                          realization = realization,
+                                                          support_uuid = support_uuid,
+                                                          uuid = uuid,
+                                                          continuous = continuous,
+                                                          points = points,
+                                                          count = count,
+                                                          indexable = indexable,
+                                                          property_kind = property_kind,
+                                                          facet_type = facet_type,
+                                                          facet = facet,
+                                                          citation_title = citation_title,
+                                                          time_series_uuid = time_series_uuid,
+                                                          time_index = time_index,
+                                                          uom = uom,
+                                                          string_lookup_uuid = string_lookup_uuid,
+                                                          categorical = categorical)
+        parts_list = temp_collection.parts()
+        if len(parts_list) == 0:
+            return None
+        assert len(parts_list) == 1, 'More than one property part matches selection criteria'
+        return parts_list[0]
 
-   def single_array_ref(
-         self,
-         realization = None,
-         support = None,  # for backward compatibility
-         support_uuid = None,
-         grid = None,  # for backward compatibility
-         uuid = None,
-         continuous = None,
-         points = None,
-         count = None,
-         indexable = None,
-         property_kind = None,
-         facet_type = None,
-         facet = None,
-         citation_title = None,
-         time_series_uuid = None,
-         time_index = None,
-         uom = None,
-         string_lookup_uuid = None,
-         categorical = None,
-         dtype = None,
-         masked = False,
-         exclude_null = False):
-      """Returns the array of data for a single part selected by those arguments which are not None.
+    def single_array_ref(
+            self,
+            realization = None,
+            support = None,  # for backward compatibility
+            support_uuid = None,
+            grid = None,  # for backward compatibility
+            uuid = None,
+            continuous = None,
+            points = None,
+            count = None,
+            indexable = None,
+            property_kind = None,
+            facet_type = None,
+            facet = None,
+            citation_title = None,
+            time_series_uuid = None,
+            time_index = None,
+            uom = None,
+            string_lookup_uuid = None,
+            categorical = None,
+            dtype = None,
+            masked = False,
+            exclude_null = False):
+        """Returns the array of data for a single part selected by those arguments which are not None.
 
       arguments:
          dtype (optional, default None): the element data type of the array to be accessed, eg 'float' or 'int';
@@ -1150,33 +1155,33 @@ class PropertyCollection():
       :meta common:
       """
 
-      if support is None:
-         support = grid
-      if support_uuid is None and support is not None:
-         support_uuid = support.uuid
+        if support is None:
+            support = grid
+        if support_uuid is None and support is not None:
+            support_uuid = support.uuid
 
-      part = self.singleton(realization = realization,
-                            support_uuid = support_uuid,
-                            uuid = uuid,
-                            continuous = continuous,
-                            points = points,
-                            count = count,
-                            indexable = indexable,
-                            property_kind = property_kind,
-                            facet_type = facet_type,
-                            facet = facet,
-                            citation_title = citation_title,
-                            time_series_uuid = time_series_uuid,
-                            time_index = time_index,
-                            uom = uom,
-                            string_lookup_uuid = string_lookup_uuid,
-                            categorical = categorical)
-      if part is None:
-         return None
-      return self.cached_part_array_ref(part, dtype = dtype, masked = masked, exclude_null = exclude_null)
+        part = self.singleton(realization = realization,
+                              support_uuid = support_uuid,
+                              uuid = uuid,
+                              continuous = continuous,
+                              points = points,
+                              count = count,
+                              indexable = indexable,
+                              property_kind = property_kind,
+                              facet_type = facet_type,
+                              facet = facet,
+                              citation_title = citation_title,
+                              time_series_uuid = time_series_uuid,
+                              time_index = time_index,
+                              uom = uom,
+                              string_lookup_uuid = string_lookup_uuid,
+                              categorical = categorical)
+        if part is None:
+            return None
+        return self.cached_part_array_ref(part, dtype = dtype, masked = masked, exclude_null = exclude_null)
 
-   def number_of_parts(self):
-      """Returns the number of parts (properties) in this collection.
+    def number_of_parts(self):
+        """Returns the number of parts (properties) in this collection.
 
       returns:
          count of the number of parts (members) in this collection; there is one part per property array (non-negative integer)
@@ -1184,10 +1189,10 @@ class PropertyCollection():
       :meta common:
       """
 
-      return len(self.dict)
+        return len(self.dict)
 
-   def part_in_collection(self, part):
-      """Returns True if named part is member of this collection; otherwise False.
+    def part_in_collection(self, part):
+        """Returns True if named part is member of this collection; otherwise False.
 
       arguments:
          part (string): part name to be tested for membership of this collection
@@ -1196,31 +1201,31 @@ class PropertyCollection():
          boolean
       """
 
-      return part in self.dict
+        return part in self.dict
 
-   # 'private' function for accessing an element from the tuple for the part
-   # the main dictionary maps from part name to a tuple of information
-   # this function simply extracts one element of the tuple in a way that returns None if the part is awol
-   def element_for_part(self, part, index):
-      if part not in self.dict:
-         return None
-      return self.dict[part][index]
+    # 'private' function for accessing an element from the tuple for the part
+    # the main dictionary maps from part name to a tuple of information
+    # this function simply extracts one element of the tuple in a way that returns None if the part is awol
+    def element_for_part(self, part, index):
+        if part not in self.dict:
+            return None
+        return self.dict[part][index]
 
-   # 'private' function for returning a list of unique values for an element from the tuples within the collection
-   # excludes None from list
-   def unique_element_list(self, index, sort_list = True):
-      s = set()
-      for _, t in self.dict.items():
-         e = t[index]
-         if e is not None:
-            s = s.union({e})
-      result = list(s)
-      if sort_list:
-         result.sort()
-      return result
+    # 'private' function for returning a list of unique values for an element from the tuples within the collection
+    # excludes None from list
+    def unique_element_list(self, index, sort_list = True):
+        s = set()
+        for _, t in self.dict.items():
+            e = t[index]
+            if e is not None:
+                s = s.union({e})
+        result = list(s)
+        if sort_list:
+            result.sort()
+        return result
 
-   def part_str(self, part, include_citation_title = True):
-      """Returns a human-readable string identifying the part.
+    def part_str(self, part, include_citation_title = True):
+        """Returns a human-readable string identifying the part.
 
       arguments:
          part (string): the part name for which a displayable string is required
@@ -1239,21 +1244,21 @@ class PropertyCollection():
       :meta common:
       """
 
-      text = self.property_kind_for_part(part)
-      facet = self.facet_for_part(part)
-      if facet:
-         text += ': ' + facet
-      time_index = self.time_index_for_part(part)
-      if time_index is not None:
-         text += '; timestep: ' + str(time_index)
-      if include_citation_title:
-         title = self.citation_title_for_part(part)
-         if title:
-            text += ' (' + title + ')'
-      return text
+        text = self.property_kind_for_part(part)
+        facet = self.facet_for_part(part)
+        if facet:
+            text += ': ' + facet
+        time_index = self.time_index_for_part(part)
+        if time_index is not None:
+            text += '; timestep: ' + str(time_index)
+        if include_citation_title:
+            title = self.citation_title_for_part(part)
+            if title:
+                text += ' (' + title + ')'
+        return text
 
-   def part_filename(self, part):
-      """Returns a string which can be used as the starting point of a filename relating to part.
+    def part_filename(self, part):
+        """Returns a string which can be used as the starting point of a filename relating to part.
 
       arguments:
          part (string): the part name for which a partial filename is required
@@ -1262,17 +1267,17 @@ class PropertyCollection():
          a string suitable as the basis of a filename for the part (typically used when exporting)
       """
 
-      text = self.property_kind_for_part(part).replace(' ', '_')
-      facet = self.facet_for_part(part)
-      if facet:
-         text += '_' + facet  # could insert facet_type prior to this
-      time_index = self.time_index_for_part(part)
-      if time_index is not None:
-         text += '_ts_' + str(time_index)
-      return text
+        text = self.property_kind_for_part(part).replace(' ', '_')
+        facet = self.facet_for_part(part)
+        if facet:
+            text += '_' + facet  # could insert facet_type prior to this
+        time_index = self.time_index_for_part(part)
+        if time_index is not None:
+            text += '_ts_' + str(time_index)
+        return text
 
-   def realization_for_part(self, part):
-      """Returns realization number (within ensemble) that the property relates to.
+    def realization_for_part(self, part):
+        """Returns realization number (within ensemble) that the property relates to.
 
       arguments:
          part (string): the part name for which the realization number (realization index) is required
@@ -1283,15 +1288,15 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 0)
+        return self.element_for_part(part, 0)
 
-   def realization_list(self, sort_list = True):
-      """Returns a list of unique realization numbers present in the collection."""
+    def realization_list(self, sort_list = True):
+        """Returns a list of unique realization numbers present in the collection."""
 
-      return self.unique_element_list(0)
+        return self.unique_element_list(0)
 
-   def support_uuid_for_part(self, part):
-      """Returns supporting representation object's uuid that the property relates to.
+    def support_uuid_for_part(self, part):
+        """Returns supporting representation object's uuid that the property relates to.
 
       arguments:
          part (string): the part name for which the related support object uuid is required
@@ -1300,10 +1305,10 @@ class PropertyCollection():
          uuid.UUID object (or string representation thereof)
       """
 
-      return self.element_for_part(part, 1)
+        return self.element_for_part(part, 1)
 
-   def grid_for_part(self, part):
-      """Returns grid object that the property relates to.
+    def grid_for_part(self, part):
+        """Returns grid object that the property relates to.
 
       arguments:
          part (string): the part name for which the related grid object is required
@@ -1316,23 +1321,23 @@ class PropertyCollection():
          for pragmatic reasons (rather than being method in GridPropertyCollection)
       """
 
-      import resqpy.grid as grr
-      import resqpy.unstructured as rug
+        import resqpy.grid as grr
+        import resqpy.unstructured as rug
 
-      support_uuid = self.support_uuid_for_part(part)
-      if support_uuid is None:
-         return None
-      if bu.matching_uuids(self.support_uuid, support_uuid):
-         return self.support
-      assert self.model is not None
-      part = self.model.part_for_uuid(support_uuid)
-      assert part is not None and self.model.type_of_part(part) in [
-         'obj_IjkGridRepresentation', 'obj_UnstructuredGridRepresentation'
-      ]
-      return grr.any_grid(self.model, uuid = support_uuid, find_properties = False)
+        support_uuid = self.support_uuid_for_part(part)
+        if support_uuid is None:
+            return None
+        if bu.matching_uuids(self.support_uuid, support_uuid):
+            return self.support
+        assert self.model is not None
+        part = self.model.part_for_uuid(support_uuid)
+        assert part is not None and self.model.type_of_part(part) in [
+            'obj_IjkGridRepresentation', 'obj_UnstructuredGridRepresentation'
+        ]
+        return grr.any_grid(self.model, uuid = support_uuid, find_properties = False)
 
-   def uuid_for_part(self, part):
-      """Returns UUID object for the property part.
+    def uuid_for_part(self, part):
+        """Returns UUID object for the property part.
 
       arguments:
          part (string): the part name for which the UUID is required
@@ -1343,10 +1348,10 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 2)
+        return self.element_for_part(part, 2)
 
-   def node_for_part(self, part):
-      """Returns the xml node for the property part.
+    def node_for_part(self, part):
+        """Returns the xml node for the property part.
 
       arguments:
          part (string): the part name for which the xml node is required
@@ -1355,10 +1360,10 @@ class PropertyCollection():
          xml Element object reference for the main xml node for the part
       """
 
-      return self.element_for_part(part, 3)
+        return self.element_for_part(part, 3)
 
-   def extra_metadata_for_part(self, part):
-      """Returns the extra_metadata dictionary for the part.
+    def extra_metadata_for_part(self, part):
+        """Returns the extra_metadata dictionary for the part.
 
       arguments:
          part (string): the part name for which the xml node is required
@@ -1366,15 +1371,15 @@ class PropertyCollection():
       returns:
          dictionary containing extra_metadata for part
       """
-      try:
-         meta = self.element_for_part(part, 18)
-      except Exception:
-         pass
-         meta = {}
-      return meta
+        try:
+            meta = self.element_for_part(part, 18)
+        except Exception:
+            pass
+            meta = {}
+        return meta
 
-   def null_value_for_part(self, part):
-      """Returns the null value for the (discrete) property part; np.NaN for continuous parts.
+    def null_value_for_part(self, part):
+        """Returns the null value for the (discrete) property part; np.NaN for continuous parts.
 
       arguments:
          part (string): the part name for which the null value is required
@@ -1383,12 +1388,12 @@ class PropertyCollection():
          int or np.NaN
       """
 
-      if self.continuous_for_part(part):
-         return np.NaN
-      return self.element_for_part(part, 19)
+        if self.continuous_for_part(part):
+            return np.NaN
+        return self.element_for_part(part, 19)
 
-   def continuous_for_part(self, part):
-      """Returns True if the property is continuous (including points); False if it is discrete (or categorical).
+    def continuous_for_part(self, part):
+        """Returns True if the property is continuous (including points); False if it is discrete (or categorical).
 
       arguments:
          part (string): the part name for which the continuous versus discrete flag is required
@@ -1408,10 +1413,10 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 4)
+        return self.element_for_part(part, 4)
 
-   def points_for_part(self, part):
-      """Returns True if the property is a points property; False otherwise.
+    def points_for_part(self, part):
+        """Returns True if the property is a points property; False otherwise.
 
       arguments:
          part (string): the part name for which the points flag is required
@@ -1421,26 +1426,26 @@ class PropertyCollection():
          covering the xyz axes; False if the part is representing a non-points property
       """
 
-      return self.element_for_part(part, 21)
+        return self.element_for_part(part, 21)
 
-   def all_continuous(self):
-      """Returns True if all the parts are for continuous (real) properties (includes points)."""
+    def all_continuous(self):
+        """Returns True if all the parts are for continuous (real) properties (includes points)."""
 
-      unique_elements = self.unique_element_list(4, sort_list = False)
-      if len(unique_elements) != 1:
-         return False
-      return unique_elements[0]
+        unique_elements = self.unique_element_list(4, sort_list = False)
+        if len(unique_elements) != 1:
+            return False
+        return unique_elements[0]
 
-   def all_discrete(self):
-      """Returns True if all the parts are for discrete or categorical (integer) properties."""
+    def all_discrete(self):
+        """Returns True if all the parts are for discrete or categorical (integer) properties."""
 
-      unique_elements = self.unique_element_list(4, sort_list = False)
-      if len(unique_elements) != 1:
-         return False
-      return not unique_elements[0]
+        unique_elements = self.unique_element_list(4, sort_list = False)
+        if len(unique_elements) != 1:
+            return False
+        return not unique_elements[0]
 
-   def count_for_part(self, part):
-      """Returns the Count value for the property part; usually 1.
+    def count_for_part(self, part):
+        """Returns the Count value for the property part; usually 1.
 
       arguments:
          part (string): the part name for which the count is required
@@ -1454,18 +1459,18 @@ class PropertyCollection():
          in the supporting representation
       """
 
-      return self.element_for_part(part, 5)
+        return self.element_for_part(part, 5)
 
-   def all_count_one(self):
-      """Returns True if the low level Count value is 1 for all the parts in the collection."""
+    def all_count_one(self):
+        """Returns True if the low level Count value is 1 for all the parts in the collection."""
 
-      unique_elements = self.unique_element_list(5, sort_list = False)
-      if len(unique_elements) != 1:
-         return False
-      return unique_elements[0] == 1
+        unique_elements = self.unique_element_list(5, sort_list = False)
+        if len(unique_elements) != 1:
+            return False
+        return unique_elements[0] == 1
 
-   def indexable_for_part(self, part):
-      """Returns the text of the IndexableElement for the property part; usually 'cells' for grid properties.
+    def indexable_for_part(self, part):
+        """Returns the text of the IndexableElement for the property part; usually 'cells' for grid properties.
 
       arguments:
          part (string): the part name for which the indexable element is required
@@ -1479,15 +1484,15 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 6)
+        return self.element_for_part(part, 6)
 
-   def unique_indexable_element_list(self, sort_list = False):
-      """Returns a list of unique values for the IndexableElement of the property parts in the collection."""
+    def unique_indexable_element_list(self, sort_list = False):
+        """Returns a list of unique values for the IndexableElement of the property parts in the collection."""
 
-      return self.unique_element_list(6, sort_list = sort_list)
+        return self.unique_element_list(6, sort_list = sort_list)
 
-   def property_kind_for_part(self, part):
-      """Returns the resqml property kind for the property part.
+    def property_kind_for_part(self, part):
+        """Returns the resqml property kind for the property part.
 
       arguments:
          part (string): the part name for which the property kind is required
@@ -1504,20 +1509,20 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 7)
+        return self.element_for_part(part, 7)
 
-   def property_kind_list(self, sort_list = True):
-      """Returns a list of unique property kinds found amongst the parts of the collection."""
+    def property_kind_list(self, sort_list = True):
+        """Returns a list of unique property kinds found amongst the parts of the collection."""
 
-      return self.unique_element_list(7, sort_list = sort_list)
+        return self.unique_element_list(7, sort_list = sort_list)
 
-   def local_property_kind_uuid(self, part):
-      """Returns the uuid of the bespoke (local) property kind for this part, or None for a standard property kind."""
+    def local_property_kind_uuid(self, part):
+        """Returns the uuid of the bespoke (local) property kind for this part, or None for a standard property kind."""
 
-      return self.element_for_part(part, 17)
+        return self.element_for_part(part, 17)
 
-   def facet_type_for_part(self, part):
-      """If relevant, returns the resqml Facet Facet for the property part, eg. 'direction'; otherwise None.
+    def facet_type_for_part(self, part):
+        """If relevant, returns the resqml Facet Facet for the property part, eg. 'direction'; otherwise None.
 
       arguments:
          part (string): the part name for which the facet type is required
@@ -1533,15 +1538,15 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 8)
+        return self.element_for_part(part, 8)
 
-   def facet_type_list(self, sort_list = True):
-      """Returns a list of unique facet types found amongst the parts of the collection."""
+    def facet_type_list(self, sort_list = True):
+        """Returns a list of unique facet types found amongst the parts of the collection."""
 
-      return self.unique_element_list(8, sort_list = sort_list)
+        return self.unique_element_list(8, sort_list = sort_list)
 
-   def facet_for_part(self, part):
-      """If relevant, returns the resqml Facet Value for the property part, eg. 'I'; otherwise None.
+    def facet_for_part(self, part):
+        """If relevant, returns the resqml Facet Value for the property part, eg. 'I'; otherwise None.
 
       arguments:
          part (string): the part name for which the facet value is required
@@ -1555,15 +1560,15 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 9)
+        return self.element_for_part(part, 9)
 
-   def facet_list(self, sort_list = True):
-      """Returns a list of unique facet values found amongst the parts of the collection."""
+    def facet_list(self, sort_list = True):
+        """Returns a list of unique facet values found amongst the parts of the collection."""
 
-      return self.unique_element_list(9, sort_list = sort_list)
+        return self.unique_element_list(9, sort_list = sort_list)
 
-   def citation_title_for_part(self, part):
-      """Returns the citation title for the property part.
+    def citation_title_for_part(self, part):
+        """Returns the citation title for the property part.
 
       arguments:
          part (string): the part name for which the citation title is required
@@ -1577,20 +1582,20 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 10)
+        return self.element_for_part(part, 10)
 
-   def title_for_part(self, part):
-      """Synonymous with citation_title_for_part()."""
+    def title_for_part(self, part):
+        """Synonymous with citation_title_for_part()."""
 
-      return self.citation_title_for_part(part)
+        return self.citation_title_for_part(part)
 
-   def titles(self):
-      """Returns a list of citation titles for the parts in the collection."""
+    def titles(self):
+        """Returns a list of citation titles for the parts in the collection."""
 
-      return [self.citation_title_for_part(p) for p in self.parts()]
+        return [self.citation_title_for_part(p) for p in self.parts()]
 
-   def time_series_uuid_for_part(self, part):
-      """If the property has an associated time series (is not static), returns the uuid for the time series.
+    def time_series_uuid_for_part(self, part):
+        """If the property has an associated time series (is not static), returns the uuid for the time series.
 
       arguments:
          part (string): the part name for which the time series uuid is required
@@ -1599,15 +1604,15 @@ class PropertyCollection():
          time series uuid (uuid.UUID) for this part
       """
 
-      return self.element_for_part(part, 11)
+        return self.element_for_part(part, 11)
 
-   def time_series_uuid_list(self, sort_list = True):
-      """Returns a list of unique time series uuids found amongst the parts of the collection."""
+    def time_series_uuid_list(self, sort_list = True):
+        """Returns a list of unique time series uuids found amongst the parts of the collection."""
 
-      return self.unique_element_list(11, sort_list = sort_list)
+        return self.unique_element_list(11, sort_list = sort_list)
 
-   def time_index_for_part(self, part):
-      """If the property has an associated time series (is not static), returns the time index within the time series.
+    def time_index_for_part(self, part):
+        """If the property has an associated time series (is not static), returns the time index within the time series.
 
       arguments:
          part (string): the part name for which the time index is required
@@ -1618,15 +1623,15 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 12)
+        return self.element_for_part(part, 12)
 
-   def time_index_list(self, sort_list = True):
-      """Returns a list of unique time indices found amongst the parts of the collection."""
+    def time_index_list(self, sort_list = True):
+        """Returns a list of unique time indices found amongst the parts of the collection."""
 
-      return self.unique_element_list(12, sort_list = sort_list)
+        return self.unique_element_list(12, sort_list = sort_list)
 
-   def minimum_value_for_part(self, part):
-      """Returns the minimum value for the property part, as stored in the xml.
+    def minimum_value_for_part(self, part):
+        """Returns the minimum value for the property part, as stored in the xml.
 
       arguments:
          part (string): the part name for which the minimum value is required
@@ -1641,16 +1646,16 @@ class PropertyCollection():
       :meta common:
       """
 
-      mini = self.element_for_part(part, 13)
-      if mini:
-         if self.continuous_for_part(part):
-            mini = float(mini)
-         else:
-            mini = int(mini)
-      return mini
+        mini = self.element_for_part(part, 13)
+        if mini:
+            if self.continuous_for_part(part):
+                mini = float(mini)
+            else:
+                mini = int(mini)
+        return mini
 
-   def maximum_value_for_part(self, part):
-      """Returns the maximum value for the property part, as stored in the xml.
+    def maximum_value_for_part(self, part):
+        """Returns the maximum value for the property part, as stored in the xml.
 
       arguments:
          part (string): the part name for which the maximum value is required
@@ -1665,16 +1670,16 @@ class PropertyCollection():
       :meta common:
       """
 
-      maxi = self.element_for_part(part, 14)
-      if maxi:
-         if self.continuous_for_part(part):
-            maxi = float(maxi)
-         else:
-            maxi = int(maxi)
-      return maxi
+        maxi = self.element_for_part(part, 14)
+        if maxi:
+            if self.continuous_for_part(part):
+                maxi = float(maxi)
+            else:
+                maxi = int(maxi)
+        return maxi
 
-   def patch_min_max_for_part(self, part, minimum = None, maximum = None, model = None):
-      """Updates the minimum and/ox maximum values stored in the metadata, optionally updating xml tree too.
+    def patch_min_max_for_part(self, part, minimum = None, maximum = None, model = None):
+        """Updates the minimum and/ox maximum values stored in the metadata, optionally updating xml tree too.
 
       arguments:
          part (str): the part name of the property
@@ -1688,28 +1693,28 @@ class PropertyCollection():
          and/or maximum nodes already exist in the tree
       """
 
-      info = list(self.dict[part])
-      if minimum is not None:
-         info[13] = minimum
-      if maximum is not None:
-         info[14] = maximum
-      self.dict[part] = tuple(info)
-      if model is not None:
-         p_root = model.root_for_part(part)
-         if p_root is not None:
-            if minimum is not None:
-               min_node = rqet.find_tag(p_root, 'MinimumValue')
-               if min_node is not None:
-                  min_node.text = str(minimum)
-                  model.set_modified()
-            if maximum is not None:
-               max_node = rqet.find_tag(p_root, 'MaximumValue')
-               if max_node is not None:
-                  max_node.text = str(maximum)
-                  model.set_modified()
+        info = list(self.dict[part])
+        if minimum is not None:
+            info[13] = minimum
+        if maximum is not None:
+            info[14] = maximum
+        self.dict[part] = tuple(info)
+        if model is not None:
+            p_root = model.root_for_part(part)
+            if p_root is not None:
+                if minimum is not None:
+                    min_node = rqet.find_tag(p_root, 'MinimumValue')
+                    if min_node is not None:
+                        min_node.text = str(minimum)
+                        model.set_modified()
+                if maximum is not None:
+                    max_node = rqet.find_tag(p_root, 'MaximumValue')
+                    if max_node is not None:
+                        max_node.text = str(maximum)
+                        model.set_modified()
 
-   def uom_for_part(self, part):
-      """Returns the resqml units of measure for the property part.
+    def uom_for_part(self, part):
+        """Returns the resqml units of measure for the property part.
 
       arguments:
          part (string): the part name for which the units of measure is required
@@ -1720,16 +1725,16 @@ class PropertyCollection():
       :meta common:
       """
 
-      # NB: this field is not set correctly in data sets generated by DGI
-      return self.element_for_part(part, 15)
+        # NB: this field is not set correctly in data sets generated by DGI
+        return self.element_for_part(part, 15)
 
-   def uom_list(self, sort_list = True):
-      """Returns a list of unique units of measure found amongst the parts of the collection."""
+    def uom_list(self, sort_list = True):
+        """Returns a list of unique units of measure found amongst the parts of the collection."""
 
-      return self.unique_element_list(15, sort_list = sort_list)
+        return self.unique_element_list(15, sort_list = sort_list)
 
-   def string_lookup_uuid_for_part(self, part):
-      """If the property has an associated string lookup (is categorical), returns the uuid for the string table lookup.
+    def string_lookup_uuid_for_part(self, part):
+        """If the property has an associated string lookup (is categorical), returns the uuid for the string table lookup.
 
       arguments:
          part (string): the part name for which the string lookup uuid is required
@@ -1738,33 +1743,33 @@ class PropertyCollection():
          string lookup uuid (uuid.UUID) for this part
       """
 
-      return self.element_for_part(part, 16)
+        return self.element_for_part(part, 16)
 
-   def string_lookup_for_part(self, part):
-      """Returns a StringLookup object for the part, if it has a string lookup uuid, otherwise None."""
+    def string_lookup_for_part(self, part):
+        """Returns a StringLookup object for the part, if it has a string lookup uuid, otherwise None."""
 
-      sl_uuid = self.string_lookup_uuid_for_part(part)
-      if sl_uuid is None:
-         return None
-      sl_root = self.model.root_for_uuid(sl_uuid)
-      assert sl_root is not None, 'string table lookup referenced by property is not present in model'
-      return StringLookup(self.model, sl_root)
+        sl_uuid = self.string_lookup_uuid_for_part(part)
+        if sl_uuid is None:
+            return None
+        sl_root = self.model.root_for_uuid(sl_uuid)
+        assert sl_root is not None, 'string table lookup referenced by property is not present in model'
+        return StringLookup(self.model, sl_root)
 
-   def string_lookup_uuid_list(self, sort_list = True):
-      """Returns a list of unique string lookup uuids found amongst the parts of the collection."""
+    def string_lookup_uuid_list(self, sort_list = True):
+        """Returns a list of unique string lookup uuids found amongst the parts of the collection."""
 
-      return self.unique_element_list(16, sort_list = sort_list)
+        return self.unique_element_list(16, sort_list = sort_list)
 
-   def part_is_categorical(self, part):
-      """Returns True if the property is categorical (not conintuous and has an associated string lookup).
+    def part_is_categorical(self, part):
+        """Returns True if the property is categorical (not conintuous and has an associated string lookup).
 
       :meta common:
       """
 
-      return not self.continuous_for_part(part) and self.string_lookup_uuid_for_part(part) is not None
+        return not self.continuous_for_part(part) and self.string_lookup_uuid_for_part(part) is not None
 
-   def constant_value_for_part(self, part):
-      """Returns the value (float or int) of a constant array part, or None for an hdf5 array.
+    def constant_value_for_part(self, part):
+        """Returns the value (float or int) of a constant array part, or None for an hdf5 array.
 
       note:
          a constant array can optionally be expanded and written to the hdf5, in which case it will
@@ -1772,10 +1777,10 @@ class PropertyCollection():
       :meta common:
       """
 
-      return self.element_for_part(part, 20)
+        return self.element_for_part(part, 20)
 
-   def override_min_max(self, part, min_value, max_value):
-      """Sets the minimum and maximum values in the metadata for the part.
+    def override_min_max(self, part, min_value, max_value):
+        """Sets the minimum and maximum values in the metadata for the part.
 
       arguments:
          part (string): the part name for which the minimum and maximum values are to be set
@@ -1789,169 +1794,169 @@ class PropertyCollection():
          a version of it masked for inactive cells
       """
 
-      if part not in self.dict:
-         return
-      property_part = list(self.dict[part])
-      property_part[13] = min_value
-      property_part[14] = max_value
-      self.dict[part] = tuple(property_part)
+        if part not in self.dict:
+            return
+        property_part = list(self.dict[part])
+        property_part[13] = min_value
+        property_part[14] = max_value
+        self.dict[part] = tuple(property_part)
 
-   def establish_time_set_kind(self):
-      """Re-evaulates the time set kind attribute based on all properties having same time index in the same time series."""
+    def establish_time_set_kind(self):
+        """Re-evaulates the time set kind attribute based on all properties having same time index in the same time series."""
 
-      self.time_set_kind_attr = 'single time'
-      #  note: other option of 'equivalent times' not catered for in this code
-      common_time_index = None
-      common_time_series_uuid = None
-      for part in self.parts():
-         part_time_index = self.time_index_for_part(part)
-         if part_time_index is None:
-            self.time_set_kind_attr = 'not a time set'
-            break
-         if common_time_index is None:
-            common_time_index = part_time_index
-         elif common_time_index != part_time_index:
-            self.time_set_kind_attr = 'not a time set'
-            break
-         part_ts_uuid = self.time_series_uuid_for_part(part)
-         if part_ts_uuid is None:
-            self.time_set_kind_attr = 'not a time set'
-            break
-         if common_time_series_uuid is None:
-            common_time_series_uuid = part_ts_uuid
-         elif not bu.matching_uuids(common_time_series_uuid, part_ts_uuid):
-            self.time_set_kind_attr = 'not a time set'
-            break
-      return self.time_set_kind_attr
+        self.time_set_kind_attr = 'single time'
+        #  note: other option of 'equivalent times' not catered for in this code
+        common_time_index = None
+        common_time_series_uuid = None
+        for part in self.parts():
+            part_time_index = self.time_index_for_part(part)
+            if part_time_index is None:
+                self.time_set_kind_attr = 'not a time set'
+                break
+            if common_time_index is None:
+                common_time_index = part_time_index
+            elif common_time_index != part_time_index:
+                self.time_set_kind_attr = 'not a time set'
+                break
+            part_ts_uuid = self.time_series_uuid_for_part(part)
+            if part_ts_uuid is None:
+                self.time_set_kind_attr = 'not a time set'
+                break
+            if common_time_series_uuid is None:
+                common_time_series_uuid = part_ts_uuid
+            elif not bu.matching_uuids(common_time_series_uuid, part_ts_uuid):
+                self.time_set_kind_attr = 'not a time set'
+                break
+        return self.time_set_kind_attr
 
-   def time_set_kind(self):
-      """Returns the time set kind attribute based on all properties having same time index in the same time series."""
+    def time_set_kind(self):
+        """Returns the time set kind attribute based on all properties having same time index in the same time series."""
 
-      if self.time_set_kind_attr is None:
-         self.establish_time_set_kind()
-      return self.time_set_kind_attr
+        if self.time_set_kind_attr is None:
+            self.establish_time_set_kind()
+        return self.time_set_kind_attr
 
-   def establish_has_single_property_kind(self):
-      """Re-evaluates the has single property kind attribute depending on whether all properties are of the same kind."""
+    def establish_has_single_property_kind(self):
+        """Re-evaluates the has single property kind attribute depending on whether all properties are of the same kind."""
 
-      self.has_single_property_kind_flag = True
-      common_property_kind = None
-      for part in self.parts():
-         part_kind = self.property_kind_for_part(part)
-         if common_property_kind is None:
-            common_property_kind = part_kind
-         elif part_kind != common_property_kind:
-            self.has_single_property_kind_flag = False
-            break
-      return self.has_single_property_kind_flag
+        self.has_single_property_kind_flag = True
+        common_property_kind = None
+        for part in self.parts():
+            part_kind = self.property_kind_for_part(part)
+            if common_property_kind is None:
+                common_property_kind = part_kind
+            elif part_kind != common_property_kind:
+                self.has_single_property_kind_flag = False
+                break
+        return self.has_single_property_kind_flag
 
-   def has_single_property_kind(self):
-      """Returns the has single property kind flag depending on whether all properties are of the same kind."""
+    def has_single_property_kind(self):
+        """Returns the has single property kind flag depending on whether all properties are of the same kind."""
 
-      if self.has_single_property_kind_flag is None:
-         self.establish_has_single_property_kind()
-      return self.has_single_property_kind_flag
+        if self.has_single_property_kind_flag is None:
+            self.establish_has_single_property_kind()
+        return self.has_single_property_kind_flag
 
-   def establish_has_single_indexable_element(self):
-      """Re-evaluates the has single indexable element attribute depending on whether all properties have the same."""
+    def establish_has_single_indexable_element(self):
+        """Re-evaluates the has single indexable element attribute depending on whether all properties have the same."""
 
-      self.has_single_indexable_element_flag = True
-      common_ie = None
-      for part in self.parts():
-         ie = self.indexable_for_part(part)
-         if common_ie is None:
-            common_ie = ie
-         elif ie != common_ie:
-            self.has_single_indexable_element_flag = False
-            break
-      return self.has_single_indexable_element_flag
+        self.has_single_indexable_element_flag = True
+        common_ie = None
+        for part in self.parts():
+            ie = self.indexable_for_part(part)
+            if common_ie is None:
+                common_ie = ie
+            elif ie != common_ie:
+                self.has_single_indexable_element_flag = False
+                break
+        return self.has_single_indexable_element_flag
 
-   def has_single_indexable_element(self):
-      """Returns the has single indexable element flag depending on whether all properties have the same."""
+    def has_single_indexable_element(self):
+        """Returns the has single indexable element flag depending on whether all properties have the same."""
 
-      if self.has_single_indexable_element_flag is None:
-         self.establish_has_single_indexable_element()
-      return self.has_single_indexable_element_flag
+        if self.has_single_indexable_element_flag is None:
+            self.establish_has_single_indexable_element()
+        return self.has_single_indexable_element_flag
 
-   def establish_has_multiple_realizations(self):
-      """Re-evaluates the has multiple realizations attribute based on whether properties belong to more than one realization."""
+    def establish_has_multiple_realizations(self):
+        """Re-evaluates the has multiple realizations attribute based on whether properties belong to more than one realization."""
 
-      self.has_multiple_realizations_flag = False
-      common_realization = None
-      for part in self.parts():
-         part_realization = self.realization_for_part(part)
-         if part_realization is None:
-            continue
-         if common_realization is None:
-            common_realization = part_realization
-            continue
-         if part_realization != common_realization:
-            self.has_multiple_realizations_flag = True
-            self.realization = None  # override single realization number applicable to whole collection
-            break
-      if not self.has_multiple_realizations_flag and common_realization is not None:
-         self.realization = common_realization
-      return self.has_multiple_realizations_flag
+        self.has_multiple_realizations_flag = False
+        common_realization = None
+        for part in self.parts():
+            part_realization = self.realization_for_part(part)
+            if part_realization is None:
+                continue
+            if common_realization is None:
+                common_realization = part_realization
+                continue
+            if part_realization != common_realization:
+                self.has_multiple_realizations_flag = True
+                self.realization = None  # override single realization number applicable to whole collection
+                break
+        if not self.has_multiple_realizations_flag and common_realization is not None:
+            self.realization = common_realization
+        return self.has_multiple_realizations_flag
 
-   def has_multiple_realizations(self):
-      """Returns the has multiple realizations flag based on whether properties belong to more than one realization.
+    def has_multiple_realizations(self):
+        """Returns the has multiple realizations flag based on whether properties belong to more than one realization.
 
       :meta common:
       """
 
-      if self.has_multiple_realizations_flag is None:
-         self.establish_has_multiple_realizations()
-      return self.has_multiple_realizations_flag
+        if self.has_multiple_realizations_flag is None:
+            self.establish_has_multiple_realizations()
+        return self.has_multiple_realizations_flag
 
-   def establish_has_single_uom(self):
-      """Re-evaluates the has single uom attribute depending on whether all properties have the same units of measure."""
+    def establish_has_single_uom(self):
+        """Re-evaluates the has single uom attribute depending on whether all properties have the same units of measure."""
 
-      self.has_single_uom_flag = True
-      common_uom = None
-      for part in self.parts():
-         part_uom = self.uom_for_part(part)
-         if common_uom is None:
-            common_uom = part_uom
-         elif part_uom != common_uom:
-            self.has_single_uom_flag = False
-            break
-      if common_uom is None:
-         self.has_single_uom_flag = True  # all uoms are None (probably discrete properties)
-      return self.has_single_uom_flag
+        self.has_single_uom_flag = True
+        common_uom = None
+        for part in self.parts():
+            part_uom = self.uom_for_part(part)
+            if common_uom is None:
+                common_uom = part_uom
+            elif part_uom != common_uom:
+                self.has_single_uom_flag = False
+                break
+        if common_uom is None:
+            self.has_single_uom_flag = True  # all uoms are None (probably discrete properties)
+        return self.has_single_uom_flag
 
-   def has_single_uom(self):
-      """Returns the has single uom flag depending on whether all properties have the same units of measure."""
+    def has_single_uom(self):
+        """Returns the has single uom flag depending on whether all properties have the same units of measure."""
 
-      if self.has_single_uom_flag is None:
-         self.establish_has_single_uom()
-      return self.has_single_uom_flag
+        if self.has_single_uom_flag is None:
+            self.establish_has_single_uom()
+        return self.has_single_uom_flag
 
-   def assign_realization_numbers(self):
-      """Assigns a distinct realization number to each property, after checking for compatibility.
+    def assign_realization_numbers(self):
+        """Assigns a distinct realization number to each property, after checking for compatibility.
 
       note:
          this method does not modify realization information in any established xml; it is intended primarily as
          a convenience to allow realization based processing of any collection of compatible properties
       """
 
-      assert self.has_single_property_kind(), 'attempt to assign realization numbers to properties of differing kinds'
-      assert self.has_single_indexable_element(
-      ), 'attempt to assign realizations to properties of differing indexable elements'
-      assert self.has_single_uom(
-      ), 'attempt to assign realization numbers to properties with differing units of measure'
+        assert self.has_single_property_kind(), 'attempt to assign realization numbers to properties of differing kinds'
+        assert self.has_single_indexable_element(
+        ), 'attempt to assign realizations to properties of differing indexable elements'
+        assert self.has_single_uom(
+        ), 'attempt to assign realization numbers to properties with differing units of measure'
 
-      new_dict = {}
-      realization = 0
-      for key, entry in self.dict.items():
-         entry_list = list(entry)
-         entry_list[0] = realization
-         new_dict[key] = tuple(entry_list)
-         realization += 1
-      self.dict = new_dict
-      self.has_multiple_realizations_flag = (realization > 1)
+        new_dict = {}
+        realization = 0
+        for key, entry in self.dict.items():
+            entry_list = list(entry)
+            entry_list[0] = realization
+            new_dict[key] = tuple(entry_list)
+            realization += 1
+        self.dict = new_dict
+        self.has_multiple_realizations_flag = (realization > 1)
 
-   def masked_array(self, simple_array, exclude_inactive = True, exclude_value = None, points = False):
-      """Returns a masked version of simple_array, using inactive mask associated with support for this property collection.
+    def masked_array(self, simple_array, exclude_inactive = True, exclude_value = None, points = False):
+        """Returns a masked version of simple_array, using inactive mask associated with support for this property collection.
 
       arguments:
          simple_array (numpy array): an unmasked numpy array with the same shape as property arrays for the support
@@ -1972,54 +1977,54 @@ class PropertyCollection():
          internally by this module); the simple_array need not be part of this collection
       """
 
-      mask = None
-      if (exclude_inactive and self.support is not None and hasattr(self.support, 'inactive') and
-          self.support.inactive is not None):
-         if not points:
-            if self.support.inactive.shape == simple_array.shape:
-               mask = self.support.inactive
-         else:
-            assert simple_array.ndim > 1 and simple_array.shape[-1] == 3
-            if (self.support.inactive.ndim + 1 == simple_array.ndim and
-                self.support.inactive.shape == tuple(simple_array.shape[:-1])):
-               mask = np.empty(simple_array.shape, dtype = bool)
-               mask[:] = self.support.inactive[:, np.newaxis]
-      if exclude_value:
-         null_mask = (simple_array == exclude_value)
-         if mask is None:
-            mask = null_mask
-         else:
-            mask = np.logical_or(mask, null_mask)
-      if mask is None:
-         mask = ma.nomask
-      return ma.masked_array(simple_array, mask = mask)
+        mask = None
+        if (exclude_inactive and self.support is not None and hasattr(self.support, 'inactive') and
+                self.support.inactive is not None):
+            if not points:
+                if self.support.inactive.shape == simple_array.shape:
+                    mask = self.support.inactive
+            else:
+                assert simple_array.ndim > 1 and simple_array.shape[-1] == 3
+                if (self.support.inactive.ndim + 1 == simple_array.ndim and
+                        self.support.inactive.shape == tuple(simple_array.shape[:-1])):
+                    mask = np.empty(simple_array.shape, dtype = bool)
+                    mask[:] = self.support.inactive[:, np.newaxis]
+        if exclude_value:
+            null_mask = (simple_array == exclude_value)
+            if mask is None:
+                mask = null_mask
+            else:
+                mask = np.logical_or(mask, null_mask)
+        if mask is None:
+            mask = ma.nomask
+        return ma.masked_array(simple_array, mask = mask)
 
-   def h5_key_pair_for_part(self, part):
-      """Return hdf5 key pair (ext uuid, internal path) for the part."""
+    def h5_key_pair_for_part(self, part):
+        """Return hdf5 key pair (ext uuid, internal path) for the part."""
 
-      # note: this method does not currently support all the possible tag values for different instances
-      # of the RESQML abstract arrays
+        # note: this method does not currently support all the possible tag values for different instances
+        # of the RESQML abstract arrays
 
-      model = self.model
-      part_node = self.node_for_part(part)
-      if part_node is None:
-         return None
-      if self.points_for_part(part):
-         patch_list = rqet.list_of_tag(part_node, 'PatchOfPoints')
-         assert len(patch_list) == 1  # todo: handle more than one patch of points
-         first_values_node = rqet.find_tag(patch_list[0], 'Points')
-         tag = 'Coordinates'
-      else:
-         patch_list = rqet.list_of_tag(part_node, 'PatchOfValues')
-         assert len(patch_list) == 1  # todo: handle more than one patch of values
-         first_values_node = rqet.find_tag(patch_list[0], 'Values')
-         tag = 'Values'
-      if first_values_node is None:
-         return None  # could treat as fatal error
-      return model.h5_uuid_and_path_for_node(first_values_node, tag = tag)
+        model = self.model
+        part_node = self.node_for_part(part)
+        if part_node is None:
+            return None
+        if self.points_for_part(part):
+            patch_list = rqet.list_of_tag(part_node, 'PatchOfPoints')
+            assert len(patch_list) == 1  # todo: handle more than one patch of points
+            first_values_node = rqet.find_tag(patch_list[0], 'Points')
+            tag = 'Coordinates'
+        else:
+            patch_list = rqet.list_of_tag(part_node, 'PatchOfValues')
+            assert len(patch_list) == 1  # todo: handle more than one patch of values
+            first_values_node = rqet.find_tag(patch_list[0], 'Values')
+            tag = 'Values'
+        if first_values_node is None:
+            return None  # could treat as fatal error
+        return model.h5_uuid_and_path_for_node(first_values_node, tag = tag)
 
-   def cached_part_array_ref(self, part, dtype = None, masked = False, exclude_null = False):
-      """Returns a numpy array containing the data for the property part; the array is cached in this collection.
+    def cached_part_array_ref(self, part, dtype = None, masked = False, exclude_null = False):
+        """Returns a numpy array containing the data for the property part; the array is cached in this collection.
 
       arguments:
          part (string): the part name for which the array reference is required
@@ -2047,75 +2052,75 @@ class PropertyCollection():
       :meta common:
       """
 
-      model = self.model
-      cached_array_name = _cache_name(part)
-      if cached_array_name is None:
-         return None
-
-      if not hasattr(self, cached_array_name):
-
-         const_value = self.constant_value_for_part(part)
-         if const_value is None:
-            part_node = self.node_for_part(part)
-            if part_node is None:
-               return None
-            if self.points_for_part(part):
-               patch_list = rqet.list_of_tag(part_node, 'PatchOfPoints')
-               assert len(patch_list) == 1  # todo: handle more than one patch of points
-               first_values_node = rqet.find_tag(patch_list[0], 'Points')
-               if first_values_node is None:
-                  return None  # could treat as fatal error
-               if dtype is None:
-                  dtype = 'float'
-               else:
-                  assert dtype in ['float', float, np.float32, np.float64]
-               tag = 'Coordinates'
-            else:
-               patch_list = rqet.list_of_tag(part_node, 'PatchOfValues')
-               assert len(patch_list) == 1  # todo: handle more than one patch of values
-               first_values_node = rqet.find_tag(patch_list[0], 'Values')
-               if first_values_node is None:
-                  return None  # could treat as fatal error
-               if dtype is None:
-                  array_type = rqet.node_type(first_values_node)
-                  assert array_type is not None
-                  if array_type == 'DoubleHdf5Array':
-                     dtype = 'float'
-                  elif array_type == 'IntegerHdf5Array':
-                     dtype = 'int'
-                  elif array_type == 'BooleanHdf5Array':
-                     dtype = 'bool'
-                  else:
-                     raise ValueError('array type not catered for: ' + str(array_type))
-               tag = 'Values'
-            h5_key_pair = model.h5_uuid_and_path_for_node(first_values_node, tag = tag)
-            if h5_key_pair is None:
-               return None
-            model.h5_array_element(h5_key_pair,
-                                   index = None,
-                                   cache_array = True,
-                                   object = self,
-                                   array_attribute = cached_array_name,
-                                   dtype = dtype)
-         else:
-            assert not self.points_for_part(part), 'constant arrays not supported for points properties'
-            assert self.support is not None
-            shape = self.supporting_shape(indexable_element = self.indexable_for_part(part),
-                                          direction = self._part_direction(part))
-            assert shape is not None
-            a = np.full(shape, const_value, dtype = float if self.continuous_for_part(part) else int)
-            setattr(self, cached_array_name, a)
-         if not hasattr(self, cached_array_name):
+        model = self.model
+        cached_array_name = _cache_name(part)
+        if cached_array_name is None:
             return None
 
-      if masked:
-         exclude_value = self.null_value_for_part(part) if exclude_null else None
-         return self.masked_array(self.__dict__[cached_array_name], exclude_value = exclude_value)
-      else:
-         return self.__dict__[cached_array_name]
+        if not hasattr(self, cached_array_name):
 
-   def h5_slice(self, part, slice_tuple):
-      """Returns a subset of the array for part, without loading the whole array.
+            const_value = self.constant_value_for_part(part)
+            if const_value is None:
+                part_node = self.node_for_part(part)
+                if part_node is None:
+                    return None
+                if self.points_for_part(part):
+                    patch_list = rqet.list_of_tag(part_node, 'PatchOfPoints')
+                    assert len(patch_list) == 1  # todo: handle more than one patch of points
+                    first_values_node = rqet.find_tag(patch_list[0], 'Points')
+                    if first_values_node is None:
+                        return None  # could treat as fatal error
+                    if dtype is None:
+                        dtype = 'float'
+                    else:
+                        assert dtype in ['float', float, np.float32, np.float64]
+                    tag = 'Coordinates'
+                else:
+                    patch_list = rqet.list_of_tag(part_node, 'PatchOfValues')
+                    assert len(patch_list) == 1  # todo: handle more than one patch of values
+                    first_values_node = rqet.find_tag(patch_list[0], 'Values')
+                    if first_values_node is None:
+                        return None  # could treat as fatal error
+                    if dtype is None:
+                        array_type = rqet.node_type(first_values_node)
+                        assert array_type is not None
+                        if array_type == 'DoubleHdf5Array':
+                            dtype = 'float'
+                        elif array_type == 'IntegerHdf5Array':
+                            dtype = 'int'
+                        elif array_type == 'BooleanHdf5Array':
+                            dtype = 'bool'
+                        else:
+                            raise ValueError('array type not catered for: ' + str(array_type))
+                    tag = 'Values'
+                h5_key_pair = model.h5_uuid_and_path_for_node(first_values_node, tag = tag)
+                if h5_key_pair is None:
+                    return None
+                model.h5_array_element(h5_key_pair,
+                                       index = None,
+                                       cache_array = True,
+                                       object = self,
+                                       array_attribute = cached_array_name,
+                                       dtype = dtype)
+            else:
+                assert not self.points_for_part(part), 'constant arrays not supported for points properties'
+                assert self.support is not None
+                shape = self.supporting_shape(indexable_element = self.indexable_for_part(part),
+                                              direction = self._part_direction(part))
+                assert shape is not None
+                a = np.full(shape, const_value, dtype = float if self.continuous_for_part(part) else int)
+                setattr(self, cached_array_name, a)
+            if not hasattr(self, cached_array_name):
+                return None
+
+        if masked:
+            exclude_value = self.null_value_for_part(part) if exclude_null else None
+            return self.masked_array(self.__dict__[cached_array_name], exclude_value = exclude_value)
+        else:
+            return self.__dict__[cached_array_name]
+
+    def h5_slice(self, part, slice_tuple):
+        """Returns a subset of the array for part, without loading the whole array.
 
       arguments:
          part (string): the part name for which the array slice is required
@@ -2131,13 +2136,13 @@ class PropertyCollection():
          an axis is 1
       """
 
-      h5_key_pair = self.h5_key_pair_for_part(part)
-      if h5_key_pair is None:
-         return None
-      return self.model.h5_array_slice(h5_key_pair, slice_tuple)
+        h5_key_pair = self.h5_key_pair_for_part(part)
+        if h5_key_pair is None:
+            return None
+        return self.model.h5_array_slice(h5_key_pair, slice_tuple)
 
-   def h5_overwrite_slice(self, part, slice_tuple, array_slice, update_cache = True):
-      """Overwrites a subset of the array for part, in the hdf5 file.
+    def h5_overwrite_slice(self, part, slice_tuple, array_slice, update_cache = True):
+        """Overwrites a subset of the array for part, in the hdf5 file.
 
       arguments:
          part (string): the part name for which the array slice is to be overwritten
@@ -2155,55 +2160,55 @@ class PropertyCollection():
          regardless of the update_cache argument
       """
 
-      h5_key_pair = self.h5_key_pair_for_part(part)
-      assert h5_key_pair is not None
-      self.model.h5_overwrite_array_slice(h5_key_pair, slice_tuple, array_slice)
-      cached_array_name = _cache_name(part)
-      if cached_array_name is None:
-         return
-      if hasattr(self, cached_array_name):
-         if update_cache:
-            self.__dict__[cached_array_name][slice_tuple] = array_slice
-         else:
-            delattr(self, cached_array_name)
+        h5_key_pair = self.h5_key_pair_for_part(part)
+        assert h5_key_pair is not None
+        self.model.h5_overwrite_array_slice(h5_key_pair, slice_tuple, array_slice)
+        cached_array_name = _cache_name(part)
+        if cached_array_name is None:
+            return
+        if hasattr(self, cached_array_name):
+            if update_cache:
+                self.__dict__[cached_array_name][slice_tuple] = array_slice
+            else:
+                delattr(self, cached_array_name)
 
-   def shape_and_type_of_part(self, part):
-      """Returns shape tuple and element type of cached or hdf5 array for part."""
+    def shape_and_type_of_part(self, part):
+        """Returns shape tuple and element type of cached or hdf5 array for part."""
 
-      model = self.model
-      cached_array_name = _cache_name(part)
-      if cached_array_name is None:
-         return None, None
+        model = self.model
+        cached_array_name = _cache_name(part)
+        if cached_array_name is None:
+            return None, None
 
-      if hasattr(self, cached_array_name):
-         return tuple(self.__dict__[cached_array_name].shape), self.__dict__[cached_array_name].dtype
+        if hasattr(self, cached_array_name):
+            return tuple(self.__dict__[cached_array_name].shape), self.__dict__[cached_array_name].dtype
 
-      part_node = self.node_for_part(part)
-      if part_node is None:
-         return None, None
+        part_node = self.node_for_part(part)
+        if part_node is None:
+            return None, None
 
-      if self.constant_value_for_part(part) is not None:
-         assert not self.points_for_part(part), 'constant array not supported for points property'
-         assert self.support is not None
-         shape = self.supporting_shape(indexable_element = self.indexable_for_part(part),
-                                       direction = self._part_direction(part))
-         assert shape is not None
-         return shape, (float if self.continuous_for_part(part) else int)
+        if self.constant_value_for_part(part) is not None:
+            assert not self.points_for_part(part), 'constant array not supported for points property'
+            assert self.support is not None
+            shape = self.supporting_shape(indexable_element = self.indexable_for_part(part),
+                                          direction = self._part_direction(part))
+            assert shape is not None
+            return shape, (float if self.continuous_for_part(part) else int)
 
-      if self.points_for_part(part):
-         patch_list = rqet.list_of_tag(part_node, 'PatchOfpoints')
-         assert len(patch_list) == 1  # todo: handle more than one patch of points
-         h5_key_pair = model.h5_uuid_and_path_for_node(rqet.find_tag(patch_list[0], tag = 'Coordinates'))
-      else:
-         patch_list = rqet.list_of_tag(part_node, 'PatchOfValues')
-         assert len(patch_list) == 1  # todo: handle more than one patch of values
-         h5_key_pair = model.h5_uuid_and_path_for_node(rqet.find_tag(patch_list[0], tag = 'Values'))
-      if h5_key_pair is None:
-         return None, None
-      return model.h5_array_shape_and_type(h5_key_pair)
+        if self.points_for_part(part):
+            patch_list = rqet.list_of_tag(part_node, 'PatchOfpoints')
+            assert len(patch_list) == 1  # todo: handle more than one patch of points
+            h5_key_pair = model.h5_uuid_and_path_for_node(rqet.find_tag(patch_list[0], tag = 'Coordinates'))
+        else:
+            patch_list = rqet.list_of_tag(part_node, 'PatchOfValues')
+            assert len(patch_list) == 1  # todo: handle more than one patch of values
+            h5_key_pair = model.h5_uuid_and_path_for_node(rqet.find_tag(patch_list[0], tag = 'Values'))
+        if h5_key_pair is None:
+            return None, None
+        return model.h5_array_shape_and_type(h5_key_pair)
 
-   def facets_array_ref(self, use_32_bit = False, indexable_element = None):  # todo: add masked argument
-      """Returns a +1D array of all parts with first axis being over facet values; Use facet_list() for lookup.
+    def facets_array_ref(self, use_32_bit = False, indexable_element = None):  # todo: add masked argument
+        """Returns a +1D array of all parts with first axis being over facet values; Use facet_list() for lookup.
 
       arguments:
          use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
@@ -2221,47 +2226,48 @@ class PropertyCollection():
          resulting array
       """
 
-      assert self.support is not None, 'attempt to build facets array for property collection without supporting representation'
-      assert self.number_of_parts() > 0, 'attempt to build facets array for empty property collection'
-      assert self.has_single_property_kind(
-      ), 'attempt to build facets array for collection containing multiple property kinds'
-      assert self.has_single_indexable_element(
-      ), 'attempt to build facets array for collection containing a variety of indexable elements'
-      assert self.has_single_uom(), 'attempt to build facets array for collection containing multiple units of measure'
+        assert self.support is not None, 'attempt to build facets array for property collection without supporting representation'
+        assert self.number_of_parts() > 0, 'attempt to build facets array for empty property collection'
+        assert self.has_single_property_kind(
+        ), 'attempt to build facets array for collection containing multiple property kinds'
+        assert self.has_single_indexable_element(
+        ), 'attempt to build facets array for collection containing a variety of indexable elements'
+        assert self.has_single_uom(
+        ), 'attempt to build facets array for collection containing multiple units of measure'
 
-      #  could check that facet_type_list() has exactly one value
-      facet_list = self.facet_list(sort_list = True)
-      facet_count = len(facet_list)
-      assert facet_count > 0, 'no facets found in property collection'
-      assert self.number_of_parts() == facet_count, 'collection covers more than facet variability'
+        #  could check that facet_type_list() has exactly one value
+        facet_list = self.facet_list(sort_list = True)
+        facet_count = len(facet_list)
+        assert facet_count > 0, 'no facets found in property collection'
+        assert self.number_of_parts() == facet_count, 'collection covers more than facet variability'
 
-      continuous = self.all_continuous()
-      if not continuous:
-         assert self.all_discrete(), 'mixture of continuous and discrete properties in collection'
+        continuous = self.all_continuous()
+        if not continuous:
+            assert self.all_discrete(), 'mixture of continuous and discrete properties in collection'
 
-      if indexable_element is None:
-         indexable_element = self.indexable_for_part(self.parts()[0])
+        if indexable_element is None:
+            indexable_element = self.indexable_for_part(self.parts()[0])
 
-      dtype = dtype_flavour(continuous, use_32_bit)
-      shape_list = self.supporting_shape(indexable_element = indexable_element)
-      shape_list.insert(0, facet_count)
+        dtype = dtype_flavour(continuous, use_32_bit)
+        shape_list = self.supporting_shape(indexable_element = indexable_element)
+        shape_list.insert(0, facet_count)
 
-      a = np.zeros(shape_list, dtype = dtype)
+        a = np.zeros(shape_list, dtype = dtype)
 
-      for part in self.parts():
-         facet_index = facet_list.index(self.facet_for_part(part))
-         pa = self.cached_part_array_ref(part, dtype = dtype)
-         a[facet_index] = pa
-         self.uncache_part_array(part)
+        for part in self.parts():
+            facet_index = facet_list.index(self.facet_for_part(part))
+            pa = self.cached_part_array_ref(part, dtype = dtype)
+            a[facet_index] = pa
+            self.uncache_part_array(part)
 
-      return a
+        return a
 
-   def realizations_array_ref(self,
-                              use_32_bit = False,
-                              fill_missing = True,
-                              fill_value = None,
-                              indexable_element = None):
-      """Returns a +1D array of all parts with first axis being over realizations.
+    def realizations_array_ref(self,
+                               use_32_bit = False,
+                               fill_missing = True,
+                               fill_value = None,
+                               indexable_element = None):
+        """Returns a +1D array of all parts with first axis being over realizations.
 
       arguments:
          use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
@@ -2287,65 +2293,65 @@ class PropertyCollection():
       :meta common:
       """
 
-      assert self.support is not None, 'attempt to build realizations array for property collection without supporting representation'
-      assert self.number_of_parts() > 0, 'attempt to build realizations array for empty property collection'
-      assert self.has_single_property_kind(
-      ), 'attempt to build realizations array for collection with multiple property kinds'
-      assert self.has_single_indexable_element(
-      ), 'attempt to build realizations array for collection containing a variety of indexable elements'
-      assert self.has_single_uom(
-      ), 'attempt to build realizations array for collection containing multiple units of measure'
+        assert self.support is not None, 'attempt to build realizations array for property collection without supporting representation'
+        assert self.number_of_parts() > 0, 'attempt to build realizations array for empty property collection'
+        assert self.has_single_property_kind(
+        ), 'attempt to build realizations array for collection with multiple property kinds'
+        assert self.has_single_indexable_element(
+        ), 'attempt to build realizations array for collection containing a variety of indexable elements'
+        assert self.has_single_uom(
+        ), 'attempt to build realizations array for collection containing multiple units of measure'
 
-      r_list = self.realization_list(sort_list = True)
-      assert self.number_of_parts() == len(r_list), 'collection covers more than realizations of a single property'
+        r_list = self.realization_list(sort_list = True)
+        assert self.number_of_parts() == len(r_list), 'collection covers more than realizations of a single property'
 
-      continuous = self.all_continuous()
-      if not continuous:
-         assert self.all_discrete(), 'mixture of continuous and discrete properties in collection'
+        continuous = self.all_continuous()
+        if not continuous:
+            assert self.all_discrete(), 'mixture of continuous and discrete properties in collection'
 
-      if fill_value is None:
-         fill_value = np.NaN if continuous else -1
+        if fill_value is None:
+            fill_value = np.NaN if continuous else -1
 
-      if indexable_element is None:
-         indexable_element = self.indexable_for_part(self.parts()[0])
+        if indexable_element is None:
+            indexable_element = self.indexable_for_part(self.parts()[0])
 
-      if fill_missing:
-         r_extent = r_list[-1] + 1
-      else:
-         r_extent = len(r_list)
+        if fill_missing:
+            r_extent = r_list[-1] + 1
+        else:
+            r_extent = len(r_list)
 
-      dtype = dtype_flavour(continuous, use_32_bit)
-      # todo: handle direction dependent shapes
-      shape_list = self.supporting_shape(indexable_element = indexable_element)
-      shape_list.insert(0, r_extent)
-      if self.points_for_part(self.parts()[0]):
-         shape_list.append(3)
+        dtype = dtype_flavour(continuous, use_32_bit)
+        # todo: handle direction dependent shapes
+        shape_list = self.supporting_shape(indexable_element = indexable_element)
+        shape_list.insert(0, r_extent)
+        if self.points_for_part(self.parts()[0]):
+            shape_list.append(3)
 
-      a = np.full(shape_list, fill_value, dtype = dtype)
+        a = np.full(shape_list, fill_value, dtype = dtype)
 
-      if fill_missing:
-         for part in self.parts():
-            realization = self.realization_for_part(part)
-            assert realization is not None and 0 <= realization < r_extent, 'realization missing (or out of range?)'
-            pa = self.cached_part_array_ref(part, dtype = dtype)
-            a[realization] = pa
-            self.uncache_part_array(part)
-      else:
-         for index in range(len(r_list)):
-            realization = r_list[index]
-            part = self.singleton(realization = realization)
-            pa = self.cached_part_array_ref(part, dtype = dtype)
-            a[index] = pa
-            self.uncache_part_array(part)
+        if fill_missing:
+            for part in self.parts():
+                realization = self.realization_for_part(part)
+                assert realization is not None and 0 <= realization < r_extent, 'realization missing (or out of range?)'
+                pa = self.cached_part_array_ref(part, dtype = dtype)
+                a[realization] = pa
+                self.uncache_part_array(part)
+        else:
+            for index in range(len(r_list)):
+                realization = r_list[index]
+                part = self.singleton(realization = realization)
+                pa = self.cached_part_array_ref(part, dtype = dtype)
+                a[index] = pa
+                self.uncache_part_array(part)
 
-      return a
+        return a
 
-   def time_series_array_ref(self,
-                             use_32_bit = False,
-                             fill_missing = True,
-                             fill_value = None,
-                             indexable_element = None):
-      """Returns a +1D array of all parts with first axis being over time indices.
+    def time_series_array_ref(self,
+                              use_32_bit = False,
+                              fill_missing = True,
+                              fill_value = None,
+                              indexable_element = None):
+        """Returns a +1D array of all parts with first axis being over time indices.
 
       arguments:
          use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
@@ -2372,61 +2378,61 @@ class PropertyCollection():
       :meta common:
       """
 
-      assert self.support is not None, 'attempt to build time series array for property collection without supporting representation'
-      assert self.number_of_parts() > 0, 'attempt to build time series array for empty property collection'
-      assert self.has_single_property_kind(
-      ), 'attempt to build time series array for collection with multiple property kinds'
-      assert self.has_single_indexable_element(
-      ), 'attempt to build time series array for collection containing a variety of indexable elements'
-      assert self.has_single_uom(
-      ), 'attempt to build time series array for collection containing multiple units of measure'
+        assert self.support is not None, 'attempt to build time series array for property collection without supporting representation'
+        assert self.number_of_parts() > 0, 'attempt to build time series array for empty property collection'
+        assert self.has_single_property_kind(
+        ), 'attempt to build time series array for collection with multiple property kinds'
+        assert self.has_single_indexable_element(
+        ), 'attempt to build time series array for collection containing a variety of indexable elements'
+        assert self.has_single_uom(
+        ), 'attempt to build time series array for collection containing multiple units of measure'
 
-      ti_list = self.time_index_list(sort_list = True)
-      assert self.number_of_parts() == len(ti_list), 'collection covers more than time indices of a single property'
+        ti_list = self.time_index_list(sort_list = True)
+        assert self.number_of_parts() == len(ti_list), 'collection covers more than time indices of a single property'
 
-      continuous = self.all_continuous()
-      if not continuous:
-         assert self.all_discrete(), 'mixture of continuous and discrete properties in collection'
+        continuous = self.all_continuous()
+        if not continuous:
+            assert self.all_discrete(), 'mixture of continuous and discrete properties in collection'
 
-      if fill_value is None:
-         fill_value = np.NaN if continuous else -1
+        if fill_value is None:
+            fill_value = np.NaN if continuous else -1
 
-      if indexable_element is None:
-         indexable_element = self.indexable_for_part(self.parts()[0])
+        if indexable_element is None:
+            indexable_element = self.indexable_for_part(self.parts()[0])
 
-      if fill_missing:
-         ti_extent = ti_list[-1] + 1
-      else:
-         ti_extent = len(ti_list)
+        if fill_missing:
+            ti_extent = ti_list[-1] + 1
+        else:
+            ti_extent = len(ti_list)
 
-      dtype = dtype_flavour(continuous, use_32_bit)
-      # todo: handle direction dependent shapes
-      shape_list = self.supporting_shape(indexable_element = indexable_element)
-      shape_list.insert(0, ti_extent)
-      if self.points_for_part(self.parts()[0]):
-         shape_list.append(3)
+        dtype = dtype_flavour(continuous, use_32_bit)
+        # todo: handle direction dependent shapes
+        shape_list = self.supporting_shape(indexable_element = indexable_element)
+        shape_list.insert(0, ti_extent)
+        if self.points_for_part(self.parts()[0]):
+            shape_list.append(3)
 
-      a = np.full(shape_list, fill_value, dtype = dtype)
+        a = np.full(shape_list, fill_value, dtype = dtype)
 
-      if fill_missing:
-         for part in self.parts():
-            time_index = self.time_index_for_part(part)
-            assert time_index is not None and 0 <= time_index < ti_extent, 'time index missing (or out of range?)'
-            pa = self.cached_part_array_ref(part, dtype = dtype)
-            a[time_index] = pa
-            self.uncache_part_array(part)
-      else:
-         for index in range(len(ti_list)):
-            time_index = ti_list[index]
-            part = self.singleton(time_index = time_index)
-            pa = self.cached_part_array_ref(part, dtype = dtype)
-            a[index] = pa
-            self.uncache_part_array(part)
+        if fill_missing:
+            for part in self.parts():
+                time_index = self.time_index_for_part(part)
+                assert time_index is not None and 0 <= time_index < ti_extent, 'time index missing (or out of range?)'
+                pa = self.cached_part_array_ref(part, dtype = dtype)
+                a[time_index] = pa
+                self.uncache_part_array(part)
+        else:
+            for index in range(len(ti_list)):
+                time_index = ti_list[index]
+                part = self.singleton(time_index = time_index)
+                pa = self.cached_part_array_ref(part, dtype = dtype)
+                a[index] = pa
+                self.uncache_part_array(part)
 
-      return a
+        return a
 
-   def combobulated_face_array(self, resqml_a):
-      """Returns a logically ordered copy of RESQML faces-per-cell property array resqml_a.
+    def combobulated_face_array(self, resqml_a):
+        """Returns a logically ordered copy of RESQML faces-per-cell property array resqml_a.
 
       argument:
          resqml_a (numpy array of shape (..., 6): a RESQML property array with indexable element faces per cell
@@ -2442,19 +2448,19 @@ class PropertyCollection():
          does not currently support points properties
       """
 
-      assert resqml_a.shape[-1] == 6
+        assert resqml_a.shape[-1] == 6
 
-      resqpy_a_shape = tuple(list(resqml_a.shape[:-1]) + [3, 2])
-      resqpy_a = np.empty(resqpy_a_shape, dtype = resqml_a.dtype)
+        resqpy_a_shape = tuple(list(resqml_a.shape[:-1]) + [3, 2])
+        resqpy_a = np.empty(resqpy_a_shape, dtype = resqml_a.dtype)
 
-      for axis in range(3):
-         for polarity in range(2):
-            resqpy_a[..., axis, polarity] = resqml_a[..., self.face_index_map[axis, polarity]]
+        for axis in range(3):
+            for polarity in range(2):
+                resqpy_a[..., axis, polarity] = resqml_a[..., self.face_index_map[axis, polarity]]
 
-      return resqpy_a
+        return resqpy_a
 
-   def discombobulated_face_array(self, resqpy_a):
-      """Returns a RESQML format copy of logical face property array a, re-ordered and reshaped regarding the six facial directions.
+    def discombobulated_face_array(self, resqpy_a):
+        """Returns a RESQML format copy of logical face property array a, re-ordered and reshaped regarding the six facial directions.
 
       argument:
          resqpy_a (numpy array of shape (..., 3, 2)): the penultimate array axis represents K,J,I and the final axis is -/+ face
@@ -2471,38 +2477,38 @@ class PropertyCollection():
          does not currently support points properties
       """
 
-      assert resqpy_a.ndim >= 2 and resqpy_a.shape[-2] == 3 and resqpy_a.shape[-1] == 2
+        assert resqpy_a.ndim >= 2 and resqpy_a.shape[-2] == 3 and resqpy_a.shape[-1] == 2
 
-      resqml_a_shape = tuple(list(resqpy_a.shape[:-2]).append(6))
-      resqml_a = np.empty(resqml_a_shape, dtype = resqpy_a.dtype)
+        resqml_a_shape = tuple(list(resqpy_a.shape[:-2]).append(6))
+        resqml_a = np.empty(resqml_a_shape, dtype = resqpy_a.dtype)
 
-      for face in range(6):
-         resqml_a[..., face] = resqpy_a[..., self.face_index_inverse_map[face]]
+        for face in range(6):
+            resqml_a[..., face] = resqpy_a[..., self.face_index_inverse_map[face]]
 
-      return resqml_a
+        return resqml_a
 
-   def cached_normalized_part_array_ref(self,
-                                        part,
-                                        masked = False,
-                                        use_logarithm = False,
-                                        discrete_cycle = None,
-                                        trust_min_max = False):
-      """DEPRECATED: replaced with normalized_part_array() method."""
+    def cached_normalized_part_array_ref(self,
+                                         part,
+                                         masked = False,
+                                         use_logarithm = False,
+                                         discrete_cycle = None,
+                                         trust_min_max = False):
+        """DEPRECATED: replaced with normalized_part_array() method."""
 
-      return self.normalized_part_array(part,
-                                        masked = masked,
-                                        use_logarithm = use_logarithm,
-                                        discrete_cycle = discrete_cycle,
-                                        trust_min_max = trust_min_max)
+        return self.normalized_part_array(part,
+                                          masked = masked,
+                                          use_logarithm = use_logarithm,
+                                          discrete_cycle = discrete_cycle,
+                                          trust_min_max = trust_min_max)
 
-   def normalized_part_array(self,
-                             part,
-                             masked = False,
-                             use_logarithm = False,
-                             discrete_cycle = None,
-                             trust_min_max = False,
-                             fix_zero_at = None):
-      """Returns a triplet of: a numpy float array containing the data normalized between 0.0 and 1.0, the min value, the max value.
+    def normalized_part_array(self,
+                              part,
+                              masked = False,
+                              use_logarithm = False,
+                              discrete_cycle = None,
+                              trust_min_max = False,
+                              fix_zero_at = None):
+        """Returns a triplet of: a numpy float array containing the data normalized between 0.0 and 1.0, the min value, the max value.
 
       arguments:
          part (string): the part name for which the normalized array reference is required
@@ -2544,84 +2550,84 @@ class PropertyCollection():
          not applicable to points properties
       """
 
-      assert not self.points_for_part(part), 'property normalisation not available for points properties'
-      assert fix_zero_at is None or not use_logarithm
+        assert not self.points_for_part(part), 'property normalisation not available for points properties'
+        assert fix_zero_at is None or not use_logarithm
 
-      p_array = self.cached_part_array_ref(part, masked = masked)
+        p_array = self.cached_part_array_ref(part, masked = masked)
 
-      if p_array is None:
-         return None, None, None
-      min_value = max_value = None
-      if trust_min_max:
-         min_value = self.minimum_value_for_part(part)
-         max_value = self.maximum_value_for_part(part)
-      if min_value is None or max_value is None:
-         min_value = np.nanmin(p_array)
-         if masked and min_value is ma.masked:
-            min_value = None
-         max_value = np.nanmax(p_array)
-         if masked and max_value is ma.masked:
-            max_value = None
-         self.override_min_max(part, min_value, max_value)  # NB: this does not modify xml
-      if min_value is None or max_value is None:
-         return None, min_value, max_value
-      if 'int' in str(
-            p_array.dtype) and discrete_cycle is not None:  # could use continuous flag in metadata instead of dtype
-         p_array = p_array % discrete_cycle
-         min_value = 0
-         max_value = discrete_cycle - 1
-      elif str(p_array.dtype).startswith('bool'):
-         min_value = int(min_value)
-         max_value = int(max_value)
-      min_value = float(min_value)  # will return np.ma.masked if all values are masked out
-      if masked and min_value is ma.masked:
-         min_value = np.nan
-      max_value = float(max_value)
-      if masked and max_value is ma.masked:
-         max_value = np.nan
-      if min_value == np.nan or max_value == np.nan:
-         return None, min_value, max_value
-      if max_value < min_value:
-         return None, min_value, max_value
-      n_prop = p_array.astype(float)
-      if use_logarithm:
-         if min_value <= 0.0:
-            n_prop[:] = np.where(n_prop < 0.0001, 0.0001, n_prop)
-         n_prop = np.log10(n_prop)
-         min_value = np.nanmin(n_prop)
-         max_value = np.nanmax(n_prop)
-         if masked:
-            if min_value is ma.masked:
-               min_value = np.nan
-            if max_value is ma.masked:
-               max_value = np.nan
-         if min_value == np.nan or max_value == np.nan:
+        if p_array is None:
+            return None, None, None
+        min_value = max_value = None
+        if trust_min_max:
+            min_value = self.minimum_value_for_part(part)
+            max_value = self.maximum_value_for_part(part)
+        if min_value is None or max_value is None:
+            min_value = np.nanmin(p_array)
+            if masked and min_value is ma.masked:
+                min_value = None
+            max_value = np.nanmax(p_array)
+            if masked and max_value is ma.masked:
+                max_value = None
+            self.override_min_max(part, min_value, max_value)  # NB: this does not modify xml
+        if min_value is None or max_value is None:
             return None, min_value, max_value
-      if fix_zero_at is not None:
-         if fix_zero_at <= 0.0:
-            if min_value < 0.0:
-               n_prop[:] = np.where(n_prop < 0.0, 0.0, n_prop)
-            min_value = 0.0
-         elif fix_zero_at >= 1.0:
-            if max_value > 0.0:
-               n_prop[:] = np.where(n_prop > 0.0, 0.0, n_prop)
-            max_value = 0.0
-         else:
-            upper_scaling = max_value / (1.0 - fix_zero_at)
-            lower_scaling = -min_value / fix_zero_at
-            if upper_scaling >= lower_scaling:
-               min_value = -upper_scaling * fix_zero_at
-               n_prop[:] = np.where(n_prop < min_value, min_value, n_prop)
+        if 'int' in str(
+                p_array.dtype) and discrete_cycle is not None:  # could use continuous flag in metadata instead of dtype
+            p_array = p_array % discrete_cycle
+            min_value = 0
+            max_value = discrete_cycle - 1
+        elif str(p_array.dtype).startswith('bool'):
+            min_value = int(min_value)
+            max_value = int(max_value)
+        min_value = float(min_value)  # will return np.ma.masked if all values are masked out
+        if masked and min_value is ma.masked:
+            min_value = np.nan
+        max_value = float(max_value)
+        if masked and max_value is ma.masked:
+            max_value = np.nan
+        if min_value == np.nan or max_value == np.nan:
+            return None, min_value, max_value
+        if max_value < min_value:
+            return None, min_value, max_value
+        n_prop = p_array.astype(float)
+        if use_logarithm:
+            if min_value <= 0.0:
+                n_prop[:] = np.where(n_prop < 0.0001, 0.0001, n_prop)
+            n_prop = np.log10(n_prop)
+            min_value = np.nanmin(n_prop)
+            max_value = np.nanmax(n_prop)
+            if masked:
+                if min_value is ma.masked:
+                    min_value = np.nan
+                if max_value is ma.masked:
+                    max_value = np.nan
+            if min_value == np.nan or max_value == np.nan:
+                return None, min_value, max_value
+        if fix_zero_at is not None:
+            if fix_zero_at <= 0.0:
+                if min_value < 0.0:
+                    n_prop[:] = np.where(n_prop < 0.0, 0.0, n_prop)
+                min_value = 0.0
+            elif fix_zero_at >= 1.0:
+                if max_value > 0.0:
+                    n_prop[:] = np.where(n_prop > 0.0, 0.0, n_prop)
+                max_value = 0.0
             else:
-               max_value = lower_scaling * (1.0 - fix_zero_at)
-               n_prop[:] = np.where(n_prop > max_value, max_value, n_prop)
-      if max_value == min_value:
-         n_prop[:] = 0.5
-         return n_prop, min_value, max_value
-      return (n_prop - min_value) / (max_value - min_value), min_value, max_value
+                upper_scaling = max_value / (1.0 - fix_zero_at)
+                lower_scaling = -min_value / fix_zero_at
+                if upper_scaling >= lower_scaling:
+                    min_value = -upper_scaling * fix_zero_at
+                    n_prop[:] = np.where(n_prop < min_value, min_value, n_prop)
+                else:
+                    max_value = lower_scaling * (1.0 - fix_zero_at)
+                    n_prop[:] = np.where(n_prop > max_value, max_value, n_prop)
+        if max_value == min_value:
+            n_prop[:] = 0.5
+            return n_prop, min_value, max_value
+        return (n_prop - min_value) / (max_value - min_value), min_value, max_value
 
-   def uncache_part_array(self, part):
-      """Removes the cached copy of the array of data for the named property part.
+    def uncache_part_array(self, part):
+        """Removes the cached copy of the array of data for the named property part.
 
       argument:
          part (string): the part name for which the cached array is to be removed
@@ -2632,28 +2638,28 @@ class PropertyCollection():
          array are released
       """
 
-      cached_array_name = _cache_name(part)
-      if cached_array_name is not None and hasattr(self, cached_array_name):
-         delattr(self, cached_array_name)
+        cached_array_name = _cache_name(part)
+        if cached_array_name is not None and hasattr(self, cached_array_name):
+            delattr(self, cached_array_name)
 
-   def add_cached_array_to_imported_list(self,
-                                         cached_array,
-                                         source_info,
-                                         keyword,
-                                         discrete = False,
-                                         uom = None,
-                                         time_index = None,
-                                         null_value = None,
-                                         property_kind = None,
-                                         local_property_kind_uuid = None,
-                                         facet_type = None,
-                                         facet = None,
-                                         realization = None,
-                                         indexable_element = None,
-                                         count = 1,
-                                         const_value = None,
-                                         points = False):
-      """Caches array and adds to the list of imported properties (but not to the collection dict).
+    def add_cached_array_to_imported_list(self,
+                                          cached_array,
+                                          source_info,
+                                          keyword,
+                                          discrete = False,
+                                          uom = None,
+                                          time_index = None,
+                                          null_value = None,
+                                          property_kind = None,
+                                          local_property_kind_uuid = None,
+                                          facet_type = None,
+                                          facet = None,
+                                          realization = None,
+                                          indexable_element = None,
+                                          count = 1,
+                                          const_value = None,
+                                          points = False):
+        """Caches array and adds to the list of imported properties (but not to the collection dict).
 
       arguments:
          cached_array: a numpy array to be added to the imported list for this collection (prior to being added
@@ -2694,58 +2700,58 @@ class PropertyCollection():
       :meta common:
       """
 
-      assert (cached_array is not None and const_value is None) or (cached_array is None and const_value is not None)
-      assert not points or not discrete
-      assert count > 0
-      if self.imported_list is None:
-         self.imported_list = []
+        assert (cached_array is not None and const_value is None) or (cached_array is None and const_value is not None)
+        assert not points or not discrete
+        assert count > 0
+        if self.imported_list is None:
+            self.imported_list = []
 
-      uuid = bu.new_uuid()
-      cached_name = _cache_name_for_uuid(uuid)
-      if cached_array is not None:
-         self.__dict__[cached_name] = cached_array
-         zorro = self.masked_array(cached_array, exclude_value = null_value)
-         if not discrete and np.all(np.isnan(zorro)):
-            min_value = max_value = None
-         else:
-            min_value = np.nanmin(zorro)
-            max_value = np.nanmax(zorro)
-         if min_value is ma.masked or min_value == np.NaN:
-            min_value = None
-         if max_value is ma.masked or max_value == np.NaN:
-            max_value = None
-      else:
-         if const_value == null_value or (not discrete and np.isnan(const_value)):
-            min_value = max_value = None
-         else:
-            min_value = max_value = const_value
-      self.imported_list.append((uuid, source_info, keyword, cached_name, discrete, uom, time_index, null_value,
-                                 min_value, max_value, property_kind, facet_type, facet, realization, indexable_element,
-                                 count, local_property_kind_uuid, const_value, points))
-      return uuid
+        uuid = bu.new_uuid()
+        cached_name = _cache_name_for_uuid(uuid)
+        if cached_array is not None:
+            self.__dict__[cached_name] = cached_array
+            zorro = self.masked_array(cached_array, exclude_value = null_value)
+            if not discrete and np.all(np.isnan(zorro)):
+                min_value = max_value = None
+            else:
+                min_value = np.nanmin(zorro)
+                max_value = np.nanmax(zorro)
+            if min_value is ma.masked or min_value == np.NaN:
+                min_value = None
+            if max_value is ma.masked or max_value == np.NaN:
+                max_value = None
+        else:
+            if const_value == null_value or (not discrete and np.isnan(const_value)):
+                min_value = max_value = None
+            else:
+                min_value = max_value = const_value
+        self.imported_list.append((uuid, source_info, keyword, cached_name, discrete, uom, time_index, null_value,
+                                   min_value, max_value, property_kind, facet_type, facet, realization,
+                                   indexable_element, count, local_property_kind_uuid, const_value, points))
+        return uuid
 
-   def remove_cached_imported_arrays(self):
-      """Removes any cached arrays that are mentioned in imported list."""
+    def remove_cached_imported_arrays(self):
+        """Removes any cached arrays that are mentioned in imported list."""
 
-      for imported in self.imported_list:
-         cached_name = imported[3]
-         if hasattr(self, cached_name):
-            delattr(self, cached_name)
+        for imported in self.imported_list:
+            cached_name = imported[3]
+            if hasattr(self, cached_name):
+                delattr(self, cached_name)
 
-   def remove_cached_part_arrays(self):
-      """Removes any cached arrays for parts of the collection."""
+    def remove_cached_part_arrays(self):
+        """Removes any cached arrays for parts of the collection."""
 
-      for part in self.dict:
-         self.uncache_part_array(part)
+        for part in self.dict:
+            self.uncache_part_array(part)
 
-   def remove_all_cached_arrays(self):
-      """Removes any cached arrays for parts or mentioned in imported list."""
+    def remove_all_cached_arrays(self):
+        """Removes any cached arrays for parts or mentioned in imported list."""
 
-      self.remove_cached_imported_arrays()
-      self.remove_cached_part_arrays()
+        self.remove_cached_imported_arrays()
+        self.remove_cached_part_arrays()
 
-   def write_hdf5_for_imported_list(self, file_name = None, mode = 'a', expand_const_arrays = False):
-      """Create or append to an hdf5 file, writing datasets for the imported arrays.
+    def write_hdf5_for_imported_list(self, file_name = None, mode = 'a', expand_const_arrays = False):
+        """Create or append to an hdf5 file, writing datasets for the imported arrays.
 
       arguments:
          file_name (str, optional): if present, this hdf5 filename will override the default
@@ -2756,49 +2762,49 @@ class PropertyCollection():
       :meta common:
       """
 
-      # NB: imported array data must all have been cached prior to calling this function
-      assert self.imported_list is not None
-      h5_reg = rwh5.H5Register(self.model)
-      for ei, entry in enumerate(self.imported_list):
-         if entry[17] is not None:  # array has constant value
-            if not expand_const_arrays:
-               continue  # constant array – handled entirely in xml
-            uuid = entry[0]
-            cached_name = _cache_name_for_uuid(uuid)
-            assert self.support is not None
-            # note: will not handle direction dependent shapes
-            shape = self.supporting_shape(indexable_element = entry[14])
-            value = float(entry[17]) if isinstance(entry[17], str) else entry[17]
-            self.__dict__[cached_name] = np.full(shape, value)
-         else:
-            uuid = entry[0]
-            cached_name = entry[3]
-         tail = 'points_patch0' if entry[18] else 'values_patch0'
-         h5_reg.register_dataset(uuid, tail, self.__dict__[cached_name])
-      h5_reg.write(file = file_name, mode = mode)
+        # NB: imported array data must all have been cached prior to calling this function
+        assert self.imported_list is not None
+        h5_reg = rwh5.H5Register(self.model)
+        for ei, entry in enumerate(self.imported_list):
+            if entry[17] is not None:  # array has constant value
+                if not expand_const_arrays:
+                    continue  # constant array – handled entirely in xml
+                uuid = entry[0]
+                cached_name = _cache_name_for_uuid(uuid)
+                assert self.support is not None
+                # note: will not handle direction dependent shapes
+                shape = self.supporting_shape(indexable_element = entry[14])
+                value = float(entry[17]) if isinstance(entry[17], str) else entry[17]
+                self.__dict__[cached_name] = np.full(shape, value)
+            else:
+                uuid = entry[0]
+                cached_name = entry[3]
+            tail = 'points_patch0' if entry[18] else 'values_patch0'
+            h5_reg.register_dataset(uuid, tail, self.__dict__[cached_name])
+        h5_reg.write(file = file_name, mode = mode)
 
-   def write_hdf5_for_part(self, part, file_name = None, mode = 'a'):
-      """Create or append to an hdf5 file, writing dataset for the specified part."""
+    def write_hdf5_for_part(self, part, file_name = None, mode = 'a'):
+        """Create or append to an hdf5 file, writing dataset for the specified part."""
 
-      if self.constant_value_for_part(part) is not None:
-         return
-      h5_reg = rwh5.H5Register(self.model)
-      a = self.cached_part_array_ref(part)
-      tail = 'points_patch0' if self.points_for_part(part) else 'values_patch0'
-      h5_reg.register_dataset(self.uuid_for_part(part), tail, a)
-      h5_reg.write(file = file_name, mode = mode)
+        if self.constant_value_for_part(part) is not None:
+            return
+        h5_reg = rwh5.H5Register(self.model)
+        a = self.cached_part_array_ref(part)
+        tail = 'points_patch0' if self.points_for_part(part) else 'values_patch0'
+        h5_reg.register_dataset(self.uuid_for_part(part), tail, a)
+        h5_reg.write(file = file_name, mode = mode)
 
-   def create_xml_for_imported_list_and_add_parts_to_model(self,
-                                                           ext_uuid = None,
-                                                           support_uuid = None,
-                                                           time_series_uuid = None,
-                                                           selected_time_indices_list = None,
-                                                           string_lookup_uuid = None,
-                                                           property_kind_uuid = None,
-                                                           find_local_property_kinds = True,
-                                                           expand_const_arrays = False,
-                                                           extra_metadata = {}):
-      """Add imported or generated grid property arrays as parts in parent model, creating xml; hdf5 should already have been written.
+    def create_xml_for_imported_list_and_add_parts_to_model(self,
+                                                            ext_uuid = None,
+                                                            support_uuid = None,
+                                                            time_series_uuid = None,
+                                                            selected_time_indices_list = None,
+                                                            string_lookup_uuid = None,
+                                                            property_kind_uuid = None,
+                                                            find_local_property_kinds = True,
+                                                            expand_const_arrays = False,
+                                                            extra_metadata = {}):
+        """Add imported or generated grid property arrays as parts in parent model, creating xml; hdf5 should already have been written.
 
       arguments:
          ext_uuid: uuid for the hdf5 external part, which must be known to the model's hdf5 dictionary
@@ -2837,119 +2843,119 @@ class PropertyCollection():
       :meta common:
       """
 
-      if self.imported_list is None:
-         return []
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
-      prop_parts_list = []
-      uuid_list = []
-      for (p_uuid, p_file_name, p_keyword, p_cached_name, p_discrete, p_uom, p_time_index, p_null_value, p_min_value,
-           p_max_value, property_kind, facet_type, facet, realization, indexable_element, count,
-           local_property_kind_uuid, const_value, points) in self.imported_list:
-         log.debug('processing imported property ' + str(p_keyword))
-         assert not points or not p_discrete
-         if local_property_kind_uuid is None:
-            local_property_kind_uuid = property_kind_uuid
-         if property_kind is None:
-            if local_property_kind_uuid is not None:
-               # note: requires local property kind to be present
-               property_kind = self.model.title(uuid = local_property_kind_uuid)
+        if self.imported_list is None:
+            return []
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
+        prop_parts_list = []
+        uuid_list = []
+        for (p_uuid, p_file_name, p_keyword, p_cached_name, p_discrete, p_uom, p_time_index, p_null_value, p_min_value,
+             p_max_value, property_kind, facet_type, facet, realization, indexable_element, count,
+             local_property_kind_uuid, const_value, points) in self.imported_list:
+            log.debug('processing imported property ' + str(p_keyword))
+            assert not points or not p_discrete
+            if local_property_kind_uuid is None:
+                local_property_kind_uuid = property_kind_uuid
+            if property_kind is None:
+                if local_property_kind_uuid is not None:
+                    # note: requires local property kind to be present
+                    property_kind = self.model.title(uuid = local_property_kind_uuid)
+                else:
+                    # todo: only if None in ab_property_list
+                    (property_kind, facet_type, facet) = property_kind_and_facet_from_keyword(p_keyword)
+            if property_kind is None:
+                # todo: the following are abstract standard property kinds, which shouldn't really have data directly associated with them
+                if p_discrete:
+                    if string_lookup_uuid is not None:
+                        property_kind = 'categorical'
+                    else:
+                        property_kind = 'discrete'
+                elif points:
+                    property_kind = 'length'
+                else:
+                    property_kind = 'continuous'
+            if hasattr(self, p_cached_name):
+                p_array = self.__dict__[p_cached_name]
             else:
-               # todo: only if None in ab_property_list
-               (property_kind, facet_type, facet) = property_kind_and_facet_from_keyword(p_keyword)
-         if property_kind is None:
-            # todo: the following are abstract standard property kinds, which shouldn't really have data directly associated with them
-            if p_discrete:
-               if string_lookup_uuid is not None:
-                  property_kind = 'categorical'
-               else:
-                  property_kind = 'discrete'
-            elif points:
-               property_kind = 'length'
+                p_array = None
+            if points or property_kind == 'categorical':
+                add_min_max = False
+            elif local_property_kind_uuid is not None and string_lookup_uuid is not None:
+                add_min_max = False
             else:
-               property_kind = 'continuous'
-         if hasattr(self, p_cached_name):
-            p_array = self.__dict__[p_cached_name]
-         else:
-            p_array = None
-         if points or property_kind == 'categorical':
-            add_min_max = False
-         elif local_property_kind_uuid is not None and string_lookup_uuid is not None:
-            add_min_max = False
-         else:
-            add_min_max = True
-         if selected_time_indices_list is not None and p_time_index is not None:
-            p_time_index = selected_time_indices_list.index(p_time_index)
-         p_node = self.create_xml(
-            ext_uuid = ext_uuid,
-            property_array = p_array,
-            title = p_keyword,
-            property_kind = property_kind,
-            support_uuid = support_uuid,
-            p_uuid = p_uuid,
-            facet_type = facet_type,
-            facet = facet,
-            discrete = p_discrete,  # todo: time series bits
-            time_series_uuid = time_series_uuid,
-            time_index = p_time_index,
-            uom = p_uom,
-            null_value = p_null_value,
-            originator = None,
-            source = p_file_name,
-            add_as_part = True,
-            add_relationships = True,
-            add_min_max = add_min_max,
-            min_value = p_min_value,
-            max_value = p_max_value,
-            realization = realization,
-            string_lookup_uuid = string_lookup_uuid,
-            property_kind_uuid = local_property_kind_uuid,
-            indexable_element = indexable_element,
-            count = count,
-            points = points,
-            find_local_property_kinds = find_local_property_kinds,
-            extra_metadata = extra_metadata,
-            const_value = const_value,
-            expand_const_arrays = expand_const_arrays)
-         if p_node is not None:
-            prop_parts_list.append(rqet.part_name_for_part_root(p_node))
-            uuid_list.append(rqet.uuid_for_part_root(p_node))
-      self.add_parts_list_to_dict(prop_parts_list)
-      self.imported_list = []
-      return uuid_list
+                add_min_max = True
+            if selected_time_indices_list is not None and p_time_index is not None:
+                p_time_index = selected_time_indices_list.index(p_time_index)
+            p_node = self.create_xml(
+                ext_uuid = ext_uuid,
+                property_array = p_array,
+                title = p_keyword,
+                property_kind = property_kind,
+                support_uuid = support_uuid,
+                p_uuid = p_uuid,
+                facet_type = facet_type,
+                facet = facet,
+                discrete = p_discrete,  # todo: time series bits
+                time_series_uuid = time_series_uuid,
+                time_index = p_time_index,
+                uom = p_uom,
+                null_value = p_null_value,
+                originator = None,
+                source = p_file_name,
+                add_as_part = True,
+                add_relationships = True,
+                add_min_max = add_min_max,
+                min_value = p_min_value,
+                max_value = p_max_value,
+                realization = realization,
+                string_lookup_uuid = string_lookup_uuid,
+                property_kind_uuid = local_property_kind_uuid,
+                indexable_element = indexable_element,
+                count = count,
+                points = points,
+                find_local_property_kinds = find_local_property_kinds,
+                extra_metadata = extra_metadata,
+                const_value = const_value,
+                expand_const_arrays = expand_const_arrays)
+            if p_node is not None:
+                prop_parts_list.append(rqet.part_name_for_part_root(p_node))
+                uuid_list.append(rqet.uuid_for_part_root(p_node))
+        self.add_parts_list_to_dict(prop_parts_list)
+        self.imported_list = []
+        return uuid_list
 
-   def create_xml(self,
-                  ext_uuid,
-                  property_array,
-                  title,
-                  property_kind,
-                  support_uuid = None,
-                  p_uuid = None,
-                  facet_type = None,
-                  facet = None,
-                  discrete = False,
-                  time_series_uuid = None,
-                  time_index = None,
-                  uom = None,
-                  null_value = None,
-                  originator = None,
-                  source = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  add_min_max = True,
-                  min_value = None,
-                  max_value = None,
-                  realization = None,
-                  string_lookup_uuid = None,
-                  property_kind_uuid = None,
-                  find_local_property_kinds = True,
-                  indexable_element = None,
-                  count = 1,
-                  points = False,
-                  extra_metadata = {},
-                  const_value = None,
-                  expand_const_arrays = False):
-      """Create a property xml node for a single property related to a given supporting representation node.
+    def create_xml(self,
+                   ext_uuid,
+                   property_array,
+                   title,
+                   property_kind,
+                   support_uuid = None,
+                   p_uuid = None,
+                   facet_type = None,
+                   facet = None,
+                   discrete = False,
+                   time_series_uuid = None,
+                   time_index = None,
+                   uom = None,
+                   null_value = None,
+                   originator = None,
+                   source = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   add_min_max = True,
+                   min_value = None,
+                   max_value = None,
+                   realization = None,
+                   string_lookup_uuid = None,
+                   property_kind_uuid = None,
+                   find_local_property_kinds = True,
+                   indexable_element = None,
+                   count = 1,
+                   points = False,
+                   extra_metadata = {},
+                   const_value = None,
+                   expand_const_arrays = False):
+        """Create a property xml node for a single property related to a given supporting representation node.
 
       arguments:
          ext_uuid (uuid.UUID): the uuid of the hdf5 external part
@@ -3019,259 +3025,265 @@ class PropertyCollection():
          between the properties and the supporting representation
       """
 
-      #      log.debug('creating property node for ' + title)
-      # currently assumes discrete properties to be 32 bit integers and continuous to be 64 bit reals
-      # also assumes property_kind is one of the standard resqml property kinds; todo: allow local p kind node as optional arg
-      assert not discrete or not points
-      assert not points or const_value is None
-      assert not points or facet_type is None
-      assert self.model is not None
-      if support_uuid is None:
-         support_uuid = self.support_uuid
-      assert support_uuid is not None
-      support_root = self.model.root_for_uuid(support_uuid)
-      # assert support_root is not None
+        #      log.debug('creating property node for ' + title)
+        # currently assumes discrete properties to be 32 bit integers and continuous to be 64 bit reals
+        # also assumes property_kind is one of the standard resqml property kinds; todo: allow local p kind node as optional arg
+        assert not discrete or not points
+        assert not points or const_value is None
+        assert not points or facet_type is None
+        assert self.model is not None
+        if support_uuid is None:
+            support_uuid = self.support_uuid
+        assert support_uuid is not None
+        support_root = self.model.root_for_uuid(support_uuid)
+        # assert support_root is not None
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      if expand_const_arrays:
-         const_value = None
+        if expand_const_arrays:
+            const_value = None
 
-      support_type = self.model.type_of_part(self.model.part_for_uuid(support_uuid))
-      if indexable_element is None:
-         if support_type in [
-               'obj_IjkGridRepresentation', 'obj_BlockedWellboreRepresentation', 'obj_Grid2dRepresentation',
-               'obj_UnstructuredGridRepresentation'
-         ]:
-            indexable_element = 'cells'
-         elif support_type == 'obj_WellboreFrameRepresentation':
-            indexable_element = 'nodes'  # note: could be 'intervals'
-         elif support_type == 'obj_GridConnectionSetRepresentation':
-            indexable_element = 'faces'
-         else:
-            raise Exception('indexable element unknown for unsupported supporting representation object')
-
-      direction = None if facet_type is None or facet_type != 'direction' else facet
-      if self.support is not None:
-         shape_list = self.supporting_shape(indexable_element = indexable_element, direction = direction)
-         if shape_list is not None:
-            if count > 1:
-               shape_list.append(count)
-            if points:
-               shape_list.append(3)
-            if property_array is not None:
-               assert tuple(shape_list) == property_array.shape,  \
-                  f'property array shape {property_array.shape} is not the expected {tuple(shape_list)}'
-      # todo: assertions:
-      #    numpy data type matches discrete flag (and assumptions about precision)
-      #    uom are valid units for property_kind
-      assert property_kind, 'missing property kind when creating xml for property'
-
-      if discrete:
-         if string_lookup_uuid is None:
-            d_or_c_text = 'Discrete'
-         else:
-            d_or_c_text = 'Categorical'
-         xsd_type = 'integer'
-         hdf5_type = 'IntegerHdf5Array'
-      elif points:
-         d_or_c_text = 'Points'
-         xsd_type = 'double'
-         hdf5_type = 'Point3dHdf5Array'
-         null_value = None
-      else:
-         d_or_c_text = 'Continuous'
-         xsd_type = 'double'
-         hdf5_type = 'DoubleHdf5Array'
-         null_value = None
-
-      p_node = self.model.new_obj_node(d_or_c_text + 'Property')
-      if p_uuid is None:
-         p_uuid = bu.uuid_from_string(p_node.attrib['uuid'])
-      else:
-         p_node.attrib['uuid'] = str(p_uuid)
-
-      self.model.create_citation(root = p_node, title = title, originator = originator)
-
-      rqet.create_metadata_xml(node = p_node, extra_metadata = extra_metadata)
-
-      if source is not None and len(source) > 0:
-         self.model.create_source(source = source, root = p_node)
-
-      count_node = rqet.SubElement(p_node, ns['resqml2'] + 'Count')
-      count_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      count_node.text = str(count)
-
-      ie_node = rqet.SubElement(p_node, ns['resqml2'] + 'IndexableElement')
-      ie_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IndexableElements')
-      ie_node.text = indexable_element
-
-      if realization is not None and realization >= 0:
-         ri_node = rqet.SubElement(p_node, ns['resqml2'] + 'RealizationIndex')
-         ri_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-         ri_node.text = str(realization)
-
-      if time_series_uuid is None or time_index is None:
-         related_time_series_node = None
-      else:
-         related_time_series_node = self.model.root(uuid = time_series_uuid)
-         time_series = rts.any_time_series(self.model, uuid = time_series_uuid)
-         time_series.create_time_index(time_index, root = p_node)
-
-      support_title = '' if support_root is None else rqet.citation_title_for_node(support_root)
-      self.model.create_supporting_representation(support_uuid = support_uuid,
-                                                  root = p_node,
-                                                  title = support_title,
-                                                  content_type = support_type)
-
-      p_kind_node = rqet.SubElement(p_node, ns['resqml2'] + 'PropertyKind')
-      p_kind_node.text = rqet.null_xml_text
-      if find_local_property_kinds and property_kind not in supported_property_kind_list:
-         if property_kind_uuid is None:
-            pk_parts_list = self.model.parts_list_of_type('PropertyKind')
-            for part in pk_parts_list:
-               if self.model.citation_title_for_part(part) == property_kind:
-                  property_kind_uuid = self.model.uuid_for_part(part)
-                  break
-            if property_kind_uuid is None:
-               # create local property kind object and fetch uuid
-               lpk = PropertyKind(self.model,
-                                  title = property_kind,
-                                  example_uom = uom,
-                                  parent_property_kind = 'discrete' if discrete else 'continuous')
-               lpk.create_xml()
-               property_kind_uuid = lpk.uuid
-      if property_kind_uuid is None:
-         p_kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StandardPropertyKind')  # todo: local prop kind ref
-         kind_node = rqet.SubElement(p_kind_node, ns['resqml2'] + 'Kind')
-         kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlPropertyKind')
-         kind_node.text = property_kind
-      else:
-         p_kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'LocalPropertyKind')  # todo: local prop kind ref
-         self.model.create_ref_node('LocalPropertyKind',
-                                    property_kind,
-                                    property_kind_uuid,
-                                    content_type = 'obj_PropertyKind',
-                                    root = p_kind_node)
-
-      # create patch node
-      const_count = None
-      if const_value is not None:
-         s_shape = self.supporting_shape(indexable_element = indexable_element, direction = direction)
-         assert s_shape is not None
-         const_count = np.product(np.array(s_shape, dtype = int))
-      _ = self.model.create_patch(p_uuid,
-                                  ext_uuid,
-                                  root = p_node,
-                                  hdf5_type = hdf5_type,
-                                  xsd_type = xsd_type,
-                                  null_value = null_value,
-                                  const_value = const_value,
-                                  const_count = const_count,
-                                  points = points)
-
-      if facet_type is not None and facet is not None:
-         facet_node = rqet.SubElement(p_node, ns['resqml2'] + 'Facet')
-         facet_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'PropertyKindFacet')
-         facet_node.text = rqet.null_xml_text
-         facet_type_node = rqet.SubElement(facet_node, ns['resqml2'] + 'Facet')
-         facet_type_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Facet')
-         facet_type_node.text = facet_type
-         facet_value_node = rqet.SubElement(facet_node, ns['resqml2'] + 'Value')
-         facet_value_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-         facet_value_node.text = facet
-
-      if add_min_max:
-         # todo: use active cell mask on numpy min and max operations; exclude null values on discrete min max
-         if const_value is not None:
-            if (discrete and const_value != null_value) or (not discrete and not np.isnan(const_value)):
-               if min_value is None:
-                  min_value = const_value
-               if max_value is None:
-                  max_value = const_value
-         elif property_array is not None:
-            if discrete:
-               if min_value is None:
-                  try:
-                     min_value = int(property_array.min())
-                  except Exception:
-                     min_value = None
-                     log.warning('no xml minimum value set for discrete property')
-               if max_value is None:
-                  try:
-                     max_value = int(property_array.max())
-                  except Exception:
-                     max_value = None
-                     log.warning('no xml maximum value set for discrete property')
+        support_type = self.model.type_of_part(self.model.part_for_uuid(support_uuid))
+        if indexable_element is None:
+            if support_type in [
+                    'obj_IjkGridRepresentation', 'obj_BlockedWellboreRepresentation', 'obj_Grid2dRepresentation',
+                    'obj_UnstructuredGridRepresentation'
+            ]:
+                indexable_element = 'cells'
+            elif support_type == 'obj_WellboreFrameRepresentation':
+                indexable_element = 'nodes'  # note: could be 'intervals'
+            elif support_type == 'obj_GridConnectionSetRepresentation':
+                indexable_element = 'faces'
             else:
-               if min_value is None or max_value is None:
-                  all_nan = np.all(np.isnan(property_array))
-               if min_value is None and not all_nan:
-                  min_value = np.nanmin(property_array)
-                  if np.isnan(min_value) or min_value is ma.masked:
-                     min_value = None
-               if max_value is None and not all_nan:
-                  max_value = np.nanmax(property_array)
-                  if np.isnan(max_value) or max_value is ma.masked:
-                     max_value = None
-         if min_value is not None:
-            min_node = rqet.SubElement(p_node, ns['resqml2'] + 'MinimumValue')
-            min_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
-            min_node.text = str(min_value)
-         if max_value is not None:
-            max_node = rqet.SubElement(p_node, ns['resqml2'] + 'MaximumValue')
-            max_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
-            max_node.text = str(max_value)
+                raise Exception('indexable element unknown for unsupported supporting representation object')
 
-      if discrete:
-         if string_lookup_uuid is not None:
-            sl_root = self.model.root_for_uuid(string_lookup_uuid)
-            assert sl_root is not None, 'string table lookup is missing whilst importing categorical property'
-            assert rqet.node_type(sl_root) == 'obj_StringTableLookup', 'referenced uuid is not for string table lookup'
-            self.model.create_ref_node('Lookup',
-                                       self.model.title_for_root(sl_root),
-                                       string_lookup_uuid,
-                                       content_type = 'obj_StringTableLookup',
-                                       root = p_node)
-      else:  # continuous
-         if not uom:
-            uom = guess_uom(property_kind, min_value, max_value, self.support, facet_type = facet_type, facet = facet)
+        direction = None if facet_type is None or facet_type != 'direction' else facet
+        if self.support is not None:
+            shape_list = self.supporting_shape(indexable_element = indexable_element, direction = direction)
+            if shape_list is not None:
+                if count > 1:
+                    shape_list.append(count)
+                if points:
+                    shape_list.append(3)
+                if property_array is not None:
+                    assert tuple(shape_list) == property_array.shape,  \
+                       f'property array shape {property_array.shape} is not the expected {tuple(shape_list)}'
+        # todo: assertions:
+        #    numpy data type matches discrete flag (and assumptions about precision)
+        #    uom are valid units for property_kind
+        assert property_kind, 'missing property kind when creating xml for property'
+
+        if discrete:
+            if string_lookup_uuid is None:
+                d_or_c_text = 'Discrete'
+            else:
+                d_or_c_text = 'Categorical'
+            xsd_type = 'integer'
+            hdf5_type = 'IntegerHdf5Array'
+        elif points:
+            d_or_c_text = 'Points'
+            xsd_type = 'double'
+            hdf5_type = 'Point3dHdf5Array'
+            null_value = None
+        else:
+            d_or_c_text = 'Continuous'
+            xsd_type = 'double'
+            hdf5_type = 'DoubleHdf5Array'
+            null_value = None
+
+        p_node = self.model.new_obj_node(d_or_c_text + 'Property')
+        if p_uuid is None:
+            p_uuid = bu.uuid_from_string(p_node.attrib['uuid'])
+        else:
+            p_node.attrib['uuid'] = str(p_uuid)
+
+        self.model.create_citation(root = p_node, title = title, originator = originator)
+
+        rqet.create_metadata_xml(node = p_node, extra_metadata = extra_metadata)
+
+        if source is not None and len(source) > 0:
+            self.model.create_source(source = source, root = p_node)
+
+        count_node = rqet.SubElement(p_node, ns['resqml2'] + 'Count')
+        count_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        count_node.text = str(count)
+
+        ie_node = rqet.SubElement(p_node, ns['resqml2'] + 'IndexableElement')
+        ie_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IndexableElements')
+        ie_node.text = indexable_element
+
+        if realization is not None and realization >= 0:
+            ri_node = rqet.SubElement(p_node, ns['resqml2'] + 'RealizationIndex')
+            ri_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+            ri_node.text = str(realization)
+
+        if time_series_uuid is None or time_index is None:
+            related_time_series_node = None
+        else:
+            related_time_series_node = self.model.root(uuid = time_series_uuid)
+            time_series = rts.any_time_series(self.model, uuid = time_series_uuid)
+            time_series.create_time_index(time_index, root = p_node)
+
+        support_title = '' if support_root is None else rqet.citation_title_for_node(support_root)
+        self.model.create_supporting_representation(support_uuid = support_uuid,
+                                                    root = p_node,
+                                                    title = support_title,
+                                                    content_type = support_type)
+
+        p_kind_node = rqet.SubElement(p_node, ns['resqml2'] + 'PropertyKind')
+        p_kind_node.text = rqet.null_xml_text
+        if find_local_property_kinds and property_kind not in supported_property_kind_list:
+            if property_kind_uuid is None:
+                pk_parts_list = self.model.parts_list_of_type('PropertyKind')
+                for part in pk_parts_list:
+                    if self.model.citation_title_for_part(part) == property_kind:
+                        property_kind_uuid = self.model.uuid_for_part(part)
+                        break
+                if property_kind_uuid is None:
+                    # create local property kind object and fetch uuid
+                    lpk = PropertyKind(self.model,
+                                       title = property_kind,
+                                       example_uom = uom,
+                                       parent_property_kind = 'discrete' if discrete else 'continuous')
+                    lpk.create_xml()
+                    property_kind_uuid = lpk.uuid
+        if property_kind_uuid is None:
+            p_kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StandardPropertyKind')  # todo: local prop kind ref
+            kind_node = rqet.SubElement(p_kind_node, ns['resqml2'] + 'Kind')
+            kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlPropertyKind')
+            kind_node.text = property_kind
+        else:
+            p_kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'LocalPropertyKind')  # todo: local prop kind ref
+            self.model.create_ref_node('LocalPropertyKind',
+                                       property_kind,
+                                       property_kind_uuid,
+                                       content_type = 'obj_PropertyKind',
+                                       root = p_kind_node)
+
+        # create patch node
+        const_count = None
+        if const_value is not None:
+            s_shape = self.supporting_shape(indexable_element = indexable_element, direction = direction)
+            assert s_shape is not None
+            const_count = np.product(np.array(s_shape, dtype = int))
+        _ = self.model.create_patch(p_uuid,
+                                    ext_uuid,
+                                    root = p_node,
+                                    hdf5_type = hdf5_type,
+                                    xsd_type = xsd_type,
+                                    null_value = null_value,
+                                    const_value = const_value,
+                                    const_count = const_count,
+                                    points = points)
+
+        if facet_type is not None and facet is not None:
+            facet_node = rqet.SubElement(p_node, ns['resqml2'] + 'Facet')
+            facet_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'PropertyKindFacet')
+            facet_node.text = rqet.null_xml_text
+            facet_type_node = rqet.SubElement(facet_node, ns['resqml2'] + 'Facet')
+            facet_type_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Facet')
+            facet_type_node.text = facet_type
+            facet_value_node = rqet.SubElement(facet_node, ns['resqml2'] + 'Value')
+            facet_value_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+            facet_value_node.text = facet
+
+        if add_min_max:
+            # todo: use active cell mask on numpy min and max operations; exclude null values on discrete min max
+            if const_value is not None:
+                if (discrete and const_value != null_value) or (not discrete and not np.isnan(const_value)):
+                    if min_value is None:
+                        min_value = const_value
+                    if max_value is None:
+                        max_value = const_value
+            elif property_array is not None:
+                if discrete:
+                    if min_value is None:
+                        try:
+                            min_value = int(property_array.min())
+                        except Exception:
+                            min_value = None
+                            log.warning('no xml minimum value set for discrete property')
+                    if max_value is None:
+                        try:
+                            max_value = int(property_array.max())
+                        except Exception:
+                            max_value = None
+                            log.warning('no xml maximum value set for discrete property')
+                else:
+                    if min_value is None or max_value is None:
+                        all_nan = np.all(np.isnan(property_array))
+                    if min_value is None and not all_nan:
+                        min_value = np.nanmin(property_array)
+                        if np.isnan(min_value) or min_value is ma.masked:
+                            min_value = None
+                    if max_value is None and not all_nan:
+                        max_value = np.nanmax(property_array)
+                        if np.isnan(max_value) or max_value is ma.masked:
+                            max_value = None
+            if min_value is not None:
+                min_node = rqet.SubElement(p_node, ns['resqml2'] + 'MinimumValue')
+                min_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
+                min_node.text = str(min_value)
+            if max_value is not None:
+                max_node = rqet.SubElement(p_node, ns['resqml2'] + 'MaximumValue')
+                max_node.set(ns['xsi'] + 'type', ns['xsd'] + xsd_type)
+                max_node.text = str(max_value)
+
+        if discrete:
+            if string_lookup_uuid is not None:
+                sl_root = self.model.root_for_uuid(string_lookup_uuid)
+                assert sl_root is not None, 'string table lookup is missing whilst importing categorical property'
+                assert rqet.node_type(
+                    sl_root) == 'obj_StringTableLookup', 'referenced uuid is not for string table lookup'
+                self.model.create_ref_node('Lookup',
+                                           self.model.title_for_root(sl_root),
+                                           string_lookup_uuid,
+                                           content_type = 'obj_StringTableLookup',
+                                           root = p_node)
+        else:  # continuous
             if not uom:
-               uom = 'Euc'  # todo: put RESQML base uom for quantity class here, instead of Euc
-               log.warning(f'uom set to Euc for property {title} of kind {property_kind}')
-         self.model.uom_node(p_node, uom)
+                uom = guess_uom(property_kind,
+                                min_value,
+                                max_value,
+                                self.support,
+                                facet_type = facet_type,
+                                facet = facet)
+                if not uom:
+                    uom = 'Euc'  # todo: put RESQML base uom for quantity class here, instead of Euc
+                    log.warning(f'uom set to Euc for property {title} of kind {property_kind}')
+            self.model.uom_node(p_node, uom)
 
-      if add_as_part:
-         self.model.add_part('obj_' + d_or_c_text + 'Property', p_uuid, p_node)
-         if add_relationships:
-            if support_root is not None:
-               self.model.create_reciprocal_relationship(p_node, 'destinationObject', support_root, 'sourceObject')
-            if property_kind_uuid is not None:
-               pk_node = self.model.root_for_uuid(property_kind_uuid)
-               if pk_node is not None:
-                  self.model.create_reciprocal_relationship(p_node, 'destinationObject', pk_node, 'sourceObject')
-            if related_time_series_node is not None:
-               self.model.create_reciprocal_relationship(p_node, 'destinationObject', related_time_series_node,
-                                                         'sourceObject')
-            if discrete and string_lookup_uuid is not None:
-               self.model.create_reciprocal_relationship(p_node, 'destinationObject', sl_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_' + d_or_c_text + 'Property', p_uuid, p_node)
+            if add_relationships:
+                if support_root is not None:
+                    self.model.create_reciprocal_relationship(p_node, 'destinationObject', support_root, 'sourceObject')
+                if property_kind_uuid is not None:
+                    pk_node = self.model.root_for_uuid(property_kind_uuid)
+                    if pk_node is not None:
+                        self.model.create_reciprocal_relationship(p_node, 'destinationObject', pk_node, 'sourceObject')
+                if related_time_series_node is not None:
+                    self.model.create_reciprocal_relationship(p_node, 'destinationObject', related_time_series_node,
+                                                              'sourceObject')
+                if discrete and string_lookup_uuid is not None:
+                    self.model.create_reciprocal_relationship(p_node, 'destinationObject', sl_root, 'sourceObject')
 
-            if const_value is None:
-               ext_node = self.model.root_for_part(
-                  rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False))
-               self.model.create_reciprocal_relationship(p_node, 'mlToExternalPartProxy', ext_node,
-                                                         'externalPartProxyToMl')
+                if const_value is None:
+                    ext_node = self.model.root_for_part(
+                        rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False))
+                    self.model.create_reciprocal_relationship(p_node, 'mlToExternalPartProxy', ext_node,
+                                                              'externalPartProxyToMl')
 
-      return p_node
+        return p_node
 
-   def create_property_set_xml(self,
-                               title,
-                               ps_uuid = None,
-                               originator = None,
-                               add_as_part = True,
-                               add_relationships = True):
-      """Creates an xml node for a property set to represent this collection of properties.
+    def create_property_set_xml(self,
+                                title,
+                                ps_uuid = None,
+                                originator = None,
+                                add_as_part = True,
+                                add_relationships = True):
+        """Creates an xml node for a property set to represent this collection of properties.
 
       arguments:
          title (string): to be used as citation title
@@ -3284,65 +3296,65 @@ class PropertyCollection():
          xml for individual properties should exist before calling this method
       """
 
-      assert self.model is not None, 'cannot create xml for property set as model is not set'
-      assert self.number_of_parts() > 0, 'cannot create xml for property set as no parts in collection'
+        assert self.model is not None, 'cannot create xml for property set as model is not set'
+        assert self.number_of_parts() > 0, 'cannot create xml for property set as no parts in collection'
 
-      ps_node = self.model.new_obj_node('PropertySet')
-      if ps_uuid is None:
-         ps_uuid = bu.uuid_from_string(ps_node.attrib['uuid'])
-      else:
-         ps_node.attrib['uuid'] = str(ps_uuid)
+        ps_node = self.model.new_obj_node('PropertySet')
+        if ps_uuid is None:
+            ps_uuid = bu.uuid_from_string(ps_node.attrib['uuid'])
+        else:
+            ps_node.attrib['uuid'] = str(ps_uuid)
 
-      self.model.create_citation(root = ps_node, title = title, originator = originator)
+        self.model.create_citation(root = ps_node, title = title, originator = originator)
 
-      tsk_node = rqet.SubElement(ps_node, ns['resqml2'] + 'TimeSetKind')
-      tsk_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeSetKind')
-      tsk_node.text = self.time_set_kind()
+        tsk_node = rqet.SubElement(ps_node, ns['resqml2'] + 'TimeSetKind')
+        tsk_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeSetKind')
+        tsk_node.text = self.time_set_kind()
 
-      hspk_node = rqet.SubElement(ps_node, ns['resqml2'] + 'HasSinglePropertyKind')
-      hspk_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-      hspk_node.text = str(self.has_single_property_kind()).lower()
+        hspk_node = rqet.SubElement(ps_node, ns['resqml2'] + 'HasSinglePropertyKind')
+        hspk_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+        hspk_node.text = str(self.has_single_property_kind()).lower()
 
-      hmr_node = rqet.SubElement(ps_node, ns['resqml2'] + 'HasMultipleRealizations')
-      hmr_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-      hmr_node.text = str(self.has_multiple_realizations()).lower()
+        hmr_node = rqet.SubElement(ps_node, ns['resqml2'] + 'HasMultipleRealizations')
+        hmr_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+        hmr_node.text = str(self.has_multiple_realizations()).lower()
 
-      if self.parent_set_root is not None:
-         parent_set_ref_node = self.model.create_ref_node('ParentSet',
-                                                          self.model.title_for_root(self.parent_set_root),
-                                                          self.parent_set_root.attrib['uuid'],
-                                                          content_type = 'obj_PropertySet',
-                                                          root = ps_node)
+        if self.parent_set_root is not None:
+            parent_set_ref_node = self.model.create_ref_node('ParentSet',
+                                                             self.model.title_for_root(self.parent_set_root),
+                                                             self.parent_set_root.attrib['uuid'],
+                                                             content_type = 'obj_PropertySet',
+                                                             root = ps_node)
 
-      prop_node_list = []
-      for part in self.parts():
-         part_root = self.model.root_for_part(part)
-         self.model.create_ref_node('Properties',
-                                    self.model.title_for_root(part_root),
-                                    part_root.attrib['uuid'],
-                                    content_type = self.model.type_of_part(part),
-                                    root = ps_node)
-         if add_as_part and add_relationships:
-            prop_node_list.append(part_root)
+        prop_node_list = []
+        for part in self.parts():
+            part_root = self.model.root_for_part(part)
+            self.model.create_ref_node('Properties',
+                                       self.model.title_for_root(part_root),
+                                       part_root.attrib['uuid'],
+                                       content_type = self.model.type_of_part(part),
+                                       root = ps_node)
+            if add_as_part and add_relationships:
+                prop_node_list.append(part_root)
 
-      if add_as_part:
-         self.model.add_part('obj_PropertySet', ps_uuid, ps_node)
-         if add_relationships:
-            # todo: add relationship with time series if time set kind is not 'not a time set'?
-            if self.parent_set_root is not None:
-               self.model.create_reciprocal_relationship(ps_node, 'destinationObject', parent_set_ref_node,
-                                                         'sourceObject')
-            for prop_node in prop_node_list:
-               self.model.create_reciprocal_relationship(ps_node, 'destinationObject', prop_node, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_PropertySet', ps_uuid, ps_node)
+            if add_relationships:
+                # todo: add relationship with time series if time set kind is not 'not a time set'?
+                if self.parent_set_root is not None:
+                    self.model.create_reciprocal_relationship(ps_node, 'destinationObject', parent_set_ref_node,
+                                                              'sourceObject')
+                for prop_node in prop_node_list:
+                    self.model.create_reciprocal_relationship(ps_node, 'destinationObject', prop_node, 'sourceObject')
 
-      return ps_node
+        return ps_node
 
-   def basic_static_property_parts(self,
-                                   realization = None,
-                                   share_perm_parts = False,
-                                   perm_k_mode = None,
-                                   perm_k_ratio = 1.0):
-      """Returns five parts: net to gross ratio, porosity, permeability rock I, J & K; each returned part may be None.
+    def basic_static_property_parts(self,
+                                    realization = None,
+                                    share_perm_parts = False,
+                                    perm_k_mode = None,
+                                    perm_k_ratio = 1.0):
+        """Returns five parts: net to gross ratio, porosity, permeability rock I, J & K; each returned part may be None.
 
       arguments:
          realization: (int, optional): if present, only properties with the given realization are considered; if None,
@@ -3371,169 +3383,170 @@ class PropertyCollection():
       :meta common:
       """
 
-      ntg_part = poro_part = perm_i_part = perm_j_part = perm_k_part = None
-      try:
-         ntg_part = self.singleton(realization = realization, property_kind = 'net to gross ratio')
-      except Exception:
-         log.error('problem with net to gross ratio data (more than one array present?)')
-         ntg_part = None
-      try:
-         poro_part = self.singleton(realization = realization, property_kind = 'porosity')
-      except Exception:
-         log.error('problem with porosity data (more than one array present?)')
-         poro_part = None
-      perms = selective_version_of_collection(self, realization = realization, property_kind = 'permeability rock')
-      if perms is None or perms.number_of_parts() == 0:
-         log.error('no rock permeabilities present')
-      else:
-         if perms.number_of_parts() == 1:
-            perm_i_part = perms.singleton()
-            if share_perm_parts:
-               perm_j_part = perm_k_part = perm_i_part
-            elif perms.facet_type_for_part(perm_i_part) == 'direction':
-               direction = perms.facet_for_part(perm_i_part)
-               if direction == 'J':
-                  perm_j_part = perm_i_part
-                  perm_i_part = None
-               elif direction == 'IJ':
-                  perm_j_part = perm_i_part
-               elif direction == 'K':
-                  perm_k_part = perm_i_part
-                  perm_i_part = None
-               elif direction == 'IJK':
-                  perm_j_part = perm_k_part = perm_i_part
-         else:
-            try:
-               perm_i_part = perms.singleton(facet_type = 'direction', facet = 'I')
-               if not perm_i_part:
-                  perm_i_part = perms.singleton(facet_type = 'direction', facet = 'IJ')
-               if not perm_i_part:
-                  perm_i_part = perms.singleton(facet_type = 'direction', facet = 'IJK')
-               if not perm_i_part:
-                  perm_i_part = perms.singleton(citation_title = 'KI')
-               if not perm_i_part:
-                  perm_i_part = perms.singleton(citation_title = 'PERMI')
-               if not perm_i_part:
-                  perm_i_part = perms.singleton(citation_title = 'KX')
-               if not perm_i_part:
-                  perm_i_part = perms.singleton(citation_title = 'PERMX')
-               if not perm_i_part:
-                  log.error('unable to discern which rock permeability to use for I direction')
-            except Exception:
-               log.error('problem with permeability data (more than one I direction array present?)')
-               perm_i_part = None
-            try:
-               perm_j_part = perms.singleton(facet_type = 'direction', facet = 'J')
-               if not perm_j_part:
-                  perm_j_part = perms.singleton(facet_type = 'direction', facet = 'IJ')
-               if not perm_j_part:
-                  perm_j_part = perms.singleton(facet_type = 'direction', facet = 'IJK')
-               if not perm_j_part:
-                  perm_j_part = perms.singleton(citation_title = 'KJ')
-               if not perm_j_part:
-                  perm_j_part = perms.singleton(citation_title = 'PERMJ')
-               if not perm_j_part:
-                  perm_j_part = perms.singleton(citation_title = 'KY')
-               if not perm_j_part:
-                  perm_j_part = perms.singleton(citation_title = 'PERMY')
-            except Exception:
-               log.error('problem with permeability data (more than one J direction array present?)')
-               perm_j_part = None
-            if perm_j_part is None and share_perm_parts:
-               perm_j_part = perm_i_part
-            elif perm_i_part is None and share_perm_parts:
-               perm_i_part = perm_j_part
-            try:
-               perm_k_part = perms.singleton(facet_type = 'direction', facet = 'K')
-               if perm_k_part is None:
-                  perm_k_part = perms.singleton(facet_type = 'direction', facet = 'IJK')
-               if not perm_k_part:
-                  perm_k_part = perms.singleton(citation_title = 'KK')
-               if not perm_k_part:
-                  perm_k_part = perms.singleton(citation_title = 'PERMK')
-               if not perm_k_part:
-                  perm_k_part = perms.singleton(citation_title = 'KZ')
-               if not perm_k_part:
-                  perm_k_part = perms.singleton(citation_title = 'PERMZ')
-            except Exception:
-               log.error('problem with permeability data (more than one K direction array present?)')
-               perm_k_part = None
-            if perm_k_part is None:
-               assert perm_k_mode in [None, 'none', 'shared', 'ratio', 'ntg', 'ntg squared']
-               # note: could switch ratio mode to shared if perm_k_ratio is 1.0
-               if perm_k_mode is None or perm_k_mode == 'none':
-                  pass
-               elif perm_k_mode == 'shared':
-                  if share_perm_parts:
-                     perm_k_part = perm_i_part
-               elif perm_i_part is not None:
-                  log.info('generating K permeability data using mode ' + str(perm_k_mode))
-                  if perm_j_part is not None and perm_j_part != perm_i_part:
-                     # generate root mean square of I & J permeabilities to use as horizontal perm
-                     kh = np.sqrt(perms.cached_part_array_ref(perm_i_part) * perms.cached_part_array_ref(perm_j_part))
-                  else:  # use I permeability as horizontal perm
-                     kh = perms.cached_part_array_ref(perm_i_part)
-                  kv = kh * perm_k_ratio
-                  if ntg_part is not None:
-                     if perm_k_mode == 'ntg':
-                        kv *= self.cached_part_array_ref(ntg_part)
-                     elif perm_k_mode == 'ntg squared':
-                        ntg = self.cached_part_array_ref(ntg_part)
-                        kv *= ntg * ntg
-                  kv_collection = PropertyCollection()
-                  kv_collection.set_support(support_uuid = self.support_uuid, model = self.model)
-                  kv_collection.add_cached_array_to_imported_list(
-                     kv,
-                     'derived from horizontal perm with mode ' + str(perm_k_mode),
-                     'KK',
-                     discrete = False,
-                     uom = 'mD',
-                     time_index = None,
-                     null_value = None,
-                     property_kind = 'permeability rock',
-                     facet_type = 'direction',
-                     facet = 'K',
-                     realization = perms.realization_for_part(perm_i_part),
-                     indexable_element = perms.indexable_for_part(perm_i_part),
-                     count = 1,
-                     points = False)
-                  self.model.h5_release()
-                  kv_collection.write_hdf5_for_imported_list()
-                  kv_collection.create_xml_for_imported_list_and_add_parts_to_model()
-                  self.inherit_parts_from_other_collection(kv_collection)
-                  perm_k_part = kv_collection.singleton()
+        ntg_part = poro_part = perm_i_part = perm_j_part = perm_k_part = None
+        try:
+            ntg_part = self.singleton(realization = realization, property_kind = 'net to gross ratio')
+        except Exception:
+            log.error('problem with net to gross ratio data (more than one array present?)')
+            ntg_part = None
+        try:
+            poro_part = self.singleton(realization = realization, property_kind = 'porosity')
+        except Exception:
+            log.error('problem with porosity data (more than one array present?)')
+            poro_part = None
+        perms = selective_version_of_collection(self, realization = realization, property_kind = 'permeability rock')
+        if perms is None or perms.number_of_parts() == 0:
+            log.error('no rock permeabilities present')
+        else:
+            if perms.number_of_parts() == 1:
+                perm_i_part = perms.singleton()
+                if share_perm_parts:
+                    perm_j_part = perm_k_part = perm_i_part
+                elif perms.facet_type_for_part(perm_i_part) == 'direction':
+                    direction = perms.facet_for_part(perm_i_part)
+                    if direction == 'J':
+                        perm_j_part = perm_i_part
+                        perm_i_part = None
+                    elif direction == 'IJ':
+                        perm_j_part = perm_i_part
+                    elif direction == 'K':
+                        perm_k_part = perm_i_part
+                        perm_i_part = None
+                    elif direction == 'IJK':
+                        perm_j_part = perm_k_part = perm_i_part
+            else:
+                try:
+                    perm_i_part = perms.singleton(facet_type = 'direction', facet = 'I')
+                    if not perm_i_part:
+                        perm_i_part = perms.singleton(facet_type = 'direction', facet = 'IJ')
+                    if not perm_i_part:
+                        perm_i_part = perms.singleton(facet_type = 'direction', facet = 'IJK')
+                    if not perm_i_part:
+                        perm_i_part = perms.singleton(citation_title = 'KI')
+                    if not perm_i_part:
+                        perm_i_part = perms.singleton(citation_title = 'PERMI')
+                    if not perm_i_part:
+                        perm_i_part = perms.singleton(citation_title = 'KX')
+                    if not perm_i_part:
+                        perm_i_part = perms.singleton(citation_title = 'PERMX')
+                    if not perm_i_part:
+                        log.error('unable to discern which rock permeability to use for I direction')
+                except Exception:
+                    log.error('problem with permeability data (more than one I direction array present?)')
+                    perm_i_part = None
+                try:
+                    perm_j_part = perms.singleton(facet_type = 'direction', facet = 'J')
+                    if not perm_j_part:
+                        perm_j_part = perms.singleton(facet_type = 'direction', facet = 'IJ')
+                    if not perm_j_part:
+                        perm_j_part = perms.singleton(facet_type = 'direction', facet = 'IJK')
+                    if not perm_j_part:
+                        perm_j_part = perms.singleton(citation_title = 'KJ')
+                    if not perm_j_part:
+                        perm_j_part = perms.singleton(citation_title = 'PERMJ')
+                    if not perm_j_part:
+                        perm_j_part = perms.singleton(citation_title = 'KY')
+                    if not perm_j_part:
+                        perm_j_part = perms.singleton(citation_title = 'PERMY')
+                except Exception:
+                    log.error('problem with permeability data (more than one J direction array present?)')
+                    perm_j_part = None
+                if perm_j_part is None and share_perm_parts:
+                    perm_j_part = perm_i_part
+                elif perm_i_part is None and share_perm_parts:
+                    perm_i_part = perm_j_part
+                try:
+                    perm_k_part = perms.singleton(facet_type = 'direction', facet = 'K')
+                    if perm_k_part is None:
+                        perm_k_part = perms.singleton(facet_type = 'direction', facet = 'IJK')
+                    if not perm_k_part:
+                        perm_k_part = perms.singleton(citation_title = 'KK')
+                    if not perm_k_part:
+                        perm_k_part = perms.singleton(citation_title = 'PERMK')
+                    if not perm_k_part:
+                        perm_k_part = perms.singleton(citation_title = 'KZ')
+                    if not perm_k_part:
+                        perm_k_part = perms.singleton(citation_title = 'PERMZ')
+                except Exception:
+                    log.error('problem with permeability data (more than one K direction array present?)')
+                    perm_k_part = None
+                if perm_k_part is None:
+                    assert perm_k_mode in [None, 'none', 'shared', 'ratio', 'ntg', 'ntg squared']
+                    # note: could switch ratio mode to shared if perm_k_ratio is 1.0
+                    if perm_k_mode is None or perm_k_mode == 'none':
+                        pass
+                    elif perm_k_mode == 'shared':
+                        if share_perm_parts:
+                            perm_k_part = perm_i_part
+                    elif perm_i_part is not None:
+                        log.info('generating K permeability data using mode ' + str(perm_k_mode))
+                        if perm_j_part is not None and perm_j_part != perm_i_part:
+                            # generate root mean square of I & J permeabilities to use as horizontal perm
+                            kh = np.sqrt(
+                                perms.cached_part_array_ref(perm_i_part) * perms.cached_part_array_ref(perm_j_part))
+                        else:  # use I permeability as horizontal perm
+                            kh = perms.cached_part_array_ref(perm_i_part)
+                        kv = kh * perm_k_ratio
+                        if ntg_part is not None:
+                            if perm_k_mode == 'ntg':
+                                kv *= self.cached_part_array_ref(ntg_part)
+                            elif perm_k_mode == 'ntg squared':
+                                ntg = self.cached_part_array_ref(ntg_part)
+                                kv *= ntg * ntg
+                        kv_collection = PropertyCollection()
+                        kv_collection.set_support(support_uuid = self.support_uuid, model = self.model)
+                        kv_collection.add_cached_array_to_imported_list(
+                            kv,
+                            'derived from horizontal perm with mode ' + str(perm_k_mode),
+                            'KK',
+                            discrete = False,
+                            uom = 'mD',
+                            time_index = None,
+                            null_value = None,
+                            property_kind = 'permeability rock',
+                            facet_type = 'direction',
+                            facet = 'K',
+                            realization = perms.realization_for_part(perm_i_part),
+                            indexable_element = perms.indexable_for_part(perm_i_part),
+                            count = 1,
+                            points = False)
+                        self.model.h5_release()
+                        kv_collection.write_hdf5_for_imported_list()
+                        kv_collection.create_xml_for_imported_list_and_add_parts_to_model()
+                        self.inherit_parts_from_other_collection(kv_collection)
+                        perm_k_part = kv_collection.singleton()
 
-      return ntg_part, poro_part, perm_i_part, perm_j_part, perm_k_part
+        return ntg_part, poro_part, perm_i_part, perm_j_part, perm_k_part
 
-   def basic_static_property_parts_dict(self,
-                                        realization = None,
-                                        share_perm_parts = False,
-                                        perm_k_mode = None,
-                                        perm_k_ratio = 1.0):
-      """Same as basic_static_property_parts() method but returning a dictionary with 5 items.
+    def basic_static_property_parts_dict(self,
+                                         realization = None,
+                                         share_perm_parts = False,
+                                         perm_k_mode = None,
+                                         perm_k_ratio = 1.0):
+        """Same as basic_static_property_parts() method but returning a dictionary with 5 items.
 
       note:
          returned dictionary contains following keys: 'NTG', 'PORO', 'PERMI', 'PERMJ', 'PERMK'
       """
 
-      five_parts = self.basic_static_property_parts(realization = realization,
-                                                    share_perm_parts = share_perm_parts,
-                                                    perm_k_mode = perm_k_mode,
-                                                    perm_k_ratio = perm_k_ratio)
-      return {
-         'NTG': five_parts[0],
-         'PORO': five_parts[1],
-         'PERMI': five_parts[2],
-         'PERMJ': five_parts[3],
-         'PERMK': five_parts[4]
-      }
+        five_parts = self.basic_static_property_parts(realization = realization,
+                                                      share_perm_parts = share_perm_parts,
+                                                      perm_k_mode = perm_k_mode,
+                                                      perm_k_ratio = perm_k_ratio)
+        return {
+            'NTG': five_parts[0],
+            'PORO': five_parts[1],
+            'PERMI': five_parts[2],
+            'PERMJ': five_parts[3],
+            'PERMK': five_parts[4]
+        }
 
-   def basic_static_property_uuids(self,
-                                   realization = None,
-                                   share_perm_parts = False,
-                                   perm_k_mode = None,
-                                   perm_k_ratio = 1.0):
-      """Returns five uuids: net to gross ratio, porosity, permeability rock I, J & K; each returned uuid may be None.
+    def basic_static_property_uuids(self,
+                                    realization = None,
+                                    share_perm_parts = False,
+                                    perm_k_mode = None,
+                                    perm_k_ratio = 1.0):
+        """Returns five uuids: net to gross ratio, porosity, permeability rock I, J & K; each returned uuid may be None.
 
       note:
          see basic_static_property_parts() method for argument documentation
@@ -3541,64 +3554,64 @@ class PropertyCollection():
       :meta common:
       """
 
-      five_parts = self.basic_static_property_parts(realization = realization,
-                                                    share_perm_parts = share_perm_parts,
-                                                    perm_k_mode = perm_k_mode,
-                                                    perm_k_ratio = perm_k_ratio)
-      uuid_list = []
-      for part in five_parts:
-         if part is None:
-            uuid_list.append(None)
-         else:
-            uuid_list.append(rqet.uuid_in_part_name(part))
-      return tuple(uuid_list)
+        five_parts = self.basic_static_property_parts(realization = realization,
+                                                      share_perm_parts = share_perm_parts,
+                                                      perm_k_mode = perm_k_mode,
+                                                      perm_k_ratio = perm_k_ratio)
+        uuid_list = []
+        for part in five_parts:
+            if part is None:
+                uuid_list.append(None)
+            else:
+                uuid_list.append(rqet.uuid_in_part_name(part))
+        return tuple(uuid_list)
 
-   def basic_static_property_uuids_dict(self,
-                                        realization = None,
-                                        share_perm_parts = False,
-                                        perm_k_mode = None,
-                                        perm_k_ratio = 1.0):
-      """Same as basic_static_property_uuids() method but returning a dictionary with 5 items.
+    def basic_static_property_uuids_dict(self,
+                                         realization = None,
+                                         share_perm_parts = False,
+                                         perm_k_mode = None,
+                                         perm_k_ratio = 1.0):
+        """Same as basic_static_property_uuids() method but returning a dictionary with 5 items.
 
       note:
          returned dictionary contains following keys: 'NTG', 'PORO', 'PERMI', 'PERMJ', 'PERMK'
       """
 
-      five_uuids = self.basic_static_property_uuids(realization = realization,
-                                                    share_perm_parts = share_perm_parts,
-                                                    perm_k_mode = perm_k_mode,
-                                                    perm_k_ratio = perm_k_ratio)
-      return {
-         'NTG': five_uuids[0],
-         'PORO': five_uuids[1],
-         'PERMI': five_uuids[2],
-         'PERMJ': five_uuids[3],
-         'PERMK': five_uuids[4]
-      }
+        five_uuids = self.basic_static_property_uuids(realization = realization,
+                                                      share_perm_parts = share_perm_parts,
+                                                      perm_k_mode = perm_k_mode,
+                                                      perm_k_ratio = perm_k_ratio)
+        return {
+            'NTG': five_uuids[0],
+            'PORO': five_uuids[1],
+            'PERMI': five_uuids[2],
+            'PERMJ': five_uuids[3],
+            'PERMK': five_uuids[4]
+        }
 
-   def _part_direction(self, part):
-      facet_t = self.facet_type_for_part(part)
-      if facet_t is None or facet_t != 'direction':
-         return None
-      return self.facet_for_part(part)
+    def _part_direction(self, part):
+        facet_t = self.facet_type_for_part(part)
+        if facet_t is None or facet_t != 'direction':
+            return None
+        return self.facet_for_part(part)
 
 
 class Property(BaseResqpy):
-   """Class for an individual property object; uses a single element PropertyCollection behind the scenes."""
+    """Class for an individual property object; uses a single element PropertyCollection behind the scenes."""
 
-   @property
-   def resqml_type(self):
-      root_node = self.root
-      if root_node is not None:
-         return rqet.node_type(root_node, strip_obj = True)
-      if (not hasattr(self, 'collection') or self.collection.number_of_parts() != 1 or self.is_continuous()):
-         return 'ContinuousProperty'
-      if self.collection.points_for_part(self.collection.parts()[0]):
-         return 'PointsProperty'
-      return 'CategoricalProperty' if self.is_categorical() else 'DiscreteProperty'
+    @property
+    def resqml_type(self):
+        root_node = self.root
+        if root_node is not None:
+            return rqet.node_type(root_node, strip_obj = True)
+        if (not hasattr(self, 'collection') or self.collection.number_of_parts() != 1 or self.is_continuous()):
+            return 'ContinuousProperty'
+        if self.collection.points_for_part(self.collection.parts()[0]):
+            return 'PointsProperty'
+        return 'CategoricalProperty' if self.is_categorical() else 'DiscreteProperty'
 
-   def __init__(self, parent_model, uuid = None, title = None, support_uuid = None, extra_metadata = None):
-      """Initialises a resqpy Property object, either for an existing RESQML property, or empty for support.
+    def __init__(self, parent_model, uuid = None, title = None, support_uuid = None, extra_metadata = None):
+        """Initialises a resqpy Property object, either for an existing RESQML property, or empty for support.
 
       arguments:
          parent_model (model.Model): the model to which the property belongs
@@ -3613,85 +3626,85 @@ class Property(BaseResqpy):
          new resqpy Property object
       """
 
-      self.collection = PropertyCollection()
-      super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
-      if support_uuid is not None:
-         if self.collection.support_uuid is None:
-            self.collection.set_support(model = parent_model, support_uuid = support_uuid)
-         else:
-            assert bu.matching_uuids(support_uuid, self.collection.support_uuid)
+        self.collection = PropertyCollection()
+        super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
+        if support_uuid is not None:
+            if self.collection.support_uuid is None:
+                self.collection.set_support(model = parent_model, support_uuid = support_uuid)
+            else:
+                assert bu.matching_uuids(support_uuid, self.collection.support_uuid)
 
-   def _load_from_xml(self):
-      """Populates this property object from xml; not usually called directly."""
+    def _load_from_xml(self):
+        """Populates this property object from xml; not usually called directly."""
 
-      part = self.part
-      assert part is not None
-      if self.collection is None:
-         self.collection = PropertyCollection()
-      if self.collection.model is None:
-         self.collection.model = self.model
-      self.collection.add_part_to_dict(part)
-      self.extra_metadata = self.collection.extra_metadata_for_part(
-         part)  # duplicate, as standard attribute in BaseResqpy
-      self.collection.has_single_property_kind_flag = True
-      self.collection.has_single_indexable_element_flag = True
-      self.collection.has_multiple_realizations_flag = False
-      assert self.collection.number_of_parts() == 1
+        part = self.part
+        assert part is not None
+        if self.collection is None:
+            self.collection = PropertyCollection()
+        if self.collection.model is None:
+            self.collection.model = self.model
+        self.collection.add_part_to_dict(part)
+        self.extra_metadata = self.collection.extra_metadata_for_part(
+            part)  # duplicate, as standard attribute in BaseResqpy
+        self.collection.has_single_property_kind_flag = True
+        self.collection.has_single_indexable_element_flag = True
+        self.collection.has_multiple_realizations_flag = False
+        assert self.collection.number_of_parts() == 1
 
-   @classmethod
-   def from_singleton_collection(cls, property_collection: PropertyCollection):
-      """Populates a new Property from a PropertyCollection containing just one part.
+    @classmethod
+    def from_singleton_collection(cls, property_collection: PropertyCollection):
+        """Populates a new Property from a PropertyCollection containing just one part.
 
       arguments:
          property_collection (PropertyCollection): the singleton collection from which to populate this Property
       """
 
-      # Validate
-      assert property_collection.model is not None
-      assert property_collection is not None
-      assert property_collection.number_of_parts() == 1
+        # Validate
+        assert property_collection.model is not None
+        assert property_collection is not None
+        assert property_collection.number_of_parts() == 1
 
-      # Instantiate the object i.e. call the class __init__ method
-      part = property_collection.parts()[0]
-      prop = cls(parent_model = property_collection.model,
-                 uuid = property_collection.uuid_for_part(part),
-                 support_uuid = property_collection.support_uuid,
-                 title = property_collection.citation_title_for_part(part),
-                 extra_metadata = property_collection.extra_metadata_for_part(part))
+        # Instantiate the object i.e. call the class __init__ method
+        part = property_collection.parts()[0]
+        prop = cls(parent_model = property_collection.model,
+                   uuid = property_collection.uuid_for_part(part),
+                   support_uuid = property_collection.support_uuid,
+                   title = property_collection.citation_title_for_part(part),
+                   extra_metadata = property_collection.extra_metadata_for_part(part))
 
-      # Edit properties of collection attribute
-      prop.collection.has_single_property_kind_flag = True
-      prop.collection.has_single_indexable_element_flag = True
-      prop.collection.has_multiple_realizations_flag = False
+        # Edit properties of collection attribute
+        prop.collection.has_single_property_kind_flag = True
+        prop.collection.has_single_indexable_element_flag = True
+        prop.collection.has_multiple_realizations_flag = False
 
-      return prop
+        return prop
 
-   @classmethod
-   def from_array(cls,
-                  parent_model,
-                  cached_array,
-                  source_info,
-                  keyword,
-                  support_uuid,
-                  property_kind = None,
-                  local_property_kind_uuid = None,
-                  indexable_element = None,
-                  facet_type = None,
-                  facet = None,
-                  discrete = False,
-                  uom = None,
-                  null_value = None,
-                  time_series_uuid = None,
-                  time_index = None,
-                  realization = None,
-                  count = 1,
-                  points = False,
-                  const_value = None,
-                  string_lookup_uuid = None,
-                  find_local_property_kind = True,
-                  expand_const_arrays = False,
-                  extra_metadata = {}):
-      """Populates a new Property from a numpy array and metadata; NB. Writes data to hdf5 and adds part to model.
+    @classmethod
+    def from_array(cls,
+                   parent_model,
+                   cached_array,
+                   source_info,
+                   keyword,
+                   support_uuid,
+                   property_kind = None,
+                   local_property_kind_uuid = None,
+                   indexable_element = None,
+                   facet_type = None,
+                   facet = None,
+                   discrete = False,
+                   uom = None,
+                   null_value = None,
+                   time_series_uuid = None,
+                   time_index = None,
+                   realization = None,
+                   count = 1,
+                   points = False,
+                   const_value = None,
+                   string_lookup_uuid = None,
+                   find_local_property_kind = True,
+                   expand_const_arrays = False,
+                   extra_metadata = {}):
+        """Populates a new Property from a numpy array and metadata; NB. Writes data to hdf5 and adds part to model.
 
       arguments:
          parent_model (model.Model): the model to which the new property belongs
@@ -3747,49 +3760,49 @@ class Property(BaseResqpy):
 
       :meta common:
       """
-      # Validate
-      assert parent_model is not None
-      assert cached_array is not None or const_value is not None
+        # Validate
+        assert parent_model is not None
+        assert cached_array is not None or const_value is not None
 
-      # Instantiate the object i.e. call the class __init__ method
-      prop = cls(parent_model = parent_model,
-                 title = keyword,
-                 support_uuid = support_uuid,
-                 extra_metadata = extra_metadata)
+        # Instantiate the object i.e. call the class __init__ method
+        prop = cls(parent_model = parent_model,
+                   title = keyword,
+                   support_uuid = support_uuid,
+                   extra_metadata = extra_metadata)
 
-      # Prepare array data in collection attribute and add to model
-      prop.collection.set_support(model = prop.model,
-                                  support_uuid = support_uuid)  # this can be expensive; todo: optimise
-      if prop.collection.model is None:
-         prop.collection.model = prop.model
-      prop.prepare_import(cached_array,
-                          source_info,
-                          keyword,
-                          discrete = discrete,
-                          uom = uom,
-                          time_index = time_index,
-                          null_value = null_value,
-                          property_kind = property_kind,
-                          local_property_kind_uuid = local_property_kind_uuid,
-                          facet_type = facet_type,
-                          facet = facet,
-                          realization = realization,
-                          indexable_element = indexable_element,
-                          count = count,
-                          points = points,
-                          const_value = const_value)
-      prop.write_hdf5(expand_const_arrays = expand_const_arrays)
-      prop.create_xml(support_uuid = support_uuid,
-                      time_series_uuid = time_series_uuid,
-                      string_lookup_uuid = string_lookup_uuid,
-                      property_kind_uuid = local_property_kind_uuid,
-                      find_local_property_kind = find_local_property_kind,
-                      expand_const_arrays = expand_const_arrays,
-                      extra_metadata = extra_metadata)
-      return prop
+        # Prepare array data in collection attribute and add to model
+        prop.collection.set_support(model = prop.model,
+                                    support_uuid = support_uuid)  # this can be expensive; todo: optimise
+        if prop.collection.model is None:
+            prop.collection.model = prop.model
+        prop.prepare_import(cached_array,
+                            source_info,
+                            keyword,
+                            discrete = discrete,
+                            uom = uom,
+                            time_index = time_index,
+                            null_value = null_value,
+                            property_kind = property_kind,
+                            local_property_kind_uuid = local_property_kind_uuid,
+                            facet_type = facet_type,
+                            facet = facet,
+                            realization = realization,
+                            indexable_element = indexable_element,
+                            count = count,
+                            points = points,
+                            const_value = const_value)
+        prop.write_hdf5(expand_const_arrays = expand_const_arrays)
+        prop.create_xml(support_uuid = support_uuid,
+                        time_series_uuid = time_series_uuid,
+                        string_lookup_uuid = string_lookup_uuid,
+                        property_kind_uuid = local_property_kind_uuid,
+                        find_local_property_kind = find_local_property_kind,
+                        expand_const_arrays = expand_const_arrays,
+                        extra_metadata = extra_metadata)
+        return prop
 
-   def array_ref(self, dtype = None, masked = False, exclude_null = False):
-      """Returns a (cached) numpy array containing the property values.
+    def array_ref(self, dtype = None, masked = False, exclude_null = False):
+        """Returns a (cached) numpy array containing the property values.
 
       arguments:
          dtype (str or type, optional): the required dtype of the array (usually float, int or bool)
@@ -3804,212 +3817,212 @@ class Property(BaseResqpy):
       :meta common:
       """
 
-      return self.collection.cached_part_array_ref(self.part,
-                                                   dtype = dtype,
-                                                   masked = masked,
-                                                   exclude_null = exclude_null)
+        return self.collection.cached_part_array_ref(self.part,
+                                                     dtype = dtype,
+                                                     masked = masked,
+                                                     exclude_null = exclude_null)
 
 
 #   def citation_title(self):
 #      return self.collection.citation_title_for_part(self.part)
 
-   def is_continuous(self):
-      """Returns boolean indicating that the property contains continuous (ie. float) data.
+    def is_continuous(self):
+        """Returns boolean indicating that the property contains continuous (ie. float) data.
 
       :meta common:
       """
-      return self.collection.continuous_for_part(self.part)
+        return self.collection.continuous_for_part(self.part)
 
-   def is_points(self):
-      """Returns boolean indicating that the property is a points property."""
+    def is_points(self):
+        """Returns boolean indicating that the property is a points property."""
 
-      return self.collection.points_for_part(self.part)
+        return self.collection.points_for_part(self.part)
 
-   def is_categorical(self):
-      """Returns boolean indicating that the property contains categorical data.
-
-      :meta common:
-      """
-      return self.collection.part_is_categorical(self.part)
-
-   def null_value(self):
-      """Returns int being the null value for the (discrete) property."""
-      return self.collection.null_value_for_part(self.part)
-
-   def count(self):
-      """Returns int being the number of values for each element (usually 1)."""
-      return self.collection.count_for_part(self.part)
-
-   def indexable_element(self):
-      """Returns string being the indexable element for the property.
+    def is_categorical(self):
+        """Returns boolean indicating that the property contains categorical data.
 
       :meta common:
       """
-      return self.collection.indexable_for_part(self.part)
+        return self.collection.part_is_categorical(self.part)
 
-   def property_kind(self):
-      """Returns string being the property kind for the property.
+    def null_value(self):
+        """Returns int being the null value for the (discrete) property."""
+        return self.collection.null_value_for_part(self.part)
+
+    def count(self):
+        """Returns int being the number of values for each element (usually 1)."""
+        return self.collection.count_for_part(self.part)
+
+    def indexable_element(self):
+        """Returns string being the indexable element for the property.
 
       :meta common:
       """
-      return self.collection.property_kind_for_part(self.part)
+        return self.collection.indexable_for_part(self.part)
 
-   def local_property_kind_uuid(self):
-      """Returns uuid of the local property kind for the property (if applicable, otherwise None)."""
-      return self.collection.local_property_kind_uuid(self.part)
+    def property_kind(self):
+        """Returns string being the property kind for the property.
 
-   def facet_type(self):
-      """Returns string being the facet type for the property, or None if no facet present.
+      :meta common:
+      """
+        return self.collection.property_kind_for_part(self.part)
+
+    def local_property_kind_uuid(self):
+        """Returns uuid of the local property kind for the property (if applicable, otherwise None)."""
+        return self.collection.local_property_kind_uuid(self.part)
+
+    def facet_type(self):
+        """Returns string being the facet type for the property, or None if no facet present.
 
       note: resqpy currently supports at most one facet per property, though RESQML allows for multiple.
 
       :meta common:
       """
-      return self.collection.facet_type_for_part(self.part)
+        return self.collection.facet_type_for_part(self.part)
 
-   def facet(self):
-      """Returns string being the facet value for the property, or None if no facet present.
+    def facet(self):
+        """Returns string being the facet value for the property, or None if no facet present.
 
       note: resqpy currently supports at most one facet per property, though RESQML allows for multiple.
 
       :meta common:
       """
-      return self.collection.facet_for_part(self.part)
+        return self.collection.facet_for_part(self.part)
 
-   def time_series_uuid(self):
-      """Returns the uuid of the related time series (if applicable, otherwise None)."""
-      return self.collection.time_series_uuid_for_part(self.part)
+    def time_series_uuid(self):
+        """Returns the uuid of the related time series (if applicable, otherwise None)."""
+        return self.collection.time_series_uuid_for_part(self.part)
 
-   def time_index(self):
-      """Returns int being the index into the related time series (if applicable, otherwise None)."""
-      return self.collection.time_index_for_part(self.part)
+    def time_index(self):
+        """Returns int being the index into the related time series (if applicable, otherwise None)."""
+        return self.collection.time_index_for_part(self.part)
 
-   def minimum_value(self):
-      """Returns the minimum value for the property as stored in xml (float or int or None)."""
-      return self.collection.minimum_value_for_part(self.part)
+    def minimum_value(self):
+        """Returns the minimum value for the property as stored in xml (float or int or None)."""
+        return self.collection.minimum_value_for_part(self.part)
 
-   def maximum_value(self):
-      """Returns the maximum value for the property as stored in xml (float or int or None)."""
-      return self.collection.maximum_value_for_part(self.part)
+    def maximum_value(self):
+        """Returns the maximum value for the property as stored in xml (float or int or None)."""
+        return self.collection.maximum_value_for_part(self.part)
 
-   def uom(self):
-      """Returns string being the units of measure (for a continuous property, otherwise None).
+    def uom(self):
+        """Returns string being the units of measure (for a continuous property, otherwise None).
 
       :meta common:
       """
-      return self.collection.uom_for_part(self.part)
+        return self.collection.uom_for_part(self.part)
 
-   def string_lookup_uuid(self):
-      """Returns the uuid of the related string lookup table (for a categorical property, otherwise None)."""
-      return self.collection.string_lookup_uuid_for_part(self.part)
+    def string_lookup_uuid(self):
+        """Returns the uuid of the related string lookup table (for a categorical property, otherwise None)."""
+        return self.collection.string_lookup_uuid_for_part(self.part)
 
-   def string_lookup(self):
-      """Returns a resqpy StringLookup table (for a categorical property, otherwise None)."""
-      return self.collection.string_lookup_for_part(self.part)
+    def string_lookup(self):
+        """Returns a resqpy StringLookup table (for a categorical property, otherwise None)."""
+        return self.collection.string_lookup_for_part(self.part)
 
-   def constant_value(self):
-      """For a constant property, returns the constant value (float or int or bool, or None if not constant)."""
-      return self.collection.constant_value_for_part(self.part)
+    def constant_value(self):
+        """For a constant property, returns the constant value (float or int or bool, or None if not constant)."""
+        return self.collection.constant_value_for_part(self.part)
 
-   def prepare_import(self,
-                      cached_array,
-                      source_info,
-                      keyword,
-                      discrete = False,
-                      uom = None,
-                      time_index = None,
-                      null_value = None,
-                      property_kind = None,
-                      local_property_kind_uuid = None,
-                      facet_type = None,
-                      facet = None,
-                      realization = None,
-                      indexable_element = None,
-                      count = 1,
-                      const_value = None,
-                      points = False):
-      """Takes a numpy array and metadata and sets up a single array import list; not usually called directly.
+    def prepare_import(self,
+                       cached_array,
+                       source_info,
+                       keyword,
+                       discrete = False,
+                       uom = None,
+                       time_index = None,
+                       null_value = None,
+                       property_kind = None,
+                       local_property_kind_uuid = None,
+                       facet_type = None,
+                       facet = None,
+                       realization = None,
+                       indexable_element = None,
+                       count = 1,
+                       const_value = None,
+                       points = False):
+        """Takes a numpy array and metadata and sets up a single array import list; not usually called directly.
 
       note:
          see the documentation for the convenience method from_array()
       """
-      assert self.collection.number_of_parts() == 0
-      assert not self.collection.imported_list
-      self.collection.add_cached_array_to_imported_list(cached_array,
-                                                        source_info,
-                                                        keyword,
-                                                        discrete = discrete,
-                                                        uom = uom,
-                                                        time_index = time_index,
-                                                        null_value = null_value,
-                                                        property_kind = property_kind,
-                                                        local_property_kind_uuid = local_property_kind_uuid,
-                                                        facet_type = facet_type,
-                                                        facet = facet,
-                                                        realization = realization,
-                                                        indexable_element = indexable_element,
-                                                        count = count,
-                                                        const_value = const_value,
-                                                        points = points)
+        assert self.collection.number_of_parts() == 0
+        assert not self.collection.imported_list
+        self.collection.add_cached_array_to_imported_list(cached_array,
+                                                          source_info,
+                                                          keyword,
+                                                          discrete = discrete,
+                                                          uom = uom,
+                                                          time_index = time_index,
+                                                          null_value = null_value,
+                                                          property_kind = property_kind,
+                                                          local_property_kind_uuid = local_property_kind_uuid,
+                                                          facet_type = facet_type,
+                                                          facet = facet,
+                                                          realization = realization,
+                                                          indexable_element = indexable_element,
+                                                          count = count,
+                                                          const_value = const_value,
+                                                          points = points)
 
-   def write_hdf5(self, file_name = None, mode = 'a', expand_const_arrays = False):
-      """Writes the array data to the hdf5 file; not usually called directly.
+    def write_hdf5(self, file_name = None, mode = 'a', expand_const_arrays = False):
+        """Writes the array data to the hdf5 file; not usually called directly.
 
       notes:
          see the documentation for the convenience method from_array();
       """
-      if not self.collection.imported_list:
-         log.warning('no imported Property array to write to hdf5')
-         return
-      self.collection.write_hdf5_for_imported_list(file_name = file_name,
-                                                   mode = mode,
-                                                   expand_const_arrays = expand_const_arrays)
+        if not self.collection.imported_list:
+            log.warning('no imported Property array to write to hdf5')
+            return
+        self.collection.write_hdf5_for_imported_list(file_name = file_name,
+                                                     mode = mode,
+                                                     expand_const_arrays = expand_const_arrays)
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  support_uuid = None,
-                  time_series_uuid = None,
-                  string_lookup_uuid = None,
-                  property_kind_uuid = None,
-                  find_local_property_kind = True,
-                  expand_const_arrays = False,
-                  extra_metadata = {}):
-      """Creates an xml tree for the property and adds it as a part to the model; not usually called directly.
+    def create_xml(self,
+                   ext_uuid = None,
+                   support_uuid = None,
+                   time_series_uuid = None,
+                   string_lookup_uuid = None,
+                   property_kind_uuid = None,
+                   find_local_property_kind = True,
+                   expand_const_arrays = False,
+                   extra_metadata = {}):
+        """Creates an xml tree for the property and adds it as a part to the model; not usually called directly.
 
       note:
          see the documentation for the convenience method from_array()
          NB. this method has the deliberate side effect of modifying the uuid and title of self to match those
          of the property collection part!
       """
-      if not self.collection.imported_list:
-         log.warning('no imported Property array to create xml for')
-         return
-      self.collection.create_xml_for_imported_list_and_add_parts_to_model(
-         ext_uuid = ext_uuid,
-         support_uuid = support_uuid,
-         time_series_uuid = time_series_uuid,
-         selected_time_indices_list = None,
-         string_lookup_uuid = string_lookup_uuid,
-         property_kind_uuid = property_kind_uuid,
-         find_local_property_kinds = find_local_property_kind,
-         expand_const_arrays = expand_const_arrays,
-         extra_metadata = extra_metadata)
-      self.collection.has_single_property_kind_flag = True
-      self.collection.has_single_uom_flag = True
-      self.collection.has_single_indexable_element_flag = True
-      self.collection.has_multiple_realizations_flag = False
-      part = self.collection.parts()[0]
-      assert part is not None
-      self.uuid = self.collection.uuid_for_part(part)
-      self.title = self.collection.citation_title_for_part(part)
-      return self.root
+        if not self.collection.imported_list:
+            log.warning('no imported Property array to create xml for')
+            return
+        self.collection.create_xml_for_imported_list_and_add_parts_to_model(
+            ext_uuid = ext_uuid,
+            support_uuid = support_uuid,
+            time_series_uuid = time_series_uuid,
+            selected_time_indices_list = None,
+            string_lookup_uuid = string_lookup_uuid,
+            property_kind_uuid = property_kind_uuid,
+            find_local_property_kinds = find_local_property_kind,
+            expand_const_arrays = expand_const_arrays,
+            extra_metadata = extra_metadata)
+        self.collection.has_single_property_kind_flag = True
+        self.collection.has_single_uom_flag = True
+        self.collection.has_single_indexable_element_flag = True
+        self.collection.has_multiple_realizations_flag = False
+        part = self.collection.parts()[0]
+        assert part is not None
+        self.uuid = self.collection.uuid_for_part(part)
+        self.title = self.collection.citation_title_for_part(part)
+        return self.root
 
 
 class GridPropertyCollection(PropertyCollection):
-   """Class for RESQML Property collection for an IJK Grid, inheriting from PropertyCollection."""
+    """Class for RESQML Property collection for an IJK Grid, inheriting from PropertyCollection."""
 
-   def __init__(self, grid = None, property_set_root = None, realization = None):
-      """Creates a new property collection related to an IJK grid.
+    def __init__(self, grid = None, property_set_root = None, realization = None):
+        """Creates a new property collection related to an IJK grid.
 
       arguments:
          grid (grid.Grid object, optional): must be present unless creating a completely blank, empty collection
@@ -4030,38 +4043,38 @@ class GridPropertyCollection(PropertyCollection):
       :meta common:
       """
 
-      if grid is not None:
-         log.debug('initialising grid property collection for grid: ' + str(rqet.citation_title_for_node(grid.root)))
-         log.debug('grid uuid: ' + str(grid.uuid))
-      super().__init__(support = grid, property_set_root = property_set_root, realization = realization)
-      self._copy_support_to_grid_attributes()
+        if grid is not None:
+            log.debug('initialising grid property collection for grid: ' + str(rqet.citation_title_for_node(grid.root)))
+            log.debug('grid uuid: ' + str(grid.uuid))
+        super().__init__(support = grid, property_set_root = property_set_root, realization = realization)
+        self._copy_support_to_grid_attributes()
 
-      # NB: RESQML documentation is not clear which order is correct; should be kept consistent with same data in fault.py
-      # face_index_map maps from (axis, p01) to face index value in range 0..5
-      #     self.face_index_map = np.array([[0, 1], [4, 2], [5, 3]], dtype = int)
-      self.face_index_map = np.array([[0, 1], [2, 4], [5, 3]], dtype = int)  # order: top, base, J-, I+, J+, I-
-      # and the inverse, maps from 0..5 to (axis, p01)
-      #     self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 1], [2, 1], [1, 0], [2, 0]], dtype = int)
-      self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 0], [2, 1], [1, 1], [2, 0]], dtype = int)
+        # NB: RESQML documentation is not clear which order is correct; should be kept consistent with same data in fault.py
+        # face_index_map maps from (axis, p01) to face index value in range 0..5
+        #     self.face_index_map = np.array([[0, 1], [4, 2], [5, 3]], dtype = int)
+        self.face_index_map = np.array([[0, 1], [2, 4], [5, 3]], dtype = int)  # order: top, base, J-, I+, J+, I-
+        # and the inverse, maps from 0..5 to (axis, p01)
+        #     self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 1], [2, 1], [1, 0], [2, 0]], dtype = int)
+        self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 0], [2, 1], [1, 1], [2, 0]], dtype = int)
 
-   def _copy_support_to_grid_attributes(self):
-      # following three pseudonyms are for backward compatibility
-      self.grid = self.support
-      self.grid_root = self.support_root
-      self.grid_uuid = self.support_uuid
+    def _copy_support_to_grid_attributes(self):
+        # following three pseudonyms are for backward compatibility
+        self.grid = self.support
+        self.grid_root = self.support_root
+        self.grid_uuid = self.support_uuid
 
-   def set_grid(self, grid, grid_root = None, modify_parts = True):
-      """Sets the supporting representation object for the collection to be the given grid.
+    def set_grid(self, grid, grid_root = None, modify_parts = True):
+        """Sets the supporting representation object for the collection to be the given grid.
 
       note:
          this method does not need to be called if the grid was passed during object initialisation.
       """
 
-      self.set_support(support = grid, modify_parts = modify_parts)
-      self._copy_support_to_grid_attributes()
+        self.set_support(support = grid, modify_parts = modify_parts)
+        self._copy_support_to_grid_attributes()
 
-   def h5_slice_for_box(self, part, box):
-      """Returns a subset of the array for part, without loading the whole array (unless already cached).
+    def h5_slice_for_box(self, part, box):
+        """Returns a subset of the array for part, without loading the whole array (unless already cached).
 
       arguments:
          part (string): the part name for which the array slice is required
@@ -4078,18 +4091,19 @@ class GridPropertyCollection(PropertyCollection):
          protocol)
       """
 
-      slice_tuple = (slice(box[0, 0], box[1, 0] + 1), slice(box[0, 1], box[1, 1] + 1), slice(box[0, 2], box[1, 2] + 1))
-      return self.h5_slice(part, slice_tuple)
+        slice_tuple = (slice(box[0, 0], box[1, 0] + 1), slice(box[0, 1],
+                                                              box[1, 1] + 1), slice(box[0, 2], box[1, 2] + 1))
+        return self.h5_slice(part, slice_tuple)
 
-   def extend_imported_list_copying_properties_from_other_grid_collection(self,
-                                                                          other,
-                                                                          box = None,
-                                                                          refinement = None,
-                                                                          coarsening = None,
-                                                                          realization = None,
-                                                                          copy_all_realizations = False,
-                                                                          uncache_other_arrays = True):
-      """Extends this collection's imported list with properties from other collection, optionally extracting for a box.
+    def extend_imported_list_copying_properties_from_other_grid_collection(self,
+                                                                           other,
+                                                                           box = None,
+                                                                           refinement = None,
+                                                                           coarsening = None,
+                                                                           realization = None,
+                                                                           copy_all_realizations = False,
+                                                                           uncache_other_arrays = True):
+        """Extends this collection's imported list with properties from other collection, optionally extracting for a box.
 
       arguments:
          other: another GridPropertyCollection object which might relate to a different grid object
@@ -4116,329 +4130,330 @@ class GridPropertyCollection(PropertyCollection):
          the box argument must be used to effect a local grid coarsening or refinement
       """
 
-      # todo: optional use of active cell mask in coarsening
+        # todo: optional use of active cell mask in coarsening
 
-      def array_box(collection, part, box = None, uncache_other_arrays = True):
-         full_array = collection.cached_part_array_ref(part)
-         if box is None:
-            a = full_array.copy()
-         else:
-            a = full_array[box[0, 0]:box[1, 0] + 1, box[0, 1]:box[1, 1] + 1, box[0, 2]:box[1, 2] + 1].copy()
-         full_array = None
-         if uncache_other_arrays:
-            other.uncache_part_array(part)
-         return a
-
-      def coarsening_sample(coarsening, a):
-         # for now just take value from first cell in box
-         # todo: find most common element in box
-         a_coarsened = np.empty(tuple(coarsening.coarse_extent_kji), dtype = a.dtype)
-         assert a.shape == tuple(coarsening.fine_extent_kji)
-         # todo: try to figure out some numpy slice operations to avoid use of for loops
-         for k in range(coarsening.coarse_extent_kji[0]):
-            for j in range(coarsening.coarse_extent_kji[1]):
-               for i in range(coarsening.coarse_extent_kji[2]):
-                  # local box within lgc space of fine cells, for 1 coarse cell
-                  cell_box = coarsening.fine_box_for_coarse((k, j, i))
-                  a_coarsened[k, j, i] = a[tuple(cell_box[0])]
-         return a_coarsened
-
-      def coarsening_sum(coarsening, a, axis = None):
-         a_coarsened = np.empty(tuple(coarsening.coarse_extent_kji))
-         assert a.shape == tuple(coarsening.fine_extent_kji)
-         # todo: try to figure out some numpy slice operations to avoid use of for loops
-         for k in range(coarsening.coarse_extent_kji[0]):
-            for j in range(coarsening.coarse_extent_kji[1]):
-               for i in range(coarsening.coarse_extent_kji[2]):
-                  cell_box = coarsening.fine_box_for_coarse(
-                     (k, j, i))  # local box within lgc space of fine cells, for 1 coarse cell
-                  # yapf: disable
-                  a_coarsened[k, j, i] = np.nansum(a[cell_box[0, 0]:cell_box[1, 0] + 1,
-                                                     cell_box[0, 1]:cell_box[1, 1] + 1,
-                                                     cell_box[0, 2]:cell_box[1, 2] + 1])
-                  # yapf: enable
-                  if axis is not None:
-                     axis_1 = (axis + 1) % 3
-                     axis_2 = (axis + 2) % 3
-                     # yapf: disable
-                     divisor = ((cell_box[1, axis_1] + 1 - cell_box[0, axis_1]) *
-                                (cell_box[1, axis_2] + 1 - cell_box[0, axis_2]))
-                     # yapf: enable
-                     a_coarsened[k, j, i] = a_coarsened[k, j, i] / float(divisor)
-         return a_coarsened
-
-      def coarsening_weighted_mean(coarsening, a, fine_weight, coarse_weight = None, zero_weight_result = np.NaN):
-         a_coarsened = np.empty(tuple(coarsening.coarse_extent_kji))
-         assert a.shape == tuple(coarsening.fine_extent_kji)
-         assert fine_weight.shape == a.shape
-         if coarse_weight is not None:
-            assert coarse_weight.shape == a_coarsened.shape
-         for k in range(coarsening.coarse_extent_kji[0]):
-            for j in range(coarsening.coarse_extent_kji[1]):
-               for i in range(coarsening.coarse_extent_kji[2]):
-                  cell_box = coarsening.fine_box_for_coarse(
-                     (k, j, i))  # local box within lgc space of fine cells, for 1 coarse cell
-                  a_coarsened[k, j, i] = np.nansum(
-                     a[cell_box[0, 0]:cell_box[1, 0] + 1, cell_box[0, 1]:cell_box[1, 1] + 1,
-                       cell_box[0, 2]:cell_box[1, 2] + 1] *
-                     fine_weight[cell_box[0, 0]:cell_box[1, 0] + 1, cell_box[0, 1]:cell_box[1, 1] + 1,
-                                 cell_box[0, 2]:cell_box[1, 2] + 1])
-                  if coarse_weight is None:
-                     weight = np.nansum(fine_weight[cell_box[0, 0]:cell_box[1, 0] + 1,
-                                                    cell_box[0, 1]:cell_box[1, 1] + 1, cell_box[0,
-                                                                                                2]:cell_box[1, 2] + 1])
-                     if np.isnan(weight) or weight == 0.0:
-                        a_coarsened[k, j, i] = zero_weight_result
-                     else:
-                        a_coarsened[k, j, i] /= weight
-         if coarse_weight is not None:
-            mask = np.logical_or(np.isnan(coarse_weight), coarse_weight == 0.0)
-            a_coarsened = np.where(mask, zero_weight_result, a_coarsened / coarse_weight)
-         return a_coarsened
-
-      def add_to_imported(collection, a, title, info, null_value = None, const_value = None):
-         collection.add_cached_array_to_imported_list(
-            a,
-            title,
-            info[10],  # citation_title
-            discrete = not info[4],
-            indexable_element = 'cells',
-            uom = info[15],
-            time_index = info[12],
-            null_value = null_value,
-            property_kind = info[7],
-            local_property_kind_uuid = info[17],
-            facet_type = info[8],
-            facet = info[9],
-            realization = info[0],
-            const_value = const_value,
-            points = info[21])
-
-      import resqpy.grid as grr  # at global level was causing issues due to circular references, ie. grid importing this module
-
-      assert other.support is not None and isinstance(other.support,
-                                                      grr.Grid), 'other property collection has no grid support'
-      assert refinement is None or coarsening is None, 'refinement and coarsening both specified simultaneously'
-
-      if box is not None:
-         assert bxu.valid_box(box, other.grid.extent_kji)
-         if refinement is not None:
-            assert tuple(bxu.extent_of_box(box)) == tuple(refinement.coarse_extent_kji)
-         elif coarsening is not None:
-            assert tuple(bxu.extent_of_box(box)) == tuple(coarsening.fine_extent_kji)
-      # todo: any contraints on realization numbers ?
-
-      if coarsening is not None:  # static upscaling of key property kinds, simple sampling of others
-
-         assert self.support is not None and tuple(self.support.extent_kji) == tuple(coarsening.coarse_extent_kji)
-
-         # look for properties by kind, process in order: rock volume, net to gross ratio, porosity, permeability, saturation
-         source_rv = selective_version_of_collection(other, realization = realization, property_kind = 'rock volume')
-         source_ntg = selective_version_of_collection(other,
-                                                      realization = realization,
-                                                      property_kind = 'net to gross ratio')
-         source_poro = selective_version_of_collection(other, realization = realization, property_kind = 'porosity')
-         source_sat = selective_version_of_collection(other, realization = realization, property_kind = 'saturation')
-         source_perm = selective_version_of_collection(other,
-                                                       realization = realization,
-                                                       property_kind = 'permeability rock')
-         # todo: add kh and some other property kinds
-
-         # bulk rock volume
-         fine_rv_array = coarse_rv_array = None
-         if source_rv.number_of_parts() == 0:
-            log.debug('computing bulk rock volume from fine and coarse grid geometries')
-            source_rv_array = other.support.volume()
+        def array_box(collection, part, box = None, uncache_other_arrays = True):
+            full_array = collection.cached_part_array_ref(part)
             if box is None:
-               fine_rv_array = source_rv_array
+                a = full_array.copy()
             else:
-               fine_rv_array = source_rv_array[box[0, 0]:box[1, 0] + 1, box[0, 1]:box[1, 1] + 1, box[0,
-                                                                                                     2]:box[1, 2] + 1]
-            coarse_rv_array = self.support.volume()
-         else:
-            for (part, info) in source_rv.dict.items():
-               if not copy_all_realizations and info[0] != realization:
-                  continue
-               fine_rv_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-               coarse_rv_array = coarsening_sum(coarsening, fine_rv_array)
-               add_to_imported(self, coarse_rv_array, 'coarsened from grid ' + str(other.support.uuid), info)
+                a = full_array[box[0, 0]:box[1, 0] + 1, box[0, 1]:box[1, 1] + 1, box[0, 2]:box[1, 2] + 1].copy()
+            full_array = None
+            if uncache_other_arrays:
+                other.uncache_part_array(part)
+            return a
 
-         # net to gross ratio
-         # note that coarsened ntg values may exceed one when reference bulk rock volumes are from grid geometries
-         fine_ntg_array = coarse_ntg_array = None
-         for (part, info) in source_ntg.dict.items():
-            if not copy_all_realizations and info[0] != realization:
-               continue
-            fine_ntg_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-            coarse_ntg_array = coarsening_weighted_mean(coarsening,
-                                                        fine_ntg_array,
-                                                        fine_rv_array,
-                                                        coarse_weight = coarse_rv_array,
-                                                        zero_weight_result = 0.0)
-            add_to_imported(self, coarse_ntg_array, 'coarsened from grid ' + str(other.support.uuid), info)
+        def coarsening_sample(coarsening, a):
+            # for now just take value from first cell in box
+            # todo: find most common element in box
+            a_coarsened = np.empty(tuple(coarsening.coarse_extent_kji), dtype = a.dtype)
+            assert a.shape == tuple(coarsening.fine_extent_kji)
+            # todo: try to figure out some numpy slice operations to avoid use of for loops
+            for k in range(coarsening.coarse_extent_kji[0]):
+                for j in range(coarsening.coarse_extent_kji[1]):
+                    for i in range(coarsening.coarse_extent_kji[2]):
+                        # local box within lgc space of fine cells, for 1 coarse cell
+                        cell_box = coarsening.fine_box_for_coarse((k, j, i))
+                        a_coarsened[k, j, i] = a[tuple(cell_box[0])]
+            return a_coarsened
 
-         if fine_ntg_array is None:
-            fine_nrv_array = fine_rv_array
-            coarse_nrv_array = coarse_rv_array
-         else:
-            fine_nrv_array = fine_rv_array * fine_ntg_array
-            coarse_nrv_array = coarse_rv_array * coarse_ntg_array
+        def coarsening_sum(coarsening, a, axis = None):
+            a_coarsened = np.empty(tuple(coarsening.coarse_extent_kji))
+            assert a.shape == tuple(coarsening.fine_extent_kji)
+            # todo: try to figure out some numpy slice operations to avoid use of for loops
+            for k in range(coarsening.coarse_extent_kji[0]):
+                for j in range(coarsening.coarse_extent_kji[1]):
+                    for i in range(coarsening.coarse_extent_kji[2]):
+                        cell_box = coarsening.fine_box_for_coarse(
+                            (k, j, i))  # local box within lgc space of fine cells, for 1 coarse cell
+                        # yapf: disable
+                        a_coarsened[k, j, i] = np.nansum(a[cell_box[0, 0]:cell_box[1, 0] + 1,
+                                                           cell_box[0, 1]:cell_box[1, 1] + 1,
+                                                           cell_box[0, 2]:cell_box[1, 2] + 1])
+                        # yapf: enable
+                        if axis is not None:
+                            axis_1 = (axis + 1) % 3
+                            axis_2 = (axis + 2) % 3
+                            # yapf: disable
+                            divisor = ((cell_box[1, axis_1] + 1 - cell_box[0, axis_1]) *
+                                       (cell_box[1, axis_2] + 1 - cell_box[0, axis_2]))
+                            # yapf: enable
+                            a_coarsened[k, j, i] = a_coarsened[k, j, i] / float(divisor)
+            return a_coarsened
 
-         fine_poro_array = coarse_poro_array = None
-         for (part, info) in source_poro.dict.items():
-            if not copy_all_realizations and info[0] != realization:
-               continue
-            fine_poro_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-            coarse_poro_array = coarsening_weighted_mean(coarsening,
-                                                         fine_poro_array,
-                                                         fine_nrv_array,
-                                                         coarse_weight = coarse_nrv_array,
-                                                         zero_weight_result = 0.0)
-            add_to_imported(self, coarse_poro_array, 'coarsened from grid ' + str(other.support.uuid), info)
+        def coarsening_weighted_mean(coarsening, a, fine_weight, coarse_weight = None, zero_weight_result = np.NaN):
+            a_coarsened = np.empty(tuple(coarsening.coarse_extent_kji))
+            assert a.shape == tuple(coarsening.fine_extent_kji)
+            assert fine_weight.shape == a.shape
+            if coarse_weight is not None:
+                assert coarse_weight.shape == a_coarsened.shape
+            for k in range(coarsening.coarse_extent_kji[0]):
+                for j in range(coarsening.coarse_extent_kji[1]):
+                    for i in range(coarsening.coarse_extent_kji[2]):
+                        cell_box = coarsening.fine_box_for_coarse(
+                            (k, j, i))  # local box within lgc space of fine cells, for 1 coarse cell
+                        a_coarsened[k, j, i] = np.nansum(
+                            a[cell_box[0, 0]:cell_box[1, 0] + 1, cell_box[0, 1]:cell_box[1, 1] + 1,
+                              cell_box[0, 2]:cell_box[1, 2] + 1] *
+                            fine_weight[cell_box[0, 0]:cell_box[1, 0] + 1, cell_box[0, 1]:cell_box[1, 1] + 1,
+                                        cell_box[0, 2]:cell_box[1, 2] + 1])
+                        if coarse_weight is None:
+                            weight = np.nansum(fine_weight[cell_box[0, 0]:cell_box[1, 0] + 1,
+                                                           cell_box[0, 1]:cell_box[1, 1] + 1,
+                                                           cell_box[0, 2]:cell_box[1, 2] + 1])
+                            if np.isnan(weight) or weight == 0.0:
+                                a_coarsened[k, j, i] = zero_weight_result
+                            else:
+                                a_coarsened[k, j, i] /= weight
+            if coarse_weight is not None:
+                mask = np.logical_or(np.isnan(coarse_weight), coarse_weight == 0.0)
+                a_coarsened = np.where(mask, zero_weight_result, a_coarsened / coarse_weight)
+            return a_coarsened
 
-         # saturations
-         fine_sat_array = coarse_sat_array = None
-         fine_sat_weight = fine_nrv_array
-         coarse_sat_weight = coarse_nrv_array
-         if fine_poro_array is not None:
-            fine_sat_weight *= fine_poro_array
-            coarse_sat_weight *= coarse_poro_array
-         for (part, info) in source_sat.dict.items():
-            if not copy_all_realizations and info[0] != realization:
-               continue
-            fine_sat_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-            coarse_sat_array = coarsening_weighted_mean(coarsening,
-                                                        fine_sat_array,
-                                                        fine_sat_weight,
-                                                        coarse_weight = coarse_sat_weight,
-                                                        zero_weight_result = 0.0)
-            add_to_imported(self, coarse_sat_array, 'coarsened from grid ' + str(other.support.uuid), info)
+        def add_to_imported(collection, a, title, info, null_value = None, const_value = None):
+            collection.add_cached_array_to_imported_list(
+                a,
+                title,
+                info[10],  # citation_title
+                discrete = not info[4],
+                indexable_element = 'cells',
+                uom = info[15],
+                time_index = info[12],
+                null_value = null_value,
+                property_kind = info[7],
+                local_property_kind_uuid = info[17],
+                facet_type = info[8],
+                facet = info[9],
+                realization = info[0],
+                const_value = const_value,
+                points = info[21])
 
-         # permeabilities
-         # todo: use more harmonic, arithmetic mean instead of just bulk rock volume weighted; consider ntg
-         for (part, info) in source_perm.dict.items():
-            if not copy_all_realizations and info[0] != realization:
-               continue
-            fine_perm_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-            coarse_perm_array = coarsening_weighted_mean(coarsening,
-                                                         fine_perm_array,
-                                                         fine_nrv_array,
-                                                         coarse_weight = coarse_nrv_array,
-                                                         zero_weight_result = 0.0)
-            add_to_imported(self, coarse_perm_array, 'coarsened from grid ' + str(other.support.uuid), info)
+        import resqpy.grid as grr  # at global level was causing issues due to circular references, ie. grid importing this module
 
-         # cell lengths
-         source_cell_lengths = selective_version_of_collection(other,
-                                                               realization = realization,
-                                                               property_kind = 'cell length')
-         for (part, info) in source_cell_lengths.dict.items():
-            if not copy_all_realizations and info[0] != realization:
-               continue
-            fine_cl_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-            assert info[5] == 1 and info[8] == 'direction'
-            axis = 'KJI'.index(info[9][0].upper())
-            coarse_cl_array = coarsening_sum(coarsening, fine_cl_array, axis = axis)
-            add_to_imported(self, coarse_cl_array, 'coarsened from grid ' + str(other.support.uuid), info)
+        assert other.support is not None and isinstance(other.support,
+                                                        grr.Grid), 'other property collection has no grid support'
+        assert refinement is None or coarsening is None, 'refinement and coarsening both specified simultaneously'
 
-         # TODO: all other supported property kinds requiring special treatment
-         # default behaviour is bulk volume weighted mean for continuous data, first cell in box for discrete
-         handled_kinds = ('rock volume', 'net to gross ratio', 'porosity', 'saturation', 'permeability rock',
-                          'rock permeability', 'cell length')
-         for (part, info) in other.dict.items():
-            if not copy_all_realizations and info[0] != realization:
-               continue
-            if info[7] in handled_kinds:
-               continue
-            fine_ordinary_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-            if info[4]:
-               coarse_ordinary_array = coarsening_weighted_mean(coarsening,
-                                                                fine_ordinary_array,
-                                                                fine_rv_array,
-                                                                coarse_weight = coarse_rv_array)
+        if box is not None:
+            assert bxu.valid_box(box, other.grid.extent_kji)
+            if refinement is not None:
+                assert tuple(bxu.extent_of_box(box)) == tuple(refinement.coarse_extent_kji)
+            elif coarsening is not None:
+                assert tuple(bxu.extent_of_box(box)) == tuple(coarsening.fine_extent_kji)
+        # todo: any contraints on realization numbers ?
+
+        if coarsening is not None:  # static upscaling of key property kinds, simple sampling of others
+
+            assert self.support is not None and tuple(self.support.extent_kji) == tuple(coarsening.coarse_extent_kji)
+
+            # look for properties by kind, process in order: rock volume, net to gross ratio, porosity, permeability, saturation
+            source_rv = selective_version_of_collection(other, realization = realization, property_kind = 'rock volume')
+            source_ntg = selective_version_of_collection(other,
+                                                         realization = realization,
+                                                         property_kind = 'net to gross ratio')
+            source_poro = selective_version_of_collection(other, realization = realization, property_kind = 'porosity')
+            source_sat = selective_version_of_collection(other, realization = realization, property_kind = 'saturation')
+            source_perm = selective_version_of_collection(other,
+                                                          realization = realization,
+                                                          property_kind = 'permeability rock')
+            # todo: add kh and some other property kinds
+
+            # bulk rock volume
+            fine_rv_array = coarse_rv_array = None
+            if source_rv.number_of_parts() == 0:
+                log.debug('computing bulk rock volume from fine and coarse grid geometries')
+                source_rv_array = other.support.volume()
+                if box is None:
+                    fine_rv_array = source_rv_array
+                else:
+                    fine_rv_array = source_rv_array[box[0, 0]:box[1, 0] + 1, box[0, 1]:box[1, 1] + 1,
+                                                    box[0, 2]:box[1, 2] + 1]
+                coarse_rv_array = self.support.volume()
             else:
-               coarse_ordinary_array = coarsening_sample(coarsening, fine_ordinary_array)
-            add_to_imported(self, coarse_ordinary_array, 'coarsened from grid ' + str(other.support.uuid), info)
+                for (part, info) in source_rv.dict.items():
+                    if not copy_all_realizations and info[0] != realization:
+                        continue
+                    fine_rv_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                    coarse_rv_array = coarsening_sum(coarsening, fine_rv_array)
+                    add_to_imported(self, coarse_rv_array, 'coarsened from grid ' + str(other.support.uuid), info)
 
-      else:
+            # net to gross ratio
+            # note that coarsened ntg values may exceed one when reference bulk rock volumes are from grid geometries
+            fine_ntg_array = coarse_ntg_array = None
+            for (part, info) in source_ntg.dict.items():
+                if not copy_all_realizations and info[0] != realization:
+                    continue
+                fine_ntg_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                coarse_ntg_array = coarsening_weighted_mean(coarsening,
+                                                            fine_ntg_array,
+                                                            fine_rv_array,
+                                                            coarse_weight = coarse_rv_array,
+                                                            zero_weight_result = 0.0)
+                add_to_imported(self, coarse_ntg_array, 'coarsened from grid ' + str(other.support.uuid), info)
 
-         if realization is None:
-            source_collection = other
-         else:
-            source_collection = selective_version_of_collection(other, realization = realization)
-
-         for (part, info) in source_collection.dict.items():
-            if not copy_all_realizations and info[0] != realization:
-               continue
-
-            const_value = info[20]
-            if const_value is None:
-               a = array_box(source_collection, part, box = box, uncache_other_arrays = uncache_other_arrays)
+            if fine_ntg_array is None:
+                fine_nrv_array = fine_rv_array
+                coarse_nrv_array = coarse_rv_array
             else:
-               a = None
+                fine_nrv_array = fine_rv_array * fine_ntg_array
+                coarse_nrv_array = coarse_rv_array * coarse_ntg_array
 
-            if refinement is not None and a is not None:  # simple resampling
-               if info[6] != 'cells':
-                  # todo: appropriate refinement of data for other indexable elements
-                  continue
-               # todo: dividing up of values when needed, eg. volumes, areas, lengths
-               assert tuple(a.shape) == tuple(refinement.coarse_extent_kji)
-               assert self.support is not None and tuple(self.support.extent_kji) == tuple(refinement.fine_extent_kji)
-               k_ratio_vector = refinement.coarse_for_fine_axial_vector(0)
-               a_refined_k = np.empty(
-                  (refinement.fine_extent_kji[0], refinement.coarse_extent_kji[1], refinement.coarse_extent_kji[2]),
-                  dtype = a.dtype)
-               a_refined_k[:, :, :] = a[k_ratio_vector, :, :]
-               j_ratio_vector = refinement.coarse_for_fine_axial_vector(1)
-               a_refined_kj = np.empty(
-                  (refinement.fine_extent_kji[0], refinement.fine_extent_kji[1], refinement.coarse_extent_kji[2]),
-                  dtype = a.dtype)
-               a_refined_kj[:, :, :] = a_refined_k[:, j_ratio_vector, :]
-               i_ratio_vector = refinement.coarse_for_fine_axial_vector(2)
-               a = np.empty(tuple(refinement.fine_extent_kji), dtype = a.dtype)
-               a[:, :, :] = a_refined_kj[:, :, i_ratio_vector]
-               # for cell length properties, scale down the values in accordance with refinement
-               if info[4] and info[7] == 'cell length' and info[8] == 'direction' and info[5] == 1:
-                  dir_ch = info[9].upper()
-                  log.debug(f'refining cell lengths for axis {dir_ch}')
-                  if dir_ch == 'K':
-                     a *= refinement.proportions_for_axis(0).reshape((-1, 1, 1))
-                  elif dir_ch == 'J':
-                     a *= refinement.proportions_for_axis(1).reshape((1, -1, 1))
-                  elif dir_ch == 'I':
-                     a *= refinement.proportions_for_axis(2).reshape((1, 1, -1))
+            fine_poro_array = coarse_poro_array = None
+            for (part, info) in source_poro.dict.items():
+                if not copy_all_realizations and info[0] != realization:
+                    continue
+                fine_poro_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                coarse_poro_array = coarsening_weighted_mean(coarsening,
+                                                             fine_poro_array,
+                                                             fine_nrv_array,
+                                                             coarse_weight = coarse_nrv_array,
+                                                             zero_weight_result = 0.0)
+                add_to_imported(self, coarse_poro_array, 'coarsened from grid ' + str(other.support.uuid), info)
 
-            self.add_cached_array_to_imported_list(
-               a,
-               'copied from grid ' + str(other.support.uuid),
-               info[10],  # citation_title
-               discrete = not info[4],
-               indexable_element = 'cells',
-               uom = info[15],
-               time_index = info[12],
-               null_value = None,  # todo: extract from other's xml
-               property_kind = info[7],
-               local_property_kind_uuid = info[17],
-               facet_type = info[8],
-               facet = info[9],
-               realization = info[0],
-               const_value = const_value,
-               points = info[21])
+            # saturations
+            fine_sat_array = coarse_sat_array = None
+            fine_sat_weight = fine_nrv_array
+            coarse_sat_weight = coarse_nrv_array
+            if fine_poro_array is not None:
+                fine_sat_weight *= fine_poro_array
+                coarse_sat_weight *= coarse_poro_array
+            for (part, info) in source_sat.dict.items():
+                if not copy_all_realizations and info[0] != realization:
+                    continue
+                fine_sat_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                coarse_sat_array = coarsening_weighted_mean(coarsening,
+                                                            fine_sat_array,
+                                                            fine_sat_weight,
+                                                            coarse_weight = coarse_sat_weight,
+                                                            zero_weight_result = 0.0)
+                add_to_imported(self, coarse_sat_array, 'coarsened from grid ' + str(other.support.uuid), info)
 
-   def import_nexus_property_to_cache(self,
-                                      file_name,
-                                      keyword,
-                                      extent_kji = None,
-                                      discrete = False,
-                                      uom = None,
-                                      time_index = None,
-                                      null_value = None,
-                                      property_kind = None,
-                                      local_property_kind_uuid = None,
-                                      facet_type = None,
-                                      facet = None,
-                                      realization = None,
-                                      use_binary = True):
-      """Reads a property array from an ascii (or pure binary) file, caches and adds to imported list (but not collection dict).
+            # permeabilities
+            # todo: use more harmonic, arithmetic mean instead of just bulk rock volume weighted; consider ntg
+            for (part, info) in source_perm.dict.items():
+                if not copy_all_realizations and info[0] != realization:
+                    continue
+                fine_perm_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                coarse_perm_array = coarsening_weighted_mean(coarsening,
+                                                             fine_perm_array,
+                                                             fine_nrv_array,
+                                                             coarse_weight = coarse_nrv_array,
+                                                             zero_weight_result = 0.0)
+                add_to_imported(self, coarse_perm_array, 'coarsened from grid ' + str(other.support.uuid), info)
+
+            # cell lengths
+            source_cell_lengths = selective_version_of_collection(other,
+                                                                  realization = realization,
+                                                                  property_kind = 'cell length')
+            for (part, info) in source_cell_lengths.dict.items():
+                if not copy_all_realizations and info[0] != realization:
+                    continue
+                fine_cl_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                assert info[5] == 1 and info[8] == 'direction'
+                axis = 'KJI'.index(info[9][0].upper())
+                coarse_cl_array = coarsening_sum(coarsening, fine_cl_array, axis = axis)
+                add_to_imported(self, coarse_cl_array, 'coarsened from grid ' + str(other.support.uuid), info)
+
+            # TODO: all other supported property kinds requiring special treatment
+            # default behaviour is bulk volume weighted mean for continuous data, first cell in box for discrete
+            handled_kinds = ('rock volume', 'net to gross ratio', 'porosity', 'saturation', 'permeability rock',
+                             'rock permeability', 'cell length')
+            for (part, info) in other.dict.items():
+                if not copy_all_realizations and info[0] != realization:
+                    continue
+                if info[7] in handled_kinds:
+                    continue
+                fine_ordinary_array = array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                if info[4]:
+                    coarse_ordinary_array = coarsening_weighted_mean(coarsening,
+                                                                     fine_ordinary_array,
+                                                                     fine_rv_array,
+                                                                     coarse_weight = coarse_rv_array)
+                else:
+                    coarse_ordinary_array = coarsening_sample(coarsening, fine_ordinary_array)
+                add_to_imported(self, coarse_ordinary_array, 'coarsened from grid ' + str(other.support.uuid), info)
+
+        else:
+
+            if realization is None:
+                source_collection = other
+            else:
+                source_collection = selective_version_of_collection(other, realization = realization)
+
+            for (part, info) in source_collection.dict.items():
+                if not copy_all_realizations and info[0] != realization:
+                    continue
+
+                const_value = info[20]
+                if const_value is None:
+                    a = array_box(source_collection, part, box = box, uncache_other_arrays = uncache_other_arrays)
+                else:
+                    a = None
+
+                if refinement is not None and a is not None:  # simple resampling
+                    if info[6] != 'cells':
+                        # todo: appropriate refinement of data for other indexable elements
+                        continue
+                    # todo: dividing up of values when needed, eg. volumes, areas, lengths
+                    assert tuple(a.shape) == tuple(refinement.coarse_extent_kji)
+                    assert self.support is not None and tuple(self.support.extent_kji) == tuple(
+                        refinement.fine_extent_kji)
+                    k_ratio_vector = refinement.coarse_for_fine_axial_vector(0)
+                    a_refined_k = np.empty((refinement.fine_extent_kji[0], refinement.coarse_extent_kji[1],
+                                            refinement.coarse_extent_kji[2]),
+                                           dtype = a.dtype)
+                    a_refined_k[:, :, :] = a[k_ratio_vector, :, :]
+                    j_ratio_vector = refinement.coarse_for_fine_axial_vector(1)
+                    a_refined_kj = np.empty(
+                        (refinement.fine_extent_kji[0], refinement.fine_extent_kji[1], refinement.coarse_extent_kji[2]),
+                        dtype = a.dtype)
+                    a_refined_kj[:, :, :] = a_refined_k[:, j_ratio_vector, :]
+                    i_ratio_vector = refinement.coarse_for_fine_axial_vector(2)
+                    a = np.empty(tuple(refinement.fine_extent_kji), dtype = a.dtype)
+                    a[:, :, :] = a_refined_kj[:, :, i_ratio_vector]
+                    # for cell length properties, scale down the values in accordance with refinement
+                    if info[4] and info[7] == 'cell length' and info[8] == 'direction' and info[5] == 1:
+                        dir_ch = info[9].upper()
+                        log.debug(f'refining cell lengths for axis {dir_ch}')
+                        if dir_ch == 'K':
+                            a *= refinement.proportions_for_axis(0).reshape((-1, 1, 1))
+                        elif dir_ch == 'J':
+                            a *= refinement.proportions_for_axis(1).reshape((1, -1, 1))
+                        elif dir_ch == 'I':
+                            a *= refinement.proportions_for_axis(2).reshape((1, 1, -1))
+
+                self.add_cached_array_to_imported_list(
+                    a,
+                    'copied from grid ' + str(other.support.uuid),
+                    info[10],  # citation_title
+                    discrete = not info[4],
+                    indexable_element = 'cells',
+                    uom = info[15],
+                    time_index = info[12],
+                    null_value = None,  # todo: extract from other's xml
+                    property_kind = info[7],
+                    local_property_kind_uuid = info[17],
+                    facet_type = info[8],
+                    facet = info[9],
+                    realization = info[0],
+                    const_value = const_value,
+                    points = info[21])
+
+    def import_nexus_property_to_cache(self,
+                                       file_name,
+                                       keyword,
+                                       extent_kji = None,
+                                       discrete = False,
+                                       uom = None,
+                                       time_index = None,
+                                       null_value = None,
+                                       property_kind = None,
+                                       local_property_kind_uuid = None,
+                                       facet_type = None,
+                                       facet = None,
+                                       realization = None,
+                                       use_binary = True):
+        """Reads a property array from an ascii (or pure binary) file, caches and adds to imported list (but not collection dict).
 
       arguments:
          file_name (string): the name of the file to read the array data from; should contain data for one array only, without
@@ -4469,44 +4484,44 @@ class GridPropertyCollection(PropertyCollection):
          string for add_cached_array_to_imported_list() for the sequence of steps)
       """
 
-      log.debug(f'importing {keyword} array from file {file_name}')
-      # note: code in resqml_import adds imported arrays to model and to dict
-      if self.imported_list is None:
-         self.imported_list = []
-      if extent_kji is None:
-         extent_kji = self.grid.extent_kji
-      if discrete:
-         data_type = 'integer'
-      else:
-         data_type = 'real'
-      try:
-         import_array = ld.load_array_from_file(file_name,
-                                                extent_kji,
-                                                data_type = data_type,
-                                                comment_char = '!',
-                                                data_free_of_comments = False,
-                                                use_binary = use_binary)
-      except Exception:
-         log.exception('failed to import {} arrau from file {}'.format(keyword, file_name))
-         return None
+        log.debug(f'importing {keyword} array from file {file_name}')
+        # note: code in resqml_import adds imported arrays to model and to dict
+        if self.imported_list is None:
+            self.imported_list = []
+        if extent_kji is None:
+            extent_kji = self.grid.extent_kji
+        if discrete:
+            data_type = 'integer'
+        else:
+            data_type = 'real'
+        try:
+            import_array = ld.load_array_from_file(file_name,
+                                                   extent_kji,
+                                                   data_type = data_type,
+                                                   comment_char = '!',
+                                                   data_free_of_comments = False,
+                                                   use_binary = use_binary)
+        except Exception:
+            log.exception('failed to import {} arrau from file {}'.format(keyword, file_name))
+            return None
 
-      self.add_cached_array_to_imported_list(import_array,
-                                             file_name,
-                                             keyword,
-                                             discrete = discrete,
-                                             uom = uom,
-                                             time_index = time_index,
-                                             null_value = null_value,
-                                             property_kind = property_kind,
-                                             local_property_kind_uuid = local_property_kind_uuid,
-                                             facet_type = facet_type,
-                                             facet = facet,
-                                             realization = realization,
-                                             points = False)
-      return import_array
+        self.add_cached_array_to_imported_list(import_array,
+                                               file_name,
+                                               keyword,
+                                               discrete = discrete,
+                                               uom = uom,
+                                               time_index = time_index,
+                                               null_value = null_value,
+                                               property_kind = property_kind,
+                                               local_property_kind_uuid = local_property_kind_uuid,
+                                               facet_type = facet_type,
+                                               facet = facet,
+                                               realization = realization,
+                                               points = False)
+        return import_array
 
-   def import_vdb_static_property_to_cache(self, vdbase, keyword, grid_name = 'ROOT', uom = None, realization = None):
-      """Reads a vdb static property array, caches and adds to imported list (but not collection dict).
+    def import_vdb_static_property_to_cache(self, vdbase, keyword, grid_name = 'ROOT', uom = None, realization = None):
+        """Reads a vdb static property array, caches and adds to imported list (but not collection dict).
 
       arguments:
          vdbase: an object of class vdb.VDB, already initialised with the path of the vdb
@@ -4526,44 +4541,44 @@ class GridPropertyCollection(PropertyCollection):
          properties
       """
 
-      log.info('importing vdb static property {} array'.format(keyword))
-      keyword = keyword.upper()
-      try:
-         discrete = True
-         dtype = None
-         if keyword[0].upper() == 'I' or keyword in ['KID', 'UID', 'UNPACK', 'DAD']:
-            # coerce to integer values (vdb stores integer data as reals!)
-            dtype = 'int32'
-         elif keyword in ['DEADCELL', 'LIVECELL']:
-            dtype = 'bool'  # could use the default dtype of 64 bit integer
-         else:
-            dtype = 'float'  # convert to 64 bit; could omit but RESQML states 64 bit
-            discrete = False
-         import_array = vdbase.grid_static_property(grid_name, keyword, dtype = dtype)
-         assert import_array is not None
-      except Exception:
-         log.exception(f'failed to import static property {keyword} from vdb')
-         return None
+        log.info('importing vdb static property {} array'.format(keyword))
+        keyword = keyword.upper()
+        try:
+            discrete = True
+            dtype = None
+            if keyword[0].upper() == 'I' or keyword in ['KID', 'UID', 'UNPACK', 'DAD']:
+                # coerce to integer values (vdb stores integer data as reals!)
+                dtype = 'int32'
+            elif keyword in ['DEADCELL', 'LIVECELL']:
+                dtype = 'bool'  # could use the default dtype of 64 bit integer
+            else:
+                dtype = 'float'  # convert to 64 bit; could omit but RESQML states 64 bit
+                discrete = False
+            import_array = vdbase.grid_static_property(grid_name, keyword, dtype = dtype)
+            assert import_array is not None
+        except Exception:
+            log.exception(f'failed to import static property {keyword} from vdb')
+            return None
 
-      self.add_cached_array_to_imported_list(import_array,
-                                             vdbase.path,
-                                             keyword,
-                                             discrete = discrete,
-                                             uom = uom,
-                                             time_index = None,
-                                             null_value = None,
-                                             realization = realization)
-      return import_array
+        self.add_cached_array_to_imported_list(import_array,
+                                               vdbase.path,
+                                               keyword,
+                                               discrete = discrete,
+                                               uom = uom,
+                                               time_index = None,
+                                               null_value = None,
+                                               realization = realization)
+        return import_array
 
-   def import_vdb_recurrent_property_to_cache(self,
-                                              vdbase,
-                                              timestep,
-                                              keyword,
-                                              grid_name = 'ROOT',
-                                              time_index = None,
-                                              uom = None,
-                                              realization = None):
-      """Reads a vdb recurrent property array for one timestep, caches and adds to imported list (but not collection dict).
+    def import_vdb_recurrent_property_to_cache(self,
+                                               vdbase,
+                                               timestep,
+                                               keyword,
+                                               grid_name = 'ROOT',
+                                               time_index = None,
+                                               uom = None,
+                                               realization = None):
+        """Reads a vdb recurrent property array for one timestep, caches and adds to imported list (but not collection dict).
 
       arguments:
          vdbase: an object of class vdb.VDB, already initialised with the path of the vdb
@@ -4586,42 +4601,42 @@ class GridPropertyCollection(PropertyCollection):
          properties
       """
 
-      log.info('importing vdb recurrent property {0} array for timestep {1}'.format(keyword, str(timestep)))
-      if time_index is None:
-         time_index = timestep
-      keyword = keyword.upper()
-      try:
-         import_array = vdbase.grid_recurrent_property_for_timestep(grid_name, keyword, timestep, dtype = 'float')
-         assert import_array is not None
-      except Exception:
-         # could raise an exception (as for static properties)
-         log.error(f'failed to import recurrent property {keyword} from vdb for timestep {timestep}')
-         return None
+        log.info('importing vdb recurrent property {0} array for timestep {1}'.format(keyword, str(timestep)))
+        if time_index is None:
+            time_index = timestep
+        keyword = keyword.upper()
+        try:
+            import_array = vdbase.grid_recurrent_property_for_timestep(grid_name, keyword, timestep, dtype = 'float')
+            assert import_array is not None
+        except Exception:
+            # could raise an exception (as for static properties)
+            log.error(f'failed to import recurrent property {keyword} from vdb for timestep {timestep}')
+            return None
 
-      self.add_cached_array_to_imported_list(import_array,
-                                             vdbase.path,
-                                             keyword,
-                                             discrete = False,
-                                             uom = uom,
-                                             time_index = time_index,
-                                             null_value = None,
-                                             realization = realization)
-      return import_array
+        self.add_cached_array_to_imported_list(import_array,
+                                               vdbase.path,
+                                               keyword,
+                                               discrete = False,
+                                               uom = uom,
+                                               time_index = time_index,
+                                               null_value = None,
+                                               realization = realization)
+        return import_array
 
-   def import_ab_property_to_cache(self,
-                                   file_name,
-                                   keyword,
-                                   extent_kji = None,
-                                   discrete = None,
-                                   uom = None,
-                                   time_index = None,
-                                   null_value = None,
-                                   property_kind = None,
-                                   local_property_kind_uuid = None,
-                                   facet_type = None,
-                                   facet = None,
-                                   realization = None):
-      """Reads a property array from a pure binary file, caches and adds to imported list (but not collection dict).
+    def import_ab_property_to_cache(self,
+                                    file_name,
+                                    keyword,
+                                    extent_kji = None,
+                                    discrete = None,
+                                    uom = None,
+                                    time_index = None,
+                                    null_value = None,
+                                    property_kind = None,
+                                    local_property_kind_uuid = None,
+                                    facet_type = None,
+                                    facet = None,
+                                    realization = None):
+        """Reads a property array from a pure binary file, caches and adds to imported list (but not collection dict).
 
       arguments:
          file_name (string): the name of the file to read the array data from; should contain data for one array only in
@@ -4648,41 +4663,41 @@ class GridPropertyCollection(PropertyCollection):
          string for add_cached_array_to_imported_list() for the sequence of steps)
       """
 
-      if self.imported_list is None:
-         self.imported_list = []
-      if extent_kji is None:
-         extent_kji = self.grid.extent_kji
-      assert file_name[-3:] in ['.db', '.fb', '.ib', '.lb',
-                                '.bb'], 'file extension not in pure binary array expected set for: ' + file_name
-      if discrete is None:
-         discrete = (file_name[-3:] in ['.ib', '.lb', '.bb'])
-      else:
-         assert discrete == (file_name[-3:]
-                             in ['.ib', '.lb',
-                                 '.bb']), 'discrete argument is not consistent with file extension for: ' + file_name
-      try:
-         import_array = abt.load_array_from_ab_file(
-            file_name, extent_kji, return_64_bit = False)  # todo: RESQML indicates 64 bit for everything
-      except Exception:
-         log.exception('failed to import property from pure binary file: ' + file_name)
-         return None
+        if self.imported_list is None:
+            self.imported_list = []
+        if extent_kji is None:
+            extent_kji = self.grid.extent_kji
+        assert file_name[-3:] in ['.db', '.fb', '.ib', '.lb',
+                                  '.bb'], 'file extension not in pure binary array expected set for: ' + file_name
+        if discrete is None:
+            discrete = (file_name[-3:] in ['.ib', '.lb', '.bb'])
+        else:
+            assert discrete == (file_name[-3:]
+                                in ['.ib', '.lb',
+                                    '.bb']), 'discrete argument is not consistent with file extension for: ' + file_name
+        try:
+            import_array = abt.load_array_from_ab_file(
+                file_name, extent_kji, return_64_bit = False)  # todo: RESQML indicates 64 bit for everything
+        except Exception:
+            log.exception('failed to import property from pure binary file: ' + file_name)
+            return None
 
-      self.add_cached_array_to_imported_list(import_array,
-                                             file_name,
-                                             keyword,
-                                             discrete = discrete,
-                                             uom = uom,
-                                             time_index = time_index,
-                                             null_value = null_value,
-                                             property_kind = property_kind,
-                                             local_property_kind_uuid = local_property_kind_uuid,
-                                             facet_type = facet_type,
-                                             facet = facet,
-                                             realization = realization)
-      return import_array
+        self.add_cached_array_to_imported_list(import_array,
+                                               file_name,
+                                               keyword,
+                                               discrete = discrete,
+                                               uom = uom,
+                                               time_index = time_index,
+                                               null_value = null_value,
+                                               property_kind = property_kind,
+                                               local_property_kind_uuid = local_property_kind_uuid,
+                                               facet_type = facet_type,
+                                               facet = facet,
+                                               realization = realization)
+        return import_array
 
-   def decoarsen_imported_list(self, decoarsen_array = None, reactivate = True):
-      """Decoarsen imported Nexus properties if needed.
+    def decoarsen_imported_list(self, decoarsen_array = None, reactivate = True):
+        """Decoarsen imported Nexus properties if needed.
 
       arguments:
          decoarsen_array (int array, optional): if present, the naturalised cell index of the coarsened host cell, for each fine cell;
@@ -4703,178 +4718,179 @@ class GridPropertyCollection(PropertyCollection):
          reactivation only modifies the grid object attribute and does not write to hdf5, so the method should be called prior to
          writing the grid in this situation
       """
-      # imported_list is list pf:
-      # (0: uuid, 1: file_name, 2: keyword, 3: cached_name, 4: discrete, 5: uom, 6: time_index, 7: null_value, 8: min_value, 9: max_value,
-      # 10: property_kind, 11: facet_type, 12: facet, 13: realization, 14: indexable_element, 15: count, 16: local_property_kind_uuid,
-      # 17: const_value)
+        # imported_list is list pf:
+        # (0: uuid, 1: file_name, 2: keyword, 3: cached_name, 4: discrete, 5: uom, 6: time_index, 7: null_value, 8: min_value, 9: max_value,
+        # 10: property_kind, 11: facet_type, 12: facet, 13: realization, 14: indexable_element, 15: count, 16: local_property_kind_uuid,
+        # 17: const_value)
 
-      skip_keywords = ['UID', 'ICOARS', 'KID', 'DAD']  # TODO: complete this list
-      decoarsen_length_kinds = ['length', 'cell length', 'thickness', 'permeability thickness', 'permeability length']
-      decoarsen_area_kinds = ['transmissibility']
-      decoarsen_volume_kinds = ['volume', 'rock volume', 'pore volume', 'fluid volume']
+        skip_keywords = ['UID', 'ICOARS', 'KID', 'DAD']  # TODO: complete this list
+        decoarsen_length_kinds = ['length', 'cell length', 'thickness', 'permeability thickness', 'permeability length']
+        decoarsen_area_kinds = ['transmissibility']
+        decoarsen_volume_kinds = ['volume', 'rock volume', 'pore volume', 'fluid volume']
 
-      assert self.grid is not None
+        assert self.grid is not None
 
-      kid_attr_name = None
-      k_share = j_share = i_share = None
+        kid_attr_name = None
+        k_share = j_share = i_share = None
 
-      if decoarsen_array is None:
-         for import_item in self.imported_list:
-            if (import_item[14] is None or import_item[14] == 'cells') and import_item[4] and hasattr(
-                  self, import_item[3]):
-               if import_item[2] == 'ICOARS':
-                  decoarsen_array = self.__dict__[import_item[3]] - 1  # ICOARS values are one based
-                  break
-               if import_item[2] == 'KID':
-                  kid_attr_name = import_item[3]
+        if decoarsen_array is None:
+            for import_item in self.imported_list:
+                if (import_item[14] is None or import_item[14] == 'cells') and import_item[4] and hasattr(
+                        self, import_item[3]):
+                    if import_item[2] == 'ICOARS':
+                        decoarsen_array = self.__dict__[import_item[3]] - 1  # ICOARS values are one based
+                        break
+                    if import_item[2] == 'KID':
+                        kid_attr_name = import_item[3]
 
-      if decoarsen_array is None and kid_attr_name is not None:
-         kid = self.__dict__[kid_attr_name]
-         kid_mask = (kid == -3)  # -3 indicates cell inactive due to coarsening
-         assert kid_mask.shape == tuple(self.grid.extent_kji)
-         if np.any(kid_mask):
-            log.debug(f'{np.count_nonzero(kid_mask)} cells marked as requiring decoarsening in KID data')
-            decoarsen_array = np.full(self.grid.extent_kji, -1, dtype = int)
-            k_share = np.zeros(self.grid.extent_kji, dtype = int)
-            j_share = np.zeros(self.grid.extent_kji, dtype = int)
-            i_share = np.zeros(self.grid.extent_kji, dtype = int)
-            natural = 0
-            for k0 in range(self.grid.nk):
-               for j0 in range(self.grid.nj):
-                  for i0 in range(self.grid.ni):
-                     #                     if decoarsen_array[k0, j0, i0] < 0:
-                     if kid[k0, j0, i0] == 0:
-                        #                        assert not kid_mask[k0, j0, i0]
-                        ke = k0 + 1
-                        while ke < self.grid.nk and kid_mask[ke, j0, i0]:
-                           ke += 1
-                        je = j0 + 1
-                        while je < self.grid.nj and kid_mask[k0, je, i0]:
-                           je += 1
-                        ie = i0 + 1
-                        while ie < self.grid.ni and kid_mask[k0, j0, ie]:
-                           ie += 1
-                        # todo: check for conflict and resolve
-                        decoarsen_array[k0:ke, j0:je, i0:ie] = natural
-                        k_share[k0:ke, j0:je, i0:ie] = ke - k0
-                        j_share[k0:ke, j0:je, i0:ie] = je - j0
-                        i_share[k0:ke, j0:je, i0:ie] = ie - i0
-                     elif not kid_mask[k0, j0, i0]:  # inactive for reasons other than coarsening
-                        decoarsen_array[k0, j0, i0] = natural
-                        k_share[k0, j0, i0] = 1
-                        j_share[k0, j0, i0] = 1
-                        i_share[k0, j0, i0] = 1
-                     natural += 1
-            assert np.all(decoarsen_array >= 0)
+        if decoarsen_array is None and kid_attr_name is not None:
+            kid = self.__dict__[kid_attr_name]
+            kid_mask = (kid == -3)  # -3 indicates cell inactive due to coarsening
+            assert kid_mask.shape == tuple(self.grid.extent_kji)
+            if np.any(kid_mask):
+                log.debug(f'{np.count_nonzero(kid_mask)} cells marked as requiring decoarsening in KID data')
+                decoarsen_array = np.full(self.grid.extent_kji, -1, dtype = int)
+                k_share = np.zeros(self.grid.extent_kji, dtype = int)
+                j_share = np.zeros(self.grid.extent_kji, dtype = int)
+                i_share = np.zeros(self.grid.extent_kji, dtype = int)
+                natural = 0
+                for k0 in range(self.grid.nk):
+                    for j0 in range(self.grid.nj):
+                        for i0 in range(self.grid.ni):
+                            #                     if decoarsen_array[k0, j0, i0] < 0:
+                            if kid[k0, j0, i0] == 0:
+                                #                        assert not kid_mask[k0, j0, i0]
+                                ke = k0 + 1
+                                while ke < self.grid.nk and kid_mask[ke, j0, i0]:
+                                    ke += 1
+                                je = j0 + 1
+                                while je < self.grid.nj and kid_mask[k0, je, i0]:
+                                    je += 1
+                                ie = i0 + 1
+                                while ie < self.grid.ni and kid_mask[k0, j0, ie]:
+                                    ie += 1
+                                # todo: check for conflict and resolve
+                                decoarsen_array[k0:ke, j0:je, i0:ie] = natural
+                                k_share[k0:ke, j0:je, i0:ie] = ke - k0
+                                j_share[k0:ke, j0:je, i0:ie] = je - j0
+                                i_share[k0:ke, j0:je, i0:ie] = ie - i0
+                            elif not kid_mask[k0, j0, i0]:  # inactive for reasons other than coarsening
+                                decoarsen_array[k0, j0, i0] = natural
+                                k_share[k0, j0, i0] = 1
+                                j_share[k0, j0, i0] = 1
+                                i_share[k0, j0, i0] = 1
+                            natural += 1
+                assert np.all(decoarsen_array >= 0)
 
-      if decoarsen_array is None:
-         return None
+        if decoarsen_array is None:
+            return None
 
-      cell_count = decoarsen_array.size
-      host_count = len(np.unique(decoarsen_array))
-      log.debug(f'{host_count} of {cell_count} are hosts; difference is {cell_count - host_count}')
-      assert cell_count == self.grid.cell_count()
-      if np.all(decoarsen_array.flatten() == np.arange(cell_count, dtype = int)):
-         return None  # identity array
+        cell_count = decoarsen_array.size
+        host_count = len(np.unique(decoarsen_array))
+        log.debug(f'{host_count} of {cell_count} are hosts; difference is {cell_count - host_count}')
+        assert cell_count == self.grid.cell_count()
+        if np.all(decoarsen_array.flatten() == np.arange(cell_count, dtype = int)):
+            return None  # identity array
 
-      if k_share is None:
-         sharing_needed = False
-         for import_item in self.imported_list:
+        if k_share is None:
+            sharing_needed = False
+            for import_item in self.imported_list:
+                kind = import_item[10]
+                if kind in decoarsen_volume_kinds or kind in decoarsen_area_kinds or kind in decoarsen_length_kinds:
+                    sharing_needed = True
+                    break
+            if sharing_needed:
+                k_share = np.zeros(self.grid.extent_kji, dtype = int)
+                j_share = np.zeros(self.grid.extent_kji, dtype = int)
+                i_share = np.zeros(self.grid.extent_kji, dtype = int)
+                natural = 0
+                for k0 in range(self.grid.nk):
+                    for j0 in range(self.grid.nj):
+                        for i0 in range(self.grid.ni):
+                            if k_share[k0, j0, i0] == 0:
+                                ke = k0 + 1
+                                while ke < self.grid.nk and decoarsen_array[ke, j0, i0] == natural:
+                                    ke += 1
+                                je = j0 + 1
+                                while je < self.grid.nj and decoarsen_array[k0, je, i0] == natural:
+                                    je += 1
+                                ie = i0 + 1
+                                while ie < self.grid.ni and decoarsen_array[k0, j0, ie] == natural:
+                                    ie += 1
+                                k_share[k0:ke, j0:je, i0:ie] = ke - k0
+                                j_share[k0:ke, j0:je, i0:ie] = je - j0
+                                i_share[k0:ke, j0:je, i0:ie] = ie - i0
+                            natural += 1
+
+        if k_share is not None:
+            assert np.all(k_share > 0) and np.all(j_share > 0) and np.all(i_share > 0)
+            volume_share = (k_share * j_share * i_share).astype(float)
+            k_share = k_share.astype(float)
+            j_share = j_share.astype(float)
+            i_share = i_share.astype(float)
+
+        property_count = 0
+        for import_item in self.imported_list:
+            if import_item[3] is None or not hasattr(self, import_item[3]):
+                continue  # todo: handle decoarsening of const arrays?
+            if import_item[14] is not None and import_item[14] != 'cells':
+                continue
+            coarsened = self.__dict__[import_item[3]].flatten()
+            assert coarsened.size == cell_count
+            keyword = import_item[2]
+            if keyword.upper() in skip_keywords:
+                continue
             kind = import_item[10]
-            if kind in decoarsen_volume_kinds or kind in decoarsen_area_kinds or kind in decoarsen_length_kinds:
-               sharing_needed = True
-               break
-         if sharing_needed:
-            k_share = np.zeros(self.grid.extent_kji, dtype = int)
-            j_share = np.zeros(self.grid.extent_kji, dtype = int)
-            i_share = np.zeros(self.grid.extent_kji, dtype = int)
-            natural = 0
-            for k0 in range(self.grid.nk):
-               for j0 in range(self.grid.nj):
-                  for i0 in range(self.grid.ni):
-                     if k_share[k0, j0, i0] == 0:
-                        ke = k0 + 1
-                        while ke < self.grid.nk and decoarsen_array[ke, j0, i0] == natural:
-                           ke += 1
-                        je = j0 + 1
-                        while je < self.grid.nj and decoarsen_array[k0, je, i0] == natural:
-                           je += 1
-                        ie = i0 + 1
-                        while ie < self.grid.ni and decoarsen_array[k0, j0, ie] == natural:
-                           ie += 1
-                        k_share[k0:ke, j0:je, i0:ie] = ke - k0
-                        j_share[k0:ke, j0:je, i0:ie] = je - j0
-                        i_share[k0:ke, j0:je, i0:ie] = ie - i0
-                     natural += 1
-
-      if k_share is not None:
-         assert np.all(k_share > 0) and np.all(j_share > 0) and np.all(i_share > 0)
-         volume_share = (k_share * j_share * i_share).astype(float)
-         k_share = k_share.astype(float)
-         j_share = j_share.astype(float)
-         i_share = i_share.astype(float)
-
-      property_count = 0
-      for import_item in self.imported_list:
-         if import_item[3] is None or not hasattr(self, import_item[3]):
-            continue  # todo: handle decoarsening of const arrays?
-         if import_item[14] is not None and import_item[14] != 'cells':
-            continue
-         coarsened = self.__dict__[import_item[3]].flatten()
-         assert coarsened.size == cell_count
-         keyword = import_item[2]
-         if keyword.upper() in skip_keywords:
-            continue
-         kind = import_item[10]
-         if kind in decoarsen_volume_kinds:
-            redistributed = coarsened[decoarsen_array] / volume_share
-         elif kind in decoarsen_area_kinds:
-            # only transmissibilty currently in this set of supported property kinds
-            log.warning(
-               f'decoarsening of transmissibility {keyword} skipped due to simple methods not yielding correct values')
-         elif kind in decoarsen_length_kinds:
-            facet_dir = import_item[12] if import_item[11] == 'direction' else None
-            if kind in ['thickness', 'permeability thickness'] or (facet_dir == 'K'):
-               redistributed = coarsened[decoarsen_array] / k_share
-            elif facet_dir == 'J':
-               redistributed = coarsened[decoarsen_array] / j_share
-            elif facet_dir == 'I':
-               redistributed = coarsened[decoarsen_array] / i_share
+            if kind in decoarsen_volume_kinds:
+                redistributed = coarsened[decoarsen_array] / volume_share
+            elif kind in decoarsen_area_kinds:
+                # only transmissibilty currently in this set of supported property kinds
+                log.warning(
+                    f'decoarsening of transmissibility {keyword} skipped due to simple methods not yielding correct values'
+                )
+            elif kind in decoarsen_length_kinds:
+                facet_dir = import_item[12] if import_item[11] == 'direction' else None
+                if kind in ['thickness', 'permeability thickness'] or (facet_dir == 'K'):
+                    redistributed = coarsened[decoarsen_array] / k_share
+                elif facet_dir == 'J':
+                    redistributed = coarsened[decoarsen_array] / j_share
+                elif facet_dir == 'I':
+                    redistributed = coarsened[decoarsen_array] / i_share
+                else:
+                    log.warning(f'decoarsening of length property {keyword} skipped as direction not established')
             else:
-               log.warning(f'decoarsening of length property {keyword} skipped as direction not established')
-         else:
-            redistributed = coarsened[decoarsen_array]
-         self.__dict__[import_item[3]] = redistributed.reshape(self.grid.extent_kji)
-         property_count += 1
+                redistributed = coarsened[decoarsen_array]
+            self.__dict__[import_item[3]] = redistributed.reshape(self.grid.extent_kji)
+            property_count += 1
 
-      if property_count:
-         log.debug(f'{property_count} properties decoarsened')
+        if property_count:
+            log.debug(f'{property_count} properties decoarsened')
 
-      if reactivate and hasattr(self.grid, 'inactive'):
-         log.debug('reactivating cells inactive due to coarsening')
-         pre_count = np.count_nonzero(self.grid.inactive)
-         self.grid.inactive = self.grid.inactive.flatten()[decoarsen_array].reshape(self.grid.extent_kji)
-         post_count = np.count_nonzero(self.grid.inactive)
-         log.debug(f'{pre_count - post_count} cells reactivated')
+        if reactivate and hasattr(self.grid, 'inactive'):
+            log.debug('reactivating cells inactive due to coarsening')
+            pre_count = np.count_nonzero(self.grid.inactive)
+            self.grid.inactive = self.grid.inactive.flatten()[decoarsen_array].reshape(self.grid.extent_kji)
+            post_count = np.count_nonzero(self.grid.inactive)
+            log.debug(f'{pre_count - post_count} cells reactivated')
 
-      return decoarsen_array
+        return decoarsen_array
 
-   def write_nexus_property(
-         self,
-         part,
-         file_name,
-         keyword = None,
-         headers = True,
-         append = False,
-         columns = 20,
-         decimals = 3,  # note: decimals only applicable to real numbers
-         blank_line_after_i_block = True,
-         blank_line_after_j_block = False,
-         space_separated = False,  # default is tab separated
-         use_binary = False,
-         binary_only = False,
-         nan_substitute_value = None):
-      """Writes the property array to a file in a format suitable for including as nexus input.
+    def write_nexus_property(
+            self,
+            part,
+            file_name,
+            keyword = None,
+            headers = True,
+            append = False,
+            columns = 20,
+            decimals = 3,  # note: decimals only applicable to real numbers
+            blank_line_after_i_block = True,
+            blank_line_after_j_block = False,
+            space_separated = False,  # default is tab separated
+            use_binary = False,
+            binary_only = False,
+            nan_substitute_value = None):
+        """Writes the property array to a file in a format suitable for including as nexus input.
 
       arguments:
          part (string): the part name for which the array is to be exported
@@ -4903,42 +4919,42 @@ class GridPropertyCollection(PropertyCollection):
             unchanged); if None, then 'nan' or 'Nan' will appear in the ascii export file
       """
 
-      array_ref = self.cached_part_array_ref(part)
-      assert (array_ref is not None)
-      extent_kji = array_ref.shape
-      assert (len(extent_kji) == 3)
-      wd.write_array_to_ascii_file(file_name,
-                                   extent_kji,
-                                   array_ref,
-                                   headers = headers,
-                                   keyword = keyword,
-                                   columns = columns,
-                                   data_type = rqet.simplified_data_type(array_ref.dtype),
-                                   decimals = decimals,
-                                   target_simulator = 'nexus',
-                                   blank_line_after_i_block = blank_line_after_i_block,
-                                   blank_line_after_j_block = blank_line_after_j_block,
-                                   space_separated = space_separated,
-                                   append = append,
-                                   use_binary = use_binary,
-                                   binary_only = binary_only,
-                                   nan_substitute_value = nan_substitute_value)
+        array_ref = self.cached_part_array_ref(part)
+        assert (array_ref is not None)
+        extent_kji = array_ref.shape
+        assert (len(extent_kji) == 3)
+        wd.write_array_to_ascii_file(file_name,
+                                     extent_kji,
+                                     array_ref,
+                                     headers = headers,
+                                     keyword = keyword,
+                                     columns = columns,
+                                     data_type = rqet.simplified_data_type(array_ref.dtype),
+                                     decimals = decimals,
+                                     target_simulator = 'nexus',
+                                     blank_line_after_i_block = blank_line_after_i_block,
+                                     blank_line_after_j_block = blank_line_after_j_block,
+                                     space_separated = space_separated,
+                                     append = append,
+                                     use_binary = use_binary,
+                                     binary_only = binary_only,
+                                     nan_substitute_value = nan_substitute_value)
 
-   def write_nexus_property_generating_filename(
-         self,
-         part,
-         directory,
-         use_title_for_keyword = False,
-         headers = True,
-         columns = 20,
-         decimals = 3,  # note: decimals only applicable to real numbers
-         blank_line_after_i_block = True,
-         blank_line_after_j_block = False,
-         space_separated = False,  # default is tab separated
-         use_binary = False,
-         binary_only = False,
-         nan_substitute_value = None):
-      """Writes the property array to a file using a filename generated from the citation title etc.
+    def write_nexus_property_generating_filename(
+            self,
+            part,
+            directory,
+            use_title_for_keyword = False,
+            headers = True,
+            columns = 20,
+            decimals = 3,  # note: decimals only applicable to real numbers
+            blank_line_after_i_block = True,
+            blank_line_after_j_block = False,
+            space_separated = False,  # default is tab separated
+            use_binary = False,
+            binary_only = False,
+            nan_substitute_value = None):
+        """Writes the property array to a file using a filename generated from the citation title etc.
 
       arguments:
          part (string): the part name for which the array is to be exported
@@ -4953,46 +4969,46 @@ class GridPropertyCollection(PropertyCollection):
          _t_ and the time_index, if the part has a time index
       """
 
-      title = self.citation_title_for_part(part).replace(' ', '_')
-      if use_title_for_keyword:
-         keyword = title
-      else:
-         keyword = None
-      fname = title
-      facet_type = self.facet_type_for_part(part)
-      if facet_type is not None:
-         fname += '_' + facet_type.replace(' ', '_') + '_' + self.facet_for_part(part).replace(' ', '_')
-      time_index = self.time_index_for_part(part)
-      if time_index is not None:
-         fname += '_t_' + str(time_index)
-      # could add .dat extension
-      self.write_nexus_property(part,
-                                os.path.join(directory, fname),
-                                keyword = keyword,
-                                headers = headers,
-                                append = False,
-                                columns = columns,
-                                decimals = decimals,
-                                blank_line_after_i_block = blank_line_after_i_block,
-                                blank_line_after_j_block = blank_line_after_j_block,
-                                space_separated = space_separated,
-                                use_binary = use_binary,
-                                binary_only = binary_only,
-                                nan_substitute_value = nan_substitute_value)
+        title = self.citation_title_for_part(part).replace(' ', '_')
+        if use_title_for_keyword:
+            keyword = title
+        else:
+            keyword = None
+        fname = title
+        facet_type = self.facet_type_for_part(part)
+        if facet_type is not None:
+            fname += '_' + facet_type.replace(' ', '_') + '_' + self.facet_for_part(part).replace(' ', '_')
+        time_index = self.time_index_for_part(part)
+        if time_index is not None:
+            fname += '_t_' + str(time_index)
+        # could add .dat extension
+        self.write_nexus_property(part,
+                                  os.path.join(directory, fname),
+                                  keyword = keyword,
+                                  headers = headers,
+                                  append = False,
+                                  columns = columns,
+                                  decimals = decimals,
+                                  blank_line_after_i_block = blank_line_after_i_block,
+                                  blank_line_after_j_block = blank_line_after_j_block,
+                                  space_separated = space_separated,
+                                  use_binary = use_binary,
+                                  binary_only = binary_only,
+                                  nan_substitute_value = nan_substitute_value)
 
-   def write_nexus_collection(self,
-                              directory,
-                              use_title_for_keyword = False,
-                              headers = True,
-                              columns = 20,
-                              decimals = 3,
-                              blank_line_after_i_block = True,
-                              blank_line_after_j_block = False,
-                              space_separated = False,
-                              use_binary = False,
-                              binary_only = False,
-                              nan_substitute_value = None):
-      """Writes a set of files, one for each part in the collection.
+    def write_nexus_collection(self,
+                               directory,
+                               use_title_for_keyword = False,
+                               headers = True,
+                               columns = 20,
+                               decimals = 3,
+                               blank_line_after_i_block = True,
+                               blank_line_after_j_block = False,
+                               space_separated = False,
+                               use_binary = False,
+                               binary_only = False,
+                               nan_substitute_value = None):
+        """Writes a set of files, one for each part in the collection.
 
       arguments:
          directory (string): the path of the diractory into which the files will be written
@@ -5004,26 +5020,26 @@ class GridPropertyCollection(PropertyCollection):
          write_nexus_property_generating_filename()
       """
 
-      for part in self.dict.keys():
-         self.write_nexus_property_generating_filename(part,
-                                                       directory,
-                                                       use_title_for_keyword = use_title_for_keyword,
-                                                       headers = headers,
-                                                       columns = columns,
-                                                       decimals = decimals,
-                                                       blank_line_after_i_block = blank_line_after_i_block,
-                                                       blank_line_after_j_block = blank_line_after_j_block,
-                                                       space_separated = space_separated,
-                                                       use_binary = use_binary,
-                                                       binary_only = binary_only,
-                                                       nan_substitute_value = nan_substitute_value)
+        for part in self.dict.keys():
+            self.write_nexus_property_generating_filename(part,
+                                                          directory,
+                                                          use_title_for_keyword = use_title_for_keyword,
+                                                          headers = headers,
+                                                          columns = columns,
+                                                          decimals = decimals,
+                                                          blank_line_after_i_block = blank_line_after_i_block,
+                                                          blank_line_after_j_block = blank_line_after_j_block,
+                                                          space_separated = space_separated,
+                                                          use_binary = use_binary,
+                                                          binary_only = binary_only,
+                                                          nan_substitute_value = nan_substitute_value)
 
 
 class WellLogCollection(PropertyCollection):
-   """Class for RESQML Property collection for a Wellbore Frame (ie well logs), inheriting from PropertyCollection."""
+    """Class for RESQML Property collection for a Wellbore Frame (ie well logs), inheriting from PropertyCollection."""
 
-   def __init__(self, frame = None, property_set_root = None, realization = None):
-      """Creates a new property collection related to a wellbore frame.
+    def __init__(self, frame = None, property_set_root = None, realization = None):
+        """Creates a new property collection related to a wellbore frame.
 
       arguments:
          frame (well.WellboreFrame object, optional): must be present unless creating a completely blank, empty collection.
@@ -5046,10 +5062,10 @@ class WellLogCollection(PropertyCollection):
 
       """
 
-      super().__init__(support = frame, property_set_root = property_set_root, realization = realization)
+        super().__init__(support = frame, property_set_root = property_set_root, realization = realization)
 
-   def add_log(self, title, data, unit, discrete = False, realization = None, write = True, source_info = ''):
-      """Add a well log to the collection, and optionally save to HDF / XML
+    def add_log(self, title, data, unit, discrete = False, realization = None, write = True, source_info = ''):
+        """Add a well log to the collection, and optionally save to HDF / XML
       
       Note:
          If write=False, the data are not written to the model and are saved to be written later.
@@ -5071,38 +5087,38 @@ class WellLogCollection(PropertyCollection):
          uuids: list of uuids of newly added properties. Only returned if write=True.
 
       """
-      # Validate
-      if self.support is None:
-         raise ValueError('Supporting WellboreFrame not present')
-      if len(data) != self.support.node_count:
-         raise ValueError(f'Data mismatch: data length={len(data)}, but MD node count={self.support.node_count}')
+        # Validate
+        if self.support is None:
+            raise ValueError('Supporting WellboreFrame not present')
+        if len(data) != self.support.node_count:
+            raise ValueError(f'Data mismatch: data length={len(data)}, but MD node count={self.support.node_count}')
 
-      # Infer valid RESQML properties
-      # TODO: Store orginal unit somewhere if it's not a valid RESQML unit
-      uom = bwam.rq_uom(unit)
-      property_kind, facet_type, facet = infer_property_kind(title, uom)
+        # Infer valid RESQML properties
+        # TODO: Store orginal unit somewhere if it's not a valid RESQML unit
+        uom = bwam.rq_uom(unit)
+        property_kind, facet_type, facet = infer_property_kind(title, uom)
 
-      # Add to the "import list"
-      self.add_cached_array_to_imported_list(
-         cached_array = np.array(data),
-         source_info = source_info,
-         keyword = title,
-         discrete = discrete,
-         uom = uom,
-         property_kind = property_kind,
-         facet_type = facet_type,
-         facet = facet,
-         realization = realization,
-      )
+        # Add to the "import list"
+        self.add_cached_array_to_imported_list(
+            cached_array = np.array(data),
+            source_info = source_info,
+            keyword = title,
+            discrete = discrete,
+            uom = uom,
+            property_kind = property_kind,
+            facet_type = facet_type,
+            facet = facet,
+            realization = realization,
+        )
 
-      if write:
-         self.write_hdf5_for_imported_list()
-         return self.create_xml_for_imported_list_and_add_parts_to_model()
-      else:
-         return None
+        if write:
+            self.write_hdf5_for_imported_list()
+            return self.create_xml_for_imported_list_and_add_parts_to_model()
+        else:
+            return None
 
-   def iter_logs(self):
-      """ Generator that yields component Log objects.
+    def iter_logs(self):
+        """ Generator that yields component Log objects.
       
       Yields:
          instances of :class:`resqpy.property.WellLog` .
@@ -5113,40 +5129,40 @@ class WellLogCollection(PropertyCollection):
             print(log.title)
       """
 
-      return (WellLog(collection = self, uuid = uuid) for uuid in self.uuids())
+        return (WellLog(collection = self, uuid = uuid) for uuid in self.uuids())
 
-   def to_df(self, include_units = False):
-      """ Return pandas dataframe of log data
+    def to_df(self, include_units = False):
+        """ Return pandas dataframe of log data
 
       Args:
          include_units (bool): include unit in column names
       """
 
-      assert self.support is not None
+        assert self.support is not None
 
-      # Get MD values
-      md_values = self.support.node_mds
-      assert md_values.ndim == 1, 'measured depths not 1D numpy array'
+        # Get MD values
+        md_values = self.support.node_mds
+        assert md_values.ndim == 1, 'measured depths not 1D numpy array'
 
-      # Get logs
-      data = {}
-      for log in self.iter_logs():
+        # Get logs
+        data = {}
+        for log in self.iter_logs():
 
-         col_name = log.title
-         if include_units and log.uom:
-            col_name += f' ({log.uom})'
+            col_name = log.title
+            if include_units and log.uom:
+                col_name += f' ({log.uom})'
 
-         values = log.values()
-         if values.ndim > 1:
-            raise NotImplementedError('Multidimensional logs not yet supported in pandas')
+            values = log.values()
+            if values.ndim > 1:
+                raise NotImplementedError('Multidimensional logs not yet supported in pandas')
 
-         data[col_name] = values
+            data[col_name] = values
 
-      df = pd.DataFrame(data = data, index = md_values)
-      return df
+        df = pd.DataFrame(data = data, index = md_values)
+        return df
 
-   def to_las(self):
-      """ Return a lasio.LASFile object, which can then be written to disk
+    def to_las(self):
+        """ Return a lasio.LASFile object, which can then be written to disk
 
       Example::
 
@@ -5154,90 +5170,90 @@ class WellLogCollection(PropertyCollection):
          las.write('example_logs.las', version=2)
 
       """
-      las = lasio.LASFile()
+        las = lasio.LASFile()
 
-      las.well.WELL = str(self.support.wellbore_interpretation.title)
-      las.well.DATE = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        las.well.WELL = str(self.support.wellbore_interpretation.title)
+        las.well.DATE = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
 
-      # todo: Get UWI from somewhere
-      # las.well.UWI = uwi
+        # todo: Get UWI from somewhere
+        # las.well.UWI = uwi
 
-      # Lookup depths from associated WellboreFrame and Trajectory
-      md_values = self.support.node_mds
-      md_unit = self.support.trajectory.md_uom
+        # Lookup depths from associated WellboreFrame and Trajectory
+        md_values = self.support.node_mds
+        md_unit = self.support.trajectory.md_uom
 
-      # Measured depths should be first column in LAS file
-      # todo: include datum information in description
-      las.append_curve('MD', md_values, unit = md_unit)
+        # Measured depths should be first column in LAS file
+        # todo: include datum information in description
+        las.append_curve('MD', md_values, unit = md_unit)
 
-      for well_log in self.iter_logs():
-         name = well_log.title
-         unit = well_log.uom
-         values = well_log.values()
-         if values.ndim > 1:
-            raise NotImplementedError('Multidimensional logs not yet supported in pandas')
-         assert len(values) > 0
-         log.debug(f"Writing log {name} of length {len(values)} and shape {values.shape}")
-         las.append_curve(name, values, unit = unit, descr = None)
-      return las
+        for well_log in self.iter_logs():
+            name = well_log.title
+            unit = well_log.uom
+            values = well_log.values()
+            if values.ndim > 1:
+                raise NotImplementedError('Multidimensional logs not yet supported in pandas')
+            assert len(values) > 0
+            log.debug(f"Writing log {name} of length {len(values)} and shape {values.shape}")
+            las.append_curve(name, values, unit = unit, descr = None)
+        return las
 
-   def set_wellbore_frame(self, frame):
-      """Sets the supporting representation object for the property collection to be the given wellbore frame object.
+    def set_wellbore_frame(self, frame):
+        """Sets the supporting representation object for the property collection to be the given wellbore frame object.
 
       note:
          this method does not need to be called if the wellbore frame was identified at the time the collection
          was initialised
       """
 
-      self.set_support(support = frame)
+        self.set_support(support = frame)
 
 
 class WellLog:
-   """ Thin wrapper class around RESQML properties for well logs """
+    """ Thin wrapper class around RESQML properties for well logs """
 
-   def __init__(self, collection, uuid):
-      """ Create a well log from a part name """
+    def __init__(self, collection, uuid):
+        """ Create a well log from a part name """
 
-      self.collection: PropertyCollection = collection
-      self.model = collection.model
-      self.uuid = uuid
+        self.collection: PropertyCollection = collection
+        self.model = collection.model
+        self.uuid = uuid
 
-      part = self.model.part_for_uuid(uuid)
-      indexable = self.collection.indexable_for_part(part)
-      if indexable != 'nodes':
-         raise NotImplementedError('well frame related property does not have nodes as indexable element')
+        part = self.model.part_for_uuid(uuid)
+        indexable = self.collection.indexable_for_part(part)
+        if indexable != 'nodes':
+            raise NotImplementedError('well frame related property does not have nodes as indexable element')
 
-      #: Name of log
-      self.title = self.model.citation_title_for_part(part)
+        #: Name of log
+        self.title = self.model.citation_title_for_part(part)
 
-      #: Unit of measure
-      self.uom = self.collection.uom_for_part(part)
+        #: Unit of measure
+        self.uom = self.collection.uom_for_part(part)
 
-   def values(self):
-      """ Return log data as numpy array
+    def values(self):
+        """ Return log data as numpy array
 
       Note:
          may return 2D numpy array with shape (num_depths, num_columns).
       """
 
-      part = self.model.part_for_uuid(self.uuid)
-      return self.collection.cached_part_array_ref(part)
+        part = self.model.part_for_uuid(self.uuid)
+        return self.collection.cached_part_array_ref(part)
 
 
 class StringLookup(BaseResqpy):
-   """Class catering for RESQML obj_StringLookupTable objects."""
+    """Class catering for RESQML obj_StringLookupTable objects."""
 
-   resqml_type = "StringTableLookup"
+    resqml_type = "StringTableLookup"
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                int_to_str_dict = None,
-                title = None,
-                extra_metadata = None,
-                originator = None):
-      """Creates a new string lookup (RESQML obj_StringTableLookup) object.
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 int_to_str_dict = None,
+                 title = None,
+                 extra_metadata = None,
+                 originator = None):
+        """Creates a new string lookup (RESQML obj_StringTableLookup) object.
 
       arguments:
          parent_model: the model to which this string lookup belongs
@@ -5252,139 +5268,140 @@ class StringLookup(BaseResqpy):
       :meta common:
       """
 
-      self.min_index = None
-      self.max_index = None
-      self.str_list = []
-      self.str_dict = {}
-      self.stored_as_list = False
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
-      if uuid is None and root_node is None:
-         self.load_from_dict(int_to_str_dict)
+        self.min_index = None
+        self.max_index = None
+        self.str_list = []
+        self.str_dict = {}
+        self.stored_as_list = False
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
+        if uuid is None and root_node is None:
+            self.load_from_dict(int_to_str_dict)
 
-   def _load_from_xml(self):
-      root_node = self.root
-      for v_node in rqet.list_of_tag(root_node, 'Value'):
-         key = rqet.find_tag_int(v_node, 'Key')
-         value = rqet.find_tag_text(v_node, 'Value')
-         assert key not in self.str_dict, 'key value ' + str(key) + ' occurs more than once in string lookup table xml'
-         self.str_dict[key] = value
-         if self.min_index is None or key < self.min_index:
-            self.min_index = key
-         if self.max_index is None or key > self.max_index:
-            self.max_index = key
+    def _load_from_xml(self):
+        root_node = self.root
+        for v_node in rqet.list_of_tag(root_node, 'Value'):
+            key = rqet.find_tag_int(v_node, 'Key')
+            value = rqet.find_tag_text(v_node, 'Value')
+            assert key not in self.str_dict, 'key value ' + str(
+                key) + ' occurs more than once in string lookup table xml'
+            self.str_dict[key] = value
+            if self.min_index is None or key < self.min_index:
+                self.min_index = key
+            if self.max_index is None or key > self.max_index:
+                self.max_index = key
 
-   def load_from_dict(self, int_to_str_dict):
-      if int_to_str_dict is None:
-         return
-      assert len(int_to_str_dict), 'empty dictionary passed to string lookup initialisation'
-      self.str_dict = int_to_str_dict.copy()
-      self.min_index = min(self.str_dict.keys())
-      self.max_index = max(self.str_dict.keys())
-      self.set_list_from_dict_conditionally()
+    def load_from_dict(self, int_to_str_dict):
+        if int_to_str_dict is None:
+            return
+        assert len(int_to_str_dict), 'empty dictionary passed to string lookup initialisation'
+        self.str_dict = int_to_str_dict.copy()
+        self.min_index = min(self.str_dict.keys())
+        self.max_index = max(self.str_dict.keys())
+        self.set_list_from_dict_conditionally()
 
-   def is_equivalent(self, other):
-      """Returns True if this lookup is the same as other (apart from uuid); False otherwise."""
+    def is_equivalent(self, other):
+        """Returns True if this lookup is the same as other (apart from uuid); False otherwise."""
 
-      if other is None:
-         return False
-      if self is other:
-         return True
-      if bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.title != other.title or self.min_index != other.min_index or self.max_index != other.max_index:
-         return False
-      return self.str_dict == other.str_dict
+        if other is None:
+            return False
+        if self is other:
+            return True
+        if bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.title != other.title or self.min_index != other.min_index or self.max_index != other.max_index:
+            return False
+        return self.str_dict == other.str_dict
 
-   def set_list_from_dict_conditionally(self):
-      """Sets a list copy of the lookup table, which can be indexed directly, if it makes sense to do so."""
+    def set_list_from_dict_conditionally(self):
+        """Sets a list copy of the lookup table, which can be indexed directly, if it makes sense to do so."""
 
-      self.str_list = []
-      self.stored_as_list = False
-      if self.min_index >= 0 and (self.max_index < 50 or 10 * len(self.str_dict) // self.max_index > 8):
-         for key in range(self.max_index + 1):
-            if key in self.str_dict:
-               self.str_list.append(self.str_dict[key])
+        self.str_list = []
+        self.stored_as_list = False
+        if self.min_index >= 0 and (self.max_index < 50 or 10 * len(self.str_dict) // self.max_index > 8):
+            for key in range(self.max_index + 1):
+                if key in self.str_dict:
+                    self.str_list.append(self.str_dict[key])
+                else:
+                    self.str_list.append(None)
+            self.stored_as_list = True
+
+    def set_string(self, key, value):
+        """Sets the string associated with a given integer key."""
+
+        self.str_dict[key] = value
+        limits_changed = False
+        if self.min_index is None or value < self.min_index:
+            self.min_index = value
+            limits_changed = True
+        if self.max_index is None or value > self.max_index:
+            self.max_index = value
+            limits_changed = True
+        if self.stored_as_list:
+            if limits_changed:
+                self.set_list_from_dict_conditionally()
             else:
-               self.str_list.append(None)
-         self.stored_as_list = True
+                self.str_list[key] = value
 
-   def set_string(self, key, value):
-      """Sets the string associated with a given integer key."""
-
-      self.str_dict[key] = value
-      limits_changed = False
-      if self.min_index is None or value < self.min_index:
-         self.min_index = value
-         limits_changed = True
-      if self.max_index is None or value > self.max_index:
-         self.max_index = value
-         limits_changed = True
-      if self.stored_as_list:
-         if limits_changed:
-            self.set_list_from_dict_conditionally()
-         else:
-            self.str_list[key] = value
-
-   def get_string(self, key):
-      """Returns the string associated with the integer key, or None if not found.
+    def get_string(self, key):
+        """Returns the string associated with the integer key, or None if not found.
 
       :meta common:
       """
 
-      if key < self.min_index or key > self.max_index:
-         return None
-      if self.stored_as_list:
-         return self.str_list[key]
-      if key not in self.str_dict:
-         return None
-      return self.str_dict[key]
-
-   def get_list(self):
-      """Returns a list of values, sorted by key.
-
-      :meta common:
-      """
-
-      if self.stored_as_list:
-         return self.str_list
-      return list(dict(sorted(list(self.str_dict.items()))).values())
-
-   def length(self):
-      """Returns the nominal length of the lookup table.
-
-      :meta common:
-      """
-
-      if self.stored_as_list:
-         return len(self.str_list)
-      return len(self.str_dict)
-
-   def get_index_for_string(self, string):
-      """Returns the integer key for the given string (exact match required), or None if not found.
-
-      :meta common:
-      """
-
-      if self.stored_as_list:
-         try:
-            index = self.str_list.index(string)
-            return index
-         except Exception:
+        if key < self.min_index or key > self.max_index:
             return None
-      if string not in self.str_dict.values():
-         return None
-      for k, v in self.str_dict.items():
-         if v == string:
-            return k
-      return None
+        if self.stored_as_list:
+            return self.str_list[key]
+        if key not in self.str_dict:
+            return None
+        return self.str_dict[key]
 
-   def create_xml(self, title = None, originator = None, add_as_part = True, reuse = True):
-      """Creates an xml node for the string table lookup.
+    def get_list(self):
+        """Returns a list of values, sorted by key.
+
+      :meta common:
+      """
+
+        if self.stored_as_list:
+            return self.str_list
+        return list(dict(sorted(list(self.str_dict.items()))).values())
+
+    def length(self):
+        """Returns the nominal length of the lookup table.
+
+      :meta common:
+      """
+
+        if self.stored_as_list:
+            return len(self.str_list)
+        return len(self.str_dict)
+
+    def get_index_for_string(self, string):
+        """Returns the integer key for the given string (exact match required), or None if not found.
+
+      :meta common:
+      """
+
+        if self.stored_as_list:
+            try:
+                index = self.str_list.index(string)
+                return index
+            except Exception:
+                return None
+        if string not in self.str_dict.values():
+            return None
+        for k, v in self.str_dict.items():
+            if v == string:
+                return k
+        return None
+
+    def create_xml(self, title = None, originator = None, add_as_part = True, reuse = True):
+        """Creates an xml node for the string table lookup.
 
       arguments:
          title (string, optional): if present, overrides the object's title attribute to be used as citation title
@@ -5394,191 +5411,191 @@ class StringLookup(BaseResqpy):
       :meta common:
       """
 
-      if title:
-         self.title = title
+        if title:
+            self.title = title
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
 
-      sl_node = super().create_xml(add_as_part = False, originator = originator)
+        sl_node = super().create_xml(add_as_part = False, originator = originator)
 
-      for k, v in self.str_dict.items():
+        for k, v in self.str_dict.items():
 
-         pair_node = rqet.SubElement(sl_node, ns['resqml2'] + 'Value')
-         pair_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StringLookup')
-         pair_node.text = rqet.null_xml_text
+            pair_node = rqet.SubElement(sl_node, ns['resqml2'] + 'Value')
+            pair_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StringLookup')
+            pair_node.text = rqet.null_xml_text
 
-         key_node = rqet.SubElement(pair_node, ns['resqml2'] + 'Key')
-         key_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         key_node.text = str(k)
+            key_node = rqet.SubElement(pair_node, ns['resqml2'] + 'Key')
+            key_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            key_node.text = str(k)
 
-         value_node = rqet.SubElement(pair_node, ns['resqml2'] + 'Value')
-         value_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-         value_node.text = str(v)
+            value_node = rqet.SubElement(pair_node, ns['resqml2'] + 'Value')
+            value_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+            value_node.text = str(v)
 
-      if add_as_part:
-         self.model.add_part('obj_StringTableLookup', self.uuid, sl_node)
+        if add_as_part:
+            self.model.add_part('obj_StringTableLookup', self.uuid, sl_node)
 
-      return sl_node
+        return sl_node
 
 
 class PropertyKind(BaseResqpy):
-   """Class catering for RESQML bespoke PropertyKind objects."""
+    """Class catering for RESQML bespoke PropertyKind objects."""
 
-   resqml_type = "PropertyKind"
+    resqml_type = "PropertyKind"
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                title = None,
-                is_abstract = False,
-                example_uom = None,
-                naming_system = 'urn:resqml:bp.com:resqpy',
-                parent_property_kind = 'continuous',
-                extra_metadata = None,
-                originator = None):
-      """Initialise a new bespoke property kind."""
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 title = None,
+                 is_abstract = False,
+                 example_uom = None,
+                 naming_system = 'urn:resqml:bp.com:resqpy',
+                 parent_property_kind = 'continuous',
+                 extra_metadata = None,
+                 originator = None):
+        """Initialise a new bespoke property kind."""
 
-      self.is_abstract = is_abstract
-      self.naming_system = naming_system
-      self.example_uom = example_uom
-      self.parent_kind = parent_property_kind
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        self.is_abstract = is_abstract
+        self.naming_system = naming_system
+        self.example_uom = example_uom
+        self.parent_kind = parent_property_kind
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-   def _load_from_xml(self):
-      root_node = self.root
-      self.is_abstract = rqet.find_tag_bool(root_node, 'IsAbstract')
-      self.naming_system = rqet.find_tag_text(root_node, 'NamingSystem')
-      self.example_uom = rqet.find_tag_text(root_node, 'RepresentativeUom')
-      ppk_node = rqet.find_tag(root_node, 'ParentPropertyKind')
-      assert ppk_node is not None
-      ppk_kind_node = rqet.find_tag(ppk_node, 'Kind')
-      assert ppk_kind_node is not None, 'only standard property kinds supported as parent kind'
-      self.parent_kind = ppk_kind_node.text
+    def _load_from_xml(self):
+        root_node = self.root
+        self.is_abstract = rqet.find_tag_bool(root_node, 'IsAbstract')
+        self.naming_system = rqet.find_tag_text(root_node, 'NamingSystem')
+        self.example_uom = rqet.find_tag_text(root_node, 'RepresentativeUom')
+        ppk_node = rqet.find_tag(root_node, 'ParentPropertyKind')
+        assert ppk_node is not None
+        ppk_kind_node = rqet.find_tag(ppk_node, 'Kind')
+        assert ppk_kind_node is not None, 'only standard property kinds supported as parent kind'
+        self.parent_kind = ppk_kind_node.text
 
-   def is_equivalent(self, other_pk, check_extra_metadata = True):
-      """Returns True if this property kind is essentially the same as the other; False otherwise."""
+    def is_equivalent(self, other_pk, check_extra_metadata = True):
+        """Returns True if this property kind is essentially the same as the other; False otherwise."""
 
-      if other_pk is None:
-         return False
-      if self is other_pk:
-         return True
-      if bu.matching_uuids(self.uuid, other_pk.uuid):
-         return True
-      if (self.parent_kind != other_pk.parent_kind or self.title != other_pk.title or
-          self.is_abstract != other_pk.is_abstract or self.naming_system != other_pk.naming_system):
-         return False
-      if (self.example_uom and other_pk.example_uom) and self.example_uom != other_pk.example_uom:
-         return False
-      if check_extra_metadata:
-         if (self.extra_metadata or other_pk.extra_metadata) and self.extra_metadata != other_pk.extra_metadata:
+        if other_pk is None:
             return False
-      return True
+        if self is other_pk:
+            return True
+        if bu.matching_uuids(self.uuid, other_pk.uuid):
+            return True
+        if (self.parent_kind != other_pk.parent_kind or self.title != other_pk.title or
+                self.is_abstract != other_pk.is_abstract or self.naming_system != other_pk.naming_system):
+            return False
+        if (self.example_uom and other_pk.example_uom) and self.example_uom != other_pk.example_uom:
+            return False
+        if check_extra_metadata:
+            if (self.extra_metadata or other_pk.extra_metadata) and self.extra_metadata != other_pk.extra_metadata:
+                return False
+        return True
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True):
-      """Create xml for this bespoke property kind."""
+    def create_xml(self, add_as_part = True, originator = None, reuse = True):
+        """Create xml for this bespoke property kind."""
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
 
-      pk = super().create_xml(add_as_part = False, originator = originator)
+        pk = super().create_xml(add_as_part = False, originator = originator)
 
-      ns_node = rqet.SubElement(pk, ns['resqml2'] + 'NamingSystem')
-      ns_node.set(ns['xsi'] + 'type', ns['xsd'] + 'anyURI')
-      ns_node.text = str(self.naming_system)
+        ns_node = rqet.SubElement(pk, ns['resqml2'] + 'NamingSystem')
+        ns_node.set(ns['xsi'] + 'type', ns['xsd'] + 'anyURI')
+        ns_node.text = str(self.naming_system)
 
-      ia_node = rqet.SubElement(pk, ns['resqml2'] + 'IsAbstract')
-      ia_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-      ia_node.text = str(self.is_abstract).lower()
+        ia_node = rqet.SubElement(pk, ns['resqml2'] + 'IsAbstract')
+        ia_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+        ia_node.text = str(self.is_abstract).lower()
 
-      # note: schema definition requires this field, even for discrete property kinds
-      uom = self.example_uom
-      if uom is None:
-         uom = 'Euc'
-      ru_node = rqet.SubElement(pk, ns['resqml2'] + 'RepresentativeUom')
-      ru_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlUom')
-      ru_node.text = str(uom)
+        # note: schema definition requires this field, even for discrete property kinds
+        uom = self.example_uom
+        if uom is None:
+            uom = 'Euc'
+        ru_node = rqet.SubElement(pk, ns['resqml2'] + 'RepresentativeUom')
+        ru_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlUom')
+        ru_node.text = str(uom)
 
-      ppk_node = rqet.SubElement(pk, ns['resqml2'] + 'ParentPropertyKind')
-      ppk_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StandardPropertyKind')
-      ppk_node.text = rqet.null_xml_text
+        ppk_node = rqet.SubElement(pk, ns['resqml2'] + 'ParentPropertyKind')
+        ppk_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StandardPropertyKind')
+        ppk_node.text = rqet.null_xml_text
 
-      ppk_kind_node = rqet.SubElement(ppk_node, ns['resqml2'] + 'Kind')
-      ppk_kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlPropertyKind')
-      ppk_kind_node.text = str(self.parent_kind)
+        ppk_kind_node = rqet.SubElement(ppk_node, ns['resqml2'] + 'Kind')
+        ppk_kind_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlPropertyKind')
+        ppk_kind_node.text = str(self.parent_kind)
 
-      if add_as_part:
-         self.model.add_part('obj_PropertyKind', self.uuid, pk)
-         # no relationships at present, if local parent property kinds were to be supported then a rel. is needed there
+        if add_as_part:
+            self.model.add_part('obj_PropertyKind', self.uuid, pk)
+            # no relationships at present, if local parent property kinds were to be supported then a rel. is needed there
 
-      return pk
+        return pk
 
 
 class WellIntervalProperty:
-   """Thin wrapper class around interval properties for a Wellbore Frame or Blocked Wellbore (ie interval or cell well logss)."""
+    """Thin wrapper class around interval properties for a Wellbore Frame or Blocked Wellbore (ie interval or cell well logss)."""
 
-   def __init__(self, collection, part):
-      """Create an interval log or blocked well log from a part name"""
+    def __init__(self, collection, part):
+        """Create an interval log or blocked well log from a part name"""
 
-      self.collection: PropertyCollection = collection
-      self.model = collection.model
-      self.part = part
+        self.collection: PropertyCollection = collection
+        self.model = collection.model
+        self.part = part
 
-      indexable = self.collection.indexable_for_part(part)
-      assert indexable in ['cells', 'intervals'], 'expected cells or intervals as indexable element'
+        indexable = self.collection.indexable_for_part(part)
+        assert indexable in ['cells', 'intervals'], 'expected cells or intervals as indexable element'
 
-      self.name = self.model.citation_title_for_part(part)
-      self.uom = self.collection.uom_for_part(part)
+        self.name = self.model.citation_title_for_part(part)
+        self.uom = self.collection.uom_for_part(part)
 
-   def values(self):
-      """Return interval log or blocked well log as numpy array"""
+    def values(self):
+        """Return interval log or blocked well log as numpy array"""
 
-      return self.collection.cached_part_array_ref(self.part)
+        return self.collection.cached_part_array_ref(self.part)
 
 
 class WellIntervalPropertyCollection(PropertyCollection):
-   """Class for RESQML property collection for a WellboreFrame for interval or blocked well logs, inheriting from PropertyCollection."""
+    """Class for RESQML property collection for a WellboreFrame for interval or blocked well logs, inheriting from PropertyCollection."""
 
-   def __init__(self, frame = None, property_set_root = None, realization = None):
-      """Creates a new property collection related to interval or blocked well logs and a wellbore frame."""
+    def __init__(self, frame = None, property_set_root = None, realization = None):
+        """Creates a new property collection related to interval or blocked well logs and a wellbore frame."""
 
-      super().__init__(support = frame, property_set_root = property_set_root, realization = realization)
+        super().__init__(support = frame, property_set_root = property_set_root, realization = realization)
 
-   def logs(self):
-      """Generator that yields component Interval log or Blocked well log objects"""
-      return (WellIntervalProperty(collection = self, part = part) for part in self.parts())
+    def logs(self):
+        """Generator that yields component Interval log or Blocked well log objects"""
+        return (WellIntervalProperty(collection = self, part = part) for part in self.parts())
 
-   def to_pandas(self, include_units = False):
-      cell_indices = [return_cell_indices(i, self.support.cell_indices) for i in self.support.cell_grid_link]
-      data = {}
-      for log in self.logs():
-         col_name = log.name
-         values = log.values()
-         data[col_name] = values
-      df = pd.DataFrame(data = data, index = cell_indices)
-      return df
+    def to_pandas(self, include_units = False):
+        cell_indices = [return_cell_indices(i, self.support.cell_indices) for i in self.support.cell_grid_link]
+        data = {}
+        for log in self.logs():
+            col_name = log.name
+            values = log.values()
+            data[col_name] = values
+        df = pd.DataFrame(data = data, index = cell_indices)
+        return df
 
 
 def same_property_kind(pk_a, pk_b):
-   """Returns True if the two property kinds are the same, or pseudonyms."""
+    """Returns True if the two property kinds are the same, or pseudonyms."""
 
-   if pk_a is None or pk_b is None:
-      return False
-   if pk_a == pk_b:
-      return True
-   if pk_a in ['permeability rock', 'rock permeability'] and pk_b in ['permeability rock', 'rock permeability']:
-      return True
-   return False
+    if pk_a is None or pk_b is None:
+        return False
+    if pk_a == pk_b:
+        return True
+    if pk_a in ['permeability rock', 'rock permeability'] and pk_b in ['permeability rock', 'rock permeability']:
+        return True
+    return False
 
 
 def create_transmisibility_multiplier_property_kind(model):
-   """Create a local property kind 'transmisibility multiplier' for a given model
+    """Create a local property kind 'transmisibility multiplier' for a given model
 
    argument:
       model: resqml model object
@@ -5586,18 +5603,18 @@ def create_transmisibility_multiplier_property_kind(model):
    returns:
       property kind uuid
    """
-   log.debug("Making a new property kind 'Transmissibility multiplier'")
-   tmult_kind = PropertyKind(parent_model = model,
-                             title = 'transmissibility multiplier',
-                             parent_property_kind = 'continuous')
-   tmult_kind.create_xml()
-   tmult_kind_uuid = tmult_kind.uuid
-   model.store_epc()
-   return tmult_kind_uuid
+    log.debug("Making a new property kind 'Transmissibility multiplier'")
+    tmult_kind = PropertyKind(parent_model = model,
+                              title = 'transmissibility multiplier',
+                              parent_property_kind = 'continuous')
+    tmult_kind.create_xml()
+    tmult_kind_uuid = tmult_kind.uuid
+    model.store_epc()
+    return tmult_kind_uuid
 
 
 def property_kind_and_facet_from_keyword(keyword):
-   """If keyword is recognised, returns equivalent resqml PropertyKind and Facet info.
+    """If keyword is recognised, returns equivalent resqml PropertyKind and Facet info.
 
    argument:
       keyword (string): Nexus grid property keyword
@@ -5610,178 +5627,178 @@ def property_kind_and_facet_from_keyword(keyword):
       the local property kind object is created if not already present
    """
 
-   # note: this code doesn't cater for a property having more than one facet, eg. direction and phase
+    # note: this code doesn't cater for a property having more than one facet, eg. direction and phase
 
-   def facet_info_for_dir_ch(dir_ch):
-      facet_type = None
-      facet = None
-      if dir_ch in ['i', 'j', 'k', 'x', 'y', 'z']:
-         facet_type = 'direction'
-         if dir_ch in ['i', 'x']:
-            facet = 'I'
-         elif dir_ch in ['j', 'y']:
-            facet = 'J'
-         else:
-            facet = 'K'
-         # NB: resqml also allows for combinations, eg. IJ, IJK
-      return (facet_type, facet)
+    def facet_info_for_dir_ch(dir_ch):
+        facet_type = None
+        facet = None
+        if dir_ch in ['i', 'j', 'k', 'x', 'y', 'z']:
+            facet_type = 'direction'
+            if dir_ch in ['i', 'x']:
+                facet = 'I'
+            elif dir_ch in ['j', 'y']:
+                facet = 'J'
+            else:
+                facet = 'K'
+            # NB: resqml also allows for combinations, eg. IJ, IJK
+        return (facet_type, facet)
 
-   # note: 'what' facet_type for made-up uses might be better changed to the generic 'qualifier' facet type
+    # note: 'what' facet_type for made-up uses might be better changed to the generic 'qualifier' facet type
 
-   property_kind = None
-   facet_type = None
-   facet = None
-   lk = keyword.lower()
-   if lk in ['bv', 'brv']:  # bulk rock volume
-      property_kind = 'rock volume'
-      facet_type = 'netgross'
-      facet = 'gross'  # todo: check this is the facet in xsd
-   elif lk in ['pv', 'pvr', 'porv']:
-      property_kind = 'pore volume'  # pore volume
-   elif lk in ['mdep', 'depth', 'tops', 'mids']:
-      property_kind = 'depth'  # depth (nexus) and tops mean top depth
-      facet_type = 'what'  # this might need to be something different
-      if lk in ['mdep', 'mids']:
-         facet = 'cell centre'
-      else:
-         facet = 'cell top'
-   elif lk in ['ntg', 'netgrs']:
-      property_kind = 'net to gross ratio'  # net-to-gross
-   elif lk in ['netv', 'nrv']:  # net volume
-      property_kind = 'rock volume'
-      facet_type = 'netgross'
-      facet = 'net'
-   elif lk in ['dzc', 'dzn', 'dz', 'dznet']:
-      property_kind = 'thickness'  # or should these keywords use cell length in K direction?
-      facet_type = 'netgross'
-      if lk.startswith('dzn'):
-         facet = 'net'
-      else:
-         facet = 'gross'
-   elif lk in ['dxc', 'dyc', 'dx', 'dy']:
-      property_kind = 'cell length'
-      (facet_type, facet) = facet_info_for_dir_ch(lk[1])
-   elif len(lk) > 2 and lk[0] == 'd' and lk[1] in 'xyz':
-      property_kind = 'length'
-      facet_type = 'direction'
-      facet = lk[1].upper()  # keep as 'X', 'Y' or 'Z'
-   elif lk in ['por', 'poro', 'porosity']:
-      property_kind = 'porosity'  # porosity
-   elif lk == 'kh':
-      property_kind = 'permeability thickness'  # K.H (not horizontal permeability)
-   elif lk[:4] == 'perm' or (len(lk) == 2 and lk[0] == 'k'):  # permeability
-      property_kind = 'permeability rock'
-      (facet_type, facet) = facet_info_for_dir_ch(lk[-1])
-   elif lk[:5] == 'trans' or (len(lk) == 2 and lk[0] == 't'):  # transmissibility (for unit viscosity)
-      property_kind = 'transmissibility'
-      (facet_type, facet) = facet_info_for_dir_ch(lk[-1])
-   elif lk in ['p', 'pressure']:
-      property_kind = 'pressure'  # pressure; todo: phase pressures
-   elif lk in ['sw', 'so', 'sg', 'satw', 'sato', 'satg', 'soil']:  # saturations
-      property_kind = 'saturation'
-      facet_type = 'what'  # todo: check use of 'what' for phase
-      if lk in ['sw', 'satw', 'swat']:
-         facet = 'water'
-      elif lk in ['so', 'sato', 'soil']:
-         facet = 'oil'
-      elif lk in ['sg', 'satg', 'sgas']:
-         facet = 'gas'
-   elif lk in ['swl', 'swr', 'sgl', 'sgr', 'swro', 'sgro', 'sor', 'swu', 'sgu']:  # nexus saturation end points
-      property_kind = 'saturation'
-      facet_type = 'what'  # note: use of 'what' for phase is a guess
-      if lk[1] == 'w':
-         facet = 'water'
-      elif lk[1] == 'g':
-         facet = 'gas'
-      elif lk[1] == 'o':
-         facet = 'oil'
-      if lk[-1] == 'l':
-         facet += ' minimum'
-      elif lk[-1] == 'u':
-         facet += ' maximum'
-      elif lk[2:] == 'ro':
-         facet += ' residual to oil'
-      elif lk[-1] == 'r':
-         facet += ' residual'
-      else:
-         assert False, 'problem deciphering saturation end point keyword: ' + lk
+    property_kind = None
+    facet_type = None
+    facet = None
+    lk = keyword.lower()
+    if lk in ['bv', 'brv']:  # bulk rock volume
+        property_kind = 'rock volume'
+        facet_type = 'netgross'
+        facet = 'gross'  # todo: check this is the facet in xsd
+    elif lk in ['pv', 'pvr', 'porv']:
+        property_kind = 'pore volume'  # pore volume
+    elif lk in ['mdep', 'depth', 'tops', 'mids']:
+        property_kind = 'depth'  # depth (nexus) and tops mean top depth
+        facet_type = 'what'  # this might need to be something different
+        if lk in ['mdep', 'mids']:
+            facet = 'cell centre'
+        else:
+            facet = 'cell top'
+    elif lk in ['ntg', 'netgrs']:
+        property_kind = 'net to gross ratio'  # net-to-gross
+    elif lk in ['netv', 'nrv']:  # net volume
+        property_kind = 'rock volume'
+        facet_type = 'netgross'
+        facet = 'net'
+    elif lk in ['dzc', 'dzn', 'dz', 'dznet']:
+        property_kind = 'thickness'  # or should these keywords use cell length in K direction?
+        facet_type = 'netgross'
+        if lk.startswith('dzn'):
+            facet = 'net'
+        else:
+            facet = 'gross'
+    elif lk in ['dxc', 'dyc', 'dx', 'dy']:
+        property_kind = 'cell length'
+        (facet_type, facet) = facet_info_for_dir_ch(lk[1])
+    elif len(lk) > 2 and lk[0] == 'd' and lk[1] in 'xyz':
+        property_kind = 'length'
+        facet_type = 'direction'
+        facet = lk[1].upper()  # keep as 'X', 'Y' or 'Z'
+    elif lk in ['por', 'poro', 'porosity']:
+        property_kind = 'porosity'  # porosity
+    elif lk == 'kh':
+        property_kind = 'permeability thickness'  # K.H (not horizontal permeability)
+    elif lk[:4] == 'perm' or (len(lk) == 2 and lk[0] == 'k'):  # permeability
+        property_kind = 'permeability rock'
+        (facet_type, facet) = facet_info_for_dir_ch(lk[-1])
+    elif lk[:5] == 'trans' or (len(lk) == 2 and lk[0] == 't'):  # transmissibility (for unit viscosity)
+        property_kind = 'transmissibility'
+        (facet_type, facet) = facet_info_for_dir_ch(lk[-1])
+    elif lk in ['p', 'pressure']:
+        property_kind = 'pressure'  # pressure; todo: phase pressures
+    elif lk in ['sw', 'so', 'sg', 'satw', 'sato', 'satg', 'soil']:  # saturations
+        property_kind = 'saturation'
+        facet_type = 'what'  # todo: check use of 'what' for phase
+        if lk in ['sw', 'satw', 'swat']:
+            facet = 'water'
+        elif lk in ['so', 'sato', 'soil']:
+            facet = 'oil'
+        elif lk in ['sg', 'satg', 'sgas']:
+            facet = 'gas'
+    elif lk in ['swl', 'swr', 'sgl', 'sgr', 'swro', 'sgro', 'sor', 'swu', 'sgu']:  # nexus saturation end points
+        property_kind = 'saturation'
+        facet_type = 'what'  # note: use of 'what' for phase is a guess
+        if lk[1] == 'w':
+            facet = 'water'
+        elif lk[1] == 'g':
+            facet = 'gas'
+        elif lk[1] == 'o':
+            facet = 'oil'
+        if lk[-1] == 'l':
+            facet += ' minimum'
+        elif lk[-1] == 'u':
+            facet += ' maximum'
+        elif lk[2:] == 'ro':
+            facet += ' residual to oil'
+        elif lk[-1] == 'r':
+            facet += ' residual'
+        else:
+            assert False, 'problem deciphering saturation end point keyword: ' + lk
 #   elif lk == 'sal':    # todo: salinity; local property kind needed; various units possible in Nexus
-   elif lk in ['wip', 'oip', 'gip', 'mobw', 'mobo', 'mobg', 'ocip']:  # todo: check these, especially ocip
-      property_kind = 'fluid volume'
-      facet_type = 'what'  # todo: check use of 'what' for phase
-      if lk in ['wip', 'mobw']:
-         facet = 'water'  # todo: add another facet indicating mobile volume
-      elif lk in ['oip', 'mobo']:
-         facet = 'oil'
-      elif lk in ['gip', 'mobg']:
-         facet = 'gas'
-      elif lk == 'ocip':
-         facet = 'oil condensate'  # todo: this seems unlikely: check
-      if lk[:3] == 'mob':
-         facet += ' (mobile)'
-   elif lk in ['tmx', 'tmy', 'tmz', 'tmflx', 'tmfly', 'tmflz', 'multx', 'multy', 'multz']:
-      property_kind = 'transmissibility multiplier'  # NB: resqpy local property kind
-      facet_type = 'direction'
-      _, facet = facet_info_for_dir_ch(lk[-1])
-   elif lk in ['multbv', 'multpv']:
-      property_kind = 'property multiplier'
-      facet_type = 'what'  # here 'what' facet indicates property affected
-      if lk == 'multbv':
-         facet = 'rock volume'  # NB: making this up as I go along
-      elif lk == 'multpv':
-         facet = 'pore volume'
-   elif lk == 'rs':
-      property_kind = 'solution gas-oil ratio'
-   elif lk == 'rv':
-      property_kind = 'vapor oil-gas ratio'
-   elif lk in ['temp', 'temperature']:
-      property_kind = 'thermodynamic temperature'
-   elif lk in ['dad', 'kid', 'unpack', 'deadcell', 'inactive']:
-      property_kind = 'code'
-      facet_type = 'what'
-      # todo: kid can only be used as an inactive cell indication for the root grid
-      if lk in ['kid', 'deadcell', 'inactive']:
-         facet = 'inactive'  # standize on 'inactive' to indicate use as mask
-      else:
-         facet = lk  # note: use deadcell or unpack for inactive, if nothing better?
-   elif lk == 'livecell' or lk.startswith('act'):
-      property_kind = 'active'  # local property kind, see RESQML (2.0.1) usage guide, section 11.17
+    elif lk in ['wip', 'oip', 'gip', 'mobw', 'mobo', 'mobg', 'ocip']:  # todo: check these, especially ocip
+        property_kind = 'fluid volume'
+        facet_type = 'what'  # todo: check use of 'what' for phase
+        if lk in ['wip', 'mobw']:
+            facet = 'water'  # todo: add another facet indicating mobile volume
+        elif lk in ['oip', 'mobo']:
+            facet = 'oil'
+        elif lk in ['gip', 'mobg']:
+            facet = 'gas'
+        elif lk == 'ocip':
+            facet = 'oil condensate'  # todo: this seems unlikely: check
+        if lk[:3] == 'mob':
+            facet += ' (mobile)'
+    elif lk in ['tmx', 'tmy', 'tmz', 'tmflx', 'tmfly', 'tmflz', 'multx', 'multy', 'multz']:
+        property_kind = 'transmissibility multiplier'  # NB: resqpy local property kind
+        facet_type = 'direction'
+        _, facet = facet_info_for_dir_ch(lk[-1])
+    elif lk in ['multbv', 'multpv']:
+        property_kind = 'property multiplier'
+        facet_type = 'what'  # here 'what' facet indicates property affected
+        if lk == 'multbv':
+            facet = 'rock volume'  # NB: making this up as I go along
+        elif lk == 'multpv':
+            facet = 'pore volume'
+    elif lk == 'rs':
+        property_kind = 'solution gas-oil ratio'
+    elif lk == 'rv':
+        property_kind = 'vapor oil-gas ratio'
+    elif lk in ['temp', 'temperature']:
+        property_kind = 'thermodynamic temperature'
+    elif lk in ['dad', 'kid', 'unpack', 'deadcell', 'inactive']:
+        property_kind = 'code'
+        facet_type = 'what'
+        # todo: kid can only be used as an inactive cell indication for the root grid
+        if lk in ['kid', 'deadcell', 'inactive']:
+            facet = 'inactive'  # standize on 'inactive' to indicate use as mask
+        else:
+            facet = lk  # note: use deadcell or unpack for inactive, if nothing better?
+    elif lk == 'livecell' or lk.startswith('act'):
+        property_kind = 'active'  # local property kind, see RESQML (2.0.1) usage guide, section 11.17
 
 
 #      property_kind = 'code'
 #      facet_type = 'what'
 #      facet = 'active'
-   elif lk[0] == 'i' or lk.startswith('reg') or lk.startswith('creg'):
-      property_kind = 'region initialization'  # local property kind, see RESQML (2.0.1) usage guide, section 11.18
-   elif lk == 'uid':
-      property_kind = 'index'
-      facet_type = 'what'
-      facet = 'uid'
-   return (property_kind, facet_type, facet)
+    elif lk[0] == 'i' or lk.startswith('reg') or lk.startswith('creg'):
+        property_kind = 'region initialization'  # local property kind, see RESQML (2.0.1) usage guide, section 11.18
+    elif lk == 'uid':
+        property_kind = 'index'
+        facet_type = 'what'
+        facet = 'uid'
+    return (property_kind, facet_type, facet)
 
 
 def infer_property_kind(name, unit):
-   """ Guess a valid property kind """
+    """ Guess a valid property kind """
 
-   # Currently unit is ignored
+    # Currently unit is ignored
 
-   valid_kinds = bwam.valid_property_kinds()
+    valid_kinds = bwam.valid_property_kinds()
 
-   if name in valid_kinds:
-      kind = name
-   else:
-      # TODO: use an appropriate default
-      kind = 'Unknown'
+    if name in valid_kinds:
+        kind = name
+    else:
+        # TODO: use an appropriate default
+        kind = 'Unknown'
 
-   # TODO: determine facet_type and facet somehow
-   facet_type = None
-   facet = None
+    # TODO: determine facet_type and facet somehow
+    facet_type = None
+    facet = None
 
-   return kind, facet_type, facet
+    return kind, facet_type, facet
 
 
 def guess_uom(property_kind, minimum, maximum, support, facet_type = None, facet = None):
-   """Returns a guess at the units of measure for the given kind of property.
+    """Returns a guess at the units of measure for the given kind of property.
 
    arguments:
       property_kind (string): a valid resqml property kind, lowercase
@@ -5801,133 +5818,133 @@ def guess_uom(property_kind, minimum, maximum, support, facet_type = None, facet
       this module currently only supports zero or one facet per property
    """
 
-   def crs_m_or_ft(crs_node):  # NB. models not-so-rarely use metres for xy and feet for z
-      if crs_node is None:
-         return None
-      xy_units = rqet.find_tag(crs_node, 'ProjectedUom').text.lower()
-      z_units = rqet.find_tag(crs_node, 'VerticalUom').text.lower()
-      if xy_units == 'm' and z_units == 'm':
-         return 'm'
-      if xy_units == 'ft' and z_units == 'ft':
-         return 'ft'
-      return None
-
-   if support is None or not hasattr(support, 'extract_crs_root'):
-      crs_node = None
-   else:
-      crs_node = support.extract_crs_root()
-   from_crs = crs_m_or_ft(crs_node)
-
-   if property_kind in ['rock volume', 'pore volume', 'volume']:
-      if from_crs is None:
-         return None
-      if from_crs == 'ft' and property_kind == 'pore volume':
-         return 'bbl'  # seems to be Nexus 'ENGLISH' uom for pv out
-      return from_crs + '3'  # ie. m3 or ft3
-   if property_kind == 'depth':
-      if crs_node is None:
-         return None
-      return rqet.find_tag(crs_node, 'VerticalUom').text.lower()
-   if property_kind == 'cell length':  # todo: pass in direction facet to pick up xy_units or z_units
-      return from_crs
-   if property_kind in ['net to gross ratio', 'porosity', 'saturation']:
-      if maximum is not None and str(maximum) != 'unknown':
-         max_real = float(maximum)
-         if max_real > 1.0 and max_real <= 100.0:
-            return '%'
-         if max_real < 0.0 or max_real > 1.0:
+    def crs_m_or_ft(crs_node):  # NB. models not-so-rarely use metres for xy and feet for z
+        if crs_node is None:
             return None
-      if from_crs == 'm':
-         return 'm3/m3'
-      if from_crs == 'ft':
-         return 'ft3/ft3'
-      return 'Euc'
-   if property_kind == 'permeability rock' or property_kind == 'rock permeability':
-      return 'mD'
-   if property_kind == 'permeability thickness':
-      z_units = rqet.find_tag(crs_node, 'VerticalUom').text.lower()
-      if z_units == 'm':
-         return 'mD.m'
-      if z_units == 'ft':
-         return 'mD.ft'
-      return None
-   if property_kind == 'permeability length':
-      xy_units = rqet.find_tag(crs_node, 'ProjectedUom').text.lower()
-      if xy_units == 'm':
-         return 'mD.m'
-      if xy_units == 'ft':
-         return 'mD.ft'
-      return None
-   if property_kind == 'fluid volume':
-      if from_crs == 'm':
-         return 'm3'
-      if from_crs == 'ft':
-         if facet_type == 'what' and facet == 'gas':
-            return '1000 ft3'  # todo: check units output by nexus for GIP
-         else:
-            return 'bbl'  # todo: check whether nexus uses 10^3 or 10^6 units
-      return None
-   if property_kind.endswith(
-         'transmissibility'):  # note: RESQML QuantityClass only includes a unit-viscosity VolumePerTimePerPressureUom
-      if from_crs == 'm':
-         return 'm3.cP/(kPa.d)'  # NB: might actually be m3/(psi.d) or m3/(bar.d)
-      if from_crs == 'ft':
-         return 'bbl.cP/(psi.d)'  # gamble on barrels per day per psi; could be ft3/(psi.d)
-      return None
-   if property_kind == 'pressure':
-      if from_crs == 'm':
-         return 'kPa'  # NB: might actually be psi or bar
-      if from_crs == 'ft':
-         return 'psi'
-      if maximum is not None:
-         max_real = float(maximum)
-         if max_real == 0.0:
+        xy_units = rqet.find_tag(crs_node, 'ProjectedUom').text.lower()
+        z_units = rqet.find_tag(crs_node, 'VerticalUom').text.lower()
+        if xy_units == 'm' and z_units == 'm':
+            return 'm'
+        if xy_units == 'ft' and z_units == 'ft':
+            return 'ft'
+        return None
+
+    if support is None or not hasattr(support, 'extract_crs_root'):
+        crs_node = None
+    else:
+        crs_node = support.extract_crs_root()
+    from_crs = crs_m_or_ft(crs_node)
+
+    if property_kind in ['rock volume', 'pore volume', 'volume']:
+        if from_crs is None:
             return None
-         if max_real > 10000.0:
-            return 'kPa'
-         if max_real < 500.0:
-            return 'bar'
-         if max_real < 5000.0:
+        if from_crs == 'ft' and property_kind == 'pore volume':
+            return 'bbl'  # seems to be Nexus 'ENGLISH' uom for pv out
+        return from_crs + '3'  # ie. m3 or ft3
+    if property_kind == 'depth':
+        if crs_node is None:
+            return None
+        return rqet.find_tag(crs_node, 'VerticalUom').text.lower()
+    if property_kind == 'cell length':  # todo: pass in direction facet to pick up xy_units or z_units
+        return from_crs
+    if property_kind in ['net to gross ratio', 'porosity', 'saturation']:
+        if maximum is not None and str(maximum) != 'unknown':
+            max_real = float(maximum)
+            if max_real > 1.0 and max_real <= 100.0:
+                return '%'
+            if max_real < 0.0 or max_real > 1.0:
+                return None
+        if from_crs == 'm':
+            return 'm3/m3'
+        if from_crs == 'ft':
+            return 'ft3/ft3'
+        return 'Euc'
+    if property_kind == 'permeability rock' or property_kind == 'rock permeability':
+        return 'mD'
+    if property_kind == 'permeability thickness':
+        z_units = rqet.find_tag(crs_node, 'VerticalUom').text.lower()
+        if z_units == 'm':
+            return 'mD.m'
+        if z_units == 'ft':
+            return 'mD.ft'
+        return None
+    if property_kind == 'permeability length':
+        xy_units = rqet.find_tag(crs_node, 'ProjectedUom').text.lower()
+        if xy_units == 'm':
+            return 'mD.m'
+        if xy_units == 'ft':
+            return 'mD.ft'
+        return None
+    if property_kind == 'fluid volume':
+        if from_crs == 'm':
+            return 'm3'
+        if from_crs == 'ft':
+            if facet_type == 'what' and facet == 'gas':
+                return '1000 ft3'  # todo: check units output by nexus for GIP
+            else:
+                return 'bbl'  # todo: check whether nexus uses 10^3 or 10^6 units
+        return None
+    if property_kind.endswith('transmissibility'
+                             ):  # note: RESQML QuantityClass only includes a unit-viscosity VolumePerTimePerPressureUom
+        if from_crs == 'm':
+            return 'm3.cP/(kPa.d)'  # NB: might actually be m3/(psi.d) or m3/(bar.d)
+        if from_crs == 'ft':
+            return 'bbl.cP/(psi.d)'  # gamble on barrels per day per psi; could be ft3/(psi.d)
+        return None
+    if property_kind == 'pressure':
+        if from_crs == 'm':
+            return 'kPa'  # NB: might actually be psi or bar
+        if from_crs == 'ft':
             return 'psi'
-      return None
-   if property_kind == 'solution gas-oil ratio':
-      if from_crs == 'm':
-         return 'm3/m3'  # NB: might actually be psi or bar
-      if from_crs == 'ft':
-         return '1000 ft3/bbl'
-      return None
-   if property_kind == 'vapor oil-gas ratio':
-      if from_crs == 'm':
-         return 'm3/m3'  # NB: might actually be psi or bar
-      if from_crs == 'ft':
-         return '0.001 bbl/ft3'
-      return None
-   if property_kind.endswith('multiplier'):
-      return 'Euc'
-   # todo: 'degC' or 'degF' for thermodynamic temperature
-   return None
+        if maximum is not None:
+            max_real = float(maximum)
+            if max_real == 0.0:
+                return None
+            if max_real > 10000.0:
+                return 'kPa'
+            if max_real < 500.0:
+                return 'bar'
+            if max_real < 5000.0:
+                return 'psi'
+        return None
+    if property_kind == 'solution gas-oil ratio':
+        if from_crs == 'm':
+            return 'm3/m3'  # NB: might actually be psi or bar
+        if from_crs == 'ft':
+            return '1000 ft3/bbl'
+        return None
+    if property_kind == 'vapor oil-gas ratio':
+        if from_crs == 'm':
+            return 'm3/m3'  # NB: might actually be psi or bar
+        if from_crs == 'ft':
+            return '0.001 bbl/ft3'
+        return None
+    if property_kind.endswith('multiplier'):
+        return 'Euc'
+    # todo: 'degC' or 'degF' for thermodynamic temperature
+    return None
 
 
 def selective_version_of_collection(
-      collection,
-      realization = None,
-      support_uuid = None,
-      grid = None,  # for backward compatibility
-      uuid = None,
-      continuous = None,
-      points = None,
-      count = None,
-      indexable = None,
-      property_kind = None,
-      facet_type = None,
-      facet = None,
-      citation_title = None,
-      time_series_uuid = None,
-      time_index = None,
-      uom = None,
-      string_lookup_uuid = None,
-      categorical = None):
-   """Returns a new PropertyCollection with those parts which match all arguments that are not None.
+        collection,
+        realization = None,
+        support_uuid = None,
+        grid = None,  # for backward compatibility
+        uuid = None,
+        continuous = None,
+        points = None,
+        count = None,
+        indexable = None,
+        property_kind = None,
+        facet_type = None,
+        facet = None,
+        citation_title = None,
+        time_series_uuid = None,
+        time_index = None,
+        uom = None,
+        string_lookup_uuid = None,
+        categorical = None):
+    """Returns a new PropertyCollection with those parts which match all arguments that are not None.
 
    arguments:
       collection: an existing PropertyCollection from which a subset will be returned as a new object;
@@ -5953,36 +5970,36 @@ def selective_version_of_collection(
       internal dictionary
    """
 
-   assert collection is not None
-   view = PropertyCollection()
-   if support_uuid is None and grid is not None:
-      support_uuid = grid.uuid
-   if support_uuid is not None:
-      view.set_support(support_uuid = support_uuid)
-   if realization is not None:
-      view.set_realization(realization)
-   view.inherit_parts_selectively_from_other_collection(collection,
-                                                        realization = realization,
-                                                        support_uuid = support_uuid,
-                                                        uuid = uuid,
-                                                        continuous = continuous,
-                                                        points = points,
-                                                        count = count,
-                                                        indexable = indexable,
-                                                        property_kind = property_kind,
-                                                        facet_type = facet_type,
-                                                        facet = facet,
-                                                        citation_title = citation_title,
-                                                        time_series_uuid = time_series_uuid,
-                                                        time_index = time_index,
-                                                        uom = uom,
-                                                        string_lookup_uuid = string_lookup_uuid,
-                                                        categorical = categorical)
-   return view
+    assert collection is not None
+    view = PropertyCollection()
+    if support_uuid is None and grid is not None:
+        support_uuid = grid.uuid
+    if support_uuid is not None:
+        view.set_support(support_uuid = support_uuid)
+    if realization is not None:
+        view.set_realization(realization)
+    view.inherit_parts_selectively_from_other_collection(collection,
+                                                         realization = realization,
+                                                         support_uuid = support_uuid,
+                                                         uuid = uuid,
+                                                         continuous = continuous,
+                                                         points = points,
+                                                         count = count,
+                                                         indexable = indexable,
+                                                         property_kind = property_kind,
+                                                         facet_type = facet_type,
+                                                         facet = facet,
+                                                         citation_title = citation_title,
+                                                         time_series_uuid = time_series_uuid,
+                                                         time_index = time_index,
+                                                         uom = uom,
+                                                         string_lookup_uuid = string_lookup_uuid,
+                                                         categorical = categorical)
+    return view
 
 
 def property_over_time_series_from_collection(collection, example_part):
-   """Returns a new PropertyCollection with parts like the example part, over all indices in its time series.
+    """Returns a new PropertyCollection with parts like the example part, over all indices in its time series.
 
    arguments:
       collection: an existing PropertyCollection from which a subset will be returned as a new object;
@@ -5995,19 +6012,19 @@ def property_over_time_series_from_collection(collection, example_part):
       (and facet, if any) as the example part and which have the same associated time series
    """
 
-   assert collection is not None and example_part is not None
-   assert collection.part_in_collection(example_part)
-   view = PropertyCollection()
-   if collection.support_uuid is not None:
-      view.set_support(support_uuid = collection.support_uuid)
-   if collection.realization is not None:
-      view.set_realization(collection.realization)
-   view.inherit_similar_parts_for_time_series_from_other_collection(collection, example_part)
-   return view
+    assert collection is not None and example_part is not None
+    assert collection.part_in_collection(example_part)
+    view = PropertyCollection()
+    if collection.support_uuid is not None:
+        view.set_support(support_uuid = collection.support_uuid)
+    if collection.realization is not None:
+        view.set_realization(collection.realization)
+    view.inherit_similar_parts_for_time_series_from_other_collection(collection, example_part)
+    return view
 
 
 def property_collection_for_keyword(collection, keyword):
-   """Returns a new PropertyCollection with parts that match the property kind and facet deduced for the keyword.
+    """Returns a new PropertyCollection with parts that match the property kind and facet deduced for the keyword.
 
    arguments:
       collection: an existing PropertyCollection from which a subset will be returned as a new object;
@@ -6027,35 +6044,35 @@ def property_collection_for_keyword(collection, keyword):
       if a different way, leading to an omission in the results of this function
    """
 
-   assert collection is not None and keyword
-   (property_kind, facet_type, facet) = property_kind_and_facet_from_keyword(keyword)
-   if property_kind is None:
-      log.warning('failed to deduce property kind for keyword: ' + keyword)
-      return None
-   return selective_version_of_collection(collection,
-                                          property_kind = property_kind,
-                                          facet_type = facet_type,
-                                          facet = facet)
+    assert collection is not None and keyword
+    (property_kind, facet_type, facet) = property_kind_and_facet_from_keyword(keyword)
+    if property_kind is None:
+        log.warning('failed to deduce property kind for keyword: ' + keyword)
+        return None
+    return selective_version_of_collection(collection,
+                                           property_kind = property_kind,
+                                           facet_type = facet_type,
+                                           facet = facet)
 
 
 def reformat_column_edges_to_resqml_format(array):
-   """Converts an array of shape (nj,ni,2,2) to shape (nj,ni,4) in RESQML edge ordering"""
-   newarray = np.empty((array.shape[0], array.shape[1], 4), dtype = array.dtype)
-   newarray[:, :, 0] = array[:, :, 1, 0]
-   newarray[:, :, 1] = array[:, :, 0, 1]
-   newarray[:, :, 2] = array[:, :, 1, 1]
-   newarray[:, :, 3] = array[:, :, 0, 0]
-   return newarray
+    """Converts an array of shape (nj,ni,2,2) to shape (nj,ni,4) in RESQML edge ordering"""
+    newarray = np.empty((array.shape[0], array.shape[1], 4), dtype = array.dtype)
+    newarray[:, :, 0] = array[:, :, 1, 0]
+    newarray[:, :, 1] = array[:, :, 0, 1]
+    newarray[:, :, 2] = array[:, :, 1, 1]
+    newarray[:, :, 3] = array[:, :, 0, 0]
+    return newarray
 
 
 def reformat_column_edges_from_resqml_format(array):
-   """Converts an array of shape (nj,ni,4) in RESQML edge ordering to shape (nj,ni,2,2)"""
-   newarray = np.empty((array.shape[0], array.shape[1], 2, 2), dtype = array.dtype)
-   newarray[:, :, 0, 0] = array[:, :, 3]
-   newarray[:, :, 0, 1] = array[:, :, 1]
-   newarray[:, :, 1, 0] = array[:, :, 0]
-   newarray[:, :, 1, 1] = array[:, :, 2]
-   return newarray
+    """Converts an array of shape (nj,ni,4) in RESQML edge ordering to shape (nj,ni,2,2)"""
+    newarray = np.empty((array.shape[0], array.shape[1], 2, 2), dtype = array.dtype)
+    newarray[:, :, 0, 0] = array[:, :, 3]
+    newarray[:, :, 0, 1] = array[:, :, 1]
+    newarray[:, :, 1, 0] = array[:, :, 0]
+    newarray[:, :, 1, 1] = array[:, :, 2]
+    return newarray
 
 
 # 'private' functions returning attribute name for cached version of property array
@@ -6063,55 +6080,55 @@ def reformat_column_edges_from_resqml_format(array):
 
 
 def _cache_name_for_uuid(uuid):
-   """
+    """
       Returns the attribute name used for the cached copy of the property array for the given uuid.
 
       :meta private:
    """
 
-   return 'c_' + bu.string_from_uuid(uuid)
+    return 'c_' + bu.string_from_uuid(uuid)
 
 
 def _cache_name(part):
-   """
+    """
       Returns the attribute name used for the cached copy of the property array for the given part.
 
       :meta private:
    """
 
-   if part is None:
-      return None
-   uuid = rqet.uuid_in_part_name(part)
-   if uuid is None:
-      return None
-   return _cache_name_for_uuid(uuid)
+    if part is None:
+        return None
+    uuid = rqet.uuid_in_part_name(part)
+    if uuid is None:
+        return None
+    return _cache_name_for_uuid(uuid)
 
 
 def dtype_flavour(continuous, use_32_bit):
-   """
+    """
       Returns the numpy elemental data type depending on the two boolean flags.
 
       :meta private:
    """
 
-   if continuous:
-      if use_32_bit:
-         dtype = np.float32
-      else:
-         dtype = np.float64
-   else:
-      if use_32_bit:
-         dtype = np.int32
-      else:
-         dtype = np.int64
-   return dtype
+    if continuous:
+        if use_32_bit:
+            dtype = np.float32
+        else:
+            dtype = np.float64
+    else:
+        if use_32_bit:
+            dtype = np.int32
+        else:
+            dtype = np.int64
+    return dtype
 
 
 def return_cell_indices(i, cell_indices):
-   if i == -1:
-      return np.nan
-   else:
-      return cell_indices[i]
+    if i == -1:
+        return np.nan
+    else:
+        return cell_indices[i]
 
 
 def write_hdf5_and_create_xml_for_active_property(model,
@@ -6121,19 +6138,19 @@ def write_hdf5_and_create_xml_for_active_property(model,
                                                   realization = None,
                                                   time_series_uuid = None,
                                                   time_index = None):
-   """Writes hdf5 data and creates xml for an active cell property; returns uuid."""
+    """Writes hdf5 data and creates xml for an active cell property; returns uuid."""
 
-   active = Property.from_array(parent_model = model,
-                                cached_array = active_property_array,
-                                source_info = None,
-                                keyword = title,
-                                support_uuid = support_uuid,
-                                property_kind = 'active',
-                                local_property_kind_uuid = None,
-                                indexable_element = 'cells',
-                                discrete = True,
-                                time_series_uuid = time_series_uuid,
-                                time_index = time_index,
-                                realization = realization,
-                                find_local_property_kind = True)
-   return active.uuid
+    active = Property.from_array(parent_model = model,
+                                 cached_array = active_property_array,
+                                 source_info = None,
+                                 keyword = title,
+                                 support_uuid = support_uuid,
+                                 property_kind = 'active',
+                                 local_property_kind_uuid = None,
+                                 indexable_element = 'cells',
+                                 discrete = True,
+                                 time_series_uuid = time_series_uuid,
+                                 time_index = time_index,
+                                 realization = realization,
+                                 find_local_property_kind = True)
+    return active.uuid

--- a/resqpy/rq_import.py
+++ b/resqpy/rq_import.py
@@ -36,607 +36,608 @@ import resqpy.weights_and_measures as bwam
 
 
 def import_nexus(
-      resqml_file_root,  # output path and file name without .epc or .h5 extension
-      extent_ijk = None,  # 3 element numpy vector
-      vdb_file = None,  # vdb input file: either this or corp_file should be not None
-      vdb_case = None,  # if None, first case in vdb is used (usually a vdb only holds one case)
-      corp_file = None,  # corp ascii input file: nexus corp data without keyword
-      corp_bin_file = None,  # corp binary file: nexus corp data in bespoke binary format
-      corp_xy_units = 'm',
-      corp_z_units = 'm',
-      corp_z_inc_down = True,
-      ijk_handedness = 'right',
-      corp_eight_mode = False,
-      geometry_defined_everywhere = True,
-      treat_as_nan = None,
-      active_mask_file = None,
-      use_binary = False,  # this refers to pure binary arrays, not corp bin format
-      resqml_xy_units = 'm',
-      resqml_z_units = 'm',
-      resqml_z_inc_down = True,
-      shift_to_local = False,
-      local_origin_place = 'centre',  # 'centre' or 'minimum'
-      max_z_void = 0.1,  # vertical gaps greater than this will introduce k gaps intp resqml grid
-      split_pillars = True,
-      split_tolerance = 0.01,  # applies to each of x, y, z differences
-      property_array_files = None,  # actually, list of (filename, keyword, uom, time_index, null_value, discrete)
-      summary_file = None,  # used to extract timestep dates when loading recurrent data from vdb
-      vdb_static_properties = True,  # if True, static vdb properties are imported (only relevant if vdb_file is not None)
-      vdb_recurrent_properties = False,
-      timestep_selection = 'all',  # 'first', 'last', 'first and last', 'all', or list of ints being reporting timestep numbers
-      use_compressed_time_series = True,
-      decoarsen = True,  # where ICOARSE is present, redistribute data to uncoarse cells
-      ab_property_list = None,  # list of (file_name, keyword, property_kind, facet_type, facet, uom, time_index, null_value, discrete)
-      create_property_set = False,
-      ensemble_case_dirs_root = None,  # path upto but excluding realisation number
-      ensemble_property_dictionary = None,  # dictionary mapping title (or keyword) to (filename, property_kind, facet_type, facet,
-      #                                           uom, time_index, null_value, discrete)
-   ensemble_size_limit = None,
-      grid_title = 'ROOT',
-      mode = 'w',
-      progress_fn = None):
-   """Read a simulation grid geometry and optionally grid properties and return a resqml model in memory & written to disc.
+        resqml_file_root,  # output path and file name without .epc or .h5 extension
+        extent_ijk = None,  # 3 element numpy vector
+        vdb_file = None,  # vdb input file: either this or corp_file should be not None
+        vdb_case = None,  # if None, first case in vdb is used (usually a vdb only holds one case)
+        corp_file = None,  # corp ascii input file: nexus corp data without keyword
+        corp_bin_file = None,  # corp binary file: nexus corp data in bespoke binary format
+        corp_xy_units = 'm',
+        corp_z_units = 'm',
+        corp_z_inc_down = True,
+        ijk_handedness = 'right',
+        corp_eight_mode = False,
+        geometry_defined_everywhere = True,
+        treat_as_nan = None,
+        active_mask_file = None,
+        use_binary = False,  # this refers to pure binary arrays, not corp bin format
+        resqml_xy_units = 'm',
+        resqml_z_units = 'm',
+        resqml_z_inc_down = True,
+        shift_to_local = False,
+        local_origin_place = 'centre',  # 'centre' or 'minimum'
+        max_z_void = 0.1,  # vertical gaps greater than this will introduce k gaps intp resqml grid
+        split_pillars = True,
+        split_tolerance = 0.01,  # applies to each of x, y, z differences
+        property_array_files = None,  # actually, list of (filename, keyword, uom, time_index, null_value, discrete)
+        summary_file = None,  # used to extract timestep dates when loading recurrent data from vdb
+        vdb_static_properties = True,  # if True, static vdb properties are imported (only relevant if vdb_file is not None)
+        vdb_recurrent_properties = False,
+        timestep_selection = 'all',  # 'first', 'last', 'first and last', 'all', or list of ints being reporting timestep numbers
+        use_compressed_time_series = True,
+        decoarsen = True,  # where ICOARSE is present, redistribute data to uncoarse cells
+        ab_property_list = None,  # list of (file_name, keyword, property_kind, facet_type, facet, uom, time_index, null_value, discrete)
+        create_property_set = False,
+        ensemble_case_dirs_root = None,  # path upto but excluding realisation number
+        ensemble_property_dictionary = None,  # dictionary mapping title (or keyword) to (filename, property_kind, facet_type, facet,
+        #                                           uom, time_index, null_value, discrete)
+    ensemble_size_limit = None,
+        grid_title = 'ROOT',
+        mode = 'w',
+        progress_fn = None):
+    """Read a simulation grid geometry and optionally grid properties and return a resqml model in memory & written to disc.
 
       Input may be from nexus ascii input files, or nexus vdb output.
    """
 
-   if resqml_file_root.endswith('.epc'):
-      resqml_file_root = resqml_file_root[:-4]
-   assert mode in ['w', 'a']
+    if resqml_file_root.endswith('.epc'):
+        resqml_file_root = resqml_file_root[:-4]
+    assert mode in ['w', 'a']
 
-   if vdb_file:
-      using_vdb = True
-      corp_file = corp_bin_file = None
-      grid_title = grid_title.upper()
-      log.info('starting import of Nexus ' + str(grid_title) + ' corp from vdb ' + str(vdb_file))
-      tm.log_nexus_tm('info')
-      vdbase = vdb.VDB(vdb_file)
-      case_list = vdbase.cases()
-      assert len(case_list) > 0, 'no cases found in vdb'
-      if vdb_case is None:
-         vdb_case = case_list[0]
-      else:
-         assert vdb_case in case_list, 'case ' + vdb_case + ' not found in vdb: ' + vdb_file
-         vdbase.set_use_case(vdb_case)
-      assert grid_title in vdbase.list_of_grids(), 'grid ' + str(grid_title) + ' not found in vdb'
-      if extent_ijk is not None:
-         vdbase.set_extent_kji(tuple(reversed(extent_ijk)))
-      log.debug('using case ' + vdb_case + ' and grid ' + grid_title + ' from vdb')
-      if vdb_recurrent_properties and not summary_file:
-         if vdb_file.endswith('.vdb.zip'):
-            summary_file = vdb_file[:-8] + '.sum'
-         elif vdb_file.endswith('.vdb') or vdb_file.endswith('.zip'):
-            summary_file = vdb_file[:-4] + '.sum'
-         else:
-            sep = vdb_file.rfind(os.sep)
-            dot = vdb_file[sep + 1:].find('.')
-            if dot > 0:
-               summary_file = vdb_file[:sep + 1 + dot] + ',sum'
+    if vdb_file:
+        using_vdb = True
+        corp_file = corp_bin_file = None
+        grid_title = grid_title.upper()
+        log.info('starting import of Nexus ' + str(grid_title) + ' corp from vdb ' + str(vdb_file))
+        tm.log_nexus_tm('info')
+        vdbase = vdb.VDB(vdb_file)
+        case_list = vdbase.cases()
+        assert len(case_list) > 0, 'no cases found in vdb'
+        if vdb_case is None:
+            vdb_case = case_list[0]
+        else:
+            assert vdb_case in case_list, 'case ' + vdb_case + ' not found in vdb: ' + vdb_file
+            vdbase.set_use_case(vdb_case)
+        assert grid_title in vdbase.list_of_grids(), 'grid ' + str(grid_title) + ' not found in vdb'
+        if extent_ijk is not None:
+            vdbase.set_extent_kji(tuple(reversed(extent_ijk)))
+        log.debug('using case ' + vdb_case + ' and grid ' + grid_title + ' from vdb')
+        if vdb_recurrent_properties and not summary_file:
+            if vdb_file.endswith('.vdb.zip'):
+                summary_file = vdb_file[:-8] + '.sum'
+            elif vdb_file.endswith('.vdb') or vdb_file.endswith('.zip'):
+                summary_file = vdb_file[:-4] + '.sum'
             else:
-               summary_file = vdb_file + '.sum'
-      cp_array = vdbase.grid_corp(grid_title)
-      cp_extent_kji = cp_array.shape[:3]
-      if cp_extent_kji[:2] == (1, 1):  # auto determination of extent failed
-         assert extent_ijk is not None, 'failed to determine extent of grid from corp data'
-         (ni, nj, nk) = extent_ijk
-         assert cp_extent_kji[2] == ni * nj * nk, 'number of cells in grid corp does not match extent'
-         cp_extent = (nk, nj, ni, 2, 2, 2, 3)  # (nk, nj, ni, kp, jp, ip, xyz)
-         cp_array = cp_array.reshape(cp_extent)
-      elif extent_ijk is not None:
-         for axis in range(3):
-            assert cp_extent_kji[axis] == extent_ijk[
-               2 - axis], 'extent of grid corp data from vdb does not match that supplied'
+                sep = vdb_file.rfind(os.sep)
+                dot = vdb_file[sep + 1:].find('.')
+                if dot > 0:
+                    summary_file = vdb_file[:sep + 1 + dot] + ',sum'
+                else:
+                    summary_file = vdb_file + '.sum'
+        cp_array = vdbase.grid_corp(grid_title)
+        cp_extent_kji = cp_array.shape[:3]
+        if cp_extent_kji[:2] == (1, 1):  # auto determination of extent failed
+            assert extent_ijk is not None, 'failed to determine extent of grid from corp data'
+            (ni, nj, nk) = extent_ijk
+            assert cp_extent_kji[2] == ni * nj * nk, 'number of cells in grid corp does not match extent'
+            cp_extent = (nk, nj, ni, 2, 2, 2, 3)  # (nk, nj, ni, kp, jp, ip, xyz)
+            cp_array = cp_array.reshape(cp_extent)
+        elif extent_ijk is not None:
+            for axis in range(3):
+                assert cp_extent_kji[axis] == extent_ijk[
+                    2 - axis], 'extent of grid corp data from vdb does not match that supplied'
 
-   elif corp_file or corp_bin_file:
-      if corp_bin_file:
-         corp_file = None
-      using_vdb = False
-      #     geometry_defined_everywhere = (active_mask_file is None)
-      log.info('starting import of Nexus corp file ' + str(corp_file if corp_file else corp_bin_file))
-      tm.log_nexus_tm('info')
-      if extent_ijk is None:  # auto detect extent
-         extent_kji = None
-         cp_extent = None
-      else:
-         (ni, nj, nk) = extent_ijk
-         extent_kji = np.array((nk, nj, ni), dtype = 'int')
-         cp_extent = (nk, nj, ni, 2, 2, 2, 3)  # (nk, nj, ni, kp, jp, ip, xyz)
-      log.debug('reading and resequencing corp data')
-      if corp_bin_file:  # bespoke nexus corp bin format, not to be confused with pure binary files used below
-         cp_array = ld.load_corp_array_from_file(
-            corp_bin_file,
-            extent_kji,
-            corp_bin = True,
-            comment_char = None,  # comment char will be detected automatically
-            data_free_of_comments = False,
-            use_binary = use_binary)
-      else:
-         cp_binary_file = abt.cp_binary_filename(corp_file,
-                                                 nexus_ordering = False)  # pure binary, not bespoke corp bin used above
-         recent_binary_exists = ld.file_exists(cp_binary_file, must_be_more_recent_than_file = corp_file)
-         cp_array = None
-         if use_binary and (extent_ijk is not None) and recent_binary_exists:
-            try:
-               cp_array = ld.load_array_from_file(cp_binary_file, cp_extent, use_binary = True)
-            except Exception:
-               cp_array = None
-         if cp_array is None:
+    elif corp_file or corp_bin_file:
+        if corp_bin_file:
+            corp_file = None
+        using_vdb = False
+        #     geometry_defined_everywhere = (active_mask_file is None)
+        log.info('starting import of Nexus corp file ' + str(corp_file if corp_file else corp_bin_file))
+        tm.log_nexus_tm('info')
+        if extent_ijk is None:  # auto detect extent
+            extent_kji = None
+            cp_extent = None
+        else:
+            (ni, nj, nk) = extent_ijk
+            extent_kji = np.array((nk, nj, ni), dtype = 'int')
+            cp_extent = (nk, nj, ni, 2, 2, 2, 3)  # (nk, nj, ni, kp, jp, ip, xyz)
+        log.debug('reading and resequencing corp data')
+        if corp_bin_file:  # bespoke nexus corp bin format, not to be confused with pure binary files used below
             cp_array = ld.load_corp_array_from_file(
-               corp_file,
-               extent_kji,
-               corp_bin = False,
-               comment_char = None,  # comment char will be detected automatically
-               data_free_of_comments = False,
-               use_binary = use_binary)
-            if use_binary:
-               wd.write_pure_binary_data(cp_binary_file,
-                                         cp_array)  # NB: this binary file is resequenced, not in nexus ordering!
+                corp_bin_file,
+                extent_kji,
+                corp_bin = True,
+                comment_char = None,  # comment char will be detected automatically
+                data_free_of_comments = False,
+                use_binary = use_binary)
+        else:
+            cp_binary_file = abt.cp_binary_filename(
+                corp_file, nexus_ordering = False)  # pure binary, not bespoke corp bin used above
+            recent_binary_exists = ld.file_exists(cp_binary_file, must_be_more_recent_than_file = corp_file)
+            cp_array = None
+            if use_binary and (extent_ijk is not None) and recent_binary_exists:
+                try:
+                    cp_array = ld.load_array_from_file(cp_binary_file, cp_extent, use_binary = True)
+                except Exception:
+                    cp_array = None
+            if cp_array is None:
+                cp_array = ld.load_corp_array_from_file(
+                    corp_file,
+                    extent_kji,
+                    corp_bin = False,
+                    comment_char = None,  # comment char will be detected automatically
+                    data_free_of_comments = False,
+                    use_binary = use_binary)
+                if use_binary:
+                    wd.write_pure_binary_data(cp_binary_file,
+                                              cp_array)  # NB: this binary file is resequenced, not in nexus ordering!
 
-   else:
-      raise ValueError('vdb_file and corp_file are both None in import_nexus() call')
+    else:
+        raise ValueError('vdb_file and corp_file are both None in import_nexus() call')
 
-   if cp_array is None:
-      log.error('failed to create corner point array')
-      return None
+    if cp_array is None:
+        log.error('failed to create corner point array')
+        return None
 
-   if extent_ijk is None:
-      cp_extent = cp_array.shape
-      extent_kji = cp_extent[:3]
-      (nk, nj, ni) = extent_kji
-      extent_ijk = (ni, nj, nk)
-   else:
-      ni, nj, nk = extent_ijk
+    if extent_ijk is None:
+        cp_extent = cp_array.shape
+        extent_kji = cp_extent[:3]
+        (nk, nj, ni) = extent_kji
+        extent_ijk = (ni, nj, nk)
+    else:
+        ni, nj, nk = extent_ijk
 
-   # convert units
-   log.debug('Converting units')
-   if corp_xy_units == corp_z_units and resqml_xy_units == resqml_z_units:
-      bwam.convert_lengths(cp_array, corp_xy_units, resqml_xy_units)
-   else:
-      bwam.convert_lengths(cp_array[:, :, :, :, :, :, 0:1], corp_xy_units, resqml_xy_units)
-      bwam.convert_lengths(cp_array[:, :, :, :, :, :, 2], corp_z_units, resqml_z_units)
+    # convert units
+    log.debug('Converting units')
+    if corp_xy_units == corp_z_units and resqml_xy_units == resqml_z_units:
+        bwam.convert_lengths(cp_array, corp_xy_units, resqml_xy_units)
+    else:
+        bwam.convert_lengths(cp_array[:, :, :, :, :, :, 0:1], corp_xy_units, resqml_xy_units)
+        bwam.convert_lengths(cp_array[:, :, :, :, :, :, 2], corp_z_units, resqml_z_units)
 
-   # invert z if required
-   if resqml_z_inc_down != corp_z_inc_down:
-      log.debug('Inverting z values')
-      inversion = np.negative(cp_array[:, :, :, :, :, :, 2])
-      cp_array[:, :, :, :, :, :, 2] = inversion
+    # invert z if required
+    if resqml_z_inc_down != corp_z_inc_down:
+        log.debug('Inverting z values')
+        inversion = np.negative(cp_array[:, :, :, :, :, :, 2])
+        cp_array[:, :, :, :, :, :, 2] = inversion
 
-   # read active cell mask
-   log.debug('Setting up active cell mask')
-   active_mask = inactive_mask = None
-   if vdb_file:
-      assert vdbase is not None, 'problem with vdb object'
-      inactive_mask = vdbase.grid_kid_inactive_mask(grid_title)  # TODO: check conversion of KID to boolean for LGRs
-      if inactive_mask is not None:
-         log.debug('using kid array as inactive cell mask')
-         active_mask = np.logical_not(inactive_mask)
-      else:
-         log.warning('kid array not found, using unpack array as active cell indicator')
-         unp = vdbase.grid_unpack(grid_title)
-         assert unp is not None, 'failed to load active cell indicator mask from vdb kid or unpack arrays'
-         active_mask = np.empty((nk, nj, ni), dtype = 'bool')
-         active_mask[:] = (unp > 0)
-         inactive_mask = np.logical_not(active_mask)
-   elif active_mask_file:
-      active_mask = ld.load_array_from_file(active_mask_file, extent_kji, data_type = 'bool', use_binary = use_binary)
-      if active_mask is None:
-         log.error('failed to load active cell indicator array from file: ' + active_mask_file)
-      else:
-         inactive_mask = np.logical_not(active_mask)  # will crash if active mask load failed
+    # read active cell mask
+    log.debug('Setting up active cell mask')
+    active_mask = inactive_mask = None
+    if vdb_file:
+        assert vdbase is not None, 'problem with vdb object'
+        inactive_mask = vdbase.grid_kid_inactive_mask(grid_title)  # TODO: check conversion of KID to boolean for LGRs
+        if inactive_mask is not None:
+            log.debug('using kid array as inactive cell mask')
+            active_mask = np.logical_not(inactive_mask)
+        else:
+            log.warning('kid array not found, using unpack array as active cell indicator')
+            unp = vdbase.grid_unpack(grid_title)
+            assert unp is not None, 'failed to load active cell indicator mask from vdb kid or unpack arrays'
+            active_mask = np.empty((nk, nj, ni), dtype = 'bool')
+            active_mask[:] = (unp > 0)
+            inactive_mask = np.logical_not(active_mask)
+    elif active_mask_file:
+        active_mask = ld.load_array_from_file(active_mask_file, extent_kji, data_type = 'bool', use_binary = use_binary)
+        if active_mask is None:
+            log.error('failed to load active cell indicator array from file: ' + active_mask_file)
+        else:
+            inactive_mask = np.logical_not(active_mask)  # will crash if active mask load failed
 
-   # shift grid geometry to local crs
-   local_origin = np.zeros(3)
-   if shift_to_local:
-      log.debug('shifting to local origin at ' + local_origin_place)
-      if local_origin_place == 'centre':
-         local_origin = np.nanmean(cp_array, axis = (0, 1, 2, 3, 4, 5))
-      elif local_origin_place == 'minimum':
-         local_origin = np.nanmin(cp_array, axis = (0, 1, 2, 3, 4, 5)) - 1.0  # The -1 ensures all coords are >0
-      else:
-         assert (False)
-      cp_array -= local_origin
+    # shift grid geometry to local crs
+    local_origin = np.zeros(3)
+    if shift_to_local:
+        log.debug('shifting to local origin at ' + local_origin_place)
+        if local_origin_place == 'centre':
+            local_origin = np.nanmean(cp_array, axis = (0, 1, 2, 3, 4, 5))
+        elif local_origin_place == 'minimum':
+            local_origin = np.nanmin(cp_array, axis = (0, 1, 2, 3, 4, 5)) - 1.0  # The -1 ensures all coords are >0
+        else:
+            assert (False)
+        cp_array -= local_origin
 
-   # create empty resqml model
-   log.debug('creating an empty resqml model')
-   if mode == 'w':
-      model = rq.Model(resqml_file_root, new_epc = True, create_basics = True, create_hdf5_ext = True)
-   else:
-      model = rq.Model(resqml_file_root)
-   assert model is not None
-   ext_uuid = model.h5_uuid()
-   assert ext_uuid is not None
+    # create empty resqml model
+    log.debug('creating an empty resqml model')
+    if mode == 'w':
+        model = rq.Model(resqml_file_root, new_epc = True, create_basics = True, create_hdf5_ext = True)
+    else:
+        model = rq.Model(resqml_file_root)
+    assert model is not None
+    ext_uuid = model.h5_uuid()
+    assert ext_uuid is not None
 
-   # create coodinate reference system (crs) in model and set references in grid object
-   log.debug('creating coordinate reference system')
-   crs_uuids = model.uuids(obj_type = 'LocalDepth3dCrs')
-   new_crs = rqc.Crs(model,
-                     x_offset = local_origin[0],
-                     y_offset = local_origin[1],
-                     z_offset = local_origin[2],
-                     xy_units = resqml_xy_units,
-                     z_units = resqml_z_units,
-                     z_inc_down = resqml_z_inc_down)
-   new_crs.create_xml(reuse = True)
-   crs_uuid = new_crs.uuid
+    # create coodinate reference system (crs) in model and set references in grid object
+    log.debug('creating coordinate reference system')
+    crs_uuids = model.uuids(obj_type = 'LocalDepth3dCrs')
+    new_crs = rqc.Crs(model,
+                      x_offset = local_origin[0],
+                      y_offset = local_origin[1],
+                      z_offset = local_origin[2],
+                      xy_units = resqml_xy_units,
+                      z_units = resqml_z_units,
+                      z_inc_down = resqml_z_inc_down)
+    new_crs.create_xml(reuse = True)
+    crs_uuid = new_crs.uuid
 
-   grid = grid_from_cp(model,
-                       cp_array,
-                       crs_uuid,
-                       active_mask = active_mask,
-                       geometry_defined_everywhere = geometry_defined_everywhere,
-                       treat_as_nan = treat_as_nan,
-                       max_z_void = max_z_void,
-                       split_pillars = split_pillars,
-                       split_tolerance = split_tolerance,
-                       ijk_handedness = ijk_handedness,
-                       known_to_be_straight = False)
+    grid = grid_from_cp(model,
+                        cp_array,
+                        crs_uuid,
+                        active_mask = active_mask,
+                        geometry_defined_everywhere = geometry_defined_everywhere,
+                        treat_as_nan = treat_as_nan,
+                        max_z_void = max_z_void,
+                        split_pillars = split_pillars,
+                        split_tolerance = split_tolerance,
+                        ijk_handedness = ijk_handedness,
+                        known_to_be_straight = False)
 
-   # create hdf5 file using arrays cached in grid above
-   log.info('writing grid geometry to hdf5 file ' + resqml_file_root + '.h5')
-   grid.write_hdf5_from_caches(resqml_file_root + '.h5', mode = mode, write_active = False)
+    # create hdf5 file using arrays cached in grid above
+    log.info('writing grid geometry to hdf5 file ' + resqml_file_root + '.h5')
+    grid.write_hdf5_from_caches(resqml_file_root + '.h5', mode = mode, write_active = False)
 
-   # build xml for grid geometry
-   log.debug('building xml for grid')
-   ijk_node = grid.create_xml(ext_uuid = None, title = grid_title, add_as_part = True, add_relationships = True)
-   assert ijk_node is not None, 'failed to create IjkGrid node in xml tree'
+    # build xml for grid geometry
+    log.debug('building xml for grid')
+    ijk_node = grid.create_xml(ext_uuid = None, title = grid_title, add_as_part = True, add_relationships = True)
+    assert ijk_node is not None, 'failed to create IjkGrid node in xml tree'
 
-   # impprt property arrays into a collection
-   prop_import_collection = None
-   decoarsen_array = None
-   ts_node = None
-   ts_uuid = None
+    # impprt property arrays into a collection
+    prop_import_collection = None
+    decoarsen_array = None
+    ts_node = None
+    ts_uuid = None
 
-   if active_mask is None and grid.inactive is not None:
-      active_mask = np.logical_not(grid.inactive)
+    if active_mask is None and grid.inactive is not None:
+        active_mask = np.logical_not(grid.inactive)
 
-   if using_vdb:
-      prop_import_collection = rp.GridPropertyCollection()
-      if vdb_static_properties:
-         props = vdbase.grid_list_of_static_properties(grid_title)
-         if len(props) > 0:
-            prop_import_collection = rp.GridPropertyCollection()
-            prop_import_collection.set_grid(grid)
-            for keyword in props:
-               prop_import_collection.import_vdb_static_property_to_cache(vdbase, keyword, grid_name = grid_title)
+    if using_vdb:
+        prop_import_collection = rp.GridPropertyCollection()
+        if vdb_static_properties:
+            props = vdbase.grid_list_of_static_properties(grid_title)
+            if len(props) > 0:
+                prop_import_collection = rp.GridPropertyCollection()
+                prop_import_collection.set_grid(grid)
+                for keyword in props:
+                    prop_import_collection.import_vdb_static_property_to_cache(vdbase, keyword, grid_name = grid_title)
 #      if active_mask is not None:
 #         prop_import_collection.add_cached_array_to_imported_list(active_mask, active_mask_file, 'ACTIVE', property_kind = 'active',
 #                                                                  discrete = True, uom = None, time_index = None, null_value = None)
 
-   elif property_array_files is not None and len(property_array_files) > 0:
-      prop_import_collection = rp.GridPropertyCollection()
-      prop_import_collection.set_grid(grid)
-      for (p_filename, p_keyword, p_uom, p_time_index, p_null_value, p_discrete) in property_array_files:
-         prop_import_collection.import_nexus_property_to_cache(p_filename,
-                                                               p_keyword,
-                                                               grid.extent_kji,
-                                                               discrete = p_discrete,
-                                                               uom = p_uom,
-                                                               time_index = p_time_index,
-                                                               null_value = p_null_value,
-                                                               use_binary = use_binary)
+    elif property_array_files is not None and len(property_array_files) > 0:
+        prop_import_collection = rp.GridPropertyCollection()
+        prop_import_collection.set_grid(grid)
+        for (p_filename, p_keyword, p_uom, p_time_index, p_null_value, p_discrete) in property_array_files:
+            prop_import_collection.import_nexus_property_to_cache(p_filename,
+                                                                  p_keyword,
+                                                                  grid.extent_kji,
+                                                                  discrete = p_discrete,
+                                                                  uom = p_uom,
+                                                                  time_index = p_time_index,
+                                                                  null_value = p_null_value,
+                                                                  use_binary = use_binary)
 #      if active_mask is not None:
 #         prop_import_collection.add_cached_array_to_imported_list(active_mask, active_mask_file, 'ACTIVE', property_kind = 'active',
 #                                                                  discrete = True, uom = None, time_index = None, null_value = None)
 
 #  ab_property_list: list of (filename, keyword, property_kind, facet_type, facet, uom, time_index, null_value, discrete)
-   elif ab_property_list is not None and len(ab_property_list) > 0:
-      prop_import_collection = rp.GridPropertyCollection()
-      prop_import_collection.set_grid(grid)
-      for (p_filename, p_keyword, p_property_kind, p_facet_type, p_facet, p_uom, p_time_index, p_null_value,
-           p_discrete) in ab_property_list:
-         prop_import_collection.import_ab_property_to_cache(p_filename,
-                                                            p_keyword,
-                                                            grid.extent_kji,
-                                                            discrete = p_discrete,
-                                                            property_kind = p_property_kind,
-                                                            facet_type = p_facet_type,
-                                                            facet = p_facet,
-                                                            uom = p_uom,
-                                                            time_index = p_time_index,
-                                                            null_value = p_null_value)
+    elif ab_property_list is not None and len(ab_property_list) > 0:
+        prop_import_collection = rp.GridPropertyCollection()
+        prop_import_collection.set_grid(grid)
+        for (p_filename, p_keyword, p_property_kind, p_facet_type, p_facet, p_uom, p_time_index, p_null_value,
+             p_discrete) in ab_property_list:
+            prop_import_collection.import_ab_property_to_cache(p_filename,
+                                                               p_keyword,
+                                                               grid.extent_kji,
+                                                               discrete = p_discrete,
+                                                               property_kind = p_property_kind,
+                                                               facet_type = p_facet_type,
+                                                               facet = p_facet,
+                                                               uom = p_uom,
+                                                               time_index = p_time_index,
+                                                               null_value = p_null_value)
 #      if active_mask is not None:
 #         prop_import_collection.add_cached_array_to_imported_list(active_mask, active_mask_file, 'ACTIVE', property_kind = 'active',
 #                                                                  discrete = True, uom = None, time_index = None, null_value = None)
 
 # ensemble_property_dictionary: mapping title (or keyword) to
 #    (filename, property_kind, facet_type, facet, uom, time_index, null_value, discrete)
-   elif ensemble_case_dirs_root and ensemble_property_dictionary:
-      case_path_list = glob.glob(ensemble_case_dirs_root + '*')
-      assert len(case_path_list) > 0, 'no case directories found with path starting: ' + str(ensemble_case_dirs_root)
-      case_number_place = len(ensemble_case_dirs_root)
-      case_zero_used = False
-      case_count = 0
-      for case_path in case_path_list:
-         if ensemble_size_limit is not None and case_count >= ensemble_size_limit:
-            log.warning('stopping after reaching ensemble size limit')
-            break
-         # NB. import each case individually rather than holding property arrays for whole ensemble in memory at once
-         prop_import_collection = rp.GridPropertyCollection()
-         prop_import_collection.set_grid(grid)
-         tail = case_path[case_number_place:]
-         try:
-            case_number = int(tail)
-            assert case_number >= 0, 'negative case number encountered'
-            if case_number == 0:
-               assert not case_zero_used, 'more than one case number evaluated to zero'
-               case_zero_used = True
-         except Exception:
-            log.error('failed to determine case number for tail: ' + str(tail))
-            continue
-         for keyword in ensemble_property_dictionary.keys():
-            (filename, p_property_kind, p_facet_type, p_facet, p_uom, p_time_index, p_null_value,
-             p_discrete) = ensemble_property_dictionary[keyword]
-            p_filename = os.path.join(case_path, filename)
-            if not os.path.exists(p_filename):
-               log.error('missing property file: ' + p_filename)
-               continue
-            prop_import_collection.import_nexus_property_to_cache(p_filename,
-                                                                  keyword,
-                                                                  grid.extent_kji,
-                                                                  discrete = p_discrete,
-                                                                  uom = p_uom,
-                                                                  time_index = p_time_index,
-                                                                  null_value = p_null_value,
-                                                                  property_kind = p_property_kind,
-                                                                  facet_type = p_facet_type,
-                                                                  facet = p_facet,
-                                                                  realization = case_number,
-                                                                  use_binary = False)
-         if len(prop_import_collection.imported_list) > 0:
-            # create hdf5 file using arrays cached in grid above
-            log.info('writing properties to hdf5 file ' + str(resqml_file_root) + '.h5 for case: ' + str(case_number))
-            grid.write_hdf5_from_caches(resqml_file_root + '.h5',
-                                        geometry = False,
-                                        imported_properties = prop_import_collection,
-                                        write_active = False)
-            # add imported properties parts to model, building property parts list
-            prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(ext_uuid,
-                                                                                       time_series_uuid = ts_uuid)
-            if create_property_set:
-               prop_import_collection.create_property_set_xml('realisation ' + str(case_number))
-            case_count += 1
-         # remove cached static property arrays from memory
+    elif ensemble_case_dirs_root and ensemble_property_dictionary:
+        case_path_list = glob.glob(ensemble_case_dirs_root + '*')
+        assert len(case_path_list) > 0, 'no case directories found with path starting: ' + str(ensemble_case_dirs_root)
+        case_number_place = len(ensemble_case_dirs_root)
+        case_zero_used = False
+        case_count = 0
+        for case_path in case_path_list:
+            if ensemble_size_limit is not None and case_count >= ensemble_size_limit:
+                log.warning('stopping after reaching ensemble size limit')
+                break
+            # NB. import each case individually rather than holding property arrays for whole ensemble in memory at once
+            prop_import_collection = rp.GridPropertyCollection()
+            prop_import_collection.set_grid(grid)
+            tail = case_path[case_number_place:]
+            try:
+                case_number = int(tail)
+                assert case_number >= 0, 'negative case number encountered'
+                if case_number == 0:
+                    assert not case_zero_used, 'more than one case number evaluated to zero'
+                    case_zero_used = True
+            except Exception:
+                log.error('failed to determine case number for tail: ' + str(tail))
+                continue
+            for keyword in ensemble_property_dictionary.keys():
+                (filename, p_property_kind, p_facet_type, p_facet, p_uom, p_time_index, p_null_value,
+                 p_discrete) = ensemble_property_dictionary[keyword]
+                p_filename = os.path.join(case_path, filename)
+                if not os.path.exists(p_filename):
+                    log.error('missing property file: ' + p_filename)
+                    continue
+                prop_import_collection.import_nexus_property_to_cache(p_filename,
+                                                                      keyword,
+                                                                      grid.extent_kji,
+                                                                      discrete = p_discrete,
+                                                                      uom = p_uom,
+                                                                      time_index = p_time_index,
+                                                                      null_value = p_null_value,
+                                                                      property_kind = p_property_kind,
+                                                                      facet_type = p_facet_type,
+                                                                      facet = p_facet,
+                                                                      realization = case_number,
+                                                                      use_binary = False)
+            if len(prop_import_collection.imported_list) > 0:
+                # create hdf5 file using arrays cached in grid above
+                log.info('writing properties to hdf5 file ' + str(resqml_file_root) + '.h5 for case: ' +
+                         str(case_number))
+                grid.write_hdf5_from_caches(resqml_file_root + '.h5',
+                                            geometry = False,
+                                            imported_properties = prop_import_collection,
+                                            write_active = False)
+                # add imported properties parts to model, building property parts list
+                prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(ext_uuid,
+                                                                                           time_series_uuid = ts_uuid)
+                if create_property_set:
+                    prop_import_collection.create_property_set_xml('realisation ' + str(case_number))
+                case_count += 1
+            # remove cached static property arrays from memory
 
 
 #         prop_import_collection.remove_all_cached_arrays()
-         del prop_import_collection
-         prop_import_collection = None
-      log.info(f'Nexus ascii ensemble input processed {case_count} cases')
-      tm.log_nexus_tm('info')
+            del prop_import_collection
+            prop_import_collection = None
+        log.info(f'Nexus ascii ensemble input processed {case_count} cases')
+        tm.log_nexus_tm('info')
 
-   # create hdf5 file using arrays cached in grid above
-   if prop_import_collection is not None and len(prop_import_collection.imported_list) > 0:
-      if decoarsen:
-         decoarsen_array = prop_import_collection.decoarsen_imported_list()
-         if decoarsen_array is not None:
-            log.info('static properties decoarsened')
-            prop_import_collection.add_cached_array_to_imported_list(decoarsen_array,
-                                                                     'decoarsen',
-                                                                     'DECOARSEN',
-                                                                     discrete = True,
-                                                                     uom = None,
-                                                                     time_index = None,
-                                                                     null_value = -1,
-                                                                     property_kind = 'discrete')
-      log.info('writing ' + str(len(prop_import_collection.imported_list)) + ' properties to hdf5 file ' +
-               resqml_file_root + '.h5')
-   elif not ensemble_case_dirs_root:
-      log.info('no static grid properties to import')
-      prop_import_collection = None
-   grid.write_hdf5_from_caches(resqml_file_root + '.h5',
-                               geometry = False,
-                               imported_properties = prop_import_collection,
-                               write_active = True)
-   # remove cached static property arrays from memory
-   if prop_import_collection is not None:
-      prop_import_collection.remove_all_cached_arrays()
-
-   ts_selection = None
-   if using_vdb and vdb_recurrent_properties and timestep_selection is not None and str(timestep_selection) != 'none':
-      if prop_import_collection is None:
-         prop_import_collection = rp.GridPropertyCollection()
-         prop_import_collection.set_grid(grid)
-      # extract timestep dates from summary file (this info might be hidden in the recurrent binary files but I couldn't find it
-      # todo: create cut down time series from recurrent files and differentiate between reporting time index and mapped time step number
-      full_time_series = rts.time_series_from_nexus_summary(summary_file)
-      if full_time_series is None:
-         log.error('failed to fetch time series from Nexus summary file; recurrent data excluded')
-         tm.log_nexus_tm('error')
-      else:
-         full_time_series.set_model(model)
-         timestep_list = vdbase.grid_list_of_timesteps(
-            grid_title)  # get list of timesteps for which recurrent files exist
-         recur_time_series = None
-         for timestep_number in timestep_list:
-            if isinstance(timestep_selection, list):
-               if timestep_number not in timestep_selection:
-                  continue
-            else:
-               if timestep_selection == 'first':
-                  if timestep_number != timestep_list[0]:
-                     break
-               elif timestep_selection == 'last':
-                  if timestep_number != timestep_list[-1]:
-                     continue
-               elif timestep_selection == 'first and last':
-                  if timestep_number != timestep_list[0] and timestep_number != timestep_list[-1]:
-                     continue
-               # default to importing all timesteps
-            stamp = full_time_series.timestamp(timestep_number)
-            if stamp is None:
-               log.error('timestamp number for which recurrent data exists was not found in summary file: ' +
-                         str(timestep_number))
-               continue
-            recur_prop_list = vdbase.grid_list_of_recurrent_properties(grid_title, timestep_number)
-            common_recur_prop_set = set()
-            if recur_time_series is None:
-               recur_time_series = rts.TimeSeries(model, first_timestamp = stamp)
-               if recur_prop_list is not None:
-                  common_recur_prop_set = set(recur_prop_list)
-            else:
-               recur_time_series.add_timestamp(stamp)
-               if recur_prop_list is not None:
-                  common_recur_prop_set = common_recur_prop_set.intersection(set(recur_prop_list))
-            step_import_collection = rp.GridPropertyCollection()
-            step_import_collection.set_grid(grid)
-            # for each property for this timestep, cache array and add to recur prop import collection for this time step
-            if recur_prop_list:
-               for keyword in recur_prop_list:
-                  if not keyword or not keyword.isalnum():
-                     continue
-                  step_import_collection.import_vdb_recurrent_property_to_cache(vdbase,
-                                                                                timestep_number,
-                                                                                keyword,
-                                                                                grid_name = grid_title)
-            # extend hdf5 with cached arrays for this timestep
-            log.info('number of recurrent grid property arrays for timestep: ' + str(timestep_number) + ' is: ' +
-                     str(step_import_collection.number_of_imports()))
+    # create hdf5 file using arrays cached in grid above
+    if prop_import_collection is not None and len(prop_import_collection.imported_list) > 0:
+        if decoarsen:
+            decoarsen_array = prop_import_collection.decoarsen_imported_list()
             if decoarsen_array is not None:
-               log.info('decoarsening recurrent properties for timestep: ' + str(timestep_number))
-               step_import_collection.decoarsen_imported_list(decoarsen_array = decoarsen_array)
-            log.info('extending hdf5 file with recurrent properties for timestep: ' + str(timestep_number))
-            grid.write_hdf5_from_caches(resqml_file_root + '.h5',
-                                        mode = 'a',
-                                        geometry = False,
-                                        imported_properties = step_import_collection,
-                                        write_active = False)
-            # add imported list for this timestep to full imported list
-            prop_import_collection.inherit_imported_list_from_other_collection(step_import_collection)
-            log.debug('total number of property arrays after timestep: ' + str(timestep_number) + ' is: ' +
-                      str(prop_import_collection.number_of_imports()))
-            # remove cached copies of arrays
-            step_import_collection.remove_all_cached_arrays()
+                log.info('static properties decoarsened')
+                prop_import_collection.add_cached_array_to_imported_list(decoarsen_array,
+                                                                         'decoarsen',
+                                                                         'DECOARSEN',
+                                                                         discrete = True,
+                                                                         uom = None,
+                                                                         time_index = None,
+                                                                         null_value = -1,
+                                                                         property_kind = 'discrete')
+        log.info('writing ' + str(len(prop_import_collection.imported_list)) + ' properties to hdf5 file ' +
+                 resqml_file_root + '.h5')
+    elif not ensemble_case_dirs_root:
+        log.info('no static grid properties to import')
+        prop_import_collection = None
+    grid.write_hdf5_from_caches(resqml_file_root + '.h5',
+                                geometry = False,
+                                imported_properties = prop_import_collection,
+                                write_active = True)
+    # remove cached static property arrays from memory
+    if prop_import_collection is not None:
+        prop_import_collection.remove_all_cached_arrays()
 
-         ts_node = full_time_series.create_xml(title = 'simulator full timestep series')
-         model.time_series = ts_node  # save as the primary time series for the model
-         ts_uuid = rqet.uuid_for_part_root(ts_node)
-         # create xml for recur_time_series (as well as for full_time_series) and add as part; not needed?
-         if recur_time_series is not None:
-            rts_node = recur_time_series.create_xml(title = 'simulator recurrent array timestep series')
-            if use_compressed_time_series:
-               ts_uuid = rqet.uuid_for_part_root(rts_node)
-               ts_selection = timestep_list
+    ts_selection = None
+    if using_vdb and vdb_recurrent_properties and timestep_selection is not None and str(timestep_selection) != 'none':
+        if prop_import_collection is None:
+            prop_import_collection = rp.GridPropertyCollection()
+            prop_import_collection.set_grid(grid)
+        # extract timestep dates from summary file (this info might be hidden in the recurrent binary files but I couldn't find it
+        # todo: create cut down time series from recurrent files and differentiate between reporting time index and mapped time step number
+        full_time_series = rts.time_series_from_nexus_summary(summary_file)
+        if full_time_series is None:
+            log.error('failed to fetch time series from Nexus summary file; recurrent data excluded')
+            tm.log_nexus_tm('error')
+        else:
+            full_time_series.set_model(model)
+            timestep_list = vdbase.grid_list_of_timesteps(
+                grid_title)  # get list of timesteps for which recurrent files exist
+            recur_time_series = None
+            for timestep_number in timestep_list:
+                if isinstance(timestep_selection, list):
+                    if timestep_number not in timestep_selection:
+                        continue
+                else:
+                    if timestep_selection == 'first':
+                        if timestep_number != timestep_list[0]:
+                            break
+                    elif timestep_selection == 'last':
+                        if timestep_number != timestep_list[-1]:
+                            continue
+                    elif timestep_selection == 'first and last':
+                        if timestep_number != timestep_list[0] and timestep_number != timestep_list[-1]:
+                            continue
+                    # default to importing all timesteps
+                stamp = full_time_series.timestamp(timestep_number)
+                if stamp is None:
+                    log.error('timestamp number for which recurrent data exists was not found in summary file: ' +
+                              str(timestep_number))
+                    continue
+                recur_prop_list = vdbase.grid_list_of_recurrent_properties(grid_title, timestep_number)
+                common_recur_prop_set = set()
+                if recur_time_series is None:
+                    recur_time_series = rts.TimeSeries(model, first_timestamp = stamp)
+                    if recur_prop_list is not None:
+                        common_recur_prop_set = set(recur_prop_list)
+                else:
+                    recur_time_series.add_timestamp(stamp)
+                    if recur_prop_list is not None:
+                        common_recur_prop_set = common_recur_prop_set.intersection(set(recur_prop_list))
+                step_import_collection = rp.GridPropertyCollection()
+                step_import_collection.set_grid(grid)
+                # for each property for this timestep, cache array and add to recur prop import collection for this time step
+                if recur_prop_list:
+                    for keyword in recur_prop_list:
+                        if not keyword or not keyword.isalnum():
+                            continue
+                        step_import_collection.import_vdb_recurrent_property_to_cache(vdbase,
+                                                                                      timestep_number,
+                                                                                      keyword,
+                                                                                      grid_name = grid_title)
+                # extend hdf5 with cached arrays for this timestep
+                log.info('number of recurrent grid property arrays for timestep: ' + str(timestep_number) + ' is: ' +
+                         str(step_import_collection.number_of_imports()))
+                if decoarsen_array is not None:
+                    log.info('decoarsening recurrent properties for timestep: ' + str(timestep_number))
+                    step_import_collection.decoarsen_imported_list(decoarsen_array = decoarsen_array)
+                log.info('extending hdf5 file with recurrent properties for timestep: ' + str(timestep_number))
+                grid.write_hdf5_from_caches(resqml_file_root + '.h5',
+                                            mode = 'a',
+                                            geometry = False,
+                                            imported_properties = step_import_collection,
+                                            write_active = False)
+                # add imported list for this timestep to full imported list
+                prop_import_collection.inherit_imported_list_from_other_collection(step_import_collection)
+                log.debug('total number of property arrays after timestep: ' + str(timestep_number) + ' is: ' +
+                          str(prop_import_collection.number_of_imports()))
+                # remove cached copies of arrays
+                step_import_collection.remove_all_cached_arrays()
 
-   # add imported properties parts to model, building property parts list
-   if prop_import_collection is not None and prop_import_collection.imported_list is not None:
-      prop_import_collection.set_grid(grid)  # update to pick up on recently created xml root node for grid
-      prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(
-         ext_uuid, time_series_uuid = ts_uuid, selected_time_indices_list = ts_selection)
-      if create_property_set:
-         prop_import_collection.create_property_set_xml('property set for import for grid ' + str(grid_title))
+            ts_node = full_time_series.create_xml(title = 'simulator full timestep series')
+            model.time_series = ts_node  # save as the primary time series for the model
+            ts_uuid = rqet.uuid_for_part_root(ts_node)
+            # create xml for recur_time_series (as well as for full_time_series) and add as part; not needed?
+            if recur_time_series is not None:
+                rts_node = recur_time_series.create_xml(title = 'simulator recurrent array timestep series')
+                if use_compressed_time_series:
+                    ts_uuid = rqet.uuid_for_part_root(rts_node)
+                    ts_selection = timestep_list
 
-   # mark model as modified (will already have happened anyway)
-   model.set_modified()
+    # add imported properties parts to model, building property parts list
+    if prop_import_collection is not None and prop_import_collection.imported_list is not None:
+        prop_import_collection.set_grid(grid)  # update to pick up on recently created xml root node for grid
+        prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(
+            ext_uuid, time_series_uuid = ts_uuid, selected_time_indices_list = ts_selection)
+        if create_property_set:
+            prop_import_collection.create_property_set_xml('property set for import for grid ' + str(grid_title))
 
-   # create epc file
-   log.info('storing model in epc file ' + resqml_file_root + '.epc')
-   model.store_epc(resqml_file_root + '.epc')
+    # mark model as modified (will already have happened anyway)
+    model.set_modified()
 
-   # return resqml model
-   return model
+    # create epc file
+    log.info('storing model in epc file ' + resqml_file_root + '.epc')
+    model.store_epc(resqml_file_root + '.epc')
+
+    # return resqml model
+    return model
 
 
 def import_vdb_all_grids(
-   resqml_file_root,  # output path and file name without .epc or .h5 extension
-   extent_ijk = None,  # 3 element numpy vector applicable to ROOT
-   vdb_file = None,
-   vdb_case = None,  # if None, first case in vdb is used (usually a vdb only holds one case)
-   corp_xy_units = 'm',
-   corp_z_units = 'm',
-   corp_z_inc_down = True,
-   ijk_handedness = 'right',
-   geometry_defined_everywhere = True,
-   treat_as_nan = None,
-   resqml_xy_units = 'm',
-   resqml_z_units = 'm',
-   resqml_z_inc_down = True,
-   shift_to_local = False,
-   local_origin_place = 'centre',  # 'centre' or 'minimum'
-   max_z_void = 0.1,  # vertical gaps greater than this will introduce k gaps intp resqml grid
-   split_pillars = True,
-   split_tolerance = 0.01,  # applies to each of x, y, z differences
-   vdb_static_properties = True,  # if True, static vdb properties are imported (only relevant if vdb_file is not None)
-   vdb_recurrent_properties = False,
-   decoarsen = True,
-   timestep_selection = 'all',  # 'first', 'last', 'first and last', 'all', or list of ints being reporting timestep numbers
-   create_property_set = False):
-   """Creates a RESQML dataset containing grids and grid properties, including LGRs, for a single realisation."""
+    resqml_file_root,  # output path and file name without .epc or .h5 extension
+    extent_ijk = None,  # 3 element numpy vector applicable to ROOT
+    vdb_file = None,
+    vdb_case = None,  # if None, first case in vdb is used (usually a vdb only holds one case)
+    corp_xy_units = 'm',
+    corp_z_units = 'm',
+    corp_z_inc_down = True,
+    ijk_handedness = 'right',
+    geometry_defined_everywhere = True,
+    treat_as_nan = None,
+    resqml_xy_units = 'm',
+    resqml_z_units = 'm',
+    resqml_z_inc_down = True,
+    shift_to_local = False,
+    local_origin_place = 'centre',  # 'centre' or 'minimum'
+    max_z_void = 0.1,  # vertical gaps greater than this will introduce k gaps intp resqml grid
+    split_pillars = True,
+    split_tolerance = 0.01,  # applies to each of x, y, z differences
+    vdb_static_properties = True,  # if True, static vdb properties are imported (only relevant if vdb_file is not None)
+    vdb_recurrent_properties = False,
+    decoarsen = True,
+    timestep_selection = 'all',  # 'first', 'last', 'first and last', 'all', or list of ints being reporting timestep numbers
+    create_property_set = False):
+    """Creates a RESQML dataset containing grids and grid properties, including LGRs, for a single realisation."""
 
-   vdbase = vdb.VDB(vdb_file)
-   case_list = vdbase.cases()
-   assert len(case_list) > 0, 'no cases found in vdb'
-   if vdb_case is None:
-      vdb_case = case_list[0]
-   else:
-      assert vdb_case in case_list, 'case ' + vdb_case + ' not found in vdb: ' + vdb_file
-      vdbase.set_use_case(vdb_case)
-   grid_list = vdbase.list_of_grids()
-   index = 0
-   for grid_name in grid_list:
-      if grid_name.upper().startswith('SMALLGRIDS'):
-         log.warning('vdb import skipping small grids')
-         continue
-      log.debug('importing vdb data for grid ' + str(grid_name))
-      import_nexus(
-         resqml_file_root,
-         extent_ijk = extent_ijk if grid_name == 'ROOT' else None,  # 3 element numpy vector applicable to ROOT
-         vdb_file = vdb_file,
-         vdb_case = vdb_case,  # if None, first case in vdb is used (usually a vdb only holds one case)
-         corp_xy_units = corp_xy_units,
-         corp_z_units = corp_z_units,
-         corp_z_inc_down = corp_z_inc_down,
-         ijk_handedness = ijk_handedness,
-         geometry_defined_everywhere = geometry_defined_everywhere,
-         treat_as_nan = treat_as_nan,
-         resqml_xy_units = resqml_xy_units,
-         resqml_z_units = resqml_z_units,
-         resqml_z_inc_down = resqml_z_inc_down,
-         shift_to_local = shift_to_local,
-         local_origin_place = local_origin_place,  # 'centre' or 'minimum'
-         max_z_void = max_z_void,  # vertical gaps greater than this will introduce k gaps intp resqml grid
-         split_pillars = split_pillars,  # NB: some LGRs may be unsplit even if ROOT is split
-         split_tolerance = split_tolerance,  # applies to each of x, y, z differences
-         vdb_static_properties = vdb_static_properties,  # if True, static vdb properties are imported
-         vdb_recurrent_properties = vdb_recurrent_properties,
-         decoarsen = decoarsen,
-         timestep_selection = timestep_selection,
-         create_property_set = create_property_set,
-         grid_title = grid_name,
-         mode = 'w' if index == 0 else 'a')
-      index += 1
+    vdbase = vdb.VDB(vdb_file)
+    case_list = vdbase.cases()
+    assert len(case_list) > 0, 'no cases found in vdb'
+    if vdb_case is None:
+        vdb_case = case_list[0]
+    else:
+        assert vdb_case in case_list, 'case ' + vdb_case + ' not found in vdb: ' + vdb_file
+        vdbase.set_use_case(vdb_case)
+    grid_list = vdbase.list_of_grids()
+    index = 0
+    for grid_name in grid_list:
+        if grid_name.upper().startswith('SMALLGRIDS'):
+            log.warning('vdb import skipping small grids')
+            continue
+        log.debug('importing vdb data for grid ' + str(grid_name))
+        import_nexus(
+            resqml_file_root,
+            extent_ijk = extent_ijk if grid_name == 'ROOT' else None,  # 3 element numpy vector applicable to ROOT
+            vdb_file = vdb_file,
+            vdb_case = vdb_case,  # if None, first case in vdb is used (usually a vdb only holds one case)
+            corp_xy_units = corp_xy_units,
+            corp_z_units = corp_z_units,
+            corp_z_inc_down = corp_z_inc_down,
+            ijk_handedness = ijk_handedness,
+            geometry_defined_everywhere = geometry_defined_everywhere,
+            treat_as_nan = treat_as_nan,
+            resqml_xy_units = resqml_xy_units,
+            resqml_z_units = resqml_z_units,
+            resqml_z_inc_down = resqml_z_inc_down,
+            shift_to_local = shift_to_local,
+            local_origin_place = local_origin_place,  # 'centre' or 'minimum'
+            max_z_void = max_z_void,  # vertical gaps greater than this will introduce k gaps intp resqml grid
+            split_pillars = split_pillars,  # NB: some LGRs may be unsplit even if ROOT is split
+            split_tolerance = split_tolerance,  # applies to each of x, y, z differences
+            vdb_static_properties = vdb_static_properties,  # if True, static vdb properties are imported
+            vdb_recurrent_properties = vdb_recurrent_properties,
+            decoarsen = decoarsen,
+            timestep_selection = timestep_selection,
+            create_property_set = create_property_set,
+            grid_title = grid_name,
+            mode = 'w' if index == 0 else 'a')
+        index += 1
 
 
 def import_vdb_ensemble(
-      epc_file,
-      ensemble_run_dir,
-      existing_epc = False,
-      keyword_list = None,
-      property_kind_list = None,
-      vdb_static_properties = True,  # if True, static vdb properties are imported
-      vdb_recurrent_properties = True,
-      decoarsen = True,
-      timestep_selection = 'all',
-      create_property_set_per_realization = True,
-      create_property_set_per_timestep = True,
-      create_complete_property_set = False,
-      # remaining arguments only used if existing_epc is False
-      extent_ijk = None,  # 3 element numpy vector
-      corp_xy_units = 'metres',
-      corp_z_units = 'metres',
-      corp_z_inc_down = True,
-      ijk_handedness = 'right',
-      geometry_defined_everywhere = True,
-      treat_as_nan = None,
-      resqml_xy_units = 'metres',
-      resqml_z_units = 'metres',
-      resqml_z_inc_down = True,
-      shift_to_local = True,
-      local_origin_place = 'centre',  # 'centre' or 'minimum'
-      max_z_void = 0.1,  # import will fail if vertical void greater than this is encountered
-      split_pillars = True,
-      split_tolerance = 0.01,  # applies to each of x, y, z differences
-      progress_fn = None):
-   """Adds properties from all vdb's within an ensemble directory tree to a single RESQML dataset, referencing a shared grid.
+        epc_file,
+        ensemble_run_dir,
+        existing_epc = False,
+        keyword_list = None,
+        property_kind_list = None,
+        vdb_static_properties = True,  # if True, static vdb properties are imported
+        vdb_recurrent_properties = True,
+        decoarsen = True,
+        timestep_selection = 'all',
+        create_property_set_per_realization = True,
+        create_property_set_per_timestep = True,
+        create_complete_property_set = False,
+        # remaining arguments only used if existing_epc is False
+        extent_ijk = None,  # 3 element numpy vector
+        corp_xy_units = 'metres',
+        corp_z_units = 'metres',
+        corp_z_inc_down = True,
+        ijk_handedness = 'right',
+        geometry_defined_everywhere = True,
+        treat_as_nan = None,
+        resqml_xy_units = 'metres',
+        resqml_z_units = 'metres',
+        resqml_z_inc_down = True,
+        shift_to_local = True,
+        local_origin_place = 'centre',  # 'centre' or 'minimum'
+        max_z_void = 0.1,  # import will fail if vertical void greater than this is encountered
+        split_pillars = True,
+        split_tolerance = 0.01,  # applies to each of x, y, z differences
+        progress_fn = None):
+    """Adds properties from all vdb's within an ensemble directory tree to a single RESQML dataset, referencing a shared grid.
 
    args:
       epc_file (string): filename of epc file to be extended with ensemble properties
@@ -702,425 +703,429 @@ def import_vdb_ensemble(
       are actually for the same date.
    """
 
-   assert epc_file.endswith('.epc')
-   assert vdb_static_properties or vdb_recurrent_properties, 'no properties selected for ensemble import'
+    assert epc_file.endswith('.epc')
+    assert vdb_static_properties or vdb_recurrent_properties, 'no properties selected for ensemble import'
 
-   if progress_fn is not None:
-      progress_fn(0.0)
+    if progress_fn is not None:
+        progress_fn(0.0)
 
-   # fetch a sorted list of the vdb paths found in the run directory tree
-   ensemble_list = vdb.ensemble_vdb_list(ensemble_run_dir)
-   if len(ensemble_list) == 0:
-      log.error("no vdb's found in run directory tree: " + str(ensemble_run_dir))
-      return None
+    # fetch a sorted list of the vdb paths found in the run directory tree
+    ensemble_list = vdb.ensemble_vdb_list(ensemble_run_dir)
+    if len(ensemble_list) == 0:
+        log.error("no vdb's found in run directory tree: " + str(ensemble_run_dir))
+        return None
 
-   if not existing_epc:
-      model = import_nexus(
-         epc_file[:-4],  # output path and file name without .epc or .h5 extension
-         extent_ijk = extent_ijk,  # 3 element numpy vector, in case extent is not automatically determined
-         vdb_file = ensemble_list[0],  # vdb input file
-         corp_xy_units = corp_xy_units,
-         corp_z_units = corp_z_units,
-         corp_z_inc_down = corp_z_inc_down,
-         ijk_handedness = ijk_handedness,
-         geometry_defined_everywhere = geometry_defined_everywhere,
-         treat_as_nan = treat_as_nan,
-         resqml_xy_units = resqml_xy_units,
-         resqml_z_units = resqml_z_units,
-         resqml_z_inc_down = resqml_z_inc_down,
-         shift_to_local = shift_to_local,
-         local_origin_place = local_origin_place,  # 'centre' or 'minimum'
-         max_z_void = max_z_void,  # import will fail if vertical void greater than this is encountered
-         split_pillars = split_pillars,
-         split_tolerance = split_tolerance,  # applies to each of x, y, z differences
-         vdb_static_properties = False,
-         vdb_recurrent_properties = False,
-         create_property_set = False)
+    if not existing_epc:
+        model = import_nexus(
+            epc_file[:-4],  # output path and file name without .epc or .h5 extension
+            extent_ijk = extent_ijk,  # 3 element numpy vector, in case extent is not automatically determined
+            vdb_file = ensemble_list[0],  # vdb input file
+            corp_xy_units = corp_xy_units,
+            corp_z_units = corp_z_units,
+            corp_z_inc_down = corp_z_inc_down,
+            ijk_handedness = ijk_handedness,
+            geometry_defined_everywhere = geometry_defined_everywhere,
+            treat_as_nan = treat_as_nan,
+            resqml_xy_units = resqml_xy_units,
+            resqml_z_units = resqml_z_units,
+            resqml_z_inc_down = resqml_z_inc_down,
+            shift_to_local = shift_to_local,
+            local_origin_place = local_origin_place,  # 'centre' or 'minimum'
+            max_z_void = max_z_void,  # import will fail if vertical void greater than this is encountered
+            split_pillars = split_pillars,
+            split_tolerance = split_tolerance,  # applies to each of x, y, z differences
+            vdb_static_properties = False,
+            vdb_recurrent_properties = False,
+            create_property_set = False)
 
-   model = rq.Model(
-      epc_file = epc_file)  # shouldn't be necessary if just created but it feels safer to re-open the model
-   assert model is not None, 'failed to instantiate model'
-   grid = model.grid()
-   assert grid is not None, 'grid not found'
-   ext_uuid = model.h5_uuid()
-   assert ext_uuid is not None, 'failed to determine uuid for hdf5 file reference'
-   hdf5_file = model.h5_file_name(uuid = ext_uuid)
+    model = rq.Model(
+        epc_file = epc_file)  # shouldn't be necessary if just created but it feels safer to re-open the model
+    assert model is not None, 'failed to instantiate model'
+    grid = model.grid()
+    assert grid is not None, 'grid not found'
+    ext_uuid = model.h5_uuid()
+    assert ext_uuid is not None, 'failed to determine uuid for hdf5 file reference'
+    hdf5_file = model.h5_file_name(uuid = ext_uuid)
 
-   # create reporting timestep time series for recurrent data, if required, based on the first realisation
-   recur_time_series = None
-   recur_ts_uuid = None
-   timestep_list = None
-   if vdb_recurrent_properties:
-      summary_file = ensemble_list[0][:-4] + '.sum'  # TODO: check timestep summary file extension, .tssum?
-      full_time_series = rts.time_series_from_nexus_summary(summary_file)
-      if full_time_series is None:
-         log.error('failed to extract info from timestep summary file; disabling recurrent property import')
-         vdb_recurrent_properties = False
-   if vdb_recurrent_properties:
-      vdbase = vdb.VDB(ensemble_list[0])
-      timestep_list = vdbase.list_of_timesteps()
-      if len(timestep_list) == 0:
-         log.warning('no ROOT recurrent data found in vdb for first realisation; disabling recurrent property import')
-         vdb_recurrent_properties = False
-   if vdb_recurrent_properties:
-      if timestep_selection == 'all' or ('first' in timestep_selection):
-         fs_index = 0
-      else:
-         fs_index = -1
-      first_stamp = full_time_series.timestamp(timestep_list[fs_index])
-      if first_stamp is None:
-         log.error('first timestamp number selected for import was not found in summary file: ' +
-                   str(timestep_list[fs_index]))
-         log.error('disabling recurrent property import')
-         vdb_recurrent_properties = False
-   if vdb_recurrent_properties:
-      recur_time_series = rts.TimeSeries(model, first_timestamp = first_stamp)
-      if timestep_selection == 'all':
-         remaining_list = timestep_list[1:]
-      elif timestep_selection == 'first and last':
-         remaining_list = [timestep_list[-1]]
-      else:
-         remaining_list = []
-      for timestep_number in remaining_list:
-         stamp = full_time_series.timestamp(timestep_number)
-         if stamp is None:
-            log.error('timestamp number for which recurrent data exists was not found in summary file: ' +
-                      str(timestep_number))
+    # create reporting timestep time series for recurrent data, if required, based on the first realisation
+    recur_time_series = None
+    recur_ts_uuid = None
+    timestep_list = None
+    if vdb_recurrent_properties:
+        summary_file = ensemble_list[0][:-4] + '.sum'  # TODO: check timestep summary file extension, .tssum?
+        full_time_series = rts.time_series_from_nexus_summary(summary_file)
+        if full_time_series is None:
+            log.error('failed to extract info from timestep summary file; disabling recurrent property import')
+            vdb_recurrent_properties = False
+    if vdb_recurrent_properties:
+        vdbase = vdb.VDB(ensemble_list[0])
+        timestep_list = vdbase.list_of_timesteps()
+        if len(timestep_list) == 0:
+            log.warning(
+                'no ROOT recurrent data found in vdb for first realisation; disabling recurrent property import')
+            vdb_recurrent_properties = False
+    if vdb_recurrent_properties:
+        if timestep_selection == 'all' or ('first' in timestep_selection):
+            fs_index = 0
+        else:
+            fs_index = -1
+        first_stamp = full_time_series.timestamp(timestep_list[fs_index])
+        if first_stamp is None:
+            log.error('first timestamp number selected for import was not found in summary file: ' +
+                      str(timestep_list[fs_index]))
             log.error('disabling recurrent property import')
             vdb_recurrent_properties = False
-            recur_time_series = None
-            break
-         recur_time_series.add_timestamp(stamp)
-   if recur_time_series is not None:
-      recur_ts_node = recur_time_series.create_xml(title = 'simulator recurrent array timestep series')
-      recur_ts_uuid = rqet.uuid_for_part_root(recur_ts_node)
-      model.time_series = recur_ts_node  # save as the primary time series for the model
+    if vdb_recurrent_properties:
+        recur_time_series = rts.TimeSeries(model, first_timestamp = first_stamp)
+        if timestep_selection == 'all':
+            remaining_list = timestep_list[1:]
+        elif timestep_selection == 'first and last':
+            remaining_list = [timestep_list[-1]]
+        else:
+            remaining_list = []
+        for timestep_number in remaining_list:
+            stamp = full_time_series.timestamp(timestep_number)
+            if stamp is None:
+                log.error('timestamp number for which recurrent data exists was not found in summary file: ' +
+                          str(timestep_number))
+                log.error('disabling recurrent property import')
+                vdb_recurrent_properties = False
+                recur_time_series = None
+                break
+            recur_time_series.add_timestamp(stamp)
+    if recur_time_series is not None:
+        recur_ts_node = recur_time_series.create_xml(title = 'simulator recurrent array timestep series')
+        recur_ts_uuid = rqet.uuid_for_part_root(recur_ts_node)
+        model.time_series = recur_ts_node  # save as the primary time series for the model
 
-   if create_complete_property_set or create_property_set_per_timestep:
-      complete_collection = rp.GridPropertyCollection()
-      complete_collection.set_grid(grid)
-   else:
-      complete_collection = None
+    if create_complete_property_set or create_property_set_per_timestep:
+        complete_collection = rp.GridPropertyCollection()
+        complete_collection.set_grid(grid)
+    else:
+        complete_collection = None
 
-   #  main loop over realisations
+    #  main loop over realisations
 
-   for realisation in range(len(ensemble_list)):
+    for realisation in range(len(ensemble_list)):
 
-      if progress_fn is not None:
-         progress_fn(float(1 + realisation) / float(1 + len(ensemble_list)))
+        if progress_fn is not None:
+            progress_fn(float(1 + realisation) / float(1 + len(ensemble_list)))
 
-      vdb_file = ensemble_list[realisation]
-      log.info('processing realisation ' + str(realisation) + ' from: ' + str(vdb_file))
-      vdbase = vdb.VDB(vdb_file)
-      #      case_list = vdbase.cases()
-      #      assert len(case_list) > 0, 'no cases found in vdb: ' + str(vdb_file)
-      #      if len(case_list) > 1: log.warning('more than one case found in vdb (using first): ' + str(vdb_file))
-      #      vdb_case = case_list[0]
-      #      vdbase.set_use_case(vdb_case)
-      vdbase.set_extent_kji(grid.extent_kji)
+        vdb_file = ensemble_list[realisation]
+        log.info('processing realisation ' + str(realisation) + ' from: ' + str(vdb_file))
+        vdbase = vdb.VDB(vdb_file)
+        #      case_list = vdbase.cases()
+        #      assert len(case_list) > 0, 'no cases found in vdb: ' + str(vdb_file)
+        #      if len(case_list) > 1: log.warning('more than one case found in vdb (using first): ' + str(vdb_file))
+        #      vdb_case = case_list[0]
+        #      vdbase.set_use_case(vdb_case)
+        vdbase.set_extent_kji(grid.extent_kji)
 
-      prop_import_collection = rp.GridPropertyCollection(realization = realisation)
-      prop_import_collection.set_grid(grid)
+        prop_import_collection = rp.GridPropertyCollection(realization = realisation)
+        prop_import_collection.set_grid(grid)
 
-      decoarsen_array = None
-      if vdb_static_properties:
-         props = vdbase.list_of_static_properties()
-         if len(props) > 0:
-            for keyword in props:
-               if keyword_list is not None and keyword not in keyword_list:
-                  continue
-               if property_kind_list is not None:
-                  prop_kind, _, _ = rp.property_kind_and_facet_from_keyword(keyword)
-                  if prop_kind not in property_kind_list and prop_kind not in ['active', 'region initialization']:
-                     continue
-               prop_import_collection.import_vdb_static_property_to_cache(vdbase, keyword, realization = realisation)
-            if decoarsen:
-               decoarsen_array = prop_import_collection.decoarsen_imported_list()
-               if decoarsen_array is not None:
-                  log.debug('static properties decoarsened for realisation ' + str(realisation))
-            grid.write_hdf5_from_caches(hdf5_file,
-                                        mode = 'a',
-                                        geometry = False,
-                                        imported_properties = prop_import_collection,
-                                        write_active = False)
-            prop_import_collection.remove_all_cached_arrays()
-
-      if vdb_recurrent_properties:
-
-         r_timestep_list = vdbase.list_of_timesteps()  # get list of timesteps for which recurrent files exist
-         if len(r_timestep_list) < recur_time_series.number_of_timestamps():
-            log.error('insufficient number of reporting timesteps; skipping recurrent data for realisation ' +
-                      str(realisation))
-         else:
-            common_recur_prop_set = None
-            for tni in range(recur_time_series.number_of_timestamps()):
-               if timestep_selection in ['all', 'first']:
-                  timestep_number = timestep_list[tni]
-                  r_timestep_number = r_timestep_list[tni]
-               elif timestep_selection == 'last' or tni > 0:
-                  timestep_number = timestep_list[-1]
-                  r_timestep_number = r_timestep_list[-1]
-               else:
-                  timestep_number = timestep_list[0]
-                  r_timestep_number = r_timestep_list[0]
-               stamp = full_time_series.timestamp(timestep_number)
-               recur_prop_list = vdbase.list_of_recurrent_properties(r_timestep_number)
-               if common_recur_prop_set is None:
-                  common_recur_prop_set = set(recur_prop_list)
-               elif recur_prop_list is not None:
-                  common_recur_prop_set = common_recur_prop_set.intersection(set(recur_prop_list))
-               step_import_collection = rp.GridPropertyCollection()
-               step_import_collection.set_grid(grid)
-               # for each property for this timestep, cache array and add to recur prop import collection for this time step
-               if recur_prop_list:
-                  for keyword in recur_prop_list:
-                     if not keyword or not keyword.isalnum():
+        decoarsen_array = None
+        if vdb_static_properties:
+            props = vdbase.list_of_static_properties()
+            if len(props) > 0:
+                for keyword in props:
+                    if keyword_list is not None and keyword not in keyword_list:
                         continue
-                     if keyword_list is not None and keyword not in keyword_list:
-                        continue
-                     if property_kind_list is not None:
+                    if property_kind_list is not None:
                         prop_kind, _, _ = rp.property_kind_and_facet_from_keyword(keyword)
-                        if prop_kind not in property_kind_list:
-                           continue
-                     step_import_collection.import_vdb_recurrent_property_to_cache(
-                        vdbase,
-                        r_timestep_number,
-                        keyword,
-                        time_index = tni,  # index into recur_time_series
-                        realization = realisation)
-               if decoarsen_array is not None:
-                  step_import_collection.decoarsen_imported_list(decoarsen_array = decoarsen_array)
-               # extend hdf5 with cached arrays for this timestep
-      #         log.info('number of recurrent grid property arrays for timestep: ' + str(timestep_number) +
-      #                  ' is: ' + str(step_import_collection.number_of_imports()))
-      #         log.info('extending hdf5 file with recurrent properties for timestep: ' + str(timestep_number))
-               grid.write_hdf5_from_caches(hdf5_file,
-                                           mode = 'a',
-                                           geometry = False,
-                                           imported_properties = step_import_collection,
-                                           write_active = False)
-               # add imported list for this timestep to full imported list
-               prop_import_collection.inherit_imported_list_from_other_collection(step_import_collection)
-               #         log.debug('total number of property arrays after timestep: ' + str(timestep_number) +
-               #                   ' is: ' + str(prop_import_collection.number_of_imports()))
-               # remove cached copies of arrays
-               step_import_collection.remove_all_cached_arrays()
+                        if prop_kind not in property_kind_list and prop_kind not in ['active', 'region initialization']:
+                            continue
+                    prop_import_collection.import_vdb_static_property_to_cache(vdbase,
+                                                                               keyword,
+                                                                               realization = realisation)
+                if decoarsen:
+                    decoarsen_array = prop_import_collection.decoarsen_imported_list()
+                    if decoarsen_array is not None:
+                        log.debug('static properties decoarsened for realisation ' + str(realisation))
+                grid.write_hdf5_from_caches(hdf5_file,
+                                            mode = 'a',
+                                            geometry = False,
+                                            imported_properties = prop_import_collection,
+                                            write_active = False)
+                prop_import_collection.remove_all_cached_arrays()
 
-      if len(prop_import_collection.imported_list) == 0:
-         log.warning('no properties imported for realisation ' + str(realisation))
-         continue
+        if vdb_recurrent_properties:
 
-      prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(ext_uuid,
-                                                                                 time_series_uuid = recur_ts_uuid)
+            r_timestep_list = vdbase.list_of_timesteps()  # get list of timesteps for which recurrent files exist
+            if len(r_timestep_list) < recur_time_series.number_of_timestamps():
+                log.error('insufficient number of reporting timesteps; skipping recurrent data for realisation ' +
+                          str(realisation))
+            else:
+                common_recur_prop_set = None
+                for tni in range(recur_time_series.number_of_timestamps()):
+                    if timestep_selection in ['all', 'first']:
+                        timestep_number = timestep_list[tni]
+                        r_timestep_number = r_timestep_list[tni]
+                    elif timestep_selection == 'last' or tni > 0:
+                        timestep_number = timestep_list[-1]
+                        r_timestep_number = r_timestep_list[-1]
+                    else:
+                        timestep_number = timestep_list[0]
+                        r_timestep_number = r_timestep_list[0]
+                    stamp = full_time_series.timestamp(timestep_number)
+                    recur_prop_list = vdbase.list_of_recurrent_properties(r_timestep_number)
+                    if common_recur_prop_set is None:
+                        common_recur_prop_set = set(recur_prop_list)
+                    elif recur_prop_list is not None:
+                        common_recur_prop_set = common_recur_prop_set.intersection(set(recur_prop_list))
+                    step_import_collection = rp.GridPropertyCollection()
+                    step_import_collection.set_grid(grid)
+                    # for each property for this timestep, cache array and add to recur prop import collection for this time step
+                    if recur_prop_list:
+                        for keyword in recur_prop_list:
+                            if not keyword or not keyword.isalnum():
+                                continue
+                            if keyword_list is not None and keyword not in keyword_list:
+                                continue
+                            if property_kind_list is not None:
+                                prop_kind, _, _ = rp.property_kind_and_facet_from_keyword(keyword)
+                                if prop_kind not in property_kind_list:
+                                    continue
+                            step_import_collection.import_vdb_recurrent_property_to_cache(
+                                vdbase,
+                                r_timestep_number,
+                                keyword,
+                                time_index = tni,  # index into recur_time_series
+                                realization = realisation)
+                    if decoarsen_array is not None:
+                        step_import_collection.decoarsen_imported_list(decoarsen_array = decoarsen_array)
+                    # extend hdf5 with cached arrays for this timestep
+        #         log.info('number of recurrent grid property arrays for timestep: ' + str(timestep_number) +
+        #                  ' is: ' + str(step_import_collection.number_of_imports()))
+        #         log.info('extending hdf5 file with recurrent properties for timestep: ' + str(timestep_number))
+                    grid.write_hdf5_from_caches(hdf5_file,
+                                                mode = 'a',
+                                                geometry = False,
+                                                imported_properties = step_import_collection,
+                                                write_active = False)
+                    # add imported list for this timestep to full imported list
+                    prop_import_collection.inherit_imported_list_from_other_collection(step_import_collection)
+                    #         log.debug('total number of property arrays after timestep: ' + str(timestep_number) +
+                    #                   ' is: ' + str(prop_import_collection.number_of_imports()))
+                    # remove cached copies of arrays
+                    step_import_collection.remove_all_cached_arrays()
 
-      if create_property_set_per_realization:
-         prop_import_collection.create_property_set_xml('property set for realization ' + str(realisation))
+        if len(prop_import_collection.imported_list) == 0:
+            log.warning('no properties imported for realisation ' + str(realisation))
+            continue
 
-      if complete_collection is not None:
-         complete_collection.inherit_parts_from_other_collection(prop_import_collection)
+        prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(ext_uuid,
+                                                                                   time_series_uuid = recur_ts_uuid)
 
-   if complete_collection is not None:
-      if create_property_set_per_timestep and recur_time_series is not None:
-         for tni in range(recur_time_series.number_of_timestamps()):
-            ts_collection = rp.selective_version_of_collection(complete_collection, time_index = tni)
-            if ts_collection.number_of_parts() > 0:
-               ts_collection.create_property_set_xml('property set for time index ' + str(tni))
-      if create_complete_property_set:
-         complete_collection.create_property_set_xml('property set for ensemble vdb import')
+        if create_property_set_per_realization:
+            prop_import_collection.create_property_set_xml('property set for realization ' + str(realisation))
 
-   # mark model as modified (will already have happened anyway)
-   model.set_modified()
+        if complete_collection is not None:
+            complete_collection.inherit_parts_from_other_collection(prop_import_collection)
 
-   # rewrite epc file
-   log.info('storing updated model in epc file ' + epc_file)
-   model.store_epc(epc_file)
+    if complete_collection is not None:
+        if create_property_set_per_timestep and recur_time_series is not None:
+            for tni in range(recur_time_series.number_of_timestamps()):
+                ts_collection = rp.selective_version_of_collection(complete_collection, time_index = tni)
+                if ts_collection.number_of_parts() > 0:
+                    ts_collection.create_property_set_xml('property set for time index ' + str(tni))
+        if create_complete_property_set:
+            complete_collection.create_property_set_xml('property set for ensemble vdb import')
 
-   if progress_fn is not None:
-      progress_fn(1.0)
+    # mark model as modified (will already have happened anyway)
+    model.set_modified()
 
-   # return updated resqml model
-   return model
+    # rewrite epc file
+    log.info('storing updated model in epc file ' + epc_file)
+    model.store_epc(epc_file)
+
+    if progress_fn is not None:
+        progress_fn(1.0)
+
+    # return updated resqml model
+    return model
 
 
 def add_ab_properties(
-   epc_file,  # existing resqml model
-   grid_uuid = None,  # optional grid uuid, required if more than one grid in model; todo: handle list of grids?
-   ext_uuid = None,  # if None, hdf5 file holding grid geometry will be used
-   ab_property_list = None
+    epc_file,  # existing resqml model
+    grid_uuid = None,  # optional grid uuid, required if more than one grid in model; todo: handle list of grids?
+    ext_uuid = None,  # if None, hdf5 file holding grid geometry will be used
+    ab_property_list = None
 ):  # list of (file_name, keyword, property_kind, facet_type, facet, uom, time_index, null_value,
-   #          discrete, realization)
-   """Process a list of pure binary property array files, adding as parts of model, related to grid (hdf5 file is appended to)."""
+    #          discrete, realization)
+    """Process a list of pure binary property array files, adding as parts of model, related to grid (hdf5 file is appended to)."""
 
-   assert ab_property_list, 'property list is empty or missing'
+    assert ab_property_list, 'property list is empty or missing'
 
-   model = rq.Model(epc_file = epc_file)
-   if grid_uuid is None:
-      grid_node = model.root_for_ijk_grid()  # will raise an exception if Model has more than 1 grid
-      assert grid_node is not None, 'grid not found in model'
-      grid_uuid = rqet.uuid_for_part_root(grid_node)
-   grid = grr.any_grid(parent_model = model, uuid = grid_uuid, find_properties = False)
+    model = rq.Model(epc_file = epc_file)
+    if grid_uuid is None:
+        grid_node = model.root_for_ijk_grid()  # will raise an exception if Model has more than 1 grid
+        assert grid_node is not None, 'grid not found in model'
+        grid_uuid = rqet.uuid_for_part_root(grid_node)
+    grid = grr.any_grid(parent_model = model, uuid = grid_uuid, find_properties = False)
 
-   if ext_uuid is None:
-      ext_node = rqet.find_nested_tags(grid.geometry_root, ['Points', 'Coordinates', 'HdfProxy', 'UUID'])
-      if ext_node is not None:
-         ext_uuid = bu.uuid_from_string(ext_node.text.strip())
+    if ext_uuid is None:
+        ext_node = rqet.find_nested_tags(grid.geometry_root, ['Points', 'Coordinates', 'HdfProxy', 'UUID'])
+        if ext_node is not None:
+            ext_uuid = bu.uuid_from_string(ext_node.text.strip())
 
-   #  ab_property_list: list of (filename, keyword, property_kind, facet_type, facet, uom, time_index, null_value, discrete, realization)
-   prop_import_collection = rp.GridPropertyCollection()
-   prop_import_collection.set_grid(grid)
-   for (p_filename, p_keyword, p_property_kind, p_facet_type, p_facet, p_uom, p_time_index, p_null_value, p_discrete,
-        p_realization) in ab_property_list:
-      prop_import_collection.import_ab_property_to_cache(p_filename,
-                                                         p_keyword,
-                                                         grid.extent_kji,
-                                                         discrete = p_discrete,
-                                                         uom = p_uom,
-                                                         time_index = p_time_index,
-                                                         null_value = p_null_value,
-                                                         property_kind = p_property_kind,
-                                                         facet_type = p_facet_type,
-                                                         facet = p_facet,
-                                                         realization = p_realization)
-      # todo: property_kind, facet_type & facet are not currently getting passed through the imported_list tuple in resqml_property
+    #  ab_property_list: list of (filename, keyword, property_kind, facet_type, facet, uom, time_index, null_value, discrete, realization)
+    prop_import_collection = rp.GridPropertyCollection()
+    prop_import_collection.set_grid(grid)
+    for (p_filename, p_keyword, p_property_kind, p_facet_type, p_facet, p_uom, p_time_index, p_null_value, p_discrete,
+         p_realization) in ab_property_list:
+        prop_import_collection.import_ab_property_to_cache(p_filename,
+                                                           p_keyword,
+                                                           grid.extent_kji,
+                                                           discrete = p_discrete,
+                                                           uom = p_uom,
+                                                           time_index = p_time_index,
+                                                           null_value = p_null_value,
+                                                           property_kind = p_property_kind,
+                                                           facet_type = p_facet_type,
+                                                           facet = p_facet,
+                                                           realization = p_realization)
+        # todo: property_kind, facet_type & facet are not currently getting passed through the imported_list tuple in resqml_property
 
-   if prop_import_collection is None:
-      log.warning('no pure binary grid properties to import')
-   else:
-      log.info('number of pure binary grid property arrays: ' + str(prop_import_collection.number_of_imports()))
+    if prop_import_collection is None:
+        log.warning('no pure binary grid properties to import')
+    else:
+        log.info('number of pure binary grid property arrays: ' + str(prop_import_collection.number_of_imports()))
 
-   # append to hdf5 file using arrays cached in grid property collection above
-   hdf5_file = model.h5_file_name()
-   log.debug('appending to hdf5 file: ' + hdf5_file)
-   grid.write_hdf5_from_caches(hdf5_file,
-                               mode = 'a',
-                               geometry = False,
-                               imported_properties = prop_import_collection,
-                               write_active = False)
-   # remove cached static property arrays from memory
-   if prop_import_collection is not None:
-      prop_import_collection.remove_all_cached_arrays()
+    # append to hdf5 file using arrays cached in grid property collection above
+    hdf5_file = model.h5_file_name()
+    log.debug('appending to hdf5 file: ' + hdf5_file)
+    grid.write_hdf5_from_caches(hdf5_file,
+                                mode = 'a',
+                                geometry = False,
+                                imported_properties = prop_import_collection,
+                                write_active = False)
+    # remove cached static property arrays from memory
+    if prop_import_collection is not None:
+        prop_import_collection.remove_all_cached_arrays()
 
-   # add imported properties parts to model, building property parts list
-   if prop_import_collection is not None and prop_import_collection.imported_list is not None:
-      prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(ext_uuid)
+    # add imported properties parts to model, building property parts list
+    if prop_import_collection is not None and prop_import_collection.imported_list is not None:
+        prop_import_collection.create_xml_for_imported_list_and_add_parts_to_model(ext_uuid)
 
-   # mark model as modified
-   model.set_modified()
+    # mark model as modified
+    model.set_modified()
 
-   # store new version of model
-   log.info('storing model with additional properties in epc file: ' + epc_file)
-   model.store_epc(epc_file)
+    # store new version of model
+    log.info('storing model with additional properties in epc file: ' + epc_file)
+    model.store_epc(epc_file)
 
-   return model
+    return model
 
 
 def add_surfaces(
-   epc_file,  # existing resqml model
-   crs_uuid = None,  # optional crs uuid, defaults to crs associated with model (usually main grid crs)
-   ext_uuid = None,  # if None, uuid for hdf5 file holding main grid geometry will be used
-   surface_file_format = 'zmap',  # zmap, rms (roxar) or GOCAD-Tsurf only formats currently supported
-   rq_class = 'surface',  # 'surface' or 'mesh': the class of object to be created
-   surface_role = 'map',  # 'map' or 'pick'
-   quad_triangles = False,  # if True, 4 triangles per quadrangle will be used for mesh formats, otherwise 2
-   surface_file_list = None,  # list of full file names (paths), each holding one surface
-   make_horizon_interpretations_and_features = True):  # if True, feature and interpretation objects are created
-   """Process a list of surface files, adding each surface as a new part in the resqml model."""
+    epc_file,  # existing resqml model
+    crs_uuid = None,  # optional crs uuid, defaults to crs associated with model (usually main grid crs)
+    ext_uuid = None,  # if None, uuid for hdf5 file holding main grid geometry will be used
+    surface_file_format = 'zmap',  # zmap, rms (roxar) or GOCAD-Tsurf only formats currently supported
+    rq_class = 'surface',  # 'surface' or 'mesh': the class of object to be created
+    surface_role = 'map',  # 'map' or 'pick'
+    quad_triangles = False,  # if True, 4 triangles per quadrangle will be used for mesh formats, otherwise 2
+    surface_file_list = None,  # list of full file names (paths), each holding one surface
+    make_horizon_interpretations_and_features = True):  # if True, feature and interpretation objects are created
+    """Process a list of surface files, adding each surface as a new part in the resqml model."""
 
-   assert surface_file_list, 'surface file list is empty or missing'
-   assert surface_file_format in ['zmap', 'rms', 'roxar',
-                                  'GOCAD-Tsurf'], 'unsupported surface file format: ' + str(surface_file_format)
-   if 'TriangulatedSet' in rq_class:
-      rq_class = 'surface'
-   elif 'Grid2d' in rq_class:
-      rq_class = 'mesh'
-   assert rq_class in ['surface', 'mesh']
+    assert surface_file_list, 'surface file list is empty or missing'
+    assert surface_file_format in ['zmap', 'rms', 'roxar',
+                                   'GOCAD-Tsurf'], 'unsupported surface file format: ' + str(surface_file_format)
+    if 'TriangulatedSet' in rq_class:
+        rq_class = 'surface'
+    elif 'Grid2d' in rq_class:
+        rq_class = 'mesh'
+    assert rq_class in ['surface', 'mesh']
 
-   log.info('accessing existing resqml model from: ' + epc_file)
-   model = rq.Model(epc_file = epc_file)
-   assert model, 'failed to read existing resqml model from file: ' + epc_file
+    log.info('accessing existing resqml model from: ' + epc_file)
+    model = rq.Model(epc_file = epc_file)
+    assert model, 'failed to read existing resqml model from file: ' + epc_file
 
-   if crs_uuid is None:
-      assert model.crs_root is not None, 'no crs uuid given and no default in model'
-      crs_uuid = rqet.uuid_for_part_root(model.crs_root)
-      assert crs_uuid is not None
-   crs_root = model.root_for_uuid(crs_uuid)
+    if crs_uuid is None:
+        assert model.crs_root is not None, 'no crs uuid given and no default in model'
+        crs_uuid = rqet.uuid_for_part_root(model.crs_root)
+        assert crs_uuid is not None
+    crs_root = model.root_for_uuid(crs_uuid)
 
-   if ext_uuid is None:
-      ext_uuid = model.h5_uuid()
-   if ext_uuid is None:  # no pre-existing hdf5 part or references in model
-      hdf5_file = epc_file[:-4] + '.h5'
-      ext_node = model.create_hdf5_ext(file_name = hdf5_file)
-      ext_uuid = rqet.uuid_for_part_root(ext_node)
-      h5_mode = 'w'
-   else:
-      hdf5_file = model.h5_file_name(uuid = ext_uuid)
-      h5_mode = 'a'
+    if ext_uuid is None:
+        ext_uuid = model.h5_uuid()
+    if ext_uuid is None:  # no pre-existing hdf5 part or references in model
+        hdf5_file = epc_file[:-4] + '.h5'
+        ext_node = model.create_hdf5_ext(file_name = hdf5_file)
+        ext_uuid = rqet.uuid_for_part_root(ext_node)
+        h5_mode = 'w'
+    else:
+        hdf5_file = model.h5_file_name(uuid = ext_uuid)
+        h5_mode = 'a'
 
-   assert ext_uuid is not None, 'failed to establish hdf5 uuid'
+    assert ext_uuid is not None, 'failed to establish hdf5 uuid'
 
-   # append to hdf5 file using arrays from Surface object's patch(es)
-   log.info('will append to hdf5 file: ' + hdf5_file)
+    # append to hdf5 file using arrays from Surface object's patch(es)
+    log.info('will append to hdf5 file: ' + hdf5_file)
 
-   for surf_file in surface_file_list:
+    for surf_file in surface_file_list:
 
-      _, short_name = os.path.split(surf_file)
-      dot = short_name.rfind('.')
-      if dot > 0:
-         short_name = short_name[:dot]
+        _, short_name = os.path.split(surf_file)
+        dot = short_name.rfind('.')
+        if dot > 0:
+            short_name = short_name[:dot]
 
-      log.info('surface ' + short_name + ' processing file: ' + surf_file + ' using format: ' + surface_file_format)
-      if rq_class == 'surface':
-         if surface_file_format == 'GOCAD-Tsurf':
-            surface = rqs.Surface(model,
-                                  tsurf_file = surf_file,
-                                  surface_role = surface_role,
-                                  quad_triangles = quad_triangles)
-         else:
-            surface = rqs.Surface(model,
-                                  mesh_file = surf_file,
-                                  mesh_format = surface_file_format,
-                                  surface_role = surface_role,
-                                  quad_triangles = quad_triangles)
-      elif rq_class == 'mesh':
-         if surface_file_format == 'GOCAD-Tsurf':
-            log.info(f"Cannot convert a GOCAD-Tsurf to mesh, only to TriangulatedSurface - skipping file {surf_file}")
-            break
-         else:
-            surface = rqs.Mesh(model,
-                               mesh_file = surf_file,
-                               mesh_format = surface_file_format,
-                               mesh_flavour = 'reg&z',
-                               surface_role = surface_role,
-                               crs_uuid = crs_uuid)
-      else:
-         log.critical('this is impossible')
-      # NB. surface may be either a Surface object or a Mesh object
+        log.info('surface ' + short_name + ' processing file: ' + surf_file + ' using format: ' + surface_file_format)
+        if rq_class == 'surface':
+            if surface_file_format == 'GOCAD-Tsurf':
+                surface = rqs.Surface(model,
+                                      tsurf_file = surf_file,
+                                      surface_role = surface_role,
+                                      quad_triangles = quad_triangles)
+            else:
+                surface = rqs.Surface(model,
+                                      mesh_file = surf_file,
+                                      mesh_format = surface_file_format,
+                                      surface_role = surface_role,
+                                      quad_triangles = quad_triangles)
+        elif rq_class == 'mesh':
+            if surface_file_format == 'GOCAD-Tsurf':
+                log.info(
+                    f"Cannot convert a GOCAD-Tsurf to mesh, only to TriangulatedSurface - skipping file {surf_file}")
+                break
+            else:
+                surface = rqs.Mesh(model,
+                                   mesh_file = surf_file,
+                                   mesh_format = surface_file_format,
+                                   mesh_flavour = 'reg&z',
+                                   surface_role = surface_role,
+                                   crs_uuid = crs_uuid)
+        else:
+            log.critical('this is impossible')
+        # NB. surface may be either a Surface object or a Mesh object
 
-      log.debug('appending to hdf5 file for surface file: ' + surf_file)
-      surface.write_hdf5(hdf5_file, mode = h5_mode)
+        log.debug('appending to hdf5 file for surface file: ' + surf_file)
+        surface.write_hdf5(hdf5_file, mode = h5_mode)
 
-      if make_horizon_interpretations_and_features:
-         feature = rqo.GeneticBoundaryFeature(model, kind = 'horizon', feature_name = short_name)
-         feature.create_xml()
-         interp = rqo.HorizonInterpretation(model, genetic_boundary_feature = feature, domain = 'depth')
-         interp_root = interp.create_xml()
-         surface.set_represented_interpretation_root(interp_root)
+        if make_horizon_interpretations_and_features:
+            feature = rqo.GeneticBoundaryFeature(model, kind = 'horizon', feature_name = short_name)
+            feature.create_xml()
+            interp = rqo.HorizonInterpretation(model, genetic_boundary_feature = feature, domain = 'depth')
+            interp_root = interp.create_xml()
+            surface.set_represented_interpretation_root(interp_root)
 
-      surface.create_xml(ext_uuid,
-                         add_as_part = True,
-                         add_relationships = True,
-                         crs_uuid = rqet.uuid_for_part_root(crs_root),
-                         title = short_name + ' sourced from ' + surf_file,
-                         originator = None)
+        surface.create_xml(ext_uuid,
+                           add_as_part = True,
+                           add_relationships = True,
+                           crs_uuid = rqet.uuid_for_part_root(crs_root),
+                           title = short_name + ' sourced from ' + surf_file,
+                           originator = None)
 
-   # mark model as modified
-   model.set_modified()
+    # mark model as modified
+    model.set_modified()
 
-   # store new version of model
-   log.info('storing model with additional parts in epc file: ' + epc_file)
-   model.store_epc(epc_file)
+    # store new version of model
+    log.info('storing model with additional parts in epc file: ' + epc_file)
+    model.store_epc(epc_file)
 
-   return model
+    return model
 
 
 def grid_from_cp(model,
@@ -1136,400 +1141,403 @@ def grid_from_cp(model,
                  split_tolerance = 0.01,
                  ijk_handedness = 'right',
                  known_to_be_straight = False):
-   """Create a resqpy.grid.Grid object from a 7D corner point array.
+    """Create a resqpy.grid.Grid object from a 7D corner point array.
 
    notes:
       this function sets up all the geometry arrays in memory but does not write to hdf5 nor create xml: use Grid methods;
       geometry_defined_everywhere is deprecated, use treat_as_nan instead
    """
 
-   if treat_as_nan is None:
-      if not geometry_defined_everywhere:
-         treat_as_nan = 'morse'
-   else:
-      assert treat_as_nan in ['none', 'dots', 'ij_dots', 'morse', 'inactive']
-      if treat_as_nan == 'none':
-         treat_as_nan = None
-   geometry_defined_everywhere = (treat_as_nan is None)
+    if treat_as_nan is None:
+        if not geometry_defined_everywhere:
+            treat_as_nan = 'morse'
+    else:
+        assert treat_as_nan in ['none', 'dots', 'ij_dots', 'morse', 'inactive']
+        if treat_as_nan == 'none':
+            treat_as_nan = None
+    geometry_defined_everywhere = (treat_as_nan is None)
 
-   assert cp_array.ndim == 7
-   nk, nj, ni = cp_array.shape[:3]
-   nk_plus_1 = nk + 1
-   nj_plus_1 = nj + 1
-   ni_plus_1 = ni + 1
+    assert cp_array.ndim == 7
+    nk, nj, ni = cp_array.shape[:3]
+    nk_plus_1 = nk + 1
+    nj_plus_1 = nj + 1
+    ni_plus_1 = ni + 1
 
-   if active_mask is None:
-      active_mask = np.ones((nk, nj, ni), dtype = 'bool')
-      inactive_mask = np.zeros((nk, nj, ni), dtype = 'bool')
-   else:
-      assert active_mask.shape == (nk, nj, ni)
-      inactive_mask = np.logical_not(active_mask)
-   all_active = np.all(active_mask)
+    if active_mask is None:
+        active_mask = np.ones((nk, nj, ni), dtype = 'bool')
+        inactive_mask = np.zeros((nk, nj, ni), dtype = 'bool')
+    else:
+        assert active_mask.shape == (nk, nj, ni)
+        inactive_mask = np.logical_not(active_mask)
+    all_active = np.all(active_mask)
 
-   if all_active and geometry_defined_everywhere:
-      cp_nan_mask = None
-   else:
-      cp_nan_mask = np.any(np.isnan(cp_array), axis = (3, 4, 5, 6))  # ie. if any nan per cell
-      if not geometry_defined_everywhere and not all_active:
-         if treat_as_nan == 'inactive':
-            log.debug('all inactive cell geometry being set to NaN')
-            cp_nan_mask = np.logical_or(cp_nan_mask, inactive_mask)
-         else:
-            if treat_as_nan == 'dots':
-               # for speed, only check primary diagonal of cells
-               log.debug('geometry for cells with no length to primary cell diagonal being set to NaN')
-               dot_mask = np.all(np.abs(cp_array[:, :, :, 1, 1, 1] - cp_array[:, :, :, 0, 0, 0]) < dot_tolerance,
-                                 axis = -1)
-            elif treat_as_nan in ['ij_dots', 'morse']:
-               # check one diagonal of each I & J face
-               log.debug(
-                  'geometry being set to NaN for inactive cells with no length to primary face diagonal for any I or J face'
-               )
-               dot_mask = np.zeros((nk, nj, ni), dtype = bool)
-               #              k_face_vecs = cp_array[:, :, :, :, 1, 1] - cp_array[:, :, :, :, 0, 0]
-               j_face_vecs = cp_array[:, :, :, 1, :, 1] - cp_array[:, :, :, 0, :, 0]
-               i_face_vecs = cp_array[:, :, :, 1, 1, :] - cp_array[:, :, :, 0, 0, :]
-               dot_mask[:] = np.where(np.all(np.abs(j_face_vecs[:, :, :, 0]) < dot_tolerance, axis = -1), True,
-                                      dot_mask)
-               dot_mask[:] = np.where(np.all(np.abs(j_face_vecs[:, :, :, 1]) < dot_tolerance, axis = -1), True,
-                                      dot_mask)
-               dot_mask[:] = np.where(np.all(np.abs(i_face_vecs[:, :, :, 0]) < dot_tolerance, axis = -1), True,
-                                      dot_mask)
-               dot_mask[:] = np.where(np.all(np.abs(i_face_vecs[:, :, :, 1]) < dot_tolerance, axis = -1), True,
-                                      dot_mask)
-               log.debug(f'dot mask set for {np.count_nonzero(dot_mask)} cells')
-               if treat_as_nan == 'morse':
-                  morse_tol_sqr = morse_tolerance * morse_tolerance
-                  # compare face vecs lengths in xy against max for active cells: where much greater set to NaN
-                  len_j_face_vecs_sqr = np.sum(j_face_vecs[..., :2] * j_face_vecs[..., :2], axis = -1)
-                  len_i_face_vecs_sqr = np.sum(j_face_vecs[..., :2] * i_face_vecs[..., :2], axis = -1)
-                  dead_mask = inactive_mask.reshape(nk, nj, ni, 1).repeat(2, -1)
-                  #                  mean_len_active_j_face_vecs_sqr = np.mean(ma.masked_array(len_j_face_vecs_sqr, mask = dead_mask))
-                  #                  mean_len_active_i_face_vecs_sqr = np.mean(ma.masked_array(len_i_face_vecs_sqr, mask = dead_mask))
-                  max_len_active_j_face_vecs_sqr = np.max(ma.masked_array(len_j_face_vecs_sqr, mask = dead_mask))
-                  max_len_active_i_face_vecs_sqr = np.max(ma.masked_array(len_i_face_vecs_sqr, mask = dead_mask))
-                  dot_mask = np.where(
-                     np.any(len_j_face_vecs_sqr > morse_tol_sqr * max_len_active_j_face_vecs_sqr, axis = -1), True,
-                     dot_mask)
-                  dot_mask = np.where(
-                     np.any(len_i_face_vecs_sqr > morse_tol_sqr * max_len_active_i_face_vecs_sqr, axis = -1), True,
-                     dot_mask)
-                  log.debug(f'morse mask set for {np.count_nonzero(dot_mask)} cells')
+    if all_active and geometry_defined_everywhere:
+        cp_nan_mask = None
+    else:
+        cp_nan_mask = np.any(np.isnan(cp_array), axis = (3, 4, 5, 6))  # ie. if any nan per cell
+        if not geometry_defined_everywhere and not all_active:
+            if treat_as_nan == 'inactive':
+                log.debug('all inactive cell geometry being set to NaN')
+                cp_nan_mask = np.logical_or(cp_nan_mask, inactive_mask)
             else:
-               raise Exception('code broken')
-            cp_nan_mask = np.logical_or(cp_nan_mask, np.logical_and(inactive_mask, dot_mask))
-      geometry_defined_everywhere = not np.any(cp_nan_mask)
-      if geometry_defined_everywhere:
-         cp_nan_mask = None
+                if treat_as_nan == 'dots':
+                    # for speed, only check primary diagonal of cells
+                    log.debug('geometry for cells with no length to primary cell diagonal being set to NaN')
+                    dot_mask = np.all(np.abs(cp_array[:, :, :, 1, 1, 1] - cp_array[:, :, :, 0, 0, 0]) < dot_tolerance,
+                                      axis = -1)
+                elif treat_as_nan in ['ij_dots', 'morse']:
+                    # check one diagonal of each I & J face
+                    log.debug(
+                        'geometry being set to NaN for inactive cells with no length to primary face diagonal for any I or J face'
+                    )
+                    dot_mask = np.zeros((nk, nj, ni), dtype = bool)
+                    #              k_face_vecs = cp_array[:, :, :, :, 1, 1] - cp_array[:, :, :, :, 0, 0]
+                    j_face_vecs = cp_array[:, :, :, 1, :, 1] - cp_array[:, :, :, 0, :, 0]
+                    i_face_vecs = cp_array[:, :, :, 1, 1, :] - cp_array[:, :, :, 0, 0, :]
+                    dot_mask[:] = np.where(np.all(np.abs(j_face_vecs[:, :, :, 0]) < dot_tolerance, axis = -1), True,
+                                           dot_mask)
+                    dot_mask[:] = np.where(np.all(np.abs(j_face_vecs[:, :, :, 1]) < dot_tolerance, axis = -1), True,
+                                           dot_mask)
+                    dot_mask[:] = np.where(np.all(np.abs(i_face_vecs[:, :, :, 0]) < dot_tolerance, axis = -1), True,
+                                           dot_mask)
+                    dot_mask[:] = np.where(np.all(np.abs(i_face_vecs[:, :, :, 1]) < dot_tolerance, axis = -1), True,
+                                           dot_mask)
+                    log.debug(f'dot mask set for {np.count_nonzero(dot_mask)} cells')
+                    if treat_as_nan == 'morse':
+                        morse_tol_sqr = morse_tolerance * morse_tolerance
+                        # compare face vecs lengths in xy against max for active cells: where much greater set to NaN
+                        len_j_face_vecs_sqr = np.sum(j_face_vecs[..., :2] * j_face_vecs[..., :2], axis = -1)
+                        len_i_face_vecs_sqr = np.sum(j_face_vecs[..., :2] * i_face_vecs[..., :2], axis = -1)
+                        dead_mask = inactive_mask.reshape(nk, nj, ni, 1).repeat(2, -1)
+                        #                  mean_len_active_j_face_vecs_sqr = np.mean(ma.masked_array(len_j_face_vecs_sqr, mask = dead_mask))
+                        #                  mean_len_active_i_face_vecs_sqr = np.mean(ma.masked_array(len_i_face_vecs_sqr, mask = dead_mask))
+                        max_len_active_j_face_vecs_sqr = np.max(ma.masked_array(len_j_face_vecs_sqr, mask = dead_mask))
+                        max_len_active_i_face_vecs_sqr = np.max(ma.masked_array(len_i_face_vecs_sqr, mask = dead_mask))
+                        dot_mask = np.where(
+                            np.any(len_j_face_vecs_sqr > morse_tol_sqr * max_len_active_j_face_vecs_sqr, axis = -1),
+                            True, dot_mask)
+                        dot_mask = np.where(
+                            np.any(len_i_face_vecs_sqr > morse_tol_sqr * max_len_active_i_face_vecs_sqr, axis = -1),
+                            True, dot_mask)
+                        log.debug(f'morse mask set for {np.count_nonzero(dot_mask)} cells')
+                else:
+                    raise Exception('code broken')
+                cp_nan_mask = np.logical_or(cp_nan_mask, np.logical_and(inactive_mask, dot_mask))
+        geometry_defined_everywhere = not np.any(cp_nan_mask)
+        if geometry_defined_everywhere:
+            cp_nan_mask = None
 
-   if cp_nan_mask is not None:
-      inactive_mask = np.logical_or(inactive_mask, cp_nan_mask)
-      active_mask = np.logical_not(inactive_mask)
+    if cp_nan_mask is not None:
+        inactive_mask = np.logical_or(inactive_mask, cp_nan_mask)
+        active_mask = np.logical_not(inactive_mask)
 
-   # set up masked version of corner point data based on cells with defined geometry
-   if geometry_defined_everywhere:
-      full_mask = None
-      masked_cp_array = ma.masked_array(cp_array, mask = ma.nomask)
-      log.info('geometry present for all cells')
-   else:
-      full_mask = cp_nan_mask.reshape((nk, nj, ni, 1)).repeat(24, axis = 3).reshape((nk, nj, ni, 2, 2, 2, 3))
-      masked_cp_array = ma.masked_array(cp_array, mask = full_mask)
-      log.info('number of cells without geometry: ' + str(np.count_nonzero(cp_nan_mask)))
+    # set up masked version of corner point data based on cells with defined geometry
+    if geometry_defined_everywhere:
+        full_mask = None
+        masked_cp_array = ma.masked_array(cp_array, mask = ma.nomask)
+        log.info('geometry present for all cells')
+    else:
+        full_mask = cp_nan_mask.reshape((nk, nj, ni, 1)).repeat(24, axis = 3).reshape((nk, nj, ni, 2, 2, 2, 3))
+        masked_cp_array = ma.masked_array(cp_array, mask = full_mask)
+        log.info('number of cells without geometry: ' + str(np.count_nonzero(cp_nan_mask)))
 
-   # convert to resqml
+    # convert to resqml
 
-   k_gaps = None
-   k_gap_after_layer = None
-   k_gap_raw_index = None
+    k_gaps = None
+    k_gap_after_layer = None
+    k_gap_raw_index = None
 
-   if nk > 1:
-      # check for (vertical) voids, or un-pillar-like anomalies, which will require k gaps in the resqml ijk grid
-      log.debug('checking for voids')
-      gap = masked_cp_array[1:, :, :, 0, :, :, :] - masked_cp_array[:-1, :, :, 1, :, :, :]
-      max_gap_by_layer_and_xyz = np.max(np.abs(gap), axis = (1, 2, 3, 4))
-      max_gap = np.max(max_gap_by_layer_and_xyz)
-      log.debug('maximum void distance: {0:.3f}'.format(max_gap))
-      if max_gap > max_z_void:
-         log.warning('maximum void distance exceeds limit, grid will include k gaps')
-         k_gaps = 0
-         k_gap_after_layer = np.zeros((nk - 1,), dtype = bool)
-         k_gap_raw_index = np.empty((nk,), dtype = int)
-         k_gap_raw_index[0] = 0
-         for k in range(nk - 1):
-            max_layer_gap = np.max(max_gap_by_layer_and_xyz[k])
-            if max_layer_gap > max_z_void:
-               k_gap_after_layer[k] = True
-               k_gaps += 1
-            elif max_layer_gap > 0.0:
-               # close void (includes shifting x & y)
-               log.debug('closing void below layer (0 based): ' + str(k))
-               layer_gap = gap[k] * 0.5
-               layer_gap_unmasked = np.where(gap[k].mask, 0.0, layer_gap)
-               masked_cp_array[k + 1, :, :, 0, :, :, :] -= layer_gap_unmasked
-               masked_cp_array[k, :, :, 1, :, :, :] += layer_gap_unmasked
-            k_gap_raw_index[k + 1] = k + k_gaps
-      elif max_gap > 0.0:
-         # close voids (includes shifting x & y)
-         log.debug('closing voids')
-         gap *= 0.5
-         gap_unmasked = np.where(gap.mask, 0.0, gap)
-         masked_cp_array[1:, :, :, 0, :, :, :] -= gap_unmasked
-         masked_cp_array[:-1, :, :, 1, :, :, :] += gap_unmasked
+    if nk > 1:
+        # check for (vertical) voids, or un-pillar-like anomalies, which will require k gaps in the resqml ijk grid
+        log.debug('checking for voids')
+        gap = masked_cp_array[1:, :, :, 0, :, :, :] - masked_cp_array[:-1, :, :, 1, :, :, :]
+        max_gap_by_layer_and_xyz = np.max(np.abs(gap), axis = (1, 2, 3, 4))
+        max_gap = np.max(max_gap_by_layer_and_xyz)
+        log.debug('maximum void distance: {0:.3f}'.format(max_gap))
+        if max_gap > max_z_void:
+            log.warning('maximum void distance exceeds limit, grid will include k gaps')
+            k_gaps = 0
+            k_gap_after_layer = np.zeros((nk - 1,), dtype = bool)
+            k_gap_raw_index = np.empty((nk,), dtype = int)
+            k_gap_raw_index[0] = 0
+            for k in range(nk - 1):
+                max_layer_gap = np.max(max_gap_by_layer_and_xyz[k])
+                if max_layer_gap > max_z_void:
+                    k_gap_after_layer[k] = True
+                    k_gaps += 1
+                elif max_layer_gap > 0.0:
+                    # close void (includes shifting x & y)
+                    log.debug('closing void below layer (0 based): ' + str(k))
+                    layer_gap = gap[k] * 0.5
+                    layer_gap_unmasked = np.where(gap[k].mask, 0.0, layer_gap)
+                    masked_cp_array[k + 1, :, :, 0, :, :, :] -= layer_gap_unmasked
+                    masked_cp_array[k, :, :, 1, :, :, :] += layer_gap_unmasked
+                k_gap_raw_index[k + 1] = k + k_gaps
+        elif max_gap > 0.0:
+            # close voids (includes shifting x & y)
+            log.debug('closing voids')
+            gap *= 0.5
+            gap_unmasked = np.where(gap.mask, 0.0, gap)
+            masked_cp_array[1:, :, :, 0, :, :, :] -= gap_unmasked
+            masked_cp_array[:-1, :, :, 1, :, :, :] += gap_unmasked
 
-   if k_gaps:
-      nk_plus_1 += k_gaps
-   if k_gap_raw_index is None:
-      k_gap_raw_index = np.arange(nk, dtype = int)
+    if k_gaps:
+        nk_plus_1 += k_gaps
+    if k_gap_raw_index is None:
+        k_gap_raw_index = np.arange(nk, dtype = int)
 
-   # reduce cp array extent in k
-   log.debug('reducing k extent of corner point array (sharing points vertically)')
-   k_reduced_cp_array = ma.masked_array(np.zeros((nk_plus_1, nj, ni, 2, 2, 3)))  # (nk+1+k_gaps, nj, ni, jp, ip, xyz)
-   k_reduced_cp_array[0, :, :, :, :, :] = masked_cp_array[0, :, :, 0, :, :, :]
-   k_reduced_cp_array[-1, :, :, :, :, :] = masked_cp_array[-1, :, :, 1, :, :, :]
-   if k_gaps:
-      raw_k = 1
-      for k in range(nk - 1):
-         # fill reduced array slice(s) for base of layer k and top of layer k + 1
-         if k_gap_after_layer[k]:
-            k_reduced_cp_array[raw_k, :, :, :, :, :] = masked_cp_array[k, :, :, 1, :, :, :]
-            raw_k += 1
-            k_reduced_cp_array[raw_k, :, :, :, :, :] = masked_cp_array[k + 1, :, :, 0, :, :, :]
-            raw_k += 1
-         else:  # take data from either possible cp slice, whichever is defined
-            slice = masked_cp_array[k + 1, :, :, 0, :, :, :]
-            k_reduced_cp_array[raw_k, :, :, :, :, :] = np.where(slice.mask, masked_cp_array[k, :, :, 1, :, :, :], slice)
-            raw_k += 1
-      assert raw_k == nk + k_gaps
-   else:
-      slice = masked_cp_array[1:, :, :, 0, :, :, :]
-      # where cell geometry undefined, if cell above is defined, take data from cell above with kp = 1 and set shared point defined
-      k_reduced_cp_array[1:-1, :, :, :, :, :] = np.where(slice.mask, masked_cp_array[:-1, :, :, 1, :, :, :], slice)
+    # reduce cp array extent in k
+    log.debug('reducing k extent of corner point array (sharing points vertically)')
+    k_reduced_cp_array = ma.masked_array(np.zeros((nk_plus_1, nj, ni, 2, 2, 3)))  # (nk+1+k_gaps, nj, ni, jp, ip, xyz)
+    k_reduced_cp_array[0, :, :, :, :, :] = masked_cp_array[0, :, :, 0, :, :, :]
+    k_reduced_cp_array[-1, :, :, :, :, :] = masked_cp_array[-1, :, :, 1, :, :, :]
+    if k_gaps:
+        raw_k = 1
+        for k in range(nk - 1):
+            # fill reduced array slice(s) for base of layer k and top of layer k + 1
+            if k_gap_after_layer[k]:
+                k_reduced_cp_array[raw_k, :, :, :, :, :] = masked_cp_array[k, :, :, 1, :, :, :]
+                raw_k += 1
+                k_reduced_cp_array[raw_k, :, :, :, :, :] = masked_cp_array[k + 1, :, :, 0, :, :, :]
+                raw_k += 1
+            else:  # take data from either possible cp slice, whichever is defined
+                slice = masked_cp_array[k + 1, :, :, 0, :, :, :]
+                k_reduced_cp_array[raw_k, :, :, :, :, :] = np.where(slice.mask, masked_cp_array[k, :, :, 1, :, :, :],
+                                                                    slice)
+                raw_k += 1
+        assert raw_k == nk + k_gaps
+    else:
+        slice = masked_cp_array[1:, :, :, 0, :, :, :]
+        # where cell geometry undefined, if cell above is defined, take data from cell above with kp = 1 and set shared point defined
+        k_reduced_cp_array[1:-1, :, :, :, :, :] = np.where(slice.mask, masked_cp_array[:-1, :, :, 1, :, :, :], slice)
 
-   # create 2D array of active columns (columns where at least one cell is active)
-   log.debug('creating 2D array of active columns')
-   active_mask_2D = np.any(active_mask, axis = 0)
+    # create 2D array of active columns (columns where at least one cell is active)
+    log.debug('creating 2D array of active columns')
+    active_mask_2D = np.any(active_mask, axis = 0)
 
-   # create primary pillar reference indices as one of four column corners around pillar, active column preferred
-   log.debug('creating primary pillar reference neighbourly indices')
-   primary_pillar_jip = np.zeros((nj_plus_1, ni_plus_1, 2), dtype = 'int')  # (nj + 1, ni + 1, jp:ip)
-   primary_pillar_jip[-1, :, 0] = 1
-   primary_pillar_jip[:, -1, 1] = 1
-   for j in range(nj_plus_1):
-      for i in range(ni_plus_1):
-         if active_mask_2D[j - primary_pillar_jip[j, i, 0], i - primary_pillar_jip[j, i, 1]]:
-            continue
-         if i > 0 and primary_pillar_jip[j, i, 1] == 0 and active_mask_2D[j - primary_pillar_jip[j, i, 0], i - 1]:
-            primary_pillar_jip[j, i, 1] = 1
-            continue
-         if j > 0 and primary_pillar_jip[j, i, 0] == 0 and active_mask_2D[j - 1, i - primary_pillar_jip[j, i, 1]]:
-            primary_pillar_jip[j, i, 0] = 1
-            continue
-         if i > 0 and j > 0 and primary_pillar_jip[j, i,
-                                                   0] == 0 and primary_pillar_jip[j, i,
-                                                                                  1] == 0 and active_mask_2D[j - 1,
-                                                                                                             i - 1]:
-            primary_pillar_jip[j, i, :] = 1
+    # create primary pillar reference indices as one of four column corners around pillar, active column preferred
+    log.debug('creating primary pillar reference neighbourly indices')
+    primary_pillar_jip = np.zeros((nj_plus_1, ni_plus_1, 2), dtype = 'int')  # (nj + 1, ni + 1, jp:ip)
+    primary_pillar_jip[-1, :, 0] = 1
+    primary_pillar_jip[:, -1, 1] = 1
+    for j in range(nj_plus_1):
+        for i in range(ni_plus_1):
+            if active_mask_2D[j - primary_pillar_jip[j, i, 0], i - primary_pillar_jip[j, i, 1]]:
+                continue
+            if i > 0 and primary_pillar_jip[j, i, 1] == 0 and active_mask_2D[j - primary_pillar_jip[j, i, 0], i - 1]:
+                primary_pillar_jip[j, i, 1] = 1
+                continue
+            if j > 0 and primary_pillar_jip[j, i, 0] == 0 and active_mask_2D[j - 1, i - primary_pillar_jip[j, i, 1]]:
+                primary_pillar_jip[j, i, 0] = 1
+                continue
+            if i > 0 and j > 0 and primary_pillar_jip[j, i,
+                                                      0] == 0 and primary_pillar_jip[j, i,
+                                                                                     1] == 0 and active_mask_2D[j - 1,
+                                                                                                                i - 1]:
+                primary_pillar_jip[j, i, :] = 1
 
-   # build extra pillar references for split pillars
-   extras_count = np.zeros((nj_plus_1, ni_plus_1), dtype = 'int')  # count (0 to 3) of extras for pillar
-   extras_list_index = np.zeros((nj_plus_1, ni_plus_1), dtype = 'int')  # index in list of 1st extra for pillar
-   extras_list = []  # list of (jp, ip)
-   extras_use = np.negative(np.ones((nj, ni, 2, 2), dtype = 'int'))  # (j, i, jp, ip); -1 means use primary
-   if split_pillars:
-      log.debug('building extra pillar references for split pillars')
-      # loop over pillars
-      for j in range(nj_plus_1):
-         for i in range(ni_plus_1):
-            primary_jp = primary_pillar_jip[j, i, 0]
-            primary_ip = primary_pillar_jip[j, i, 1]
-            p_col_j = j - primary_jp
-            p_col_i = i - primary_ip
-            # loop over 4 columns surrounding this pillar
+    # build extra pillar references for split pillars
+    extras_count = np.zeros((nj_plus_1, ni_plus_1), dtype = 'int')  # count (0 to 3) of extras for pillar
+    extras_list_index = np.zeros((nj_plus_1, ni_plus_1), dtype = 'int')  # index in list of 1st extra for pillar
+    extras_list = []  # list of (jp, ip)
+    extras_use = np.negative(np.ones((nj, ni, 2, 2), dtype = 'int'))  # (j, i, jp, ip); -1 means use primary
+    if split_pillars:
+        log.debug('building extra pillar references for split pillars')
+        # loop over pillars
+        for j in range(nj_plus_1):
+            for i in range(ni_plus_1):
+                primary_jp = primary_pillar_jip[j, i, 0]
+                primary_ip = primary_pillar_jip[j, i, 1]
+                p_col_j = j - primary_jp
+                p_col_i = i - primary_ip
+                # loop over 4 columns surrounding this pillar
+                for jp in range(2):
+                    col_j = j - jp
+                    if col_j < 0 or col_j >= nj:
+                        continue  # no column this side of pillar in j
+                    for ip in range(2):
+                        col_i = i - ip
+                        if col_i < 0 or col_i >= ni:
+                            continue  # no column this side of pillar in i
+                        if jp == primary_jp and ip == primary_ip:
+                            continue  # this column is the primary for this pillar
+                        discrepancy = np.max(
+                            np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
+                                   k_reduced_cp_array[:, p_col_j, p_col_i, primary_jp, primary_ip, :]))
+                        if discrepancy <= split_tolerance:
+                            continue  # data for this column's corner aligns with primary
+                        for e in range(extras_count[j, i]):
+                            eli = extras_list_index[j, i] + e
+                            pillar_j_extra = j - extras_list[eli][0]
+                            pillar_i_extra = i - extras_list[eli][1]
+                            discrepancy = np.max(
+                                np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
+                                       k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, extras_list[eli][0],
+                                                          extras_list[eli][1], :]))
+                            if discrepancy <= split_tolerance:  # data for this corner aligns with existing extra
+                                extras_use[col_j, col_i, jp, ip] = e
+                                break
+                        if extras_use[col_j, col_i, jp, ip] >= 0:  # reusing an existing extra for this pillar
+                            continue
+                        # add this corner as an extra
+                        if extras_count[j, i] == 0:  # create entry point for this pillar in extras
+                            extras_list_index[j, i] = len(extras_list)
+                        extras_list.append((jp, ip))
+                        extras_use[col_j, col_i, jp, ip] = extras_count[j, i]
+                        extras_count[j, i] += 1
+        if len(extras_list) == 0:
+            split_pillars = False
+        log.debug('number of extra pillars: ' + str(len(extras_list)))
+
+    # create points array as used in resqml
+    log.debug('creating points array as used in resqml format')
+    if split_pillars:
+        points_array = np.zeros(
+            (nk_plus_1, (nj_plus_1 * ni_plus_1) + len(extras_list), 3))  # note: nk_plus_1 might include k_gaps
+        index = 0
+        # primary pillars
+        for pillar_j in range(nj_plus_1):
+            for pillar_i in range(ni_plus_1):
+                (jp, ip) = primary_pillar_jip[pillar_j, pillar_i]
+                slice = k_reduced_cp_array[:, pillar_j - jp, pillar_i - ip, jp, ip, :]
+                points_array[:, index, :] = np.where(slice.mask, np.nan,
+                                                     slice)  # NaN indicates undefined/invalid geometry
+                index += 1
+        # add extras for split pillars
+        for pillar_j in range(nj_plus_1):
+            for pillar_i in range(ni_plus_1):
+                for e in range(extras_count[pillar_j, pillar_i]):
+                    eli = extras_list_index[pillar_j, pillar_i] + e
+                    (jp, ip) = extras_list[eli]
+                    pillar_j_extra = pillar_j - jp
+                    pillar_i_extra = pillar_i - ip
+                    slice = k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, jp, ip, :]
+                    points_array[:, index, :] = np.where(slice.mask, np.nan,
+                                                         slice)  # NaN indicates unedefined/invalid geometry
+                    index += 1
+        assert (index == (nj_plus_1 * ni_plus_1) + len(extras_list))
+    else:  # unsplit pillars
+        points_array = np.zeros((nk_plus_1, nj_plus_1, ni_plus_1, 3))
+        for j in range(nj_plus_1):
+            for i in range(ni_plus_1):
+                (jp, ip) = primary_pillar_jip[j, i]
+                slice = k_reduced_cp_array[:, j - jp, i - ip, jp, ip, :]
+                points_array[:, j, i, :] = np.where(slice.mask, np.nan,
+                                                    slice)  # NaN indicates undefined/invalid geometry
+
+    # create an empty grid object and fill in some basic info
+    log.debug('initialising grid object')
+    grid = grr.Grid(model)
+    grid.grid_representation = 'IjkGrid'
+    grid.extent_kji = np.array((nk, nj, ni), dtype = 'int')
+    grid.nk, grid.nj, grid.ni = nk, nj, ni
+    grid.k_direction_is_down = True  # assumed direction for corp; todo: determine from geometry and crs z_inc_down flag
+    if known_to_be_straight:
+        grid.pillar_shape = 'straight'
+    else:
+        grid.pillar_shape = 'curved'
+    grid.has_split_coordinate_lines = split_pillars
+    grid.k_gaps = k_gaps
+    grid.k_gap_after_array = k_gap_after_layer
+    grid.k_raw_index_array = k_gap_raw_index
+
+    grid.crs_uuid = crs_uuid
+    grid.crs_root = model.root_for_uuid(crs_uuid)
+    crs = rqc.Crs(model, uuid = crs_uuid)
+
+    # add pillar points array to grid object
+    log.debug('attaching points array to grid object')
+    grid.points_cached = points_array  # NB: reference to points_array, array not copied here
+
+    # add split pillar arrays to grid object
+    if split_pillars:
+        log.debug('adding split pillar arrays to grid object')
+        split_pillar_indices_list = []
+        cumulative_length_list = []
+        cols_for_extra_pillar_list = []
+        cumulative_length = 0
+        for pillar_j in range(nj_plus_1):
+            for pillar_i in range(ni_plus_1):
+                for e in range(extras_count[pillar_j, pillar_i]):
+                    split_pillar_indices_list.append((pillar_j * ni_plus_1) + pillar_i)
+                    use_count = 0
+                    for jp in range(2):
+                        j = pillar_j - jp
+                        if j < 0 or j >= nj:
+                            continue
+                        for ip in range(2):
+                            i = pillar_i - ip
+                            if i < 0 or i >= ni:
+                                continue
+                            if extras_use[j, i, jp, ip] == e:
+                                use_count += 1
+                                cols_for_extra_pillar_list.append((j * ni) + i)
+                    assert (use_count > 0)
+                    cumulative_length += use_count
+                    cumulative_length_list.append(cumulative_length)
+        log.debug('number of extra pillars: ' + str(len(split_pillar_indices_list)))
+        assert (len(cumulative_length_list) == len(split_pillar_indices_list))
+        grid.split_pillar_indices_cached = np.array(split_pillar_indices_list, dtype = 'int')
+        log.debug('number of uses of extra pillars: ' + str(len(cols_for_extra_pillar_list)))
+        assert (len(cols_for_extra_pillar_list) == np.count_nonzero(extras_use + 1))
+        assert (len(cols_for_extra_pillar_list) == cumulative_length)
+        grid.cols_for_split_pillars = np.array(cols_for_extra_pillar_list, dtype = 'int')
+        assert (len(cumulative_length_list) == len(extras_list))
+        grid.cols_for_split_pillars_cl = np.array(cumulative_length_list, dtype = 'int')
+        grid.split_pillars_count = len(extras_list)
+
+    # following is not part of resqml standard but is used by resqml_grid module for speed optimisation
+    log.debug('setting up column to pillars mapping')
+    base_pillar_count = nj_plus_1 * ni_plus_1
+    grid.pillars_for_column = np.empty((nj, ni, 2, 2), dtype = 'int')
+    for j in range(nj):
+        for i in range(ni):
             for jp in range(2):
-               col_j = j - jp
-               if col_j < 0 or col_j >= nj:
-                  continue  # no column this side of pillar in j
-               for ip in range(2):
-                  col_i = i - ip
-                  if col_i < 0 or col_i >= ni:
-                     continue  # no column this side of pillar in i
-                  if jp == primary_jp and ip == primary_ip:
-                     continue  # this column is the primary for this pillar
-                  discrepancy = np.max(
-                     np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
-                            k_reduced_cp_array[:, p_col_j, p_col_i, primary_jp, primary_ip, :]))
-                  if discrepancy <= split_tolerance:
-                     continue  # data for this column's corner aligns with primary
-                  for e in range(extras_count[j, i]):
-                     eli = extras_list_index[j, i] + e
-                     pillar_j_extra = j - extras_list[eli][0]
-                     pillar_i_extra = i - extras_list[eli][1]
-                     discrepancy = np.max(
-                        np.abs(k_reduced_cp_array[:, col_j, col_i, jp, ip, :] -
-                               k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, extras_list[eli][0],
-                                                  extras_list[eli][1], :]))
-                     if discrepancy <= split_tolerance:  # data for this corner aligns with existing extra
-                        extras_use[col_j, col_i, jp, ip] = e
-                        break
-                  if extras_use[col_j, col_i, jp, ip] >= 0:  # reusing an existing extra for this pillar
-                     continue
-                  # add this corner as an extra
-                  if extras_count[j, i] == 0:  # create entry point for this pillar in extras
-                     extras_list_index[j, i] = len(extras_list)
-                  extras_list.append((jp, ip))
-                  extras_use[col_j, col_i, jp, ip] = extras_count[j, i]
-                  extras_count[j, i] += 1
-      if len(extras_list) == 0:
-         split_pillars = False
-      log.debug('number of extra pillars: ' + str(len(extras_list)))
+                for ip in range(2):
+                    if not split_pillars or extras_use[j, i, jp, ip] < 0:  # use primary pillar
+                        pillar_index = (j + jp) * ni_plus_1 + i + ip
+                    else:
+                        eli = extras_list_index[j + jp, i + ip] + extras_use[j, i, jp, ip]
+                        pillar_index = base_pillar_count + eli
+                    grid.pillars_for_column[j, i, jp, ip] = pillar_index
 
-   # create points array as used in resqml
-   log.debug('creating points array as used in resqml format')
-   if split_pillars:
-      points_array = np.zeros(
-         (nk_plus_1, (nj_plus_1 * ni_plus_1) + len(extras_list), 3))  # note: nk_plus_1 might include k_gaps
-      index = 0
-      # primary pillars
-      for pillar_j in range(nj_plus_1):
-         for pillar_i in range(ni_plus_1):
-            (jp, ip) = primary_pillar_jip[pillar_j, pillar_i]
-            slice = k_reduced_cp_array[:, pillar_j - jp, pillar_i - ip, jp, ip, :]
-            points_array[:, index, :] = np.where(slice.mask, np.nan, slice)  # NaN indicates undefined/invalid geometry
-            index += 1
-      # add extras for split pillars
-      for pillar_j in range(nj_plus_1):
-         for pillar_i in range(ni_plus_1):
-            for e in range(extras_count[pillar_j, pillar_i]):
-               eli = extras_list_index[pillar_j, pillar_i] + e
-               (jp, ip) = extras_list[eli]
-               pillar_j_extra = pillar_j - jp
-               pillar_i_extra = pillar_i - ip
-               slice = k_reduced_cp_array[:, pillar_j_extra, pillar_i_extra, jp, ip, :]
-               points_array[:, index, :] = np.where(slice.mask, np.nan,
-                                                    slice)  # NaN indicates unedefined/invalid geometry
-               index += 1
-      assert (index == (nj_plus_1 * ni_plus_1) + len(extras_list))
-   else:  # unsplit pillars
-      points_array = np.zeros((nk_plus_1, nj_plus_1, ni_plus_1, 3))
-      for j in range(nj_plus_1):
-         for i in range(ni_plus_1):
-            (jp, ip) = primary_pillar_jip[j, i]
-            slice = k_reduced_cp_array[:, j - jp, i - ip, jp, ip, :]
-            points_array[:, j, i, :] = np.where(slice.mask, np.nan, slice)  # NaN indicates undefined/invalid geometry
+    # add inactive cell mask to grid
+    log.debug('setting inactive cell mask')
+    grid.inactive = inactive_mask.copy()
 
-   # create an empty grid object and fill in some basic info
-   log.debug('initialising grid object')
-   grid = grr.Grid(model)
-   grid.grid_representation = 'IjkGrid'
-   grid.extent_kji = np.array((nk, nj, ni), dtype = 'int')
-   grid.nk, grid.nj, grid.ni = nk, nj, ni
-   grid.k_direction_is_down = True  # assumed direction for corp; todo: determine from geometry and crs z_inc_down flag
-   if known_to_be_straight:
-      grid.pillar_shape = 'straight'
-   else:
-      grid.pillar_shape = 'curved'
-   grid.has_split_coordinate_lines = split_pillars
-   grid.k_gaps = k_gaps
-   grid.k_gap_after_array = k_gap_after_layer
-   grid.k_raw_index_array = k_gap_raw_index
+    # add cell geometry defined array to model (using active cell mask unless geometry_defined_everywhere is True)
+    if geometry_defined_everywhere:
+        grid.geometry_defined_for_all_cells_cached = True
+        grid.array_cell_geometry_is_defined = None
+    else:
+        log.debug('using active cell mask as indicator of defined cell geometry')
+        grid.array_cell_geometry_is_defined = active_mask.copy()  # a bit harsh: disallows reactivation of cells
+        grid.geometry_defined_for_all_cells_cached = np.all(active_mask)
+    grid.geometry_defined_for_all_pillars_cached = True  # following fesapi convention of defining all pillars regardless
+    # note: grid.array_pillar_geometry_is_defined not set, as line above should be sufficient
 
-   grid.crs_uuid = crs_uuid
-   grid.crs_root = model.root_for_uuid(crs_uuid)
-   crs = rqc.Crs(model, uuid = crs_uuid)
+    # tentatively add corner point array to grid object in case it is needed
+    log.debug('noting corner point array in grid')
+    grid.array_corner_points = cp_array
 
-   # add pillar points array to grid object
-   log.debug('attaching points array to grid object')
-   grid.points_cached = points_array  # NB: reference to points_array, array not copied here
+    # set handedness of ijk axes
+    if ijk_handedness is None or ijk_handedness == 'auto':
+        # work out handedness from sample cell / column axes directions and handedness of crs
+        sample_kji0 = tuple(np.array(grid.extent_kji) // 2)
+        if not geometry_defined_everywhere and not grid.array_cell_geometry_is_defined[sample_kji0]:
+            where_defined = np.where(
+                np.logical_and(grid.array_cell_geometry_is_defined, np.logical_not(grid.pinched_out())))
+            assert len(where_defined) == 3 and len(where_defined[0]) > 0, 'no extant cell geometries'
+            sample_kji0 = (where_defined[0][0], where_defined[1][0], where_defined[2][0])
+        sample_cp = cp_array[sample_kji0]
+        cell_ijk_lefthanded = (vec.clockwise(sample_cp[0, 0, 0], sample_cp[0, 1, 0], sample_cp[0, 0, 1]) >= 0.0)
+        if not grid.k_direction_is_down:
+            cell_ijk_lefthanded = not cell_ijk_lefthanded
+        if crs.is_right_handed_xyz():
+            cell_ijk_lefthanded = not cell_ijk_lefthanded
+        grid.grid_is_right_handed = not cell_ijk_lefthanded
+    else:
+        assert ijk_handedness in ['left', 'right']
+        grid.grid_is_right_handed = (ijk_handedness == 'right')
 
-   # add split pillar arrays to grid object
-   if split_pillars:
-      log.debug('adding split pillar arrays to grid object')
-      split_pillar_indices_list = []
-      cumulative_length_list = []
-      cols_for_extra_pillar_list = []
-      cumulative_length = 0
-      for pillar_j in range(nj_plus_1):
-         for pillar_i in range(ni_plus_1):
-            for e in range(extras_count[pillar_j, pillar_i]):
-               split_pillar_indices_list.append((pillar_j * ni_plus_1) + pillar_i)
-               use_count = 0
-               for jp in range(2):
-                  j = pillar_j - jp
-                  if j < 0 or j >= nj:
-                     continue
-                  for ip in range(2):
-                     i = pillar_i - ip
-                     if i < 0 or i >= ni:
-                        continue
-                     if extras_use[j, i, jp, ip] == e:
-                        use_count += 1
-                        cols_for_extra_pillar_list.append((j * ni) + i)
-               assert (use_count > 0)
-               cumulative_length += use_count
-               cumulative_length_list.append(cumulative_length)
-      log.debug('number of extra pillars: ' + str(len(split_pillar_indices_list)))
-      assert (len(cumulative_length_list) == len(split_pillar_indices_list))
-      grid.split_pillar_indices_cached = np.array(split_pillar_indices_list, dtype = 'int')
-      log.debug('number of uses of extra pillars: ' + str(len(cols_for_extra_pillar_list)))
-      assert (len(cols_for_extra_pillar_list) == np.count_nonzero(extras_use + 1))
-      assert (len(cols_for_extra_pillar_list) == cumulative_length)
-      grid.cols_for_split_pillars = np.array(cols_for_extra_pillar_list, dtype = 'int')
-      assert (len(cumulative_length_list) == len(extras_list))
-      grid.cols_for_split_pillars_cl = np.array(cumulative_length_list, dtype = 'int')
-      grid.split_pillars_count = len(extras_list)
-
-   # following is not part of resqml standard but is used by resqml_grid module for speed optimisation
-   log.debug('setting up column to pillars mapping')
-   base_pillar_count = nj_plus_1 * ni_plus_1
-   grid.pillars_for_column = np.empty((nj, ni, 2, 2), dtype = 'int')
-   for j in range(nj):
-      for i in range(ni):
-         for jp in range(2):
-            for ip in range(2):
-               if not split_pillars or extras_use[j, i, jp, ip] < 0:  # use primary pillar
-                  pillar_index = (j + jp) * ni_plus_1 + i + ip
-               else:
-                  eli = extras_list_index[j + jp, i + ip] + extras_use[j, i, jp, ip]
-                  pillar_index = base_pillar_count + eli
-               grid.pillars_for_column[j, i, jp, ip] = pillar_index
-
-   # add inactive cell mask to grid
-   log.debug('setting inactive cell mask')
-   grid.inactive = inactive_mask.copy()
-
-   # add cell geometry defined array to model (using active cell mask unless geometry_defined_everywhere is True)
-   if geometry_defined_everywhere:
-      grid.geometry_defined_for_all_cells_cached = True
-      grid.array_cell_geometry_is_defined = None
-   else:
-      log.debug('using active cell mask as indicator of defined cell geometry')
-      grid.array_cell_geometry_is_defined = active_mask.copy()  # a bit harsh: disallows reactivation of cells
-      grid.geometry_defined_for_all_cells_cached = np.all(active_mask)
-   grid.geometry_defined_for_all_pillars_cached = True  # following fesapi convention of defining all pillars regardless
-   # note: grid.array_pillar_geometry_is_defined not set, as line above should be sufficient
-
-   # tentatively add corner point array to grid object in case it is needed
-   log.debug('noting corner point array in grid')
-   grid.array_corner_points = cp_array
-
-   # set handedness of ijk axes
-   if ijk_handedness is None or ijk_handedness == 'auto':
-      # work out handedness from sample cell / column axes directions and handedness of crs
-      sample_kji0 = tuple(np.array(grid.extent_kji) // 2)
-      if not geometry_defined_everywhere and not grid.array_cell_geometry_is_defined[sample_kji0]:
-         where_defined = np.where(
-            np.logical_and(grid.array_cell_geometry_is_defined, np.logical_not(grid.pinched_out())))
-         assert len(where_defined) == 3 and len(where_defined[0]) > 0, 'no extant cell geometries'
-         sample_kji0 = (where_defined[0][0], where_defined[1][0], where_defined[2][0])
-      sample_cp = cp_array[sample_kji0]
-      cell_ijk_lefthanded = (vec.clockwise(sample_cp[0, 0, 0], sample_cp[0, 1, 0], sample_cp[0, 0, 1]) >= 0.0)
-      if not grid.k_direction_is_down:
-         cell_ijk_lefthanded = not cell_ijk_lefthanded
-      if crs.is_right_handed_xyz():
-         cell_ijk_lefthanded = not cell_ijk_lefthanded
-      grid.grid_is_right_handed = not cell_ijk_lefthanded
-   else:
-      assert ijk_handedness in ['left', 'right']
-      grid.grid_is_right_handed = (ijk_handedness == 'right')
-
-   return grid
+    return grid

--- a/resqpy/strata.py
+++ b/resqpy/strata.py
@@ -21,9 +21,9 @@ from resqpy.olio.base import BaseResqpy
 
 # note: two compositions have a spurious trailing space in the RESQML xsd; resqpy hides this from calling code
 valid_compositions = [
-   'intrusive clay ', 'intrusive clay', 'organic', 'intrusive mud ', 'intrusive mud', 'evaporite salt',
-   'evaporite non salt', 'sedimentary siliclastic', 'carbonate', 'magmatic intrusive granitoid',
-   'magmatic intrusive pyroclastic', 'magmatic extrusive lava flow', 'other chemichal rock', 'sedimentary turbidite'
+    'intrusive clay ', 'intrusive clay', 'organic', 'intrusive mud ', 'intrusive mud', 'evaporite salt',
+    'evaporite non salt', 'sedimentary siliclastic', 'carbonate', 'magmatic intrusive granitoid',
+    'magmatic intrusive pyroclastic', 'magmatic extrusive lava flow', 'other chemichal rock', 'sedimentary turbidite'
 ]
 
 valid_implacements = ['autochtonous', 'allochtonous']
@@ -31,17 +31,17 @@ valid_implacements = ['autochtonous', 'allochtonous']
 valid_domains = ('depth', 'time', 'mixed')
 
 valid_deposition_modes = [
-   'proportional between top and bottom', 'parallel to bottom', 'parallel to top', 'parallel to another boundary'
+    'proportional between top and bottom', 'parallel to bottom', 'parallel to top', 'parallel to another boundary'
 ]
 
 valid_ordering_criteria = ['age', 'apparent depth', 'measured depth']  # stratigraphic column must be ordered by age
 
 valid_contact_relationships = [
-   'frontier feature to frontier feature', 'genetic boundary to frontier feature',
-   'genetic boundary to genetic boundary', 'genetic boundary to tectonic boundary',
-   'stratigraphic unit to frontier feature', 'stratigraphic unit to stratigraphic unit',
-   'tectonic boundary to frontier feature', 'tectonic boundary to genetic boundary',
-   'tectonic boundary to tectonic boundary'
+    'frontier feature to frontier feature', 'genetic boundary to frontier feature',
+    'genetic boundary to genetic boundary', 'genetic boundary to tectonic boundary',
+    'stratigraphic unit to frontier feature', 'stratigraphic unit to stratigraphic unit',
+    'tectonic boundary to frontier feature', 'tectonic boundary to genetic boundary',
+    'tectonic boundary to tectonic boundary'
 ]
 
 valid_contact_verbs = ['splits', 'interrupts', 'contains', 'erodes', 'stops at', 'crosses', 'includes']
@@ -52,7 +52,7 @@ valid_contact_modes = ['baselap', 'erosion', 'extended', 'proportional']
 
 
 class StratigraphicUnitFeature(BaseResqpy):
-   """Class for RESQML Stratigraphic Unit Feature objects.
+    """Class for RESQML Stratigraphic Unit Feature objects.
 
    RESQML documentation:
 
@@ -63,17 +63,17 @@ class StratigraphicUnitFeature(BaseResqpy):
       for example, from the International Commission on Stratigraphy (http://www.stratigraphy.org).
    """
 
-   resqml_type = 'StratigraphicUnitFeature'
+    resqml_type = 'StratigraphicUnitFeature'
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                top_unit_uuid = None,
-                bottom_unit_uuid = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Initialises a stratigraphic unit feature object.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 top_unit_uuid = None,
+                 bottom_unit_uuid = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Initialises a stratigraphic unit feature object.
 
       arguments:
          parent_model (model.Model): the model with which the new feature will be associated
@@ -91,18 +91,18 @@ class StratigraphicUnitFeature(BaseResqpy):
          a new stratigraphic unit feature resqpy object
       """
 
-      # todo: clarify with Energistics whether the 2 references are to other StratigraphicUnitFeatures or what?
-      self.top_unit_uuid = top_unit_uuid
-      self.bottom_unit_uuid = bottom_unit_uuid
+        # todo: clarify with Energistics whether the 2 references are to other StratigraphicUnitFeatures or what?
+        self.top_unit_uuid = top_unit_uuid
+        self.bottom_unit_uuid = bottom_unit_uuid
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this feature is essentially the same as the other; otherwise False.
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this feature is essentially the same as the other; otherwise False.
 
       arguments:
          other (StratigraphicUnitFeature): the other feature to compare this one against
@@ -113,28 +113,29 @@ class StratigraphicUnitFeature(BaseResqpy):
          bool: True if this feature is essentially the same as the other feature; False otherwise
       """
 
-      if not isinstance(other, StratigraphicUnitFeature):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      return (self.title == other.title and ((not check_extra_metadata) or rqo.equivalent_extra_metadata(self, other)))
+        if not isinstance(other, StratigraphicUnitFeature):
+            return False
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        return (self.title == other.title and
+                ((not check_extra_metadata) or rqo.equivalent_extra_metadata(self, other)))
 
-   def _load_from_xml(self):
-      """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
-      root_node = self.root
-      assert root_node is not None
-      bottom_ref_uuid = rqet.find_nested_tags_text(root_node, ['ChronostratigraphicBottom', 'UUID'])
-      top_ref_uuid = rqet.find_nested_tags_text(root_node, ['ChronostratigraphicTop', 'UUID'])
-      # todo: find out if these are meant to be references to other stratigraphic unit features or geologic unit features
-      # and if so, instantiate those objects?
-      # for now, simply note the uuids
-      if bottom_ref_uuid is not None:
-         self.bottom_unit_uuid = bu.uuid_from_string(bottom_ref_uuid)
-      if top_ref_uuid is not None:
-         self.top_unit_uuid = bu.uuid_from_string(top_ref_uuid)
+    def _load_from_xml(self):
+        """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
+        root_node = self.root
+        assert root_node is not None
+        bottom_ref_uuid = rqet.find_nested_tags_text(root_node, ['ChronostratigraphicBottom', 'UUID'])
+        top_ref_uuid = rqet.find_nested_tags_text(root_node, ['ChronostratigraphicTop', 'UUID'])
+        # todo: find out if these are meant to be references to other stratigraphic unit features or geologic unit features
+        # and if so, instantiate those objects?
+        # for now, simply note the uuids
+        if bottom_ref_uuid is not None:
+            self.bottom_unit_uuid = bu.uuid_from_string(bottom_ref_uuid)
+        if top_ref_uuid is not None:
+            self.top_unit_uuid = bu.uuid_from_string(top_ref_uuid)
 
-   def create_xml(self, add_as_part = True, originator = None, reuse = True, add_relationships = True):
-      """Creates xml for this stratigraphic unit feature.
+    def create_xml(self, add_as_part = True, originator = None, reuse = True, add_relationships = True):
+        """Creates xml for this stratigraphic unit feature.
 
       arguments:
          add_as_part (bool, default True): if True, the feature is added to the parent model as a high level part
@@ -148,40 +149,42 @@ class StratigraphicUnitFeature(BaseResqpy):
          lxml.etree._Element: the root node of the newly created xml tree for the feature
       """
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
-      # create node with citation block
-      suf = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
+        # create node with citation block
+        suf = super().create_xml(add_as_part = False, originator = originator)
 
-      if self.bottom_unit_uuid is not None:
-         self.model.create_ref_node('ChronostratigraphicBottom',
-                                    self.model.title(uuid = self.bottom_unit_uuid),
-                                    self.bottom_unit_uuid,
-                                    content_type = self.model.type_of_uuid(self.bottom_unit_uuid),
-                                    root = suf)
+        if self.bottom_unit_uuid is not None:
+            self.model.create_ref_node('ChronostratigraphicBottom',
+                                       self.model.title(uuid = self.bottom_unit_uuid),
+                                       self.bottom_unit_uuid,
+                                       content_type = self.model.type_of_uuid(self.bottom_unit_uuid),
+                                       root = suf)
 
-      if self.top_unit_uuid is not None:
-         self.model.create_ref_node('ChronostratigraphicTop',
-                                    self.model.title(uuid = self.top_unit_uuid),
-                                    self.top_unit_uuid,
-                                    content_type = self.model.type_of_uuid(self.top_unit_uuid),
-                                    root = suf)
+        if self.top_unit_uuid is not None:
+            self.model.create_ref_node('ChronostratigraphicTop',
+                                       self.model.title(uuid = self.top_unit_uuid),
+                                       self.top_unit_uuid,
+                                       content_type = self.model.type_of_uuid(self.top_unit_uuid),
+                                       root = suf)
 
-      if add_as_part:
-         self.model.add_part('obj_StratigraphicUnitFeature', self.uuid, suf)
-         if add_relationships:
-            if self.bottom_unit_uuid is not None:
-               self.model.create_reciprocal_relationship(suf, 'destinationObject',
-                                                         self.model.root(uuid = self.bottom_unit_uuid), 'sourceObject')
-            if self.top_unit_uuid is not None and not bu.matching_uuids(self.bottom_unit_uuid, self.top_unit_uuid):
-               self.model.create_reciprocal_relationship(suf, 'destinationObject',
-                                                         self.model.root(uuid = self.top_unit_uuid), 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_StratigraphicUnitFeature', self.uuid, suf)
+            if add_relationships:
+                if self.bottom_unit_uuid is not None:
+                    self.model.create_reciprocal_relationship(suf, 'destinationObject',
+                                                              self.model.root(uuid = self.bottom_unit_uuid),
+                                                              'sourceObject')
+                if self.top_unit_uuid is not None and not bu.matching_uuids(self.bottom_unit_uuid, self.top_unit_uuid):
+                    self.model.create_reciprocal_relationship(suf, 'destinationObject',
+                                                              self.model.root(uuid = self.top_unit_uuid),
+                                                              'sourceObject')
 
-      return suf
+        return suf
 
 
 class GeologicUnitInterpretation(BaseResqpy):
-   """Class for RESQML Geologic Unit Interpretation objects.
+    """Class for RESQML Geologic Unit Interpretation objects.
 
    These objects can be parts in their own right. NB: Various more specialised classes also derive from this.
 
@@ -190,19 +193,19 @@ class GeologicUnitInterpretation(BaseResqpy):
       The main class for data describing an opinion of a volume-based geologic feature or unit.
    """
 
-   resqml_type = 'GeologicUnitInterpretation'
+    resqml_type = 'GeologicUnitInterpretation'
 
-   def __init__(
-         self,
-         parent_model,
-         uuid = None,
-         title = None,
-         domain = 'time',  # or should this be depth?
-         geologic_unit_feature = None,
-         composition = None,
-         material_implacement = None,
-         extra_metadata = None):
-      """Initialises an geologic unit interpretation object.
+    def __init__(
+            self,
+            parent_model,
+            uuid = None,
+            title = None,
+            domain = 'time',  # or should this be depth?
+            geologic_unit_feature = None,
+            composition = None,
+            material_implacement = None,
+            extra_metadata = None):
+        """Initialises an geologic unit interpretation object.
 
       arguments:
          parent_model (model.Model): the model with which the new interpretation will be associated
@@ -230,40 +233,39 @@ class GeologicUnitInterpretation(BaseResqpy):
          in xml)
       """
 
-      self.domain = domain
-      self.geologic_unit_feature = geologic_unit_feature  # InterpretedFeature RESQML field
-      self.has_occurred_during = (None, None)  # optional RESQML item
-      if (not title) and geologic_unit_feature is not None:
-         title = geologic_unit_feature.feature_name
-      self.composition = composition  # optional RESQML item
-      self.material_implacement = material_implacement  # optional RESQML item
-      super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
-      if self.composition:
-         assert self.composition in valid_compositions,  \
-            f'invalid composition {self.composition} for geological unit interpretation'
-         self.composition = self.composition.strip()
-      if self.material_implacement:
-         assert self.material_implacement in valid_implacements,  \
-            f'invalid material implacement {self.material_implacement} for geological unit interpretation'
+        self.domain = domain
+        self.geologic_unit_feature = geologic_unit_feature  # InterpretedFeature RESQML field
+        self.has_occurred_during = (None, None)  # optional RESQML item
+        if (not title) and geologic_unit_feature is not None:
+            title = geologic_unit_feature.feature_name
+        self.composition = composition  # optional RESQML item
+        self.material_implacement = material_implacement  # optional RESQML item
+        super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
+        if self.composition:
+            assert self.composition in valid_compositions,  \
+               f'invalid composition {self.composition} for geological unit interpretation'
+            self.composition = self.composition.strip()
+        if self.material_implacement:
+            assert self.material_implacement in valid_implacements,  \
+               f'invalid material implacement {self.material_implacement} for geological unit interpretation'
 
-   def _load_from_xml(self):
-      """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
-      root_node = self.root
-      assert root_node is not None
-      self.domain = rqet.find_tag_text(root_node, 'Domain')
-      # following allows derived StratigraphicUnitInterpretation to instantiate its own interpreted feature
-      if self.resqml_type == 'GeologicUnitInterpretation':
-         feature_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(root_node, ['InterpretedFeature', 'UUID']))
-         if feature_uuid is not None:
-            self.geologic_unit_feature = rqo.GeologicUnitFeature(self.model,
-                                                                 uuid = feature_uuid,
-                                                                 feature_name = self.model.title(uuid = feature_uuid))
-      self.has_occurred_during = rqo.extract_has_occurred_during(root_node)
-      self.composition = rqet.find_tag_text(root_node, 'GeologicUnitComposition')
-      self.material_implacement = rqet.find_tag_text(root_node, 'GeologicUnitMaterialImplacement')
+    def _load_from_xml(self):
+        """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
+        root_node = self.root
+        assert root_node is not None
+        self.domain = rqet.find_tag_text(root_node, 'Domain')
+        # following allows derived StratigraphicUnitInterpretation to instantiate its own interpreted feature
+        if self.resqml_type == 'GeologicUnitInterpretation':
+            feature_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(root_node, ['InterpretedFeature', 'UUID']))
+            if feature_uuid is not None:
+                self.geologic_unit_feature = rqo.GeologicUnitFeature(
+                    self.model, uuid = feature_uuid, feature_name = self.model.title(uuid = feature_uuid))
+        self.has_occurred_during = rqo.extract_has_occurred_during(root_node)
+        self.composition = rqet.find_tag_text(root_node, 'GeologicUnitComposition')
+        self.material_implacement = rqet.find_tag_text(root_node, 'GeologicUnitMaterialImplacement')
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False.
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False.
 
       arguments:
          other (GeologicUnitInterpretation or StratigraphicUnitInterpretation): the other interpretation to
@@ -275,29 +277,29 @@ class GeologicUnitInterpretation(BaseResqpy):
          bool: True if this interpretation is essentially the same as the other; False otherwise
       """
 
-      # this method is coded to allow use by the derived StratigraphicUnitInterpretation class
-      if other is None or not isinstance(other, type(self)):
-         return False
-      if self is other or bu.matching_uuids(self.uuid, other.uuid):
-         return True
-      if self.geologic_unit_feature is not None:
-         if not self.geologic_unit_feature.is_equivalent(other.geologic_unit_feature):
+        # this method is coded to allow use by the derived StratigraphicUnitInterpretation class
+        if other is None or not isinstance(other, type(self)):
             return False
-      elif other.geologic_unit_feature is not None:
-         return False
-      if self.root is not None and other.root is not None:
-         if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+        if self is other or bu.matching_uuids(self.uuid, other.uuid):
+            return True
+        if self.geologic_unit_feature is not None:
+            if not self.geologic_unit_feature.is_equivalent(other.geologic_unit_feature):
+                return False
+        elif other.geologic_unit_feature is not None:
             return False
-      elif self.root is not None or other.root is not None:
-         return False
-      if check_extra_metadata and not rqo.equivalent_extra_metadata(self, other):
-         return False
-      return (self.composition == other.composition and self.material_implacement == other.material_implacement and
-              self.domain == other.domain and
-              rqo.equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during))
+        if self.root is not None and other.root is not None:
+            if rqet.citation_title_for_node(self.root) != rqet.citation_title_for_node(other.root):
+                return False
+        elif self.root is not None or other.root is not None:
+            return False
+        if check_extra_metadata and not rqo.equivalent_extra_metadata(self, other):
+            return False
+        return (self.composition == other.composition and self.material_implacement == other.material_implacement and
+                self.domain == other.domain and
+                rqo.equivalent_chrono_pairs(self.has_occurred_during, other.has_occurred_during))
 
-   def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
-      """Creates a geologic unit interpretation xml tree.
+    def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
+        """Creates a geologic unit interpretation xml tree.
 
       arguments:
          add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
@@ -311,55 +313,55 @@ class GeologicUnitInterpretation(BaseResqpy):
          lxml.etree._Element: the root node of the newly created xml tree for the interpretation
       """
 
-      # note: related feature xml must be created first and is referenced here
-      # this method is coded to allow use by the derived StratigraphicUnitInterpretation class
+        # note: related feature xml must be created first and is referenced here
+        # this method is coded to allow use by the derived StratigraphicUnitInterpretation class
 
-      if reuse and self.try_reuse():
-         return self.root
-      gu = super().create_xml(add_as_part = False, originator = originator)
+        if reuse and self.try_reuse():
+            return self.root
+        gu = super().create_xml(add_as_part = False, originator = originator)
 
-      assert self.geologic_unit_feature is not None
-      guf_root = self.geologic_unit_feature.root
-      assert guf_root is not None, 'interpreted feature not established for geologic unit interpretation'
+        assert self.geologic_unit_feature is not None
+        guf_root = self.geologic_unit_feature.root
+        assert guf_root is not None, 'interpreted feature not established for geologic unit interpretation'
 
-      assert self.domain in valid_domains, 'illegal domain value for geologic unit interpretation'
-      dom_node = rqet.SubElement(gu, ns['resqml2'] + 'Domain')
-      dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      dom_node.text = self.domain
+        assert self.domain in valid_domains, 'illegal domain value for geologic unit interpretation'
+        dom_node = rqet.SubElement(gu, ns['resqml2'] + 'Domain')
+        dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        dom_node.text = self.domain
 
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.geologic_unit_feature.title,
-                                 self.geologic_unit_feature.uuid,
-                                 content_type = self.geologic_unit_feature.resqml_type,
-                                 root = gu)
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.geologic_unit_feature.title,
+                                   self.geologic_unit_feature.uuid,
+                                   content_type = self.geologic_unit_feature.resqml_type,
+                                   root = gu)
 
-      rqo.create_xml_has_occurred_during(self.model, gu, self.has_occurred_during)
+        rqo.create_xml_has_occurred_during(self.model, gu, self.has_occurred_during)
 
-      if self.composition is not None:
-         assert self.composition in valid_compositions, f'invalid composition {self.composition} for geologic unit interpretation'
-         comp_node = rqet.SubElement(gu, ns['resqml2'] + 'GeologicUnitComposition')
-         comp_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitComposition')
-         comp_node.text = self.composition
-         if self.composition + ' ' in valid_compositions:  # RESQML xsd has spurious trailing space for two compositions
-            comp_node.text += ' '
+        if self.composition is not None:
+            assert self.composition in valid_compositions, f'invalid composition {self.composition} for geologic unit interpretation'
+            comp_node = rqet.SubElement(gu, ns['resqml2'] + 'GeologicUnitComposition')
+            comp_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitComposition')
+            comp_node.text = self.composition
+            if self.composition + ' ' in valid_compositions:  # RESQML xsd has spurious trailing space for two compositions
+                comp_node.text += ' '
 
-      if self.material_implacement is not None:
-         assert self.material_implacement in valid_implacements,  \
-            f'invalid material implacement {self.material_implacement} for geologic unit interpretation'
-         mi_node = rqet.SubElement(gu, ns['resqml2'] + 'GeologicUnitMaterialImplacement')
-         mi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitMaterialImplacement')
-         mi_node.text = self.material_implacement
+        if self.material_implacement is not None:
+            assert self.material_implacement in valid_implacements,  \
+               f'invalid material implacement {self.material_implacement} for geologic unit interpretation'
+            mi_node = rqet.SubElement(gu, ns['resqml2'] + 'GeologicUnitMaterialImplacement')
+            mi_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'GeologicUnitMaterialImplacement')
+            mi_node.text = self.material_implacement
 
-      if add_as_part:
-         self.model.add_part('obj_' + self.resqml_type, self.uuid, gu)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(gu, 'destinationObject', guf_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_' + self.resqml_type, self.uuid, gu)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(gu, 'destinationObject', guf_root, 'sourceObject')
 
-      return gu
+        return gu
 
 
 class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
-   """Class for RESQML Stratigraphic Unit Interpretation objects.
+    """Class for RESQML Stratigraphic Unit Interpretation objects.
 
    RESQML documentation:
 
@@ -367,23 +369,23 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
       the deposition mode.
    """
 
-   resqml_type = 'StratigraphicUnitInterpretation'
+    resqml_type = 'StratigraphicUnitInterpretation'
 
-   def __init__(
-         self,
-         parent_model,
-         uuid = None,
-         title = None,
-         domain = 'time',  # or should this be depth?
-         stratigraphic_unit_feature = None,
-         composition = None,
-         material_implacement = None,
-         deposition_mode = None,
-         min_thickness = None,
-         max_thickness = None,
-         thickness_uom = None,
-         extra_metadata = None):
-      """Initialises a stratigraphic unit interpretation object.
+    def __init__(
+            self,
+            parent_model,
+            uuid = None,
+            title = None,
+            domain = 'time',  # or should this be depth?
+            stratigraphic_unit_feature = None,
+            composition = None,
+            material_implacement = None,
+            deposition_mode = None,
+            min_thickness = None,
+            max_thickness = None,
+            thickness_uom = None,
+            extra_metadata = None):
+        """Initialises a stratigraphic unit interpretation object.
 
       arguments:
          parent_model (model.Model): the model with which the new interpretation will be associated
@@ -420,55 +422,55 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
          in xml)
       """
 
-      self.deposition_mode = deposition_mode
-      self.min_thickness = min_thickness
-      self.max_thickness = max_thickness
-      self.thickness_uom = thickness_uom
-      super().__init__(parent_model,
-                       uuid = uuid,
-                       title = title,
-                       domain = domain,
-                       geologic_unit_feature = stratigraphic_unit_feature,
-                       composition = composition,
-                       material_implacement = material_implacement,
-                       extra_metadata = extra_metadata)
-      if self.deposition_mode is not None:
-         assert self.deposition_mode in valid_deposition_modes
-      if self.min_thickness is not None or self.max_thickness is not None:
-         assert self.thickness_uom in wam.valid_uoms(quantity = 'length')
+        self.deposition_mode = deposition_mode
+        self.min_thickness = min_thickness
+        self.max_thickness = max_thickness
+        self.thickness_uom = thickness_uom
+        super().__init__(parent_model,
+                         uuid = uuid,
+                         title = title,
+                         domain = domain,
+                         geologic_unit_feature = stratigraphic_unit_feature,
+                         composition = composition,
+                         material_implacement = material_implacement,
+                         extra_metadata = extra_metadata)
+        if self.deposition_mode is not None:
+            assert self.deposition_mode in valid_deposition_modes
+        if self.min_thickness is not None or self.max_thickness is not None:
+            assert self.thickness_uom in wam.valid_uoms(quantity = 'length')
 
-   @property
-   def stratigraphic_unit_feature(self):
-      return self.geologic_unit_feature
+    @property
+    def stratigraphic_unit_feature(self):
+        return self.geologic_unit_feature
 
-   def _load_from_xml(self):
-      """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
-      super()._load_from_xml()
-      root_node = self.root
-      assert root_node is not None
-      feature_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(root_node, ['InterpretedFeature', 'UUID']))
-      if feature_uuid is not None:
-         self.geologic_unit_feature = StratigraphicUnitFeature(self.model,
-                                                               uuid = feature_uuid,
-                                                               title = self.model.title(uuid = feature_uuid))
-      # load deposition mode and min & max thicknesses (& uom), if present
-      self.deposition_mode = rqet.find_tag_text(root_node, 'DepositionMode')
-      for min_max in ['Min', 'Max']:
-         thick_node = rqet.find_tag(root_node, min_max + 'Thickness')
-         if thick_node is not None:
-            thick = float(thick_node.text)
-            if min_max == 'Min':
-               self.min_thickness = thick
-            else:
-               self.max_thickness = thick
-            thick_uom = thick_node.attrib['uom']  # todo: check this is correct uom representation
-            if self.thickness_uom is None:
-               self.thickness_uom = thick_uom
-            else:
-               assert thick_uom == self.thickness_uom, 'inconsistent length units of measure for stratigraphic thicknesses'
+    def _load_from_xml(self):
+        """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
+        super()._load_from_xml()
+        root_node = self.root
+        assert root_node is not None
+        feature_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(root_node, ['InterpretedFeature', 'UUID']))
+        if feature_uuid is not None:
+            self.geologic_unit_feature = StratigraphicUnitFeature(self.model,
+                                                                  uuid = feature_uuid,
+                                                                  title = self.model.title(uuid = feature_uuid))
+        # load deposition mode and min & max thicknesses (& uom), if present
+        self.deposition_mode = rqet.find_tag_text(root_node, 'DepositionMode')
+        for min_max in ['Min', 'Max']:
+            thick_node = rqet.find_tag(root_node, min_max + 'Thickness')
+            if thick_node is not None:
+                thick = float(thick_node.text)
+                if min_max == 'Min':
+                    self.min_thickness = thick
+                else:
+                    self.max_thickness = thick
+                thick_uom = thick_node.attrib['uom']  # todo: check this is correct uom representation
+                if self.thickness_uom is None:
+                    self.thickness_uom = thick_uom
+                else:
+                    assert thick_uom == self.thickness_uom, 'inconsistent length units of measure for stratigraphic thicknesses'
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False.
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False.
 
       arguments:
          other (StratigraphicUnitInterpretation): the other interpretation to compare this one against
@@ -478,15 +480,15 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
       returns:
          bool: True if this interpretation is essentially the same as the other; False otherwise
       """
-      if not super().is_equivalent(other):
-         return False
-      if self.deposition_mode is not None and other.deposition_mode is not None:
-         return self.deposition_mode == other.deposition_mode
-      # note: thickness range information might be lost as not deemed of significance in comparison
-      return True
+        if not super().is_equivalent(other):
+            return False
+        if self.deposition_mode is not None and other.deposition_mode is not None:
+            return self.deposition_mode == other.deposition_mode
+        # note: thickness range information might be lost as not deemed of significance in comparison
+        return True
 
-   def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
-      """Creates a stratigraphic unit interpretation xml tree.
+    def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
+        """Creates a stratigraphic unit interpretation xml tree.
 
       arguments:
          add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
@@ -500,42 +502,42 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
          lxml.etree._Element: the root node of the newly created xml tree for the interpretation
       """
 
-      if reuse and self.try_reuse():
-         return self.root
+        if reuse and self.try_reuse():
+            return self.root
 
-      sui = super().create_xml(add_as_part = add_as_part,
-                               add_relationships = add_relationships,
-                               originator = originator,
-                               reuse = False)
-      assert sui is not None
+        sui = super().create_xml(add_as_part = add_as_part,
+                                 add_relationships = add_relationships,
+                                 originator = originator,
+                                 reuse = False)
+        assert sui is not None
 
-      if self.deposition_mode is not None:
-         assert self.deposition_mode in valid_deposition_modes,  \
-            f'invalid deposition mode {self.deposition_mode} for stratigraphic unit interpretation'
-         dm_node = rqet.SubElement(sui, ns['resqml2'] + 'DepositionMode')
-         dm_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DepositionMode')
-         dm_node.text = self.deposition_mode
+        if self.deposition_mode is not None:
+            assert self.deposition_mode in valid_deposition_modes,  \
+               f'invalid deposition mode {self.deposition_mode} for stratigraphic unit interpretation'
+            dm_node = rqet.SubElement(sui, ns['resqml2'] + 'DepositionMode')
+            dm_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DepositionMode')
+            dm_node.text = self.deposition_mode
 
-      if self.min_thickness is not None or self.max_thickness is not None:
-         assert self.thickness_uom in wam.valid_uoms(quantity = 'length')
+        if self.min_thickness is not None or self.max_thickness is not None:
+            assert self.thickness_uom in wam.valid_uoms(quantity = 'length')
 
-      if self.min_thickness is not None:
-         min_thick_node = rqet.SubElement(sui, ns['resqml2'] + 'MinThickness')
-         min_thick_node.set(ns['xsi'] + 'type', ns['eml'] + 'LengthMeasure')
-         min_thick_node.set('uom', self.thickness_uom)  # todo: check this
-         min_thick_node.text = str(self.min_thickness)
+        if self.min_thickness is not None:
+            min_thick_node = rqet.SubElement(sui, ns['resqml2'] + 'MinThickness')
+            min_thick_node.set(ns['xsi'] + 'type', ns['eml'] + 'LengthMeasure')
+            min_thick_node.set('uom', self.thickness_uom)  # todo: check this
+            min_thick_node.text = str(self.min_thickness)
 
-      if self.max_thickness is not None:
-         max_thick_node = rqet.SubElement(sui, ns['resqml2'] + 'MaxThickness')
-         max_thick_node.set(ns['xsi'] + 'type', ns['eml'] + 'LengthMeasure')
-         max_thick_node.set('uom', self.thickness_uom)
-         max_thick_node.text = str(self.max_thickness)
+        if self.max_thickness is not None:
+            max_thick_node = rqet.SubElement(sui, ns['resqml2'] + 'MaxThickness')
+            max_thick_node.set(ns['xsi'] + 'type', ns['eml'] + 'LengthMeasure')
+            max_thick_node.set('uom', self.thickness_uom)
+            max_thick_node.text = str(self.max_thickness)
 
-      return sui
+        return sui
 
 
 class StratigraphicColumn(BaseResqpy):
-   """Class for RESQML stratigraphic column objects.
+    """Class for RESQML stratigraphic column objects.
 
    RESQML documentation:
 
@@ -546,12 +548,12 @@ class StratigraphicColumn(BaseResqpy):
       must be ordered by age.
    """
 
-   resqml_type = 'StratigraphicColumn'
+    resqml_type = 'StratigraphicColumn'
 
-   # todo: integrate with EarthModelInterpretation class which can optionally refer to a stratigraphic column
+    # todo: integrate with EarthModelInterpretation class which can optionally refer to a stratigraphic column
 
-   def __init__(self, parent_model, uuid = None, rank_uuid_list = None, title = None, extra_metadata = None):
-      """Initialises a Stratigraphic Column object.
+    def __init__(self, parent_model, uuid = None, rank_uuid_list = None, title = None, extra_metadata = None):
+        """Initialises a Stratigraphic Column object.
 
       arguments:
          parent_model (model.Model): the model with which the new stratigraphic column will be associated
@@ -564,31 +566,31 @@ class StratigraphicColumn(BaseResqpy):
          extra_metadata (dict, optional): extra metadata items for the new feature
       """
 
-      self.ranks = []  # list of Stratigraphic Column Rank Interpretation objects, maintained in rank index order
+        self.ranks = []  # list of Stratigraphic Column Rank Interpretation objects, maintained in rank index order
 
-      super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
+        super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
 
-      if self.root is None and rank_uuid_list:
-         for rank_uuid in rank_uuid_list:
-            rank = StratigraphicColumnRank(self.model, uuid = rank_uuid)
+        if self.root is None and rank_uuid_list:
+            for rank_uuid in rank_uuid_list:
+                rank = StratigraphicColumnRank(self.model, uuid = rank_uuid)
+                self.add_rank(rank)
+
+    def _load_from_xml(self):
+        """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
+        rank_node_list = rqet.list_of_tag(self.root, 'Ranks')
+        assert rank_node_list is not None, 'no stratigraphic column ranks in xml for stratigraphic column'
+        for rank_node in rank_node_list:
+            rank = StratigraphicColumnRank(self.model, uuid = rqet.find_tag_text(rank_node, 'UUID'))
             self.add_rank(rank)
 
-   def _load_from_xml(self):
-      """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
-      rank_node_list = rqet.list_of_tag(self.root, 'Ranks')
-      assert rank_node_list is not None, 'no stratigraphic column ranks in xml for stratigraphic column'
-      for rank_node in rank_node_list:
-         rank = StratigraphicColumnRank(self.model, uuid = rqet.find_tag_text(rank_node, 'UUID'))
-         self.add_rank(rank)
+    def iter_ranks(self):
+        """Yields the stratigraphic column ranks which constitute this stratigraphic colunn."""
 
-   def iter_ranks(self):
-      """Yields the stratigraphic column ranks which constitute this stratigraphic colunn."""
+        for rank in self.ranks:
+            yield rank
 
-      for rank in self.ranks:
-         yield rank
-
-   def add_rank(self, rank):
-      """Adds another stratigraphic column rank to this stratigraphic column.
+    def add_rank(self, rank):
+        """Adds another stratigraphic column rank to this stratigraphic column.
 
       arguments:
          rank (StratigraphicColumnRank): an established rank to be added to this stratigraphic column
@@ -597,16 +599,16 @@ class StratigraphicColumn(BaseResqpy):
          ranks should be ordered from geologically oldest to youngest, with increasing index values
       """
 
-      assert rank is not None and rank.index is not None
-      self.ranks.append(rank)
-      self._sort_ranks()
+        assert rank is not None and rank.index is not None
+        self.ranks.append(rank)
+        self._sort_ranks()
 
-   def _sort_ranks(self):
-      """Sort the list of ranks, in situ, by their index values."""
-      self.ranks.sort(key = _index_attr)
+    def _sort_ranks(self):
+        """Sort the list of ranks, in situ, by their index values."""
+        self.ranks.sort(key = _index_attr)
 
-   def is_equivalent(self, other, check_extra_metadata = True):
-      """Returns True if this interpretation is essentially the same as the other; otherwise False.
+    def is_equivalent(self, other, check_extra_metadata = True):
+        """Returns True if this interpretation is essentially the same as the other; otherwise False.
 
       arguments:
          other (StratigraphicColumn): the other stratigraphic column to compare this one against
@@ -617,21 +619,21 @@ class StratigraphicColumn(BaseResqpy):
          bool: True if this stratigraphic column is essentially the same as the other; False otherwise
       """
 
-      if not isinstance(other, StratigraphicColumn):
-         return False
-      if self is other or bu.matching_uuid(self.uuid, other.uuid):
-         return True
-      if len(self.ranks) != len(other.ranks):
-         return False
-      for rank_a, rank_b in zip(self.ranks, other.ranks):
-         if rank_a != rank_b:
+        if not isinstance(other, StratigraphicColumn):
             return False
-      if check_extra_metadata and not rqo.equivalent_extra_metadata(self, other):
-         return False
-      return True
+        if self is other or bu.matching_uuid(self.uuid, other.uuid):
+            return True
+        if len(self.ranks) != len(other.ranks):
+            return False
+        for rank_a, rank_b in zip(self.ranks, other.ranks):
+            if rank_a != rank_b:
+                return False
+        if check_extra_metadata and not rqo.equivalent_extra_metadata(self, other):
+            return False
+        return True
 
-   def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
-      """Creates xml tree for a stratigraphic column object.
+    def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
+        """Creates xml tree for a stratigraphic column object.
 
       arguments:
          add_as_part (bool, default True): if True, the stratigraphic column is added to the parent model as a high level part
@@ -645,52 +647,52 @@ class StratigraphicColumn(BaseResqpy):
          lxml.etree._Element: the root node of the newly created xml tree for the stratigraphic column
       """
 
-      assert self.ranks, 'attempt to create xml for stratigraphic column without any contributing ranks'
+        assert self.ranks, 'attempt to create xml for stratigraphic column without any contributing ranks'
 
-      if reuse and self.try_reuse():
-         return self.root
+        if reuse and self.try_reuse():
+            return self.root
 
-      sci = super().create_xml(add_as_part = False, originator = originator)
+        sci = super().create_xml(add_as_part = False, originator = originator)
 
-      assert sci is not None
+        assert sci is not None
 
-      for rank in self.ranks:
-         self.model.create_ref_node('Ranks',
-                                    rank.title,
-                                    rank.uuid,
-                                    content_type = 'obj_StratigraphicColumnRankInterpretation',
-                                    root = sci)
+        for rank in self.ranks:
+            self.model.create_ref_node('Ranks',
+                                       rank.title,
+                                       rank.uuid,
+                                       content_type = 'obj_StratigraphicColumnRankInterpretation',
+                                       root = sci)
 
-      if add_as_part:
-         self.model.add_part('obj_StratigraphicColumn', self.uuid, sci)
-         if add_relationships:
-            for rank in self.ranks:
-               self.model.create_reciprocal_relationship(sci, 'destinationObject', rank.root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_StratigraphicColumn', self.uuid, sci)
+            if add_relationships:
+                for rank in self.ranks:
+                    self.model.create_reciprocal_relationship(sci, 'destinationObject', rank.root, 'sourceObject')
 
-      return sci
+        return sci
 
 
 class StratigraphicColumnRank(BaseResqpy):
-   """Class for RESQML StratigraphicColumnRankInterpretation objects.
+    """Class for RESQML StratigraphicColumnRankInterpretation objects.
 
    A list of stratigraphic unit interpretations, ordered from geologically oldest to youngest.
    """
 
-   resqml_type = 'StratigraphicColumnRankInterpretation'
+    resqml_type = 'StratigraphicColumnRankInterpretation'
 
-   # note: ordering of stratigraphic units and contacts is from geologically oldest to youngest
+    # note: ordering of stratigraphic units and contacts is from geologically oldest to youngest
 
-   def __init__(
-         self,
-         parent_model,
-         uuid = None,
-         domain = 'time',  # or should this be depth?
-         rank_index = None,
-         earth_model_feature_uuid = None,
-         strata_uuid_list = None,  # ordered list of stratigraphic unit interpretations
-         title = None,
-         extra_metadata = None):
-      """Initialises a Stratigraphic Column Rank resqpy object (RESQML StratigraphicColumnRankInterpretation).
+    def __init__(
+            self,
+            parent_model,
+            uuid = None,
+            domain = 'time',  # or should this be depth?
+            rank_index = None,
+            earth_model_feature_uuid = None,
+            strata_uuid_list = None,  # ordered list of stratigraphic unit interpretations
+            title = None,
+            extra_metadata = None):
+        """Initialises a Stratigraphic Column Rank resqpy object (RESQML StratigraphicColumnRankInterpretation).
 
       arguments:
          parent_model (model.Model): the model with which the new interpretation will be associated
@@ -709,64 +711,64 @@ class StratigraphicColumnRank(BaseResqpy):
          extra_metadata (dict, optional): extra metadata items for the new stratigraphic column rank interpretation
       """
 
-      self.feature_uuid = earth_model_feature_uuid  # interpreted earth model feature uuid
-      self.domain = domain
-      self.index = rank_index
-      self.has_occurred_during = (None, None)  # optional RESQML item
-      self.units = []  # ordered list of (index, stratagraphic unit interpretation uuid)
-      self.contacts = []  # optional ordered list of binary contact interpretations
+        self.feature_uuid = earth_model_feature_uuid  # interpreted earth model feature uuid
+        self.domain = domain
+        self.index = rank_index
+        self.has_occurred_during = (None, None)  # optional RESQML item
+        self.units = []  # ordered list of (index, stratagraphic unit interpretation uuid)
+        self.contacts = []  # optional ordered list of binary contact interpretations
 
-      super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
+        super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
 
-      if self.root is None and strata_uuid_list is not None:
-         self.set_units(strata_uuid_list)
+        if self.root is None and strata_uuid_list is not None:
+            self.set_units(strata_uuid_list)
 
-   def _load_from_xml(self):
-      """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
-      root_node = self.root
-      assert root_node is not None
-      assert rqet.find_tag_text(root_node, 'OrderingCriteria') == 'age',  \
-         'stratigraphic column rank interpretation ordering criterion must be age'
-      self.domain = rqet.find_tag_text(root_node, 'Domain')
-      self.feature_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(root_node, ['InterpretedFeature', 'UUID']))
-      self.has_occurred_during = rqo.extract_has_occurred_during(root_node)
-      self.index = rqet.find_tag_int(root_node, 'Index')
-      self.units = []
-      for su_node in rqet.list_of_tag(root_node, 'StratigraphicUnits'):
-         index = rqet.find_tag_int(su_node, 'Index')
-         unit_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(su_node, ['Unit', 'UUID']))
-         assert index is not None and unit_uuid is not None
-         assert self.model.type_of_uuid(unit_uuid, strip_obj = True) == 'StratigraphicUnitInterpretation'
-         self.units.append((index, StratigraphicUnitInterpretation(self.model, uuid = unit_uuid)))
-      self._sort_units()
-      self.contacts = []
-      for contact_node in rqet.list_of_tag(root_node, 'ContactInterpretation'):
-         self.contacts.append(BinaryContactInterpretation(self.model, existing_xml_node = contact_node))
-      self._sort_contacts()
+    def _load_from_xml(self):
+        """Loads class specific attributes from xml for an existing RESQML object; called from BaseResqpy."""
+        root_node = self.root
+        assert root_node is not None
+        assert rqet.find_tag_text(root_node, 'OrderingCriteria') == 'age',  \
+           'stratigraphic column rank interpretation ordering criterion must be age'
+        self.domain = rqet.find_tag_text(root_node, 'Domain')
+        self.feature_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(root_node, ['InterpretedFeature', 'UUID']))
+        self.has_occurred_during = rqo.extract_has_occurred_during(root_node)
+        self.index = rqet.find_tag_int(root_node, 'Index')
+        self.units = []
+        for su_node in rqet.list_of_tag(root_node, 'StratigraphicUnits'):
+            index = rqet.find_tag_int(su_node, 'Index')
+            unit_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(su_node, ['Unit', 'UUID']))
+            assert index is not None and unit_uuid is not None
+            assert self.model.type_of_uuid(unit_uuid, strip_obj = True) == 'StratigraphicUnitInterpretation'
+            self.units.append((index, StratigraphicUnitInterpretation(self.model, uuid = unit_uuid)))
+        self._sort_units()
+        self.contacts = []
+        for contact_node in rqet.list_of_tag(root_node, 'ContactInterpretation'):
+            self.contacts.append(BinaryContactInterpretation(self.model, existing_xml_node = contact_node))
+        self._sort_contacts()
 
-   def set_units(self, strata_uuid_list):
-      """Discard any previous units and set list of units based on ordered list of uuids.
+    def set_units(self, strata_uuid_list):
+        """Discard any previous units and set list of units based on ordered list of uuids.
 
       arguments:
          strata_uuid_list (list of uuid.UUID): the uuids of the stratigraphic unit interpretations which constitute
             this stratigraphic column, ordered from geologically oldest to youngest
       """
 
-      self.units = []
-      for i, uuid in enumerate(strata_uuid_list):
-         assert self.model.type_of_uuid(uuid, strip_obj = True) == 'StratigraphicUnitInterpretation'
-         self.units.append((i, StratigraphicUnitInterpretation(self.model, uuid = uuid)))
+        self.units = []
+        for i, uuid in enumerate(strata_uuid_list):
+            assert self.model.type_of_uuid(uuid, strip_obj = True) == 'StratigraphicUnitInterpretation'
+            self.units.append((i, StratigraphicUnitInterpretation(self.model, uuid = uuid)))
 
-   def _sort_units(self):
-      """Sorts units list, in situ, into increasing order of index values."""
-      self.units.sort()
+    def _sort_units(self):
+        """Sorts units list, in situ, into increasing order of index values."""
+        self.units.sort()
 
-   def _sort_contacts(self):
-      """Sorts contacts list, in situ, into increasing order of index values."""
-      self.contacts.sort(key = _index_attr)
+    def _sort_contacts(self):
+        """Sorts contacts list, in situ, into increasing order of index values."""
+        self.contacts.sort(key = _index_attr)
 
-   def set_contacts_from_horizons(self, horizon_uuids, older_contact_mode = None, younger_contact_mode = None):
-      """Sets the list of contacts from an ordered list of horizons, of length one less than the number of units.
+    def set_contacts_from_horizons(self, horizon_uuids, older_contact_mode = None, younger_contact_mode = None):
+        """Sets the list of contacts from an ordered list of horizons, of length one less than the number of units.
 
       arguments:
          horizon_uuids (list of uuid.UUID): list of horizon interpretation uuids, ordered from geologically oldest
@@ -782,50 +784,50 @@ class StratigraphicColumnRank(BaseResqpy):
          then interate over the contacts setting each mode individually (after this method returns)
       """
 
-      # this method uses older unit as subject, younger as direct object
-      # todo: check this is consistent with any RESQML usage guidance and/or any RMS usage
+        # this method uses older unit as subject, younger as direct object
+        # todo: check this is consistent with any RESQML usage guidance and/or any RMS usage
 
-      self.contacts = []
-      assert len(horizon_uuids) == len(self.units) - 1
-      for i, horizon_uuid in enumerate(horizon_uuids):
-         assert self.model.type_of_uuid(horizon_uuid, strip_obj = True) == 'HorizonInterpretation'
-         contact = BinaryContactInterpretation(self.model,
-                                               index = i,
-                                               contact_relationship = 'stratigraphic unit to stratigraphic unit',
-                                               verb = 'stops at',
-                                               subject_uuid = self.units[i][1].uuid,
-                                               direct_object_uuid = self.units[i + 1][1].uuid,
-                                               subject_contact_side = 'older',
-                                               subject_contact_mode = older_contact_mode,
-                                               direct_object_contact_side = 'younger',
-                                               direct_object_contact_mode = younger_contact_mode,
-                                               part_of_uuid = horizon_uuid)
-         self.contacts.append(contact)
+        self.contacts = []
+        assert len(horizon_uuids) == len(self.units) - 1
+        for i, horizon_uuid in enumerate(horizon_uuids):
+            assert self.model.type_of_uuid(horizon_uuid, strip_obj = True) == 'HorizonInterpretation'
+            contact = BinaryContactInterpretation(self.model,
+                                                  index = i,
+                                                  contact_relationship = 'stratigraphic unit to stratigraphic unit',
+                                                  verb = 'stops at',
+                                                  subject_uuid = self.units[i][1].uuid,
+                                                  direct_object_uuid = self.units[i + 1][1].uuid,
+                                                  subject_contact_side = 'older',
+                                                  subject_contact_mode = older_contact_mode,
+                                                  direct_object_contact_side = 'younger',
+                                                  direct_object_contact_mode = younger_contact_mode,
+                                                  part_of_uuid = horizon_uuid)
+            self.contacts.append(contact)
 
-   def iter_units(self):
-      """Yields the ordered stratigraphic unit interpretations which constitute this stratigraphic colunn."""
+    def iter_units(self):
+        """Yields the ordered stratigraphic unit interpretations which constitute this stratigraphic colunn."""
 
-      for _, unit in self.units:
-         yield unit
+        for _, unit in self.units:
+            yield unit
 
-   def unit_for_unit_index(self, index):
-      """Returns the stratigraphic unit interpretation with the given index in this stratigraphic colunn."""
+    def unit_for_unit_index(self, index):
+        """Returns the stratigraphic unit interpretation with the given index in this stratigraphic colunn."""
 
-      for i, unit in self.units:
-         if i == index:
-            return unit
-      return None
+        for i, unit in self.units:
+            if i == index:
+                return unit
+        return None
 
-   def iter_contacts(self):
-      """Yields the internal binary contact interpretations of this stratigraphic colunn."""
+    def iter_contacts(self):
+        """Yields the internal binary contact interpretations of this stratigraphic colunn."""
 
-      for contact in self.contacts:
-         yield contact
+        for contact in self.contacts:
+            yield contact
 
-   # todo: implement a strict validation method checking contact exists for each neighbouring unit pair
+    # todo: implement a strict validation method checking contact exists for each neighbouring unit pair
 
-   def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
-      """Creates a stratigraphic column rank interpretation xml tree.
+    def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
+        """Creates a stratigraphic column rank interpretation xml tree.
 
       arguments:
          add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
@@ -839,174 +841,175 @@ class StratigraphicColumnRank(BaseResqpy):
          lxml.etree._Element: the root node of the newly created xml tree for the interpretation
       """
 
-      # note: xml for referenced objects must be created before calling this method
+        # note: xml for referenced objects must be created before calling this method
 
-      assert len(self.units), 'attempting to create xml for stratigraphic column rank without any units'
+        assert len(self.units), 'attempting to create xml for stratigraphic column rank without any units'
 
-      if reuse and self.try_reuse():
-         return self.root
+        if reuse and self.try_reuse():
+            return self.root
 
-      if self.index is None:
-         self.index = 0
+        if self.index is None:
+            self.index = 0
 
-      scri = super().create_xml(add_as_part = False, originator = originator)
+        scri = super().create_xml(add_as_part = False, originator = originator)
 
-      assert self.feature_uuid is not None
-      assert self.model.type_of_uuid(self.feature_uuid, strip_obj = True) == 'OrganizationFeature'
-      # todo: could also check that the kind is 'earth model'
-      self.model.create_ref_node('InterpretedFeature',
-                                 self.model.title(uuid = self.feature_uuid),
-                                 self.feature_uuid,
-                                 content_type = 'OrganizationFeature',
-                                 root = scri)
+        assert self.feature_uuid is not None
+        assert self.model.type_of_uuid(self.feature_uuid, strip_obj = True) == 'OrganizationFeature'
+        # todo: could also check that the kind is 'earth model'
+        self.model.create_ref_node('InterpretedFeature',
+                                   self.model.title(uuid = self.feature_uuid),
+                                   self.feature_uuid,
+                                   content_type = 'OrganizationFeature',
+                                   root = scri)
 
-      assert self.domain in valid_domains, 'illegal domain value for stratigraphic column rank interpretation'
-      dom_node = rqet.SubElement(scri, ns['resqml2'] + 'Domain')
-      dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
-      dom_node.text = self.domain
+        assert self.domain in valid_domains, 'illegal domain value for stratigraphic column rank interpretation'
+        dom_node = rqet.SubElement(scri, ns['resqml2'] + 'Domain')
+        dom_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Domain')
+        dom_node.text = self.domain
 
-      rqo.create_xml_has_occurred_during(self.model, scri, self.has_occurred_during)
+        rqo.create_xml_has_occurred_during(self.model, scri, self.has_occurred_during)
 
-      oc_node = rqet.SubElement(scri, ns['resqml2'] + 'OrderingCriteria')
-      oc_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'OrderingCriteria')
-      oc_node.text = 'age'
+        oc_node = rqet.SubElement(scri, ns['resqml2'] + 'OrderingCriteria')
+        oc_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'OrderingCriteria')
+        oc_node.text = 'age'
 
-      i_node = rqet.SubElement(scri, ns['resqml2'] + 'Index')
-      i_node.set(ns['xsi'] + 'type', ns['xsi'] + 'nonNegativeInteger')
-      i_node.text = str(self.index)
+        i_node = rqet.SubElement(scri, ns['resqml2'] + 'Index')
+        i_node.set(ns['xsi'] + 'type', ns['xsi'] + 'nonNegativeInteger')
+        i_node.text = str(self.index)
 
-      for i, unit in self.units:
+        for i, unit in self.units:
 
-         su_node = rqet.SubElement(scri, ns['resqml2'] + 'StratigraphicUnits')
-         su_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StratigraphicUnitInterpretationIndex')
-         su_node.text = ''
+            su_node = rqet.SubElement(scri, ns['resqml2'] + 'StratigraphicUnits')
+            su_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'StratigraphicUnitInterpretationIndex')
+            su_node.text = ''
 
-         si_node = rqet.SubElement(su_node, ns['resqml2'] + 'Index')
-         si_node.set(ns['xsi'] + 'type', ns['xsi'] + 'nonNegativeInteger')
-         si_node.text = str(i)
+            si_node = rqet.SubElement(su_node, ns['resqml2'] + 'Index')
+            si_node.set(ns['xsi'] + 'type', ns['xsi'] + 'nonNegativeInteger')
+            si_node.text = str(i)
 
-         self.model.create_ref_node('Unit',
-                                    unit.title,
-                                    unit.uuid,
-                                    content_type = 'StratigraphicUnitInterpretation',
-                                    root = su_node)
+            self.model.create_ref_node('Unit',
+                                       unit.title,
+                                       unit.uuid,
+                                       content_type = 'StratigraphicUnitInterpretation',
+                                       root = su_node)
 
-      for contact in self.contacts:
-         contact.create_xml(scri)
+        for contact in self.contacts:
+            contact.create_xml(scri)
 
-      if add_as_part:
-         self.model.add_part('obj_StratigraphicColumnRankInterpretation', self.uuid, scri)
-         if add_relationships:
-            emi_root = self.model.root(uuid = self.feature_uuid)
-            self.model.create_reciprocal_relationship(scri, 'destinationObject', emi_root, 'sourceObject')
-            for _, unit in self.units:
-               self.model.create_reciprocal_relationship(scri, 'destinationObject', unit.root, 'sourceObject')
-            for contact in self.contacts:
-               if contact.part_of_uuid is not None:
-                  horizon_root = self.model.root(uuid = contact.part_of_uuid)
-                  if horizon_root is not None:
-                     self.model.create_reciprocal_relationship(scri, 'destinationObject', horizon_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_StratigraphicColumnRankInterpretation', self.uuid, scri)
+            if add_relationships:
+                emi_root = self.model.root(uuid = self.feature_uuid)
+                self.model.create_reciprocal_relationship(scri, 'destinationObject', emi_root, 'sourceObject')
+                for _, unit in self.units:
+                    self.model.create_reciprocal_relationship(scri, 'destinationObject', unit.root, 'sourceObject')
+                for contact in self.contacts:
+                    if contact.part_of_uuid is not None:
+                        horizon_root = self.model.root(uuid = contact.part_of_uuid)
+                        if horizon_root is not None:
+                            self.model.create_reciprocal_relationship(scri, 'destinationObject', horizon_root,
+                                                                      'sourceObject')
 
-      return scri
+        return scri
 
 
 class BinaryContactInterpretation:
-   """Internal class for contact between 2 geological entities; not a high level class but used by others."""
+    """Internal class for contact between 2 geological entities; not a high level class but used by others."""
 
-   def __init__(
-         self,
-         model,
-         existing_xml_node = None,
-         index = None,
-         contact_relationship: str = None,
-         verb: str = None,
-         subject_uuid = None,
-         direct_object_uuid = None,
-         subject_contact_side = None,  # optional
-         subject_contact_mode = None,  # optional
-         direct_object_contact_side = None,  # optional
-         direct_object_contact_mode = None,  # optional
-         part_of_uuid = None):  # optional
-      """Creates a new binary contact interpretation internal object.
+    def __init__(
+            self,
+            model,
+            existing_xml_node = None,
+            index = None,
+            contact_relationship: str = None,
+            verb: str = None,
+            subject_uuid = None,
+            direct_object_uuid = None,
+            subject_contact_side = None,  # optional
+            subject_contact_mode = None,  # optional
+            direct_object_contact_side = None,  # optional
+            direct_object_contact_mode = None,  # optional
+            part_of_uuid = None):  # optional
+        """Creates a new binary contact interpretation internal object.
 
       note:
          if an existing xml node is present, then all the later arguments are ignored
       """
-      # index (non-negative integer, should increase with decreasing age for horizon contacts)
-      # contact relationship (one of valid_contact_relationships)
-      # subject (reference to e.g. stratigraphic unit interpretation)
-      # verb (one of valid_contact_verbs)
-      # direct object (reference to e.g. stratigraphic unit interpretation)
-      # contact sides and modes (optional)
-      # part of (reference to e.g. horizon interpretation, optional)
+        # index (non-negative integer, should increase with decreasing age for horizon contacts)
+        # contact relationship (one of valid_contact_relationships)
+        # subject (reference to e.g. stratigraphic unit interpretation)
+        # verb (one of valid_contact_verbs)
+        # direct object (reference to e.g. stratigraphic unit interpretation)
+        # contact sides and modes (optional)
+        # part of (reference to e.g. horizon interpretation, optional)
 
-      self.model = model
+        self.model = model
 
-      if existing_xml_node is not None:
-         self._load_from_xml(existing_xml_node)
+        if existing_xml_node is not None:
+            self._load_from_xml(existing_xml_node)
 
-      else:
-         assert index >= 0
-         assert contact_relationship in valid_contact_relationships
-         assert verb in valid_contact_verbs
-         assert subject_uuid is not None and direct_object_uuid is not None
-         if subject_contact_side is not None:
-            assert subject_contact_side in valid_contact_sides
-         if subject_contact_mode is not None:
-            assert subject_contact_mode in valid_contact_modes
-         if direct_object_contact_side is not None:
-            assert direct_object_contact_side in valid_contact_sides
-         if direct_object_contact_mode is not None:
-            assert direct_object_contact_mode in valid_contact_modes
-         self.index = index
-         self.contact_relationship = contact_relationship
-         self.verb = verb
-         self.subject_uuid = subject_uuid
-         self.direct_object_uuid = direct_object_uuid
-         self.subject_contact_side = subject_contact_side
-         self.subject_contact_mode = subject_contact_mode
-         self.direct_object_contact_side = direct_object_contact_side
-         self.direct_object_contact_mode = direct_object_contact_mode
-         self.part_of_uuid = part_of_uuid
+        else:
+            assert index >= 0
+            assert contact_relationship in valid_contact_relationships
+            assert verb in valid_contact_verbs
+            assert subject_uuid is not None and direct_object_uuid is not None
+            if subject_contact_side is not None:
+                assert subject_contact_side in valid_contact_sides
+            if subject_contact_mode is not None:
+                assert subject_contact_mode in valid_contact_modes
+            if direct_object_contact_side is not None:
+                assert direct_object_contact_side in valid_contact_sides
+            if direct_object_contact_mode is not None:
+                assert direct_object_contact_mode in valid_contact_modes
+            self.index = index
+            self.contact_relationship = contact_relationship
+            self.verb = verb
+            self.subject_uuid = subject_uuid
+            self.direct_object_uuid = direct_object_uuid
+            self.subject_contact_side = subject_contact_side
+            self.subject_contact_mode = subject_contact_mode
+            self.direct_object_contact_side = direct_object_contact_side
+            self.direct_object_contact_mode = direct_object_contact_mode
+            self.part_of_uuid = part_of_uuid
 
-   def _load_from_xml(self, bci_node):
-      """Populates this binary contact interpretation based on existing xml.
+    def _load_from_xml(self, bci_node):
+        """Populates this binary contact interpretation based on existing xml.
 
       arguments:
          bci_node (lxml.etree._Element): the root xml node for the binary contact interpretation sub-tree
       """
 
-      assert bci_node is not None
+        assert bci_node is not None
 
-      self.contact_relationship = rqet.find_tag_text(bci_node, 'ContactRelationship')
-      assert self.contact_relationship in valid_contact_relationships,  \
-         f'missing or invalid contact relationship {self.contact_relationship} in xml for binary contact interpretation'
+        self.contact_relationship = rqet.find_tag_text(bci_node, 'ContactRelationship')
+        assert self.contact_relationship in valid_contact_relationships,  \
+           f'missing or invalid contact relationship {self.contact_relationship} in xml for binary contact interpretation'
 
-      self.index = rqet.find_tag_int(bci_node, 'Index')
-      assert self.index is not None, 'missing index in xml for binary contact interpretation'
+        self.index = rqet.find_tag_int(bci_node, 'Index')
+        assert self.index is not None, 'missing index in xml for binary contact interpretation'
 
-      self.part_of_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(bci_node, ['PartOf', 'UUID']))
+        self.part_of_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(bci_node, ['PartOf', 'UUID']))
 
-      sr_node = rqet.find_tag(bci_node, 'Subject')
-      assert sr_node is not None, 'missing subject in xml for binary contact interpretation'
-      self.subject_uuid = bu.uuid_from_string(rqet.find_tag_text(sr_node, 'UUID'))
-      assert self.subject_uuid is not None
-      self.subject_contact_side = rqet.find_tag_text(sr_node, 'Qualifier')
-      self.subject_contact_mode = rqet.find_tag_text(sr_node, 'SecondaryQualifier')
+        sr_node = rqet.find_tag(bci_node, 'Subject')
+        assert sr_node is not None, 'missing subject in xml for binary contact interpretation'
+        self.subject_uuid = bu.uuid_from_string(rqet.find_tag_text(sr_node, 'UUID'))
+        assert self.subject_uuid is not None
+        self.subject_contact_side = rqet.find_tag_text(sr_node, 'Qualifier')
+        self.subject_contact_mode = rqet.find_tag_text(sr_node, 'SecondaryQualifier')
 
-      dor_node = rqet.find_tag(bci_node, 'DirectObject')
-      assert dor_node is not None, 'missing direct object in xml for binary contact interpretation'
-      self.direct_object_uuid = bu.uuid_from_string(rqet.find_tag_text(dor_node, 'UUID'))
-      assert self.direct_object_uuid is not None
-      self.direct_object_contact_side = rqet.find_tag_text(dor_node, 'Qualifier')
-      self.direct_object_contact_mode = rqet.find_tag_text(dor_node, 'SecondaryQualifier')
+        dor_node = rqet.find_tag(bci_node, 'DirectObject')
+        assert dor_node is not None, 'missing direct object in xml for binary contact interpretation'
+        self.direct_object_uuid = bu.uuid_from_string(rqet.find_tag_text(dor_node, 'UUID'))
+        assert self.direct_object_uuid is not None
+        self.direct_object_contact_side = rqet.find_tag_text(dor_node, 'Qualifier')
+        self.direct_object_contact_mode = rqet.find_tag_text(dor_node, 'SecondaryQualifier')
 
-      self.verb = rqet.find_tag_text(bci_node, 'Verb')
-      assert self.verb in valid_contact_verbs,  \
-         f'missing or invalid contact verb {self.verb} in xml for binary contact interpretation'
+        self.verb = rqet.find_tag_text(bci_node, 'Verb')
+        assert self.verb in valid_contact_verbs,  \
+           f'missing or invalid contact verb {self.verb} in xml for binary contact interpretation'
 
-   def create_xml(self, parent_node = None):
-      """Generates xml sub-tree for this contact interpretation, for inclusion as element of high level interpretation.
+    def create_xml(self, parent_node = None):
+        """Generates xml sub-tree for this contact interpretation, for inclusion as element of high level interpretation.
 
       arguments:
          parent_node (lxml.etree._Element, optional): if present, the created sub-tree is added as a child to this node
@@ -1015,69 +1018,69 @@ class BinaryContactInterpretation:
          lxml.etree._Element: the root node of the newly created xml sub-tree for the contact interpretation
       """
 
-      bci = rqet.Element(ns['resqml2'] + 'ContactInterpretation')
-      bci.set(ns['xsi'] + 'type', ns['resqml2'] + 'BinaryContactInterpretationPart')
-      bci.text = ''
+        bci = rqet.Element(ns['resqml2'] + 'ContactInterpretation')
+        bci.set(ns['xsi'] + 'type', ns['resqml2'] + 'BinaryContactInterpretationPart')
+        bci.text = ''
 
-      cr_node = rqet.SubElement(bci, ns['resqml2'] + 'ContactRelationship')
-      cr_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactRelationship')
-      cr_node.text = self.contact_relationship
+        cr_node = rqet.SubElement(bci, ns['resqml2'] + 'ContactRelationship')
+        cr_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactRelationship')
+        cr_node.text = self.contact_relationship
 
-      i_node = rqet.SubElement(bci, ns['resqml2'] + 'Index')
-      i_node.set(ns['xsi'] + 'type', ns['xsi'] + 'nonNegativeInteger')
-      i_node.text = str(self.index)
+        i_node = rqet.SubElement(bci, ns['resqml2'] + 'Index')
+        i_node.set(ns['xsi'] + 'type', ns['xsi'] + 'nonNegativeInteger')
+        i_node.text = str(self.index)
 
-      if self.part_of_uuid is not None:
-         self.model.create_ref_node('PartOf',
-                                    self.model.title(uuid = self.part_of_uuid),
-                                    self.part_of_uuid,
-                                    content_type = self.model.type_of_uuid(self.part_of_uuid),
-                                    root = bci)
+        if self.part_of_uuid is not None:
+            self.model.create_ref_node('PartOf',
+                                       self.model.title(uuid = self.part_of_uuid),
+                                       self.part_of_uuid,
+                                       content_type = self.model.type_of_uuid(self.part_of_uuid),
+                                       root = bci)
 
-      dor_node = self.model.create_ref_node('DirectObject',
-                                            self.model.title(uuid = self.direct_object_uuid),
-                                            self.direct_object_uuid,
-                                            content_type = self.model.type_of_uuid(self.direct_object_uuid),
-                                            root = bci)
-      dor_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactElementReference')
+        dor_node = self.model.create_ref_node('DirectObject',
+                                              self.model.title(uuid = self.direct_object_uuid),
+                                              self.direct_object_uuid,
+                                              content_type = self.model.type_of_uuid(self.direct_object_uuid),
+                                              root = bci)
+        dor_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactElementReference')
 
-      if self.direct_object_contact_side:
-         doq_node = rqet.SubElement(dor_node, ns['resqml2'] + 'Qualifier')
-         doq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactSide')
-         doq_node.text = self.direct_object_contact_side
+        if self.direct_object_contact_side:
+            doq_node = rqet.SubElement(dor_node, ns['resqml2'] + 'Qualifier')
+            doq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactSide')
+            doq_node.text = self.direct_object_contact_side
 
-      if self.direct_object_contact_mode:
-         dosq_node = rqet.SubElement(dor_node, ns['resqml2'] + 'SecondaryQualifier')
-         dosq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactMode')
-         dosq_node.text = self.direct_object_contact_mode
+        if self.direct_object_contact_mode:
+            dosq_node = rqet.SubElement(dor_node, ns['resqml2'] + 'SecondaryQualifier')
+            dosq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactMode')
+            dosq_node.text = self.direct_object_contact_mode
 
-      v_node = rqet.SubElement(bci, ns['resqml2'] + 'Verb')
-      v_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactVerb')
-      v_node.text = self.verb
+        v_node = rqet.SubElement(bci, ns['resqml2'] + 'Verb')
+        v_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactVerb')
+        v_node.text = self.verb
 
-      sr_node = self.model.create_ref_node('Subject',
-                                           self.model.title(uuid = self.subject_uuid),
-                                           self.subject_uuid,
-                                           content_type = self.model.type_of_uuid(self.subject_uuid),
-                                           root = bci)
-      sr_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactElementReference')
+        sr_node = self.model.create_ref_node('Subject',
+                                             self.model.title(uuid = self.subject_uuid),
+                                             self.subject_uuid,
+                                             content_type = self.model.type_of_uuid(self.subject_uuid),
+                                             root = bci)
+        sr_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactElementReference')
 
-      if self.subject_contact_side:
-         sq_node = rqet.SubElement(sr_node, ns['resqml2'] + 'Qualifier')
-         sq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactSide')
-         sq_node.text = self.subject_contact_side
+        if self.subject_contact_side:
+            sq_node = rqet.SubElement(sr_node, ns['resqml2'] + 'Qualifier')
+            sq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactSide')
+            sq_node.text = self.subject_contact_side
 
-      if self.subject_contact_mode:
-         ssq_node = rqet.SubElement(sr_node, ns['resqml2'] + 'SecondaryQualifier')
-         ssq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactMode')
-         ssq_node.text = self.subject_contact_mode
+        if self.subject_contact_mode:
+            ssq_node = rqet.SubElement(sr_node, ns['resqml2'] + 'SecondaryQualifier')
+            ssq_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ContactMode')
+            ssq_node.text = self.subject_contact_mode
 
-      if parent_node is not None:
-         parent_node.append(bci)
+        if parent_node is not None:
+            parent_node.append(bci)
 
-      return bci
+        return bci
 
 
 def _index_attr(obj):
-   """Returns the index attribute of any object – typically used as a sort key function."""
-   return obj.index
+    """Returns the index attribute of any object – typically used as a sort key function."""
+    return obj.index

--- a/resqpy/surface.py
+++ b/resqpy/surface.py
@@ -30,91 +30,93 @@ import resqpy.organize as rqo
 
 
 class _BaseSurface(BaseResqpy):
-   """Base class to implement shared methods for other classes in this module"""
+    """Base class to implement shared methods for other classes in this module"""
 
-   def create_interpretation_and_feature(self,
-                                         kind = 'horizon',
-                                         name = None,
-                                         interp_title_suffix = None,
-                                         is_normal = True):
-      """Creates xml and objects for a represented interpretaion and interpreted feature, if not already present."""
+    def create_interpretation_and_feature(self,
+                                          kind = 'horizon',
+                                          name = None,
+                                          interp_title_suffix = None,
+                                          is_normal = True):
+        """Creates xml and objects for a represented interpretaion and interpreted feature, if not already present."""
 
-      assert kind in ['horizon', 'fault', 'fracture', 'geobody boundary']
-      assert name or self.title, 'title missing'
-      if not name:
-         name = self.title
+        assert kind in ['horizon', 'fault', 'fracture', 'geobody boundary']
+        assert name or self.title, 'title missing'
+        if not name:
+            name = self.title
 
-      if self.represented_interpretation_root is not None:
-         log.debug(f'represented interpretation already exisrs for surface {self.title}')
-         return
-      if kind in ['horizon', 'geobody boundary']:
-         feature = rqo.GeneticBoundaryFeature(self.model, kind = kind, feature_name = name)
-         feature.create_xml()
-         if kind == 'horizon':
-            interp = rqo.HorizonInterpretation(self.model, genetic_boundary_feature = feature, domain = 'depth')
-         else:
-            interp = rqo.GeobodyBoundaryInterpretation(self.model, genetic_boundary_feature = feature, domain = 'depth')
-      elif kind in ['fault', 'fracture']:
-         feature = rqo.TectonicBoundaryFeature(self.model, kind = kind, feature_name = name)
-         feature.create_xml()
-         interp = rqo.FaultInterpretation(self.model,
-                                          is_normal = is_normal,
-                                          tectonic_boundary_feature = feature,
-                                          domain = 'depth')  # might need more arguments
-      else:
-         log.critical('code failure')
-      interp_root = interp.create_xml(title_suffix = interp_title_suffix)
-      self.set_represented_interpretation_root(interp_root)
+        if self.represented_interpretation_root is not None:
+            log.debug(f'represented interpretation already exisrs for surface {self.title}')
+            return
+        if kind in ['horizon', 'geobody boundary']:
+            feature = rqo.GeneticBoundaryFeature(self.model, kind = kind, feature_name = name)
+            feature.create_xml()
+            if kind == 'horizon':
+                interp = rqo.HorizonInterpretation(self.model, genetic_boundary_feature = feature, domain = 'depth')
+            else:
+                interp = rqo.GeobodyBoundaryInterpretation(self.model,
+                                                           genetic_boundary_feature = feature,
+                                                           domain = 'depth')
+        elif kind in ['fault', 'fracture']:
+            feature = rqo.TectonicBoundaryFeature(self.model, kind = kind, feature_name = name)
+            feature.create_xml()
+            interp = rqo.FaultInterpretation(self.model,
+                                             is_normal = is_normal,
+                                             tectonic_boundary_feature = feature,
+                                             domain = 'depth')  # might need more arguments
+        else:
+            log.critical('code failure')
+        interp_root = interp.create_xml(title_suffix = interp_title_suffix)
+        self.set_represented_interpretation_root(interp_root)
 
 
 class TriangulatedPatch:
-   """Class for RESQML TrianglePatch objects (used by Surface objects inter alia)."""
+    """Class for RESQML TrianglePatch objects (used by Surface objects inter alia)."""
 
-   def __init__(self, parent_model, patch_index = None, patch_node = None, crs_uuid = None):
-      """Create an empty TriangulatedPatch (TrianglePatch) node and optionally load from xml.
+    def __init__(self, parent_model, patch_index = None, patch_node = None, crs_uuid = None):
+        """Create an empty TriangulatedPatch (TrianglePatch) node and optionally load from xml.
 
       note:
          not usually instantiated directly by application code
       """
 
-      self.model = parent_model
-      self.node = patch_node
-      self.patch_index = patch_index  # if not None and extracting from xml, patch_index must match xml
-      self.triangle_count = 0
-      self.node_count = 0
-      self.triangles = None
-      self.quad_triangles = None
-      self.ni = None  # used to convert a triangle index back into a (j, i) pair when freshly built from mesh
-      self.points = None
-      self.crs_uuid = crs_uuid
-      self.crs_root = None
-      if patch_node is not None:
-         xml_patch_index = rqet.find_tag_int(patch_node, 'PatchIndex')
-         assert xml_patch_index is not None
-         if self.patch_index is not None:
-            assert self.patch_index == xml_patch_index, 'triangle patch index mismatch'
-         else:
-            self.patch_index = xml_patch_index
-         self.triangle_count = rqet.find_tag_int(patch_node, 'Count')
-         assert self.triangle_count is not None
-         self.node_count = rqet.find_tag_int(patch_node, 'NodeCount')
-         assert self.node_count is not None
-         self.extract_crs_root_and_uuid()
+        self.model = parent_model
+        self.node = patch_node
+        self.patch_index = patch_index  # if not None and extracting from xml, patch_index must match xml
+        self.triangle_count = 0
+        self.node_count = 0
+        self.triangles = None
+        self.quad_triangles = None
+        self.ni = None  # used to convert a triangle index back into a (j, i) pair when freshly built from mesh
+        self.points = None
+        self.crs_uuid = crs_uuid
+        self.crs_root = None
+        if patch_node is not None:
+            xml_patch_index = rqet.find_tag_int(patch_node, 'PatchIndex')
+            assert xml_patch_index is not None
+            if self.patch_index is not None:
+                assert self.patch_index == xml_patch_index, 'triangle patch index mismatch'
+            else:
+                self.patch_index = xml_patch_index
+            self.triangle_count = rqet.find_tag_int(patch_node, 'Count')
+            assert self.triangle_count is not None
+            self.node_count = rqet.find_tag_int(patch_node, 'NodeCount')
+            assert self.node_count is not None
+            self.extract_crs_root_and_uuid()
 
-   def extract_crs_root_and_uuid(self):
-      """Caches root and uuid for coordinate reference system, as stored in geometry xml sub-tree."""
+    def extract_crs_root_and_uuid(self):
+        """Caches root and uuid for coordinate reference system, as stored in geometry xml sub-tree."""
 
-      if self.crs_root is not None and self.crs_uuid is not None:
-         return self.crs_root, self.crs_uuid
-      self.crs_root = rqet.find_nested_tags(self.node, ['Geometry', 'LocalCrs'])
-      if self.crs_root is None:
-         self.crs_uuid = None
-      else:
-         self.crs_uuid = bu.uuid_from_string(rqet.find_tag_text(self.crs_root, 'UUID'))
-      return self.crs_root, self.crs_uuid
+        if self.crs_root is not None and self.crs_uuid is not None:
+            return self.crs_root, self.crs_uuid
+        self.crs_root = rqet.find_nested_tags(self.node, ['Geometry', 'LocalCrs'])
+        if self.crs_root is None:
+            self.crs_uuid = None
+        else:
+            self.crs_uuid = bu.uuid_from_string(rqet.find_tag_text(self.crs_root, 'UUID'))
+        return self.crs_root, self.crs_uuid
 
-   def triangles_and_points(self):
-      """Returns arrays representing the patch.
+    def triangles_and_points(self):
+        """Returns arrays representing the patch.
 
       Returns:
          Tuple (triangles, points):
@@ -124,45 +126,45 @@ class TriangulatedPatch:
          * points (float array of shape[:, 3]): flat array of xyz points, indexed by triangles
 
       """
-      if self.triangles is not None:
-         return (self.triangles, self.points)
-      assert self.triangle_count is not None and self.node_count is not None
+        if self.triangles is not None:
+            return (self.triangles, self.points)
+        assert self.triangle_count is not None and self.node_count is not None
 
-      geometry_node = rqet.find_tag(self.node, 'Geometry')
-      assert geometry_node is not None
-      p_root = rqet.find_tag(geometry_node, 'Points')
-      assert p_root is not None, 'Points xml node not found for triangle patch'
-      assert rqet.node_type(p_root) == 'Point3dHdf5Array'
-      h5_key_pair = self.model.h5_uuid_and_path_for_node(p_root, tag = 'Coordinates')
-      if h5_key_pair is None:
-         return (None, None)
-      try:
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'points',
-                                     dtype = 'float')
-      except Exception:
-         log.error('hdf5 points failure for triangle patch ' + str(self.patch_index))
-         raise
-      triangles_node = rqet.find_tag(self.node, 'Triangles')
-      h5_key_pair = self.model.h5_uuid_and_path_for_node(triangles_node)
-      if h5_key_pair is None:
-         log.warning('No Triangles found in xml for patch index: ' + str(self.patch_index))
-         return (None, None)
-      try:
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'triangles',
-                                     dtype = 'int')
-      except Exception:
-         log.error('hdf5 triangles failure for triangle patch ' + str(self.patch_index))
-         raise
-      return (self.triangles, self.points)
+        geometry_node = rqet.find_tag(self.node, 'Geometry')
+        assert geometry_node is not None
+        p_root = rqet.find_tag(geometry_node, 'Points')
+        assert p_root is not None, 'Points xml node not found for triangle patch'
+        assert rqet.node_type(p_root) == 'Point3dHdf5Array'
+        h5_key_pair = self.model.h5_uuid_and_path_for_node(p_root, tag = 'Coordinates')
+        if h5_key_pair is None:
+            return (None, None)
+        try:
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'points',
+                                        dtype = 'float')
+        except Exception:
+            log.error('hdf5 points failure for triangle patch ' + str(self.patch_index))
+            raise
+        triangles_node = rqet.find_tag(self.node, 'Triangles')
+        h5_key_pair = self.model.h5_uuid_and_path_for_node(triangles_node)
+        if h5_key_pair is None:
+            log.warning('No Triangles found in xml for patch index: ' + str(self.patch_index))
+            return (None, None)
+        try:
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'triangles',
+                                        dtype = 'int')
+        except Exception:
+            log.error('hdf5 triangles failure for triangle patch ' + str(self.patch_index))
+            raise
+        return (self.triangles, self.points)
 
-   def set_to_horizontal_plane(self, depth, box_xyz, border = 0.0):
-      """Populate this (empty) patch with two triangles defining a flat, horizontal plane at a given depth.
+    def set_to_horizontal_plane(self, depth, box_xyz, border = 0.0):
+        """Populate this (empty) patch with two triangles defining a flat, horizontal plane at a given depth.
 
          arguments:
             depth (float): z value to use in all points in the triangulated patch
@@ -170,238 +172,238 @@ class TriangulatedPatch:
             border (float): an optional border width added around the x,y area defined by box_xyz
       """
 
-      # expand area by border
-      box = box_xyz.copy()
-      box[0, :2] -= border
-      box[1, :2] += border
-      self.node_count = 4
-      self.points = np.empty((4, 3))
-      # set 2 points common to both triangles
-      self.points[0, :] = box[0, :]
-      self.points[1, :] = box[1, :]
-      # and 2 others to form a rectangle aligned with x,y axes
-      self.points[2, 0], self.points[2, 1] = box[0, 0], box[1, 1]  # min x, max y
-      self.points[3, 0], self.points[3, 1] = box[1, 0], box[0, 1]  # max x, min y
-      # set depth for all points
-      self.points[:, 2] = depth
-      # create pair of triangles
-      self.triangle_count = 2
-      self.triangles = np.array([[0, 1, 2], [0, 3, 1]], dtype = int)
+        # expand area by border
+        box = box_xyz.copy()
+        box[0, :2] -= border
+        box[1, :2] += border
+        self.node_count = 4
+        self.points = np.empty((4, 3))
+        # set 2 points common to both triangles
+        self.points[0, :] = box[0, :]
+        self.points[1, :] = box[1, :]
+        # and 2 others to form a rectangle aligned with x,y axes
+        self.points[2, 0], self.points[2, 1] = box[0, 0], box[1, 1]  # min x, max y
+        self.points[3, 0], self.points[3, 1] = box[1, 0], box[0, 1]  # max x, min y
+        # set depth for all points
+        self.points[:, 2] = depth
+        # create pair of triangles
+        self.triangle_count = 2
+        self.triangles = np.array([[0, 1, 2], [0, 3, 1]], dtype = int)
 
-   def set_to_triangle(self, corners):
-      """Populate this (empty) patch with a single triangle."""
+    def set_to_triangle(self, corners):
+        """Populate this (empty) patch with a single triangle."""
 
-      assert corners.shape == (3, 3)
-      self.node_count = 3
-      self.points = corners.copy()
-      self.triangle_count = 1
-      self.triangles = np.array([[0, 1, 2]], dtype = int)
+        assert corners.shape == (3, 3)
+        self.node_count = 3
+        self.points = corners.copy()
+        self.triangle_count = 1
+        self.triangles = np.array([[0, 1, 2]], dtype = int)
 
-   def set_from_triangles_and_points(self, triangles, points):
-      """Populate this (empty) patch from triangle node indices and points from elsewhere."""
+    def set_from_triangles_and_points(self, triangles, points):
+        """Populate this (empty) patch from triangle node indices and points from elsewhere."""
 
-      assert triangles.ndim == 2 and triangles.shape[-1] == 3
-      assert points.ndim == 2 and points.shape[1] in [2, 3]
-      if points.shape[1] == 2:
-         p = np.zeros((points.shape[0], 3))
-         p[:, :2] = points
-         points = p
-      self.node_count = points.shape[0]
-      self.points = points.copy()
-      self.triangle_count = triangles.shape[0]
-      self.triangles = triangles.copy()
+        assert triangles.ndim == 2 and triangles.shape[-1] == 3
+        assert points.ndim == 2 and points.shape[1] in [2, 3]
+        if points.shape[1] == 2:
+            p = np.zeros((points.shape[0], 3))
+            p[:, :2] = points
+            points = p
+        self.node_count = points.shape[0]
+        self.points = points.copy()
+        self.triangle_count = triangles.shape[0]
+        self.triangles = triangles.copy()
 
-   def set_to_sail(self, n, centre, radius, azimuth, delta_theta):
-      """Populate this (empty) patch with triangles for a big triangle wrapped on a sphere."""
+    def set_to_sail(self, n, centre, radius, azimuth, delta_theta):
+        """Populate this (empty) patch with triangles for a big triangle wrapped on a sphere."""
 
-      def sail_point(centre, radius, a, d):
-         #        m = vec.rotation_3d_matrix((d, 0.0, 90.0 - a))
-         #        m = vec.tilt_3d_matrix(a, d)
-         v = np.array((0.0, radius, 0.0))
-         m = vec.rotation_matrix_3d_axial(0, d)
-         v = vec.rotate_vector(m, v)
-         m = vec.rotation_matrix_3d_axial(2, 90.0 + a)
-         v = vec.rotate_vector(m, v)
-         return centre + v
+        def sail_point(centre, radius, a, d):
+            #        m = vec.rotation_3d_matrix((d, 0.0, 90.0 - a))
+            #        m = vec.tilt_3d_matrix(a, d)
+            v = np.array((0.0, radius, 0.0))
+            m = vec.rotation_matrix_3d_axial(0, d)
+            v = vec.rotate_vector(m, v)
+            m = vec.rotation_matrix_3d_axial(2, 90.0 + a)
+            v = vec.rotate_vector(m, v)
+            return centre + v
 
-      assert n >= 1
-      self.node_count = (n + 1) * (n + 2) // 2
-      self.points = np.empty((self.node_count, 3))
-      self.triangle_count = n * n
-      self.triangles = np.empty((self.triangle_count, 3), dtype = int)
-      self.points[0] = sail_point(centre, radius, azimuth, 0.0).copy()
-      p = 0
-      t = 0
-      for row in range(n):
-         azimuth -= 0.5 * delta_theta
-         dip = (row + 1) * delta_theta
-         az = azimuth
-         for pp in range(row + 2):
-            p += 1
-            self.points[p] = sail_point(centre, radius, az, dip).copy()
-            az += delta_theta
+        assert n >= 1
+        self.node_count = (n + 1) * (n + 2) // 2
+        self.points = np.empty((self.node_count, 3))
+        self.triangle_count = n * n
+        self.triangles = np.empty((self.triangle_count, 3), dtype = int)
+        self.points[0] = sail_point(centre, radius, azimuth, 0.0).copy()
+        p = 0
+        t = 0
+        for row in range(n):
+            azimuth -= 0.5 * delta_theta
+            dip = (row + 1) * delta_theta
+            az = azimuth
+            for pp in range(row + 2):
+                p += 1
+                self.points[p] = sail_point(centre, radius, az, dip).copy()
+                az += delta_theta
 
 
 #           log.debug('p: ' + str(p) + '; dip: {0:3.1f}; az: {1:3.1f}'.format(dip, az))
-         p1 = row * (row + 1) // 2
-         p2 = (row + 1) * (row + 2) // 2
-         self.triangles[t] = (p1, p2, p2 + 1)
-         t += 1
-         for tri in range(row):
-            self.triangles[t] = (p1, p1 + 1, p2 + 1)
-            t += 1
-            p1 += 1
-            p2 += 1
+            p1 = row * (row + 1) // 2
+            p2 = (row + 1) * (row + 2) // 2
             self.triangles[t] = (p1, p2, p2 + 1)
             t += 1
-      log.debug('sail point zero: ' + str(self.points[0]))
-      log.debug('sail xyz box: {0:4.2f}:{1:4.2f}  {2:4.2f}:{3:4.2f}  {4:4.2f}:{5:4.2f}'.format(
-         np.min(self.points[:, 0]), np.max(self.points[:, 0]), np.min(self.points[:, 1]), np.max(self.points[:, 1]),
-         np.min(self.points[:, 2]), np.max(self.points[:, 2])))
+            for tri in range(row):
+                self.triangles[t] = (p1, p1 + 1, p2 + 1)
+                t += 1
+                p1 += 1
+                p2 += 1
+                self.triangles[t] = (p1, p2, p2 + 1)
+                t += 1
+        log.debug('sail point zero: ' + str(self.points[0]))
+        log.debug('sail xyz box: {0:4.2f}:{1:4.2f}  {2:4.2f}:{3:4.2f}  {4:4.2f}:{5:4.2f}'.format(
+            np.min(self.points[:, 0]), np.max(self.points[:, 0]), np.min(self.points[:, 1]), np.max(self.points[:, 1]),
+            np.min(self.points[:, 2]), np.max(self.points[:, 2])))
 
-   def set_from_irregular_mesh(self, mesh_xyz, quad_triangles = False):
-      """Populate this (empty) patch from an untorn mesh array of shape (N, M, 3)."""
+    def set_from_irregular_mesh(self, mesh_xyz, quad_triangles = False):
+        """Populate this (empty) patch from an untorn mesh array of shape (N, M, 3)."""
 
-      mesh_shape = mesh_xyz.shape
-      assert len(mesh_shape) == 3 and mesh_shape[0] > 1 and mesh_shape[1] > 1 and mesh_shape[2] == 3
-      ni = mesh_shape[1]
-      if quad_triangles:
-         # generate centre points:
-         quad_centres = np.empty(((mesh_shape[0] - 1) * (mesh_shape[1] - 1), 3))
-         quad_centres[:, :] = 0.25 * (mesh_xyz[:-1, :-1, :] + mesh_xyz[:-1, 1:, :] + mesh_xyz[1:, :-1, :] +
-                                      mesh_xyz[1:, 1:, :]).reshape((-1, 3))
-         self.points = np.concatenate((mesh_xyz.copy().reshape((-1, 3)), quad_centres))
-         mesh_size = mesh_xyz.size // 3
-         self.node_count = self.points.size // 3
-         self.triangle_count = 4 * (mesh_shape[0] - 1) * (mesh_shape[1] - 1)
-         self.quad_triangles = True
-         triangles = np.empty((mesh_shape[0] - 1, mesh_shape[1] - 1, 4, 3), dtype = int)  # flatten later
-         nic = ni - 1
-         for j in range(mesh_shape[0] - 1):
-            for i in range(nic):
-               triangles[j, i, :, 0] = mesh_size + j * nic + i  # quad centre
-               triangles[j, i, 0, 1] = j * ni + i
-               triangles[j, i, 0, 2] = triangles[j, i, 1, 1] = j * ni + i + 1
-               triangles[j, i, 1, 2] = triangles[j, i, 2, 1] = (j + 1) * ni + i + 1
-               triangles[j, i, 2, 2] = triangles[j, i, 3, 1] = (j + 1) * ni + i
-               triangles[j, i, 3, 2] = j * ni + i
-      else:
-         self.points = mesh_xyz.copy().reshape((-1, 3))
-         self.node_count = mesh_shape[0] * mesh_shape[1]
-         self.triangle_count = 2 * (mesh_shape[0] - 1) * (mesh_shape[1] - 1)
-         self.quad_triangles = False
-         triangles = np.empty((mesh_shape[0] - 1, mesh_shape[1] - 1, 2, 3), dtype = int)  # flatten later
-         for j in range(mesh_shape[0] - 1):
+        mesh_shape = mesh_xyz.shape
+        assert len(mesh_shape) == 3 and mesh_shape[0] > 1 and mesh_shape[1] > 1 and mesh_shape[2] == 3
+        ni = mesh_shape[1]
+        if quad_triangles:
+            # generate centre points:
+            quad_centres = np.empty(((mesh_shape[0] - 1) * (mesh_shape[1] - 1), 3))
+            quad_centres[:, :] = 0.25 * (mesh_xyz[:-1, :-1, :] + mesh_xyz[:-1, 1:, :] + mesh_xyz[1:, :-1, :] +
+                                         mesh_xyz[1:, 1:, :]).reshape((-1, 3))
+            self.points = np.concatenate((mesh_xyz.copy().reshape((-1, 3)), quad_centres))
+            mesh_size = mesh_xyz.size // 3
+            self.node_count = self.points.size // 3
+            self.triangle_count = 4 * (mesh_shape[0] - 1) * (mesh_shape[1] - 1)
+            self.quad_triangles = True
+            triangles = np.empty((mesh_shape[0] - 1, mesh_shape[1] - 1, 4, 3), dtype = int)  # flatten later
+            nic = ni - 1
+            for j in range(mesh_shape[0] - 1):
+                for i in range(nic):
+                    triangles[j, i, :, 0] = mesh_size + j * nic + i  # quad centre
+                    triangles[j, i, 0, 1] = j * ni + i
+                    triangles[j, i, 0, 2] = triangles[j, i, 1, 1] = j * ni + i + 1
+                    triangles[j, i, 1, 2] = triangles[j, i, 2, 1] = (j + 1) * ni + i + 1
+                    triangles[j, i, 2, 2] = triangles[j, i, 3, 1] = (j + 1) * ni + i
+                    triangles[j, i, 3, 2] = j * ni + i
+        else:
+            self.points = mesh_xyz.copy().reshape((-1, 3))
+            self.node_count = mesh_shape[0] * mesh_shape[1]
+            self.triangle_count = 2 * (mesh_shape[0] - 1) * (mesh_shape[1] - 1)
+            self.quad_triangles = False
+            triangles = np.empty((mesh_shape[0] - 1, mesh_shape[1] - 1, 2, 3), dtype = int)  # flatten later
+            for j in range(mesh_shape[0] - 1):
+                for i in range(mesh_shape[1] - 1):
+                    triangles[j, i, 0, 0] = j * ni + i
+                    triangles[j, i, :, 1] = j * ni + i + 1
+                    triangles[j, i, :, 2] = (j + 1) * ni + i
+                    triangles[j, i, 1, 0] = (j + 1) * ni + i + 1
+        self.ni = ni - 1
+        self.triangles = triangles.reshape((-1, 3))
+
+    def set_from_sparse_mesh(self, mesh_xyz):
+        """Populate this (empty) patch from a mesh array of shape (N, M, 3), with some NaNs in z."""
+
+        # todo: add quad_triangles argument to apply to 'squares' with no NaNs
+        mesh_shape = mesh_xyz.shape
+        assert len(mesh_shape) == 3 and mesh_shape[0] > 1 and mesh_shape[1] > 1 and mesh_shape[2] == 3
+        self.quad_triangles = False
+        points = np.zeros(mesh_xyz.shape).reshape((-1, 3))
+        indices = np.zeros(mesh_xyz.shape[:2], dtype = int) - 1
+        n_p = 0
+        # this could probably be speeded up with some numpy where operation
+        for j in range(mesh_shape[0]):
+            for i in range(mesh_shape[1]):
+                if not np.isnan(mesh_xyz[j, i, 2]):
+                    points[n_p] = mesh_xyz[j, i]
+                    indices[j, i] = n_p
+                    n_p += 1
+        self.points = points[:n_p, :]
+        self.node_count = n_p
+        triangles = np.zeros((2 * (mesh_shape[0] - 1) * (mesh_shape[1] - 1), 3), dtype = int)  # truncate later
+        nt = 0
+        for j in range(mesh_shape[0] - 1):
             for i in range(mesh_shape[1] - 1):
-               triangles[j, i, 0, 0] = j * ni + i
-               triangles[j, i, :, 1] = j * ni + i + 1
-               triangles[j, i, :, 2] = (j + 1) * ni + i
-               triangles[j, i, 1, 0] = (j + 1) * ni + i + 1
-      self.ni = ni - 1
-      self.triangles = triangles.reshape((-1, 3))
+                nan_nodes = np.count_nonzero(np.isnan(mesh_xyz[j:j + 2, i:i + 2, 2]))
+                if nan_nodes > 1:
+                    continue
+                if nan_nodes == 0:
+                    triangles[nt, 0] = indices[j, i]
+                    triangles[nt:nt + 2, 1] = indices[j, i + 1]
+                    triangles[nt:nt + 2, 2] = indices[j + 1, i]
+                    triangles[nt + 1, 0] = indices[j + 1, i + 1]
+                    nt += 2
+                elif indices[j, i] < 0:
+                    triangles[nt, 0] = indices[j, i + 1]
+                    triangles[nt, 1] = indices[j + 1, i]
+                    triangles[nt, 2] = indices[j + 1, i + 1]
+                    nt += 1
+                elif indices[j, i + 1] < 0:
+                    triangles[nt, 0] = indices[j, i]
+                    triangles[nt, 1] = indices[j + 1, i]
+                    triangles[nt, 2] = indices[j + 1, i + 1]
+                    nt += 1
+                elif indices[j + 1, i] < 0:
+                    triangles[nt, 0] = indices[j, i + 1]
+                    triangles[nt, 1] = indices[j, i]
+                    triangles[nt, 2] = indices[j + 1, i + 1]
+                    nt += 1
+                elif indices[j + 1, i + 1] < 0:
+                    triangles[nt, 0] = indices[j, i + 1]
+                    triangles[nt, 1] = indices[j + 1, i]
+                    triangles[nt, 2] = indices[j, i]
+                    nt += 1
+                else:
+                    raise Exception('code failure in sparse mesh processing')
+        self.ni = None
+        self.triangles = triangles[:nt, :]
+        self.triangle_count = nt
 
-   def set_from_sparse_mesh(self, mesh_xyz):
-      """Populate this (empty) patch from a mesh array of shape (N, M, 3), with some NaNs in z."""
+    def set_from_torn_mesh(self, mesh_xyz, quad_triangles = False):
+        """Populate this (empty) patch from a torn mesh array of shape (nj, ni, 2, 2, 3)."""
 
-      # todo: add quad_triangles argument to apply to 'squares' with no NaNs
-      mesh_shape = mesh_xyz.shape
-      assert len(mesh_shape) == 3 and mesh_shape[0] > 1 and mesh_shape[1] > 1 and mesh_shape[2] == 3
-      self.quad_triangles = False
-      points = np.zeros(mesh_xyz.shape).reshape((-1, 3))
-      indices = np.zeros(mesh_xyz.shape[:2], dtype = int) - 1
-      n_p = 0
-      # this could probably be speeded up with some numpy where operation
-      for j in range(mesh_shape[0]):
-         for i in range(mesh_shape[1]):
-            if not np.isnan(mesh_xyz[j, i, 2]):
-               points[n_p] = mesh_xyz[j, i]
-               indices[j, i] = n_p
-               n_p += 1
-      self.points = points[:n_p, :]
-      self.node_count = n_p
-      triangles = np.zeros((2 * (mesh_shape[0] - 1) * (mesh_shape[1] - 1), 3), dtype = int)  # truncate later
-      nt = 0
-      for j in range(mesh_shape[0] - 1):
-         for i in range(mesh_shape[1] - 1):
-            nan_nodes = np.count_nonzero(np.isnan(mesh_xyz[j:j + 2, i:i + 2, 2]))
-            if nan_nodes > 1:
-               continue
-            if nan_nodes == 0:
-               triangles[nt, 0] = indices[j, i]
-               triangles[nt:nt + 2, 1] = indices[j, i + 1]
-               triangles[nt:nt + 2, 2] = indices[j + 1, i]
-               triangles[nt + 1, 0] = indices[j + 1, i + 1]
-               nt += 2
-            elif indices[j, i] < 0:
-               triangles[nt, 0] = indices[j, i + 1]
-               triangles[nt, 1] = indices[j + 1, i]
-               triangles[nt, 2] = indices[j + 1, i + 1]
-               nt += 1
-            elif indices[j, i + 1] < 0:
-               triangles[nt, 0] = indices[j, i]
-               triangles[nt, 1] = indices[j + 1, i]
-               triangles[nt, 2] = indices[j + 1, i + 1]
-               nt += 1
-            elif indices[j + 1, i] < 0:
-               triangles[nt, 0] = indices[j, i + 1]
-               triangles[nt, 1] = indices[j, i]
-               triangles[nt, 2] = indices[j + 1, i + 1]
-               nt += 1
-            elif indices[j + 1, i + 1] < 0:
-               triangles[nt, 0] = indices[j, i + 1]
-               triangles[nt, 1] = indices[j + 1, i]
-               triangles[nt, 2] = indices[j, i]
-               nt += 1
-            else:
-               raise Exception('code failure in sparse mesh processing')
-      self.ni = None
-      self.triangles = triangles[:nt, :]
-      self.triangle_count = nt
+        mesh_shape = mesh_xyz.shape
+        assert len(mesh_shape) == 5 and mesh_shape[0] > 0 and mesh_shape[1] > 0 and mesh_shape[2:] == (2, 2, 3)
+        nj = mesh_shape[0]
+        ni = mesh_shape[1]
+        if quad_triangles:
+            # generate centre points:
+            quad_centres = np.empty((nj, ni, 3))
+            quad_centres[:, :, :] = 0.25 * np.sum(mesh_xyz, axis = (2, 3))
+            self.points = np.concatenate((mesh_xyz.copy().reshape((-1, 3)), quad_centres.reshape((-1, 3))))
+            mesh_size = mesh_xyz.size // 3
+            self.node_count = 5 * nj * ni
+            self.triangle_count = 4 * nj * ni
+            self.quad_triangles = True
+            triangles = np.empty((nj, ni, 4, 3), dtype = int)  # flatten later
+            for j in range(nj):
+                for i in range(ni):
+                    base_p = 4 * (j * ni + i)
+                    triangles[j, i, :, 0] = mesh_size + j * ni + i  # quad centre
+                    triangles[j, i, 0, 1] = base_p
+                    triangles[j, i, 0, 2] = triangles[j, i, 1, 1] = base_p + 1
+                    triangles[j, i, 1, 2] = triangles[j, i, 2, 1] = base_p + 3
+                    triangles[j, i, 2, 2] = triangles[j, i, 3, 1] = base_p + 2
+                    triangles[j, i, 3, 2] = base_p
+        else:
+            self.points = mesh_xyz.copy().reshape((-1, 3))
+            self.node_count = 4 * nj * ni
+            self.triangle_count = 2 * nj * ni
+            self.quad_triangles = False
+            triangles = np.empty((nj, ni, 2, 3), dtype = int)  # flatten later
+            for j in range(nj):
+                for i in range(ni):
+                    base_p = 4 * (j * ni + i)
+                    triangles[j, i, 0, 0] = base_p
+                    triangles[j, i, :, 1] = base_p + 1
+                    triangles[j, i, :, 2] = base_p + 2
+                    triangles[j, i, 1, 0] = base_p + 3
+        self.ni = ni
+        self.triangles = triangles.reshape((-1, 3))
 
-   def set_from_torn_mesh(self, mesh_xyz, quad_triangles = False):
-      """Populate this (empty) patch from a torn mesh array of shape (nj, ni, 2, 2, 3)."""
-
-      mesh_shape = mesh_xyz.shape
-      assert len(mesh_shape) == 5 and mesh_shape[0] > 0 and mesh_shape[1] > 0 and mesh_shape[2:] == (2, 2, 3)
-      nj = mesh_shape[0]
-      ni = mesh_shape[1]
-      if quad_triangles:
-         # generate centre points:
-         quad_centres = np.empty((nj, ni, 3))
-         quad_centres[:, :, :] = 0.25 * np.sum(mesh_xyz, axis = (2, 3))
-         self.points = np.concatenate((mesh_xyz.copy().reshape((-1, 3)), quad_centres.reshape((-1, 3))))
-         mesh_size = mesh_xyz.size // 3
-         self.node_count = 5 * nj * ni
-         self.triangle_count = 4 * nj * ni
-         self.quad_triangles = True
-         triangles = np.empty((nj, ni, 4, 3), dtype = int)  # flatten later
-         for j in range(nj):
-            for i in range(ni):
-               base_p = 4 * (j * ni + i)
-               triangles[j, i, :, 0] = mesh_size + j * ni + i  # quad centre
-               triangles[j, i, 0, 1] = base_p
-               triangles[j, i, 0, 2] = triangles[j, i, 1, 1] = base_p + 1
-               triangles[j, i, 1, 2] = triangles[j, i, 2, 1] = base_p + 3
-               triangles[j, i, 2, 2] = triangles[j, i, 3, 1] = base_p + 2
-               triangles[j, i, 3, 2] = base_p
-      else:
-         self.points = mesh_xyz.copy().reshape((-1, 3))
-         self.node_count = 4 * nj * ni
-         self.triangle_count = 2 * nj * ni
-         self.quad_triangles = False
-         triangles = np.empty((nj, ni, 2, 3), dtype = int)  # flatten later
-         for j in range(nj):
-            for i in range(ni):
-               base_p = 4 * (j * ni + i)
-               triangles[j, i, 0, 0] = base_p
-               triangles[j, i, :, 1] = base_p + 1
-               triangles[j, i, :, 2] = base_p + 2
-               triangles[j, i, 1, 0] = base_p + 3
-      self.ni = ni
-      self.triangles = triangles.reshape((-1, 3))
-
-   def column_from_triangle_index(self, triangle_index):
-      """For patch freshly built from fully defined mesh, returns (j, i) for given triangle index.
+    def column_from_triangle_index(self, triangle_index):
+        """For patch freshly built from fully defined mesh, returns (j, i) for given triangle index.
 
       argument:
          triangle_index (int or numpy int array): the triangle index (or array of indices) for which column(s) are being
@@ -417,120 +419,120 @@ class TriangulatedPatch:
          if triangle_index is a numpy int array, a pair of similarly shaped numpy arrays is returned
       """
 
-      if self.quad_triangles is None or self.ni is None:
-         return (None, None)
-      if isinstance(triangle_index, int):
-         if triangle_index >= self.triangle_count:
+        if self.quad_triangles is None or self.ni is None:
             return (None, None)
-      else:
-         if np.any(triangle_index >= self.triangle_count):
-            return (None, None)
-      if self.quad_triangles:
-         face = triangle_index // 4
-      else:
-         face = triangle_index // 2
-      if isinstance(face, int):
-         return divmod(face, self.ni)
-      return np.divmod(face, self.ni)
+        if isinstance(triangle_index, int):
+            if triangle_index >= self.triangle_count:
+                return (None, None)
+        else:
+            if np.any(triangle_index >= self.triangle_count):
+                return (None, None)
+        if self.quad_triangles:
+            face = triangle_index // 4
+        else:
+            face = triangle_index // 2
+        if isinstance(face, int):
+            return divmod(face, self.ni)
+        return np.divmod(face, self.ni)
 
-   def set_to_cell_faces_from_corner_points(self, cp, quad_triangles = True):
-      """Populates this (empty) patch to represent faces of a cell, from corner points of shape (2, 2, 2, 3)."""
+    def set_to_cell_faces_from_corner_points(self, cp, quad_triangles = True):
+        """Populates this (empty) patch to represent faces of a cell, from corner points of shape (2, 2, 2, 3)."""
 
-      assert cp.shape == (2, 2, 2, 3)
-      self.quad_triangles = quad_triangles
-      if quad_triangles:
-         self.triangle_count = 24
-         quad_centres = np.empty((3, 2, 3))
-         quad_centres[0, 0, :] = 0.25 * np.sum(cp[0, :, :, :], axis = (0, 1))  # K-
-         quad_centres[0, 1, :] = 0.25 * np.sum(cp[1, :, :, :], axis = (0, 1))  # K+
-         quad_centres[1, 0, :] = 0.25 * np.sum(cp[:, 0, :, :], axis = (0, 1))  # J-
-         quad_centres[1, 1, :] = 0.25 * np.sum(cp[:, 1, :, :], axis = (0, 1))  # J+
-         quad_centres[2, 0, :] = 0.25 * np.sum(cp[:, :, 0, :], axis = (0, 1))  # I-
-         quad_centres[2, 1, :] = 0.25 * np.sum(cp[:, :, 1, :], axis = (0, 1))  # I+
-         self.node_count = 14
-         self.points = np.concatenate((cp.copy().reshape((-1, 3)), quad_centres.reshape((-1, 3))))
-         triangles = np.empty((3, 2, 4, 3), dtype = int)  # flatten later
-         for axis in range(3):
-            if axis == 0:
-               ip1, ip2 = 2, 1
-            elif axis == 1:
-               ip1, ip2 = 4, 1
-            else:
-               ip1, ip2 = 4, 2
-            for ip in range(2):
-               centre_p = 8 + 2 * axis + ip
-               ips = -2 * ip + 1  # +1 for -ve face; -1 for +ve face!
-               base_p = 7 * ip
-               triangles[axis, ip, :, 0] = centre_p  # quad centre
-               triangles[axis, ip, 0, 1] = base_p
-               triangles[axis, ip, 0, 2] = triangles[axis, ip, 1, 1] = base_p + ips * (ip2)
-               triangles[axis, ip, 1, 2] = triangles[axis, ip, 2, 1] = base_p + ips * (ip1 + ip2)
-               triangles[axis, ip, 2, 2] = triangles[axis, ip, 3, 1] = base_p + ips * (ip1)
-               triangles[axis, ip, 3, 2] = base_p
-      else:
-         self.triangle_count = 12
-         self.node_count = 8
-         self.points = cp.copy().reshape((-1, 3))
-         triangles = np.empty((3, 2, 2, 3), dtype = int)  # flatten later
-         for axis in range(3):
-            if axis == 0:
-               ip1, ip2 = 2, 1
-            elif axis == 1:
-               ip1, ip2 = 4, 1
-            else:
-               ip1, ip2 = 4, 2
-            for ip in range(2):
-               ips = -2 * ip + 1  # +1 for -ve face; -1 for +ve face!
-               base_p = 7 * ip
-               triangles[axis, ip, :, 0] = base_p
-               triangles[axis, ip, :, 1] = base_p + ips * (ip1 + ip2)
-               triangles[axis, ip, 0, 2] = base_p + ips * (ip2)
-               triangles[axis, ip, 1, 2] = base_p + ips * (ip1)
-      self.triangles = triangles.reshape((-1, 3))
+        assert cp.shape == (2, 2, 2, 3)
+        self.quad_triangles = quad_triangles
+        if quad_triangles:
+            self.triangle_count = 24
+            quad_centres = np.empty((3, 2, 3))
+            quad_centres[0, 0, :] = 0.25 * np.sum(cp[0, :, :, :], axis = (0, 1))  # K-
+            quad_centres[0, 1, :] = 0.25 * np.sum(cp[1, :, :, :], axis = (0, 1))  # K+
+            quad_centres[1, 0, :] = 0.25 * np.sum(cp[:, 0, :, :], axis = (0, 1))  # J-
+            quad_centres[1, 1, :] = 0.25 * np.sum(cp[:, 1, :, :], axis = (0, 1))  # J+
+            quad_centres[2, 0, :] = 0.25 * np.sum(cp[:, :, 0, :], axis = (0, 1))  # I-
+            quad_centres[2, 1, :] = 0.25 * np.sum(cp[:, :, 1, :], axis = (0, 1))  # I+
+            self.node_count = 14
+            self.points = np.concatenate((cp.copy().reshape((-1, 3)), quad_centres.reshape((-1, 3))))
+            triangles = np.empty((3, 2, 4, 3), dtype = int)  # flatten later
+            for axis in range(3):
+                if axis == 0:
+                    ip1, ip2 = 2, 1
+                elif axis == 1:
+                    ip1, ip2 = 4, 1
+                else:
+                    ip1, ip2 = 4, 2
+                for ip in range(2):
+                    centre_p = 8 + 2 * axis + ip
+                    ips = -2 * ip + 1  # +1 for -ve face; -1 for +ve face!
+                    base_p = 7 * ip
+                    triangles[axis, ip, :, 0] = centre_p  # quad centre
+                    triangles[axis, ip, 0, 1] = base_p
+                    triangles[axis, ip, 0, 2] = triangles[axis, ip, 1, 1] = base_p + ips * (ip2)
+                    triangles[axis, ip, 1, 2] = triangles[axis, ip, 2, 1] = base_p + ips * (ip1 + ip2)
+                    triangles[axis, ip, 2, 2] = triangles[axis, ip, 3, 1] = base_p + ips * (ip1)
+                    triangles[axis, ip, 3, 2] = base_p
+        else:
+            self.triangle_count = 12
+            self.node_count = 8
+            self.points = cp.copy().reshape((-1, 3))
+            triangles = np.empty((3, 2, 2, 3), dtype = int)  # flatten later
+            for axis in range(3):
+                if axis == 0:
+                    ip1, ip2 = 2, 1
+                elif axis == 1:
+                    ip1, ip2 = 4, 1
+                else:
+                    ip1, ip2 = 4, 2
+                for ip in range(2):
+                    ips = -2 * ip + 1  # +1 for -ve face; -1 for +ve face!
+                    base_p = 7 * ip
+                    triangles[axis, ip, :, 0] = base_p
+                    triangles[axis, ip, :, 1] = base_p + ips * (ip1 + ip2)
+                    triangles[axis, ip, 0, 2] = base_p + ips * (ip2)
+                    triangles[axis, ip, 1, 2] = base_p + ips * (ip1)
+        self.triangles = triangles.reshape((-1, 3))
 
-   def face_from_triangle_index(self, triangle_index):
-      """For patch freshly built for cell faces, returns (axis, polarity) for given triangle index."""
+    def face_from_triangle_index(self, triangle_index):
+        """For patch freshly built for cell faces, returns (axis, polarity) for given triangle index."""
 
-      if self.quad_triangles:
-         assert self.node_count == 30 and self.triangle_count == 24
-         assert 0 <= triangle_index < 24
-         face = triangle_index // 4
-      else:
-         assert self.node_count == 24 and self.triangle_count == 12
-         assert 0 <= triangle_index < 12
-         face = triangle_index // 2
-      axis, polarity = divmod(face, 2)
-      return axis, polarity
+        if self.quad_triangles:
+            assert self.node_count == 30 and self.triangle_count == 24
+            assert 0 <= triangle_index < 24
+            face = triangle_index // 4
+        else:
+            assert self.node_count == 24 and self.triangle_count == 12
+            assert 0 <= triangle_index < 12
+            face = triangle_index // 2
+        axis, polarity = divmod(face, 2)
+        return axis, polarity
 
-   def vertical_rescale_points(self, ref_depth, scaling_factor):
-      """Modify the z values of points for this patch by stretching the distance from reference depth by scaling factor."""
+    def vertical_rescale_points(self, ref_depth, scaling_factor):
+        """Modify the z values of points for this patch by stretching the distance from reference depth by scaling factor."""
 
-      _, _ = self.triangles_and_points()  # ensure points are loaded
-      z_values = self.points[:, 2].copy()
-      self.points[:, 2] = ref_depth + scaling_factor * (z_values - ref_depth)
+        _, _ = self.triangles_and_points()  # ensure points are loaded
+        z_values = self.points[:, 2].copy()
+        self.points[:, 2] = ref_depth + scaling_factor * (z_values - ref_depth)
 
 
 class Surface(_BaseSurface):
-   """Class for RESQML triangulated set surfaces."""
+    """Class for RESQML triangulated set surfaces."""
 
-   resqml_type = 'TriangulatedSetRepresentation'
+    resqml_type = 'TriangulatedSetRepresentation'
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                surface_root = None,
-                point_set = None,
-                mesh = None,
-                mesh_file = None,
-                mesh_format = None,
-                tsurf_file = None,
-                quad_triangles = False,
-                title = None,
-                surface_role = 'map',
-                crs_uuid = None,
-                originator = None,
-                extra_metadata = {}):
-      """Create an empty Surface object (RESQML TriangulatedSetRepresentation) and optionally populates from xml, point set or mesh.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 surface_root = None,
+                 point_set = None,
+                 mesh = None,
+                 mesh_file = None,
+                 mesh_format = None,
+                 tsurf_file = None,
+                 quad_triangles = False,
+                 title = None,
+                 surface_role = 'map',
+                 crs_uuid = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Create an empty Surface object (RESQML TriangulatedSetRepresentation) and optionally populates from xml, point set or mesh.
 
       arguments:
          parent_model (model.Model object): the model to which this surface belongs
@@ -579,84 +581,84 @@ class Surface(_BaseSurface):
       :meta common:
       """
 
-      assert surface_role in ['map', 'pick']
+        assert surface_role in ['map', 'pick']
 
-      self.surface_role = surface_role
-      self.patch_list = []  # ordered list of patches
-      self.crs_uuid = crs_uuid
-      self.triangles = None  # composite triangles (all patches)
-      self.points = None  # composite points (all patches)
-      self.boundaries = None  # todo: read up on what this is for and look out for examples
-      self.represented_interpretation_root = None
-      self.title = title
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = surface_root)
-      if self.root is not None:
-         pass
-      elif point_set is not None:
-         self.set_from_point_set(point_set)
-      elif mesh is not None:
-         self.set_from_mesh_object(mesh, quad_triangles = quad_triangles)
-      elif mesh_file and mesh_format:
-         self.set_from_mesh_file(mesh_file, mesh_format, quad_triangles = quad_triangles)
-      elif tsurf_file is not None:
-         self.set_from_tsurf_file(tsurf_file)
+        self.surface_role = surface_role
+        self.patch_list = []  # ordered list of patches
+        self.crs_uuid = crs_uuid
+        self.triangles = None  # composite triangles (all patches)
+        self.points = None  # composite points (all patches)
+        self.boundaries = None  # todo: read up on what this is for and look out for examples
+        self.represented_interpretation_root = None
+        self.title = title
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = surface_root)
+        if self.root is not None:
+            pass
+        elif point_set is not None:
+            self.set_from_point_set(point_set)
+        elif mesh is not None:
+            self.set_from_mesh_object(mesh, quad_triangles = quad_triangles)
+        elif mesh_file and mesh_format:
+            self.set_from_mesh_file(mesh_file, mesh_format, quad_triangles = quad_triangles)
+        elif tsurf_file is not None:
+            self.set_from_tsurf_file(tsurf_file)
 
-   def _load_from_xml(self):
-      root_node = self.root
-      assert root_node is not None
-      self.extract_patches(root_node)
-      ref_node = rqet.find_tag(root_node, 'RepresentedInterpretation')
-      if ref_node is not None:
-         interp_root = self.model.referenced_node(ref_node)
-         self.set_represented_interpretation_root(interp_root)
+    def _load_from_xml(self):
+        root_node = self.root
+        assert root_node is not None
+        self.extract_patches(root_node)
+        ref_node = rqet.find_tag(root_node, 'RepresentedInterpretation')
+        if ref_node is not None:
+            interp_root = self.model.referenced_node(ref_node)
+            self.set_represented_interpretation_root(interp_root)
 
-   @property
-   def represented_interpretation_uuid(self):
-      return rqet.uuid_for_part_root(self.represented_interpretation_root)
+    @property
+    def represented_interpretation_uuid(self):
+        return rqet.uuid_for_part_root(self.represented_interpretation_root)
 
-   def set_represented_interpretation_root(self, interp_root):
-      """Makes a note of the xml root of the represented interpretation."""
+    def set_represented_interpretation_root(self, interp_root):
+        """Makes a note of the xml root of the represented interpretation."""
 
-      self.represented_interpretation_root = interp_root
+        self.represented_interpretation_root = interp_root
 
-   def extract_patches(self, surface_root):
-      """Scan surface root for triangle patches, create TriangulatedPatch objects and build up patch_list."""
+    def extract_patches(self, surface_root):
+        """Scan surface root for triangle patches, create TriangulatedPatch objects and build up patch_list."""
 
-      if len(self.patch_list):
-         return
-      assert surface_root is not None
-      paired_list = []
-      self.patch_list = []
-      for child in surface_root:
-         if rqet.stripped_of_prefix(child.tag) != 'TrianglePatch':
-            continue
-         patch_index = rqet.find_tag_int(child, 'PatchIndex')
-         assert patch_index is not None
-         triangulated_patch = TriangulatedPatch(self.model, patch_index = patch_index, patch_node = child)
-         assert triangulated_patch is not None
-         if self.crs_uuid is None:
-            self.crs_uuid = triangulated_patch.crs_uuid
-         else:
-            if not bu.matching_uuids(triangulated_patch.crs_uuid, self.crs_uuid):
-               log.warning('mixed coordinate reference systems in use within a surface')
-         paired_list.append((patch_index, triangulated_patch))
-      paired_list.sort()
-      assert len(paired_list) and paired_list[0][0] == 0 and len(paired_list) == paired_list[-1][0] + 1
-      for _, patch in paired_list:
-         self.patch_list.append(patch)
+        if len(self.patch_list):
+            return
+        assert surface_root is not None
+        paired_list = []
+        self.patch_list = []
+        for child in surface_root:
+            if rqet.stripped_of_prefix(child.tag) != 'TrianglePatch':
+                continue
+            patch_index = rqet.find_tag_int(child, 'PatchIndex')
+            assert patch_index is not None
+            triangulated_patch = TriangulatedPatch(self.model, patch_index = patch_index, patch_node = child)
+            assert triangulated_patch is not None
+            if self.crs_uuid is None:
+                self.crs_uuid = triangulated_patch.crs_uuid
+            else:
+                if not bu.matching_uuids(triangulated_patch.crs_uuid, self.crs_uuid):
+                    log.warning('mixed coordinate reference systems in use within a surface')
+            paired_list.append((patch_index, triangulated_patch))
+        paired_list.sort()
+        assert len(paired_list) and paired_list[0][0] == 0 and len(paired_list) == paired_list[-1][0] + 1
+        for _, patch in paired_list:
+            self.patch_list.append(patch)
 
-   def set_model(self, parent_model):
-      """Associate the surface with a resqml model (does not create xml or write hdf5 data)."""
+    def set_model(self, parent_model):
+        """Associate the surface with a resqml model (does not create xml or write hdf5 data)."""
 
-      self.model = parent_model
+        self.model = parent_model
 
-   def triangles_and_points(self):
-      """Returns arrays representing combination of all the patches in the surface.
+    def triangles_and_points(self):
+        """Returns arrays representing combination of all the patches in the surface.
 
       Returns:
          Tuple (triangles, points):
@@ -668,43 +670,43 @@ class Surface(_BaseSurface):
       :meta common:
       """
 
-      if self.triangles is not None:
-         return (self.triangles, self.points)
-      self.extract_patches(self.root)
-      points_offset = 0
-      for triangulated_patch in self.patch_list:
-         (t, p) = triangulated_patch.triangles_and_points()
-         if points_offset == 0:
-            self.triangles = t.copy()
-            self.points = p.copy()
-         else:
-            self.triangles = np.concatenate((self.triangles, t.copy() + points_offset))
-            self.points = np.concatenate((self.points, p.copy()))
-         points_offset += p.shape[0]
-      return (self.triangles, self.points)
+        if self.triangles is not None:
+            return (self.triangles, self.points)
+        self.extract_patches(self.root)
+        points_offset = 0
+        for triangulated_patch in self.patch_list:
+            (t, p) = triangulated_patch.triangles_and_points()
+            if points_offset == 0:
+                self.triangles = t.copy()
+                self.points = p.copy()
+            else:
+                self.triangles = np.concatenate((self.triangles, t.copy() + points_offset))
+                self.points = np.concatenate((self.points, p.copy()))
+            points_offset += p.shape[0]
+        return (self.triangles, self.points)
 
-   def distinct_edges(self):
-      """Returns a numpy int array of shape (N, 2) being the ordered node pairs of distinct edges of triangles."""
+    def distinct_edges(self):
+        """Returns a numpy int array of shape (N, 2) being the ordered node pairs of distinct edges of triangles."""
 
-      triangles, _ = self.triangles_and_points()
-      assert triangles is not None
-      tri_count = len(triangles)
-      all_edges = np.empty((tri_count, 3, 2))
-      for i in range(3):
-         all_edges[:, i, 0] = triangles[:, i - 1]
-         all_edges[:, i, 1] = triangles[:, i]
-      return np.unique(np.sort(all_edges.reshape((-1, 2)), axis = 1), axis = 0)
+        triangles, _ = self.triangles_and_points()
+        assert triangles is not None
+        tri_count = len(triangles)
+        all_edges = np.empty((tri_count, 3, 2))
+        for i in range(3):
+            all_edges[:, i, 0] = triangles[:, i - 1]
+            all_edges[:, i, 1] = triangles[:, i]
+        return np.unique(np.sort(all_edges.reshape((-1, 2)), axis = 1), axis = 0)
 
-   def set_from_triangles_and_points(self, triangles, points):
-      """Populate this (empty) Surface object from an array of triangle corner indices and an array of points."""
+    def set_from_triangles_and_points(self, triangles, points):
+        """Populate this (empty) Surface object from an array of triangle corner indices and an array of points."""
 
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_from_triangles_and_points(triangles, points)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_from_triangles_and_points(triangles, points)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def set_from_point_set(self, point_set, convexity_parameter = 5.0):
-      """Populate this (empty) Surface object with a Delaunay triangulation of points in a PointSet object.
+    def set_from_point_set(self, point_set, convexity_parameter = 5.0):
+        """Populate this (empty) Surface object with a Delaunay triangulation of points in a PointSet object.
 
       arguments:
          point_set (PointSet): the set of points to be triangulated to form a surface
@@ -713,15 +715,15 @@ class Surface(_BaseSurface):
             chance of even a slight concavity
       """
 
-      p = point_set.full_array_ref()
-      log.debug('number of points going into dt: ' + str(len(p)))
-      t = triangulate.dt(p[:, :2], container_size_factor = convexity_parameter)
-      log.debug('number of triangles: ' + str(len(t)))
-      self.crs_uuid = point_set.crs_uuid
-      self.set_from_triangles_and_points(t, p)
+        p = point_set.full_array_ref()
+        log.debug('number of points going into dt: ' + str(len(p)))
+        t = triangulate.dt(p[:, :2], container_size_factor = convexity_parameter)
+        log.debug('number of triangles: ' + str(len(t)))
+        self.crs_uuid = point_set.crs_uuid
+        self.set_from_triangles_and_points(t, p)
 
-   def set_from_irregular_mesh(self, mesh_xyz, quad_triangles = False):
-      """Populate this (empty) Surface object from an untorn mesh array of shape (N, M, 3).
+    def set_from_irregular_mesh(self, mesh_xyz, quad_triangles = False):
+        """Populate this (empty) Surface object from an untorn mesh array of shape (N, M, 3).
 
          arguments:
             mesh_xyz (numpy float array of shape (N, M, 3)): a 2D lattice of points in 3D space
@@ -731,38 +733,38 @@ class Surface(_BaseSurface):
                mode gives a non-unique triangulated result
       """
 
-      mesh_shape = mesh_xyz.shape
-      assert len(mesh_shape) == 3 and mesh_shape[2] == 3
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_from_irregular_mesh(mesh_xyz, quad_triangles = quad_triangles)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        mesh_shape = mesh_xyz.shape
+        assert len(mesh_shape) == 3 and mesh_shape[2] == 3
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_from_irregular_mesh(mesh_xyz, quad_triangles = quad_triangles)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def set_from_sparse_mesh(self, mesh_xyz):
-      """Populate this (empty) Surface object from a mesh array of shape (N, M, 3) with NaNs.
+    def set_from_sparse_mesh(self, mesh_xyz):
+        """Populate this (empty) Surface object from a mesh array of shape (N, M, 3) with NaNs.
 
          arguments:
             mesh_xyz (numpy float array of shape (N, M, 3)): a 2D lattice of points in 3D space, with NaNs in z
       """
 
-      mesh_shape = mesh_xyz.shape
-      assert len(mesh_shape) == 3 and mesh_shape[2] == 3
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_from_sparse_mesh(mesh_xyz)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        mesh_shape = mesh_xyz.shape
+        assert len(mesh_shape) == 3 and mesh_shape[2] == 3
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_from_sparse_mesh(mesh_xyz)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def set_from_mesh_object(self, mesh, quad_triangles = False):
-      """Populate the (empty) Surface object from a Mesh object."""
+    def set_from_mesh_object(self, mesh, quad_triangles = False):
+        """Populate the (empty) Surface object from a Mesh object."""
 
-      xyz = mesh.full_array_ref()
-      if np.any(np.isnan(xyz)):
-         self.set_from_sparse_mesh(xyz)
-      else:
-         self.set_from_irregular_mesh(xyz, quad_triangles = quad_triangles)
+        xyz = mesh.full_array_ref()
+        if np.any(np.isnan(xyz)):
+            self.set_from_sparse_mesh(xyz)
+        else:
+            self.set_from_irregular_mesh(xyz, quad_triangles = quad_triangles)
 
-   def set_from_torn_mesh(self, mesh_xyz, quad_triangles = False):
-      """Populate this (empty) Surface object from a torn mesh array of shape (nj, ni, 2, 2, 3).
+    def set_from_torn_mesh(self, mesh_xyz, quad_triangles = False):
+        """Populate this (empty) Surface object from a torn mesh array of shape (nj, ni, 2, 2, 3).
 
          arguments:
             mesh_xyz (numpy float array of shape (nj, ni, 2, 2, 3)): corner points of 2D faces in 3D space
@@ -772,15 +774,15 @@ class Surface(_BaseSurface):
                mode gives a non-unique triangulated result
       """
 
-      mesh_shape = mesh_xyz.shape
-      assert len(mesh_shape) == 5 and mesh_shape[2:] == (2, 2, 3)
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_from_torn_mesh(mesh_xyz, quad_triangles = quad_triangles)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        mesh_shape = mesh_xyz.shape
+        assert len(mesh_shape) == 5 and mesh_shape[2:] == (2, 2, 3)
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_from_torn_mesh(mesh_xyz, quad_triangles = quad_triangles)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def column_from_triangle_index(self, triangle_index):
-      """For surface freshly built from fully defined mesh, returns (j, i) for given triangle index.
+    def column_from_triangle_index(self, triangle_index):
+        """For surface freshly built from fully defined mesh, returns (j, i) for given triangle index.
 
       argument:
          triangle_index (int or numpy int array): the triangle index (or array of indices) for which column(s) is/are
@@ -799,34 +801,34 @@ class Surface(_BaseSurface):
       :meta common:
       """
 
-      assert len(self.patch_list) == 1
-      return self.patch_list[0].column_from_triangle_index(triangle_index)
+        assert len(self.patch_list) == 1
+        return self.patch_list[0].column_from_triangle_index(triangle_index)
 
-   def set_to_single_cell_faces_from_corner_points(self, cp, quad_triangles = True):
-      """Populates this (empty) surface to represent faces of a cell, from corner points of shape (2, 2, 2, 3)."""
+    def set_to_single_cell_faces_from_corner_points(self, cp, quad_triangles = True):
+        """Populates this (empty) surface to represent faces of a cell, from corner points of shape (2, 2, 2, 3)."""
 
-      assert cp.size == 24
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_to_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        assert cp.size == 24
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_to_cell_faces_from_corner_points(cp, quad_triangles = quad_triangles)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def set_to_multi_cell_faces_from_corner_points(self, cp, quad_triangles = True):
-      """Populates this (empty) surface to represent faces of a set of cells, from corner points of shape (N, 2, 2, 2, 3)."""
+    def set_to_multi_cell_faces_from_corner_points(self, cp, quad_triangles = True):
+        """Populates this (empty) surface to represent faces of a set of cells, from corner points of shape (N, 2, 2, 2, 3)."""
 
-      assert cp.size % 24 == 0
-      cp = cp.reshape((-1, 2, 2, 2, 3))
-      self.patch_list = []
-      p_index = 0
-      for cell_cp in cp:
-         tri_patch = TriangulatedPatch(self.model, patch_index = p_index, crs_uuid = self.crs_uuid)
-         tri_patch.set_to_cell_faces_from_corner_points(cell_cp, quad_triangles = quad_triangles)
-         self.patch_list.append(tri_patch)
-         p_index += 1
-      self.uuid = bu.new_uuid()
+        assert cp.size % 24 == 0
+        cp = cp.reshape((-1, 2, 2, 2, 3))
+        self.patch_list = []
+        p_index = 0
+        for cell_cp in cp:
+            tri_patch = TriangulatedPatch(self.model, patch_index = p_index, crs_uuid = self.crs_uuid)
+            tri_patch.set_to_cell_faces_from_corner_points(cell_cp, quad_triangles = quad_triangles)
+            self.patch_list.append(tri_patch)
+            p_index += 1
+        self.uuid = bu.new_uuid()
 
-   def cell_axis_and_polarity_from_triangle_index(self, triangle_index):
-      """For surface freshly built for cell faces, returns (cell_number, face_axis, polarity) for given triangle index.
+    def cell_axis_and_polarity_from_triangle_index(self, triangle_index):
+        """For surface freshly built for cell faces, returns (cell_number, face_axis, polarity) for given triangle index.
 
       argument:
          triangle_index (int or numpy int array): the triangle index (or array of indices) for which cell face
@@ -839,14 +841,14 @@ class Surface(_BaseSurface):
          if the surface was built for a single cell, the returned cell number will be zero
       """
 
-      triangles_per_face = 4 if self.patch_list[0].quad_triangles else 2
-      face_index = triangle_index // triangles_per_face
-      cell_number, remainder = divmod(face_index, 6)
-      axis, polarity = divmod(remainder, 2)
-      return cell_number, axis, polarity
+        triangles_per_face = 4 if self.patch_list[0].quad_triangles else 2
+        face_index = triangle_index // triangles_per_face
+        cell_number, remainder = divmod(face_index, 6)
+        axis, polarity = divmod(remainder, 2)
+        return cell_number, axis, polarity
 
-   def set_to_horizontal_plane(self, depth, box_xyz, border = 0.0):
-      """Populate this (empty) surface with a patch of two triangles defining a flat, horizontal plane at a given depth.
+    def set_to_horizontal_plane(self, depth, box_xyz, border = 0.0):
+        """Populate this (empty) surface with a patch of two triangles defining a flat, horizontal plane at a given depth.
 
          arguments:
             depth (float): z value to use in all points in the triangulated patch
@@ -856,112 +858,112 @@ class Surface(_BaseSurface):
       :meta common:
       """
 
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_to_horizontal_plane(depth, box_xyz, border = border)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_to_horizontal_plane(depth, box_xyz, border = border)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def set_to_triangle(self, corners):
-      """Populate this (empty) surface with a patch of one triangle."""
+    def set_to_triangle(self, corners):
+        """Populate this (empty) surface with a patch of one triangle."""
 
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_to_triangle(corners)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_to_triangle(corners)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def set_to_sail(self, n, centre, radius, azimuth, delta_theta):
-      """Populate this (empty) surface with a patch representing a triangle wrapped on a sphere."""
+    def set_to_sail(self, n, centre, radius, azimuth, delta_theta):
+        """Populate this (empty) surface with a patch representing a triangle wrapped on a sphere."""
 
-      tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
-      tri_patch.set_to_sail(n, centre, radius, azimuth, delta_theta)
-      self.patch_list = [tri_patch]
-      self.uuid = bu.new_uuid()
+        tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
+        tri_patch.set_to_sail(n, centre, radius, azimuth, delta_theta)
+        self.patch_list = [tri_patch]
+        self.uuid = bu.new_uuid()
 
-   def set_from_mesh_file(self, filename, format, quad_triangles = False):
-      """Populate this (empty) surface from a zmap or RMS text mesh file."""
+    def set_from_mesh_file(self, filename, format, quad_triangles = False):
+        """Populate this (empty) surface from a zmap or RMS text mesh file."""
 
-      assert format in ['zmap', 'rms', 'roxar']  # 'roxar' is synonymous with 'rms'
-      x, y, z = read_mesh(filename, format = format)
-      assert x is not None and y is not None or z is not None, 'failed to read surface from zmap file'
-      assert x.size == y.size and x.size == z.size, 'non matching array sizes from zmap reader'
-      assert x.shape == y.shape and x.shape == z.shape, 'non matching array shapes from zmap reader'
+        assert format in ['zmap', 'rms', 'roxar']  # 'roxar' is synonymous with 'rms'
+        x, y, z = read_mesh(filename, format = format)
+        assert x is not None and y is not None or z is not None, 'failed to read surface from zmap file'
+        assert x.size == y.size and x.size == z.size, 'non matching array sizes from zmap reader'
+        assert x.shape == y.shape and x.shape == z.shape, 'non matching array shapes from zmap reader'
 
-      xyz_mesh = np.stack((x, y, z), axis = -1)
-      if np.any(np.isnan(z)):
-         self.set_from_sparse_mesh(xyz_mesh)
-      else:
-         self.set_from_irregular_mesh(xyz_mesh, quad_triangles = quad_triangles)
+        xyz_mesh = np.stack((x, y, z), axis = -1)
+        if np.any(np.isnan(z)):
+            self.set_from_sparse_mesh(xyz_mesh)
+        else:
+            self.set_from_irregular_mesh(xyz_mesh, quad_triangles = quad_triangles)
 
-   def set_from_tsurf_file(self, filename):
-      """Populate this (empty) surface from a GOCAD tsurf file."""
-      triangles, vertices = [], []
-      with open(filename, 'r') as fl:
-         lines = fl.readlines()
-         for line in lines:
-            if "VRTX" in line:
-               vertices.append(line.rstrip().split(" ")[2:])
-            elif "TRGL" in line:
-               triangles.append(line.rstrip().split(" ")[1:])
-      triangles = np.array(triangles, dtype = int)
-      vertices = np.array(vertices, dtype = float)
-      self.set_from_triangles_and_points(triangles = triangles, points = vertices)
+    def set_from_tsurf_file(self, filename):
+        """Populate this (empty) surface from a GOCAD tsurf file."""
+        triangles, vertices = [], []
+        with open(filename, 'r') as fl:
+            lines = fl.readlines()
+            for line in lines:
+                if "VRTX" in line:
+                    vertices.append(line.rstrip().split(" ")[2:])
+                elif "TRGL" in line:
+                    triangles.append(line.rstrip().split(" ")[1:])
+        triangles = np.array(triangles, dtype = int)
+        vertices = np.array(vertices, dtype = float)
+        self.set_from_triangles_and_points(triangles = triangles, points = vertices)
 
-   def set_from_zmap_file(self, filename, quad_triangles = False):
-      """Populate this (empty) surface from a zmap mesh file."""
+    def set_from_zmap_file(self, filename, quad_triangles = False):
+        """Populate this (empty) surface from a zmap mesh file."""
 
-      self.set_from_mesh_file(filename, 'zmap', quad_triangles = quad_triangles)
+        self.set_from_mesh_file(filename, 'zmap', quad_triangles = quad_triangles)
 
-   def set_from_roxar_file(self, filename, quad_triangles = False):
-      """Populate this (empty) surface from an RMS text mesh file."""
+    def set_from_roxar_file(self, filename, quad_triangles = False):
+        """Populate this (empty) surface from an RMS text mesh file."""
 
-      self.set_from_mesh_file(filename, 'rms', quad_triangles = quad_triangles)
+        self.set_from_mesh_file(filename, 'rms', quad_triangles = quad_triangles)
 
-   def set_from_rms_file(self, filename, quad_triangles = False):
-      """Populate this (empty) surface from an RMS text mesh file."""
+    def set_from_rms_file(self, filename, quad_triangles = False):
+        """Populate this (empty) surface from an RMS text mesh file."""
 
-      self.set_from_mesh_file(filename, 'rms', quad_triangles = quad_triangles)
+        self.set_from_mesh_file(filename, 'rms', quad_triangles = quad_triangles)
 
-   def vertical_rescale_points(self, ref_depth = None, scaling_factor = 1.0):
-      """Modify the z values of points for this surface by stretching the distance from reference depth by scaling factor."""
+    def vertical_rescale_points(self, ref_depth = None, scaling_factor = 1.0):
+        """Modify the z values of points for this surface by stretching the distance from reference depth by scaling factor."""
 
-      if scaling_factor == 1.0:
-         return
-      if ref_depth is None:
-         for patch in self.patch_list:
-            patch_min = np.min(patch.points[:, 2])
-            if ref_depth is None or patch_min < ref_depth:
-               ref_depth = patch_min
-      assert ref_depth is not None, 'no z values found for vertical rescaling of surface'
-      self.triangles = None  # invalidate any cached triangles & points in surface object
-      self.points = None
-      for patch in self.patch_list:
-         patch.vertical_rescale_points(ref_depth, scaling_factor)
+        if scaling_factor == 1.0:
+            return
+        if ref_depth is None:
+            for patch in self.patch_list:
+                patch_min = np.min(patch.points[:, 2])
+                if ref_depth is None or patch_min < ref_depth:
+                    ref_depth = patch_min
+        assert ref_depth is not None, 'no z values found for vertical rescaling of surface'
+        self.triangles = None  # invalidate any cached triangles & points in surface object
+        self.points = None
+        for patch in self.patch_list:
+            patch.vertical_rescale_points(ref_depth, scaling_factor)
 
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Create or append to an hdf5 file, writing datasets for the triangulated patches after caching arrays.
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Create or append to an hdf5 file, writing datasets for the triangulated patches after caching arrays.
 
       :meta common:
       """
 
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
-      # NB: patch arrays must all have been set up prior to calling this function
-      h5_reg = rwh5.H5Register(self.model)
-      # todo: sort patches by patch index and check sequence
-      for triangulated_patch in self.patch_list:
-         (t, p) = triangulated_patch.triangles_and_points()
-         h5_reg.register_dataset(self.uuid, 'points_patch{}'.format(triangulated_patch.patch_index), p)
-         h5_reg.register_dataset(self.uuid, 'triangles_patch{}'.format(triangulated_patch.patch_index), t)
-      h5_reg.write(file_name, mode = mode)
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
+        # NB: patch arrays must all have been set up prior to calling this function
+        h5_reg = rwh5.H5Register(self.model)
+        # todo: sort patches by patch index and check sequence
+        for triangulated_patch in self.patch_list:
+            (t, p) = triangulated_patch.triangles_and_points()
+            h5_reg.register_dataset(self.uuid, 'points_patch{}'.format(triangulated_patch.patch_index), p)
+            h5_reg.register_dataset(self.uuid, 'triangles_patch{}'.format(triangulated_patch.patch_index), t)
+        h5_reg.write(file_name, mode = mode)
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  crs_uuid = None,
-                  title = None,
-                  originator = None):
-      """Creates a triangulated surface xml node from this surface object and optionally adds as part of model.
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   crs_uuid = None,
+                   title = None,
+                   originator = None):
+        """Creates a triangulated surface xml node from this surface object and optionally adds as part of model.
 
          arguments:
             ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the surface arrays
@@ -981,119 +983,119 @@ class Surface(_BaseSurface):
       :meta common:
       """
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
-      if not self.title:
-         self.title = 'surface'
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
+        if not self.title:
+            self.title = 'surface'
 
-      tri_rep = super().create_xml(add_as_part = False, title = title, originator = originator)
+        tri_rep = super().create_xml(add_as_part = False, title = title, originator = originator)
 
-      # todo: if crs_root is None, attempt to derive from surface patch crs uuid (within patch loop, below)
-      if crs_uuid is None:
-         crs_root = self.model.crs_root  # maverick use of model's default crs
-         crs_uuid = rqet.uuid_for_part_root(crs_root)
-      else:
-         crs_root = self.model.root_for_uuid(crs_uuid)
+        # todo: if crs_root is None, attempt to derive from surface patch crs uuid (within patch loop, below)
+        if crs_uuid is None:
+            crs_root = self.model.crs_root  # maverick use of model's default crs
+            crs_uuid = rqet.uuid_for_part_root(crs_root)
+        else:
+            crs_root = self.model.root_for_uuid(crs_uuid)
 
-      if self.represented_interpretation_root is not None:
-         interp_root = self.represented_interpretation_root
-         interp_uuid = bu.uuid_from_string(interp_root.attrib['uuid'])
-         interp_part = self.model.part_for_uuid(interp_uuid)
-         interp_title = rqet.find_nested_tags_text(interp_root, ['Citation', 'Title'])
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    interp_title,
-                                    interp_uuid,
-                                    content_type = self.model.type_of_part(interp_part),
-                                    root = tri_rep)
-         if interp_title and not title:
-            title = interp_title
+        if self.represented_interpretation_root is not None:
+            interp_root = self.represented_interpretation_root
+            interp_uuid = bu.uuid_from_string(interp_root.attrib['uuid'])
+            interp_part = self.model.part_for_uuid(interp_uuid)
+            interp_title = rqet.find_nested_tags_text(interp_root, ['Citation', 'Title'])
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       interp_title,
+                                       interp_uuid,
+                                       content_type = self.model.type_of_part(interp_part),
+                                       root = tri_rep)
+            if interp_title and not title:
+                title = interp_title
 
-      # if not title: title = 'surface'
-      # self.model.create_citation(root = tri_rep, title = title, originator = originator)
+        # if not title: title = 'surface'
+        # self.model.create_citation(root = tri_rep, title = title, originator = originator)
 
-      role_node = rqet.SubElement(tri_rep, ns['resqml2'] + 'SurfaceRole')
-      role_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'SurfaceRole')
-      role_node.text = self.surface_role
+        role_node = rqet.SubElement(tri_rep, ns['resqml2'] + 'SurfaceRole')
+        role_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'SurfaceRole')
+        role_node.text = self.surface_role
 
-      for patch in self.patch_list:
+        for patch in self.patch_list:
 
-         p_node = rqet.SubElement(tri_rep, ns['resqml2'] + 'TrianglePatch')
-         p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TrianglePatch')
-         p_node.text = '\n'
+            p_node = rqet.SubElement(tri_rep, ns['resqml2'] + 'TrianglePatch')
+            p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TrianglePatch')
+            p_node.text = '\n'
 
-         pi_node = rqet.SubElement(p_node, ns['resqml2'] + 'PatchIndex')
-         pi_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-         pi_node.text = str(patch.patch_index)
+            pi_node = rqet.SubElement(p_node, ns['resqml2'] + 'PatchIndex')
+            pi_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+            pi_node.text = str(patch.patch_index)
 
-         ct_node = rqet.SubElement(p_node, ns['resqml2'] + 'Count')
-         ct_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         ct_node.text = str(patch.triangle_count)
+            ct_node = rqet.SubElement(p_node, ns['resqml2'] + 'Count')
+            ct_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            ct_node.text = str(patch.triangle_count)
 
-         cn_node = rqet.SubElement(p_node, ns['resqml2'] + 'NodeCount')
-         cn_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-         cn_node.text = str(patch.node_count)
+            cn_node = rqet.SubElement(p_node, ns['resqml2'] + 'NodeCount')
+            cn_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+            cn_node.text = str(patch.node_count)
 
-         triangles_node = rqet.SubElement(p_node, ns['resqml2'] + 'Triangles')
-         triangles_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-         triangles_node.text = '\n'
+            triangles_node = rqet.SubElement(p_node, ns['resqml2'] + 'Triangles')
+            triangles_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+            triangles_node.text = '\n'
 
-         # not sure if null value node is needed, not actually used in data
-         triangles_null = rqet.SubElement(triangles_node, ns['resqml2'] + 'NullValue')
-         triangles_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         triangles_null.text = '-1'  # or set to number of points in surface coords?
+            # not sure if null value node is needed, not actually used in data
+            triangles_null = rqet.SubElement(triangles_node, ns['resqml2'] + 'NullValue')
+            triangles_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            triangles_null.text = '-1'  # or set to number of points in surface coords?
 
-         triangles_values = rqet.SubElement(triangles_node, ns['resqml2'] + 'Values')
-         triangles_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         triangles_values.text = '\n'
+            triangles_values = rqet.SubElement(triangles_node, ns['resqml2'] + 'Values')
+            triangles_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            triangles_values.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid,
-                                            self.uuid,
-                                            'triangles_patch{}'.format(patch.patch_index),
-                                            root = triangles_values)
+            self.model.create_hdf5_dataset_ref(ext_uuid,
+                                               self.uuid,
+                                               'triangles_patch{}'.format(patch.patch_index),
+                                               root = triangles_values)
 
-         geom = rqet.SubElement(p_node, ns['resqml2'] + 'Geometry')
-         geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
-         geom.text = '\n'
+            geom = rqet.SubElement(p_node, ns['resqml2'] + 'Geometry')
+            geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
+            geom.text = '\n'
 
-         self.model.create_crs_reference(crs_uuid = crs_uuid, root = geom)
+            self.model.create_crs_reference(crs_uuid = crs_uuid, root = geom)
 
-         points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
-         points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-         points_node.text = '\n'
+            points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
+            points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+            points_node.text = '\n'
 
-         coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
-         coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         coords.text = '\n'
+            coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
+            coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            coords.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid,
-                                            self.uuid,
-                                            'points_patch{}'.format(patch.patch_index),
-                                            root = coords)
+            self.model.create_hdf5_dataset_ref(ext_uuid,
+                                               self.uuid,
+                                               'points_patch{}'.format(patch.patch_index),
+                                               root = coords)
 
-         patch.node = p_node
+            patch.node = p_node
 
-      if add_as_part:
-         self.model.add_part('obj_TriangulatedSetRepresentation', self.uuid, tri_rep)
-         if add_relationships:
-            # todo: add multiple crs'es (one per patch)?
-            self.model.create_reciprocal_relationship(tri_rep, 'destinationObject', crs_root, 'sourceObject')
-            if self.represented_interpretation_root is not None:
-               self.model.create_reciprocal_relationship(tri_rep, 'destinationObject',
-                                                         self.represented_interpretation_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_TriangulatedSetRepresentation', self.uuid, tri_rep)
+            if add_relationships:
+                # todo: add multiple crs'es (one per patch)?
+                self.model.create_reciprocal_relationship(tri_rep, 'destinationObject', crs_root, 'sourceObject')
+                if self.represented_interpretation_root is not None:
+                    self.model.create_reciprocal_relationship(tri_rep, 'destinationObject',
+                                                              self.represented_interpretation_root, 'sourceObject')
 
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(tri_rep, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(tri_rep, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
 
-      return tri_rep
+        return tri_rep
 
 
 class CombinedSurface:
-   """Class allowing a collection of Surface objects to be treated as a single surface (not a RESQML class in its own right)."""
+    """Class allowing a collection of Surface objects to be treated as a single surface (not a RESQML class in its own right)."""
 
-   def __init__(self, surface_list, crs_uuid = None):
-      """Initialise a CombinedSurface object from a list of Surface (and/or CombinedSurface) objects.
+    def __init__(self, surface_list, crs_uuid = None):
+        """Initialise a CombinedSurface object from a list of Surface (and/or CombinedSurface) objects.
 
       arguments:
          surface_list (list of Surface and/or CombinedSurface objects): the new object is the combination of these surfaces
@@ -1105,76 +1107,76 @@ class CombinedSurface:
          standard and cannot be saved in a RESQML dataset - it is a high level derived object class
       """
 
-      assert len(surface_list) > 0
-      self.surface_list = surface_list
-      self.crs_uuid = crs_uuid
-      if self.crs_uuid is None:
-         self.crs_uuid = surface_list[0].crs_uuid
-      self.patch_count_list = []
-      self.triangle_count_list = []
-      self.points_count_list = []
-      self.is_combined_list = []
-      self.triangles = None
-      self.points = None
-      for surface in surface_list:
-         is_combined = isinstance(surface, CombinedSurface)
-         self.is_combined_list.append(is_combined)
-         if is_combined:
-            self.patch_count_list.append(sum(surface.patch_count_list))
-         else:
-            self.patch_count_list.append(len(surface.patch_list))
-         t, p = surface.triangles_and_points()
-         self.triangle_count_list.append(len(t))
-         self.points_count_list.append(len(p))
-
-   def surface_index_for_triangle_index(self, tri_index):
-      """For a triangle index in the combined surface, returns the index of the surface containing rhe triangle and local triangle index."""
-
-      for s_i in range(len(self.surface_list)):
-         if tri_index < self.triangle_count_list[s_i]:
-            return s_i, tri_index
-         tri_index -= self.triangle_count_list[s_i]
-      return None
-
-   def triangles_and_points(self):
-      """Returns the composite triangles and points for the combined surface."""
-
-      if self.triangles is None:
-         points_offset = 0
-         for surface in self.surface_list:
-            (t, p) = surface.triangles_and_points()
-            if points_offset == 0:
-               self.triangles = t.copy()
-               self.points = p.copy()
+        assert len(surface_list) > 0
+        self.surface_list = surface_list
+        self.crs_uuid = crs_uuid
+        if self.crs_uuid is None:
+            self.crs_uuid = surface_list[0].crs_uuid
+        self.patch_count_list = []
+        self.triangle_count_list = []
+        self.points_count_list = []
+        self.is_combined_list = []
+        self.triangles = None
+        self.points = None
+        for surface in surface_list:
+            is_combined = isinstance(surface, CombinedSurface)
+            self.is_combined_list.append(is_combined)
+            if is_combined:
+                self.patch_count_list.append(sum(surface.patch_count_list))
             else:
-               self.triangles = np.concatenate((self.triangles, t.copy() + points_offset))
-               self.points = np.concatenate((self.points, p.copy()))
-            points_offset += p.shape[0]
+                self.patch_count_list.append(len(surface.patch_list))
+            t, p = surface.triangles_and_points()
+            self.triangle_count_list.append(len(t))
+            self.points_count_list.append(len(p))
 
-      return self.triangles, self.points
+    def surface_index_for_triangle_index(self, tri_index):
+        """For a triangle index in the combined surface, returns the index of the surface containing rhe triangle and local triangle index."""
+
+        for s_i in range(len(self.surface_list)):
+            if tri_index < self.triangle_count_list[s_i]:
+                return s_i, tri_index
+            tri_index -= self.triangle_count_list[s_i]
+        return None
+
+    def triangles_and_points(self):
+        """Returns the composite triangles and points for the combined surface."""
+
+        if self.triangles is None:
+            points_offset = 0
+            for surface in self.surface_list:
+                (t, p) = surface.triangles_and_points()
+                if points_offset == 0:
+                    self.triangles = t.copy()
+                    self.points = p.copy()
+                else:
+                    self.triangles = np.concatenate((self.triangles, t.copy() + points_offset))
+                    self.points = np.concatenate((self.points, p.copy()))
+                points_offset += p.shape[0]
+
+        return self.triangles, self.points
 
 
 class PointSet(_BaseSurface):
-   """Class for RESQML Point Set Representation within resqpy model object."""  # TODO: Work in Progress
+    """Class for RESQML Point Set Representation within resqpy model object."""  # TODO: Work in Progress
 
-   resqml_type = 'PointSetRepresentation'
+    resqml_type = 'PointSetRepresentation'
 
-   def __init__(self,
-                parent_model,
-                point_set_root = None,
-                uuid = None,
-                load_hdf5 = False,
-                points_array = None,
-                crs_uuid = None,
-                polyset = None,
-                polyline = None,
-                random_point_count = None,
-                charisma_file = None,
-                irap_file = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Creates an empty Point Set object and optionally populates from xml or other source.
+    def __init__(self,
+                 parent_model,
+                 point_set_root = None,
+                 uuid = None,
+                 load_hdf5 = False,
+                 points_array = None,
+                 crs_uuid = None,
+                 polyset = None,
+                 polyline = None,
+                 random_point_count = None,
+                 charisma_file = None,
+                 irap_file = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Creates an empty Point Set object and optionally populates from xml or other source.
 
       arguments:
          parent_model (model.Model object): the model to which the new point set belongs
@@ -1210,234 +1212,236 @@ class PointSet(_BaseSurface):
       :meta common:
       """
 
-      self.crs_uuid = crs_uuid
-      self.patch_count = None
-      self.patch_ref_list = []  # ordered list of (patch hdf5 ext uuid, path in hdf5, point count)
-      self.patch_array_list = []  # ordered list of numpy float arrays (or None before loading), each of shape (N, 3)
-      self.full_array = None
-      self.points = None  # composite points (all patches)
-      self.represented_interpretation_root = None
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       root_node = point_set_root,
-                       extra_metadata = extra_metadata)
+        self.crs_uuid = crs_uuid
+        self.patch_count = None
+        self.patch_ref_list = []  # ordered list of (patch hdf5 ext uuid, path in hdf5, point count)
+        self.patch_array_list = []  # ordered list of numpy float arrays (or None before loading), each of shape (N, 3)
+        self.full_array = None
+        self.points = None  # composite points (all patches)
+        self.represented_interpretation_root = None
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         root_node = point_set_root,
+                         extra_metadata = extra_metadata)
 
-      if self.root is not None:
-         if load_hdf5:
-            self.load_all_patches()
+        if self.root is not None:
+            if load_hdf5:
+                self.load_all_patches()
 
-      elif points_array is not None:
-         assert self.crs_uuid is not None, 'missing crs uuid when establishing point set from array'
-         self.add_patch(points_array)
+        elif points_array is not None:
+            assert self.crs_uuid is not None, 'missing crs uuid when establishing point set from array'
+            self.add_patch(points_array)
 
-      elif polyline is not None:  # Points from or within polyline
-         if random_point_count:
-            assert polyline.is_convex()
-            points = np.zeros((random_point_count, 3))
-            points[:, :2] = np.random.random((random_point_count, 2))
-            for p_i in range(random_point_count):
-               points[p_i, :2] = polyline.denormalised_xy(points[p_i, 0], points[p_i, 1])
-            self.add_patch(points)
-         else:
-            self.add_patch(polyline.coordinates)
-            if polyline.rep_int_root is not None:
-               self.set_represented_interpretation_root(polyline.rep_int_root)
-         if self.crs_uuid is None:
-            self.crs_uuid = polyline.crs_uuid
-         else:
-            assert bu.matching_uuids(self.crs_uuid, polyline.crs_uuid), 'mismatched crs uuids'
-         if not self.title:
-            self.title = polyline.title
-
-      elif polyset is not None:  # Points from polylineSet
-         for poly in polyset.polys:
-            if poly == polyset.polys[0]:
-               master_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
-               self.crs_root = poly.crs_root
-               if poly.isclosed and vec.isclose(poly.coordinates[0], poly.coordinates[-1]):
-                  poly_coords = poly.coordinates[:-1].copy()
-               else:
-                  poly_coords = poly.coordinates.copy()
+        elif polyline is not None:  # Points from or within polyline
+            if random_point_count:
+                assert polyline.is_convex()
+                points = np.zeros((random_point_count, 3))
+                points[:, :2] = np.random.random((random_point_count, 2))
+                for p_i in range(random_point_count):
+                    points[p_i, :2] = polyline.denormalised_xy(points[p_i, 0], points[p_i, 1])
+                self.add_patch(points)
             else:
-               curr_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
-               if not curr_crs.is_equivalent(master_crs):
-                  shifted = curr_crs.convert_array_to(master_crs, poly.coordinates)
-                  if poly.isclosed and vec.isclose(shifted[0], shifted[-1]):
-                     poly_coords = np.concatenate((poly_coords, shifted[:-1]))
-                  else:
-                     poly_coords = np.concatenate((poly_coords, shifted))
-               else:
-                  if poly.isclosed and vec.isclose(poly.coordinates[0], poly.coordinates[-1]):
-                     poly_coords = np.concatenate((poly_coords, poly.coordinates[:-1]))
-                  else:
-                     poly_coords = np.concatenate((poly_coords, poly.coordinates))
-         self.add_patch(poly_coords)
-         if polyset.rep_int_root is not None:
-            self.set_represented_interpretation_root(polyset.rep_int_root)
-         if self.crs_uuid is None:
-            self.crs_uuid = polyset.polys[0].crs_uuid
-         else:
-            assert bu.matching_uuids(self.crs_uuid, polyset.polys[0].crs_uuid), 'mismatched crs uuids'
-         if not self.title:
-            self.title = polyset.title
+                self.add_patch(polyline.coordinates)
+                if polyline.rep_int_root is not None:
+                    self.set_represented_interpretation_root(polyline.rep_int_root)
+            if self.crs_uuid is None:
+                self.crs_uuid = polyline.crs_uuid
+            else:
+                assert bu.matching_uuids(self.crs_uuid, polyline.crs_uuid), 'mismatched crs uuids'
+            if not self.title:
+                self.title = polyline.title
 
-      elif charisma_file is not None:  # Points from Charisma 3D interpretation lines
-         with open(charisma_file, 'r') as surf:
-            for i, line in enumerate(surf.readlines()):
-               if i == 0:
-                  cpoints = np.array([[float(x) for x in line.split()[6:]]])
-               else:
-                  curr = np.array([[float(x) for x in line.split()[6:]]])
-                  cpoints = np.concatenate((cpoints, curr))
-         self.add_patch(cpoints)
-         assert self.crs_uuid is not None, 'crs uuid missing when establishing point set from charisma file'
-         if not self.title:
-            self.title = charisma_file
+        elif polyset is not None:  # Points from polylineSet
+            for poly in polyset.polys:
+                if poly == polyset.polys[0]:
+                    master_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
+                    self.crs_root = poly.crs_root
+                    if poly.isclosed and vec.isclose(poly.coordinates[0], poly.coordinates[-1]):
+                        poly_coords = poly.coordinates[:-1].copy()
+                    else:
+                        poly_coords = poly.coordinates.copy()
+                else:
+                    curr_crs = rcrs.Crs(self.model, uuid = poly.crs_uuid)
+                    if not curr_crs.is_equivalent(master_crs):
+                        shifted = curr_crs.convert_array_to(master_crs, poly.coordinates)
+                        if poly.isclosed and vec.isclose(shifted[0], shifted[-1]):
+                            poly_coords = np.concatenate((poly_coords, shifted[:-1]))
+                        else:
+                            poly_coords = np.concatenate((poly_coords, shifted))
+                    else:
+                        if poly.isclosed and vec.isclose(poly.coordinates[0], poly.coordinates[-1]):
+                            poly_coords = np.concatenate((poly_coords, poly.coordinates[:-1]))
+                        else:
+                            poly_coords = np.concatenate((poly_coords, poly.coordinates))
+            self.add_patch(poly_coords)
+            if polyset.rep_int_root is not None:
+                self.set_represented_interpretation_root(polyset.rep_int_root)
+            if self.crs_uuid is None:
+                self.crs_uuid = polyset.polys[0].crs_uuid
+            else:
+                assert bu.matching_uuids(self.crs_uuid, polyset.polys[0].crs_uuid), 'mismatched crs uuids'
+            if not self.title:
+                self.title = polyset.title
 
-      elif irap_file is not None:  # Points from IRAP simple points
-         with open(irap_file, 'r') as points:
-            for i, line in enumerate(points.readlines()):
-               if i == 0:
-                  cpoints = np.array([[float(x) for x in line.split(" ")]])
-               else:
-                  curr = np.array([[float(x) for x in line.split(" ")]])
-                  cpoints = np.concatenate((cpoints, curr))
-         self.add_patch(cpoints)
-         assert self.crs_uuid is not None, 'crs uuid missing when establishing point set from irap file'
-         if not self.title:
-            self.title = irap_file
+        elif charisma_file is not None:  # Points from Charisma 3D interpretation lines
+            with open(charisma_file, 'r') as surf:
+                for i, line in enumerate(surf.readlines()):
+                    if i == 0:
+                        cpoints = np.array([[float(x) for x in line.split()[6:]]])
+                    else:
+                        curr = np.array([[float(x) for x in line.split()[6:]]])
+                        cpoints = np.concatenate((cpoints, curr))
+            self.add_patch(cpoints)
+            assert self.crs_uuid is not None, 'crs uuid missing when establishing point set from charisma file'
+            if not self.title:
+                self.title = charisma_file
 
-      if not self.title:
-         self.title = 'point set'
+        elif irap_file is not None:  # Points from IRAP simple points
+            with open(irap_file, 'r') as points:
+                for i, line in enumerate(points.readlines()):
+                    if i == 0:
+                        cpoints = np.array([[float(x) for x in line.split(" ")]])
+                    else:
+                        curr = np.array([[float(x) for x in line.split(" ")]])
+                        cpoints = np.concatenate((cpoints, curr))
+            self.add_patch(cpoints)
+            assert self.crs_uuid is not None, 'crs uuid missing when establishing point set from irap file'
+            if not self.title:
+                self.title = irap_file
 
-   def _load_from_xml(self):
-      root_node = self.root
-      assert root_node is not None
-      self.patch_count = rqet.count_tag(root_node, 'NodePatch')
-      assert self.patch_count, 'no patches found in xml for point set'
-      self.patch_array_list = [None for _ in range(self.patch_count)]
-      patch_index = 0
-      for child in rqet.list_of_tag(root_node, 'NodePatch'):
-         point_count = rqet.find_tag_int(child, 'Count')
-         geom_node = rqet.find_tag(child, 'Geometry')
-         assert geom_node is not None, 'geometry missing in xml for point set patch'
-         crs_uuid = rqet.find_nested_tags_text(geom_node, ['LocalCrs', 'UUID'])
-         assert crs_uuid, 'crs uuid missing in geometry xml for point set patch'
-         if self.crs_uuid is None:
-            self.crs_uuid = crs_uuid
-         else:
-            assert bu.matching_uuids(crs_uuid, self.crs_uuid), 'mixed coordinate reference systems in point set'
-         ext_uuid = rqet.find_nested_tags_text(geom_node, ['Points', 'Coordinates', 'HdfProxy', 'UUID'])
-         assert ext_uuid, 'missing hdf5 uuid in goemetry xml for point set patch'
-         hdf5_path = rqet.find_nested_tags_text(geom_node, ['Points', 'Coordinates', 'PathInHdfFile'])
-         assert hdf5_path, 'missing internal hdf5 path in goemetry xml for point set patch'
-         self.patch_ref_list.append((ext_uuid, hdf5_path, point_count))
-         patch_index += 1
-      ref_node = rqet.find_tag(self.root, 'RepresentedInterpretation')
-      if ref_node is not None:
-         interp_root = self.model.referenced_node(ref_node)
-         self.set_represented_interpretation_root(interp_root)
-      # note: load of patches handled elsewhere
+        if not self.title:
+            self.title = 'point set'
 
-   def set_represented_interpretation_root(self, interp_root):
-      """Makes a note of the xml root of the represented interpretation."""
+    def _load_from_xml(self):
+        root_node = self.root
+        assert root_node is not None
+        self.patch_count = rqet.count_tag(root_node, 'NodePatch')
+        assert self.patch_count, 'no patches found in xml for point set'
+        self.patch_array_list = [None for _ in range(self.patch_count)]
+        patch_index = 0
+        for child in rqet.list_of_tag(root_node, 'NodePatch'):
+            point_count = rqet.find_tag_int(child, 'Count')
+            geom_node = rqet.find_tag(child, 'Geometry')
+            assert geom_node is not None, 'geometry missing in xml for point set patch'
+            crs_uuid = rqet.find_nested_tags_text(geom_node, ['LocalCrs', 'UUID'])
+            assert crs_uuid, 'crs uuid missing in geometry xml for point set patch'
+            if self.crs_uuid is None:
+                self.crs_uuid = crs_uuid
+            else:
+                assert bu.matching_uuids(crs_uuid, self.crs_uuid), 'mixed coordinate reference systems in point set'
+            ext_uuid = rqet.find_nested_tags_text(geom_node, ['Points', 'Coordinates', 'HdfProxy', 'UUID'])
+            assert ext_uuid, 'missing hdf5 uuid in goemetry xml for point set patch'
+            hdf5_path = rqet.find_nested_tags_text(geom_node, ['Points', 'Coordinates', 'PathInHdfFile'])
+            assert hdf5_path, 'missing internal hdf5 path in goemetry xml for point set patch'
+            self.patch_ref_list.append((ext_uuid, hdf5_path, point_count))
+            patch_index += 1
+        ref_node = rqet.find_tag(self.root, 'RepresentedInterpretation')
+        if ref_node is not None:
+            interp_root = self.model.referenced_node(ref_node)
+            self.set_represented_interpretation_root(interp_root)
+        # note: load of patches handled elsewhere
 
-      self.represented_interpretation_root = interp_root
+    def set_represented_interpretation_root(self, interp_root):
+        """Makes a note of the xml root of the represented interpretation."""
 
-   def single_patch_array_ref(self, patch_index):
-      """Load numpy array for one patch of the point set from hdf5, cache and return it."""
+        self.represented_interpretation_root = interp_root
 
-      assert 0 <= patch_index < self.patch_count, 'point set patch index out of range'
-      if self.patch_array_list[patch_index] is not None:
-         return self.patch_array_list[patch_index]
-      h5_key_pair = (self.patch_ref_list[patch_index][0], self.patch_ref_list[patch_index][1])  # ext uuid, path in hdf5
-      try:
-         self.model.h5_array_element(h5_key_pair,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'temp_points',
-                                     dtype = 'float')
-      except Exception:
-         log.exception('hdf5 points failure for point set patch ' + str(patch_index))
-      assert self.temp_points.ndim == 2 and self.temp_points.shape[1] == 3, 'unsupported dimensionality to points array'
-      self.patch_array_list[patch_index] = self.temp_points.copy()
-      delattr(self, 'temp_points')
-      return self.patch_array_list[patch_index]
+    def single_patch_array_ref(self, patch_index):
+        """Load numpy array for one patch of the point set from hdf5, cache and return it."""
 
-   def load_all_patches(self):
-      """Load hdf5 data for all patches and cache as separate numpy arrays; not usually called directly."""
+        assert 0 <= patch_index < self.patch_count, 'point set patch index out of range'
+        if self.patch_array_list[patch_index] is not None:
+            return self.patch_array_list[patch_index]
+        h5_key_pair = (self.patch_ref_list[patch_index][0], self.patch_ref_list[patch_index][1]
+                      )  # ext uuid, path in hdf5
+        try:
+            self.model.h5_array_element(h5_key_pair,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'temp_points',
+                                        dtype = 'float')
+        except Exception:
+            log.exception('hdf5 points failure for point set patch ' + str(patch_index))
+        assert self.temp_points.ndim == 2 and self.temp_points.shape[
+            1] == 3, 'unsupported dimensionality to points array'
+        self.patch_array_list[patch_index] = self.temp_points.copy()
+        delattr(self, 'temp_points')
+        return self.patch_array_list[patch_index]
 
-      for patch_index in range(self.patch_count):
-         self.single_patch_array_ref(patch_index)
+    def load_all_patches(self):
+        """Load hdf5 data for all patches and cache as separate numpy arrays; not usually called directly."""
 
-   def full_array_ref(self):
-      """Return a single numpy float array of shape (N, 3) containing all points from all patches.
+        for patch_index in range(self.patch_count):
+            self.single_patch_array_ref(patch_index)
 
-      :meta common:
-      """
-
-      if self.full_array is not None:
-         return self.full_array
-      self.load_all_patches()
-      if self.patch_count == 1:  # optimisation, as usually the case
-         self.full_array = self.patch_array_list[0]
-         return self.full_array
-      point_count = 0
-      for patch_index in range(self.patch_count):
-         point_count += self.patch_ref_list[patch_index][2]
-      self.full_array = np.empty((point_count, 3))
-      full_index = 0
-      for patch_index in range(self.patch_count):
-         self.full_array[full_index:full_index +
-                         self.patch_ref_list[patch_index][2]] = self.patch_array_list[patch_index]
-         full_index += self.patch_ref_list[patch_index][2]
-      assert full_index == point_count, 'point count mismatch when constructing full array for point set'
-      return self.full_array
-
-   def add_patch(self, points_array):
-      """Extend the current point set with a new patch of points."""
-
-      assert points_array.ndim >= 2 and points_array.shape[-1] in [2, 3]
-      if points_array.shape[-1] == 2:
-         shape = list(points_array.shape)
-         shape[-1] = 3
-         p = np.zeros(shape)
-         p[..., :2] = points_array
-         points_array = p
-      self.patch_array_list.append(points_array.reshape(-1, 3).copy())
-      self.patch_ref_list.append((None, None, points_array.shape[0]))
-      self.full_array = None
-      if self.patch_count is None:
-         self.patch_count = 0
-      self.patch_count += 1
-
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Create or append to an hdf5 file, writing datasets for the point set patches after caching arrays.
+    def full_array_ref(self):
+        """Return a single numpy float array of shape (N, 3) containing all points from all patches.
 
       :meta common:
       """
 
-      if not file_name:
-         file_name = self.model.h5_file_name()
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
-      # NB: patch arrays must all have been set up prior to calling this function
-      h5_reg = rwh5.H5Register(self.model)
-      for patch_index in range(self.patch_count):
-         h5_reg.register_dataset(self.uuid, 'points_{}'.format(patch_index), self.patch_array_list[patch_index])
-      h5_reg.write(file_name, mode = mode)
+        if self.full_array is not None:
+            return self.full_array
+        self.load_all_patches()
+        if self.patch_count == 1:  # optimisation, as usually the case
+            self.full_array = self.patch_array_list[0]
+            return self.full_array
+        point_count = 0
+        for patch_index in range(self.patch_count):
+            point_count += self.patch_ref_list[patch_index][2]
+        self.full_array = np.empty((point_count, 3))
+        full_index = 0
+        for patch_index in range(self.patch_count):
+            self.full_array[full_index:full_index +
+                            self.patch_ref_list[patch_index][2]] = self.patch_array_list[patch_index]
+            full_index += self.patch_ref_list[patch_index][2]
+        assert full_index == point_count, 'point count mismatch when constructing full array for point set'
+        return self.full_array
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  crs_root = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  root = None,
-                  title = None,
-                  originator = None):
-      """Creates a point set representation xml node from this point set object and optionally adds as part of model.
+    def add_patch(self, points_array):
+        """Extend the current point set with a new patch of points."""
+
+        assert points_array.ndim >= 2 and points_array.shape[-1] in [2, 3]
+        if points_array.shape[-1] == 2:
+            shape = list(points_array.shape)
+            shape[-1] = 3
+            p = np.zeros(shape)
+            p[..., :2] = points_array
+            points_array = p
+        self.patch_array_list.append(points_array.reshape(-1, 3).copy())
+        self.patch_ref_list.append((None, None, points_array.shape[0]))
+        self.full_array = None
+        if self.patch_count is None:
+            self.patch_count = 0
+        self.patch_count += 1
+
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Create or append to an hdf5 file, writing datasets for the point set patches after caching arrays.
+
+      :meta common:
+      """
+
+        if not file_name:
+            file_name = self.model.h5_file_name()
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
+        # NB: patch arrays must all have been set up prior to calling this function
+        h5_reg = rwh5.H5Register(self.model)
+        for patch_index in range(self.patch_count):
+            h5_reg.register_dataset(self.uuid, 'points_{}'.format(patch_index), self.patch_array_list[patch_index])
+        h5_reg.write(file_name, mode = mode)
+
+    def create_xml(self,
+                   ext_uuid = None,
+                   crs_root = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   root = None,
+                   title = None,
+                   originator = None):
+        """Creates a point set representation xml node from this point set object and optionally adds as part of model.
 
          arguments:
             ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the points array(s)
@@ -1457,139 +1461,139 @@ class PointSet(_BaseSurface):
       :meta common:
       """
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      ps_node = super().create_xml(add_as_part = False, title = title, originator = originator)
+        ps_node = super().create_xml(add_as_part = False, title = title, originator = originator)
 
-      if crs_root is None:
-         if self.crs_uuid is None:
-            crs_root = self.model.crs_root  # maverick use of model's default crs
+        if crs_root is None:
+            if self.crs_uuid is None:
+                crs_root = self.model.crs_root  # maverick use of model's default crs
+                self.crs_uuid = rqet.uuid_for_part_root(crs_root)
+            else:
+                crs_root = self.model.root_for_part(self.model.part_for_uuid(self.crs_uuid))
+        else:
             self.crs_uuid = rqet.uuid_for_part_root(crs_root)
-         else:
-            crs_root = self.model.root_for_part(self.model.part_for_uuid(self.crs_uuid))
-      else:
-         self.crs_uuid = rqet.uuid_for_part_root(crs_root)
 
-      if self.represented_interpretation_root is not None:
-         interp_root = self.represented_interpretation_root
-         interp_uuid = bu.uuid_from_string(interp_root.attrib['uuid'])
-         interp_part = self.model.part_for_uuid(interp_uuid)
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
-                                    interp_uuid,
-                                    content_type = self.model.type_of_part(interp_part),
-                                    root = ps_node)
+        if self.represented_interpretation_root is not None:
+            interp_root = self.represented_interpretation_root
+            interp_uuid = bu.uuid_from_string(interp_root.attrib['uuid'])
+            interp_part = self.model.part_for_uuid(interp_uuid)
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
+                                       interp_uuid,
+                                       content_type = self.model.type_of_part(interp_part),
+                                       root = ps_node)
 
-      for patch_index in range(self.patch_count):
+        for patch_index in range(self.patch_count):
 
-         p_node = rqet.SubElement(ps_node, ns['resqml2'] + 'NodePatch')
-         p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'NodePatch')
-         p_node.text = '\n'
+            p_node = rqet.SubElement(ps_node, ns['resqml2'] + 'NodePatch')
+            p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'NodePatch')
+            p_node.text = '\n'
 
-         pi_node = rqet.SubElement(p_node, ns['resqml2'] + 'PatchIndex')
-         pi_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-         pi_node.text = str(patch_index)
+            pi_node = rqet.SubElement(p_node, ns['resqml2'] + 'PatchIndex')
+            pi_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+            pi_node.text = str(patch_index)
 
-         ct_node = rqet.SubElement(p_node, ns['resqml2'] + 'Count')
-         ct_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         ct_node.text = str(self.patch_ref_list[patch_index][2])
+            ct_node = rqet.SubElement(p_node, ns['resqml2'] + 'Count')
+            ct_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            ct_node.text = str(self.patch_ref_list[patch_index][2])
 
-         geom = rqet.SubElement(p_node, ns['resqml2'] + 'Geometry')
-         geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
-         geom.text = '\n'
+            geom = rqet.SubElement(p_node, ns['resqml2'] + 'Geometry')
+            geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
+            geom.text = '\n'
 
-         self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+            self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
-         points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
-         points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-         points_node.text = '\n'
+            points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
+            points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+            points_node.text = '\n'
 
-         coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
-         coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         coords.text = '\n'
+            coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
+            coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            coords.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points_{}'.format(patch_index), root = coords)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points_{}'.format(patch_index), root = coords)
 
-      if root is not None:
-         root.append(ps_node)
-      if add_as_part:
-         self.model.add_part('obj_PointSetRepresentation', self.uuid, ps_node)
-         if add_relationships:
-            # todo: add multiple crs'es (one per patch)?
-            self.model.create_reciprocal_relationship(ps_node, 'destinationObject', crs_root, 'sourceObject')
-            if self.represented_interpretation_root is not None:
-               self.model.create_reciprocal_relationship(ps_node, 'destinationObject',
-                                                         self.represented_interpretation_root, 'sourceObject')
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(ps_node, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+        if root is not None:
+            root.append(ps_node)
+        if add_as_part:
+            self.model.add_part('obj_PointSetRepresentation', self.uuid, ps_node)
+            if add_relationships:
+                # todo: add multiple crs'es (one per patch)?
+                self.model.create_reciprocal_relationship(ps_node, 'destinationObject', crs_root, 'sourceObject')
+                if self.represented_interpretation_root is not None:
+                    self.model.create_reciprocal_relationship(ps_node, 'destinationObject',
+                                                              self.represented_interpretation_root, 'sourceObject')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(ps_node, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
 
-      return ps_node
+        return ps_node
 
-   def convert_to_charisma(self, file_name):
-      """Output to Charisma 3D interepretation format from a pointset
+    def convert_to_charisma(self, file_name):
+        """Output to Charisma 3D interepretation format from a pointset
 
       If file_name exists, it will be overwritten.
 
       args:
           file_name: output file name to save to
       """
-      #      hznname = self.title.replace(" ","_")
-      lines = []
-      self.load_all_patches()
-      for patch in self.patch_array_list:
-         for points in patch:
-            lines.append(f"INLINE :\t1 XLINE :\t1\t{points[0]}\t{points[1]}\t{points[2]}\n")
-      with open(file_name, 'w') as f:
-         for item in lines:
-            f.write(item)
+        #      hznname = self.title.replace(" ","_")
+        lines = []
+        self.load_all_patches()
+        for patch in self.patch_array_list:
+            for points in patch:
+                lines.append(f"INLINE :\t1 XLINE :\t1\t{points[0]}\t{points[1]}\t{points[2]}\n")
+        with open(file_name, 'w') as f:
+            for item in lines:
+                f.write(item)
 
-   def convert_to_irap(self, file_name):
-      """Output to IRAP simple points format from a pointset
+    def convert_to_irap(self, file_name):
+        """Output to IRAP simple points format from a pointset
 
       If file_name exists, it will be overwritten.
 
       args:
           file_name: output file name to save to
       """
-      #      hznname = self.title.replace(" ","_")
-      lines = []
-      self.load_all_patches()
-      for patch in self.patch_array_list:
-         for points in patch:
-            lines.append(f"{points[0]} {points[1]} {points[2]}\n")
-      with open(file_name, 'w') as f:
-         for item in lines:
-            f.write(item)
+        #      hznname = self.title.replace(" ","_")
+        lines = []
+        self.load_all_patches()
+        for patch in self.patch_array_list:
+            for points in patch:
+                lines.append(f"{points[0]} {points[1]} {points[2]}\n")
+        with open(file_name, 'w') as f:
+            for item in lines:
+                f.write(item)
 
 
 class Mesh(_BaseSurface):
-   """Class covering meshes (lattices: surfaces where points form a 2D grid; RESQML obj_Grid2dRepresentation)."""
+    """Class covering meshes (lattices: surfaces where points form a 2D grid; RESQML obj_Grid2dRepresentation)."""
 
-   resqml_type = 'Grid2dRepresentation'
+    resqml_type = 'Grid2dRepresentation'
 
-   def __init__(self,
-                parent_model,
-                root_node = None,
-                uuid = None,
-                mesh_file = None,
-                mesh_format = None,
-                mesh_flavour = 'explicit',
-                xyz_values = None,
-                nj = None,
-                ni = None,
-                origin = None,
-                dxyz_dij = None,
-                z_values = None,
-                z_supporting_mesh_uuid = None,
-                surface_role = 'map',
-                crs_uuid = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Initialises a Mesh object from xml, or a regular mesh from arguments.
+    def __init__(self,
+                 parent_model,
+                 root_node = None,
+                 uuid = None,
+                 mesh_file = None,
+                 mesh_format = None,
+                 mesh_flavour = 'explicit',
+                 xyz_values = None,
+                 nj = None,
+                 ni = None,
+                 origin = None,
+                 dxyz_dij = None,
+                 z_values = None,
+                 z_supporting_mesh_uuid = None,
+                 surface_role = 'map',
+                 crs_uuid = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Initialises a Mesh object from xml, or a regular mesh from arguments.
 
       arguments:
          parent_model (model.Model object): the model to which this Mesh object will be associated
@@ -1643,352 +1647,355 @@ class Mesh(_BaseSurface):
          6. leave all optional arguments as None for an empty Mesh object
       """
 
-      assert surface_role in ['map', 'pick']
+        assert surface_role in ['map', 'pick']
 
-      self.surface_role = surface_role
-      self.ni = None  # NB: these are the number of nodes (points) in the mesh, unlike 3D grids
-      self.nj = None
-      self.flavour = None  # 'explicit', 'regular', 'ref&z' or 'reg&z'
-      self.full_array = None  # loaded on demand, shape (NJ, NI, 3 or 2) being xyz or xy points at each node
-      self.explicit_h5_key_pair = None
-      self.regular_origin = None  # xyz of origin of regular mesh
-      self.regular_dxyz_dij = None  # numpy array of shape (2, 3) being xyz increment with each step in i, j
-      self.ref_uuid = None
-      self.ref_mesh = None
-      self.ref_z_h5_key_pair = None
-      # note: in this class, z values for ref&z meshes are held in the full_array (xy data will be duplicated in memory)
-      self.crs_uuid = crs_uuid
-      self.represented_interpretation_root = None
+        self.surface_role = surface_role
+        self.ni = None  # NB: these are the number of nodes (points) in the mesh, unlike 3D grids
+        self.nj = None
+        self.flavour = None  # 'explicit', 'regular', 'ref&z' or 'reg&z'
+        self.full_array = None  # loaded on demand, shape (NJ, NI, 3 or 2) being xyz or xy points at each node
+        self.explicit_h5_key_pair = None
+        self.regular_origin = None  # xyz of origin of regular mesh
+        self.regular_dxyz_dij = None  # numpy array of shape (2, 3) being xyz increment with each step in i, j
+        self.ref_uuid = None
+        self.ref_mesh = None
+        self.ref_z_h5_key_pair = None
+        # note: in this class, z values for ref&z meshes are held in the full_array (xy data will be duplicated in memory)
+        self.crs_uuid = crs_uuid
+        self.represented_interpretation_root = None
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = root_node)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = root_node)
 
-      self.crs_root = None if self.crs_uuid is None else self.model.root_for_uuid(self.crs_uuid)
+        self.crs_root = None if self.crs_uuid is None else self.model.root_for_uuid(self.crs_uuid)
 
-      if self.root is not None:
-         pass
+        if self.root is not None:
+            pass
 
-      elif mesh_file and mesh_format and crs_uuid is not None:
-         # load an explicit mesh from an ascii file in RMS text or zmap format
-         assert mesh_format in ['rms', 'roxar', 'zmap']  # 'roxar' is treated synonymously with 'rms'
-         assert mesh_flavour in ['explicit', 'regular', 'reg&z', 'ref&z']
-         x, y, z = read_mesh(mesh_file, format = mesh_format)
-         self.flavour = mesh_flavour
-         self.nj = z.shape[0]
-         self.ni = z.shape[1]
-         assert self.nj > 1 and self.ni > 1
-         self.full_array = np.stack((x, y, z), axis = -1)
-         if mesh_flavour != 'explicit':
-            min_x = x.flatten()[0]
-            max_x = x.flatten()[-1]
-            min_y = y.flatten()[0]
-            max_y = y.flatten()[-1]
-            dxyz_dij = np.array([[(max_x - min_x) /
-                                  (self.ni - 1), 0.0, 0.0], [0.0, (max_y - min_y) / (self.nj - 1), 0.0]],
-                                dtype = float)
-            if mesh_flavour in ['regular', 'reg&z']:
-               self.regular_origin = (min_x, min_y, 0.0)
-               self.regular_dxyz_dij = dxyz_dij
-            elif mesh_flavour == 'ref&z':
-               self.ref_mesh = Mesh(self.model,
-                                    ni = self.ni,
-                                    nj = self.nj,
-                                    origin = self.regular_origin,
-                                    dxyz_dij = dxyz_dij,
-                                    crs_uuid = crs_uuid)
-               assert self.ref_mesh is not None
-               assert self.ref_mesh.nj == nj and self.ref_mesh.ni == ni
-            else:
-               log.critical('code failure')
-         assert self.crs_uuid is not None, 'crs uuid missing'
-         # todo: option to create a regular and ref&z pair instead of an explicit mesh
+        elif mesh_file and mesh_format and crs_uuid is not None:
+            # load an explicit mesh from an ascii file in RMS text or zmap format
+            assert mesh_format in ['rms', 'roxar', 'zmap']  # 'roxar' is treated synonymously with 'rms'
+            assert mesh_flavour in ['explicit', 'regular', 'reg&z', 'ref&z']
+            x, y, z = read_mesh(mesh_file, format = mesh_format)
+            self.flavour = mesh_flavour
+            self.nj = z.shape[0]
+            self.ni = z.shape[1]
+            assert self.nj > 1 and self.ni > 1
+            self.full_array = np.stack((x, y, z), axis = -1)
+            if mesh_flavour != 'explicit':
+                min_x = x.flatten()[0]
+                max_x = x.flatten()[-1]
+                min_y = y.flatten()[0]
+                max_y = y.flatten()[-1]
+                dxyz_dij = np.array([[(max_x - min_x) /
+                                      (self.ni - 1), 0.0, 0.0], [0.0, (max_y - min_y) / (self.nj - 1), 0.0]],
+                                    dtype = float)
+                if mesh_flavour in ['regular', 'reg&z']:
+                    self.regular_origin = (min_x, min_y, 0.0)
+                    self.regular_dxyz_dij = dxyz_dij
+                elif mesh_flavour == 'ref&z':
+                    self.ref_mesh = Mesh(self.model,
+                                         ni = self.ni,
+                                         nj = self.nj,
+                                         origin = self.regular_origin,
+                                         dxyz_dij = dxyz_dij,
+                                         crs_uuid = crs_uuid)
+                    assert self.ref_mesh is not None
+                    assert self.ref_mesh.nj == nj and self.ref_mesh.ni == ni
+                else:
+                    log.critical('code failure')
+            assert self.crs_uuid is not None, 'crs uuid missing'
+            # todo: option to create a regular and ref&z pair instead of an explicit mesh
 
-      elif xyz_values is not None and crs_uuid is not None:
-         # create an explicit mesh directly from a numpy array of points
-         assert xyz_values.ndim == 3 and xyz_values.shape[2] == 3 and xyz_values.shape[0] > 1 and xyz_values.shape[1] > 1
-         self.flavour = 'explicit'
-         self.nj = xyz_values.shape[0]
-         self.ni = xyz_values.shape[1]
-         self.full_array = xyz_values.copy()
-         assert self.crs_uuid is not None, 'crs uuid missing'
+        elif xyz_values is not None and crs_uuid is not None:
+            # create an explicit mesh directly from a numpy array of points
+            assert xyz_values.ndim == 3 and xyz_values.shape[
+                2] == 3 and xyz_values.shape[0] > 1 and xyz_values.shape[1] > 1
+            self.flavour = 'explicit'
+            self.nj = xyz_values.shape[0]
+            self.ni = xyz_values.shape[1]
+            self.full_array = xyz_values.copy()
+            assert self.crs_uuid is not None, 'crs uuid missing'
 
-      elif (nj is not None and ni is not None and origin is not None and dxyz_dij is not None and
-            crs_uuid is not None and z_values is None):
-         # create a regular mesh from arguments
-         assert nj > 0 and ni > 0
-         assert len(origin) == 3
-         assert dxyz_dij.shape == (2, 3)
-         self.flavour = 'regular'
-         self.nj = nj
-         self.ni = ni
-         self.regular_origin = origin
-         self.regular_dxyz_dij = np.array(dxyz_dij, dtype = float)
-         assert self.crs_uuid is not None, 'crs uuid missing'
+        elif (nj is not None and ni is not None and origin is not None and dxyz_dij is not None and
+              crs_uuid is not None and z_values is None):
+            # create a regular mesh from arguments
+            assert nj > 0 and ni > 0
+            assert len(origin) == 3
+            assert dxyz_dij.shape == (2, 3)
+            self.flavour = 'regular'
+            self.nj = nj
+            self.ni = ni
+            self.regular_origin = origin
+            self.regular_dxyz_dij = np.array(dxyz_dij, dtype = float)
+            assert self.crs_uuid is not None, 'crs uuid missing'
 
-      elif nj is not None and ni is not None and z_values is not None and z_supporting_mesh_uuid is not None:
-         # create a ref&z mesh from arguments
-         assert nj > 0 and ni > 0
-         assert z_values.shape == (nj, ni) or z_values.shape == (nj * ni,)
-         self.flavour = 'ref&z'
-         self.nj = nj
-         self.ni = ni
-         self.ref_uuid = z_supporting_mesh_uuid
-         self.ref_mesh = Mesh(self.model, uuid = z_supporting_mesh_uuid)
-         assert self.ref_mesh is not None
-         assert self.ref_mesh.nj == nj and self.ref_mesh.ni == ni
-         self.full_array = self.ref_mesh.full_array_ref().copy()
-         self.full_array[..., 2] = z_values.reshape(tuple(self.full_array.shape[:-1]))
-         assert self.crs_uuid is not None, 'crs uuid missing'
+        elif nj is not None and ni is not None and z_values is not None and z_supporting_mesh_uuid is not None:
+            # create a ref&z mesh from arguments
+            assert nj > 0 and ni > 0
+            assert z_values.shape == (nj, ni) or z_values.shape == (nj * ni,)
+            self.flavour = 'ref&z'
+            self.nj = nj
+            self.ni = ni
+            self.ref_uuid = z_supporting_mesh_uuid
+            self.ref_mesh = Mesh(self.model, uuid = z_supporting_mesh_uuid)
+            assert self.ref_mesh is not None
+            assert self.ref_mesh.nj == nj and self.ref_mesh.ni == ni
+            self.full_array = self.ref_mesh.full_array_ref().copy()
+            self.full_array[..., 2] = z_values.reshape(tuple(self.full_array.shape[:-1]))
+            assert self.crs_uuid is not None, 'crs uuid missing'
 
-      elif (nj is not None and ni is not None and z_values is not None and dxyz_dij is not None and
-            crs_uuid is not None and origin is not None):
-         # create a reg&z mesh from arguments
-         assert nj > 0 and ni > 0
-         assert len(origin) == 3
-         assert dxyz_dij.shape == (2, 3)
-         assert z_values.shape == (nj, ni) or z_values.shape == (nj * ni,)
-         self.nj = nj
-         self.ni = ni
-         self.regular_origin = origin
-         self.regular_dxyz_dij = np.array(dxyz_dij, dtype = float)
-         assert self.crs_uuid is not None, 'crs uuid missing'
-         self.flavour = 'regular'
-         self.full_array = None
-         _ = self.full_array_ref()
-         self.full_array[..., 2] = z_values.reshape(tuple(self.full_array.shape[:-1]))
-         self.flavour = 'reg&z'
+        elif (nj is not None and ni is not None and z_values is not None and dxyz_dij is not None and
+              crs_uuid is not None and origin is not None):
+            # create a reg&z mesh from arguments
+            assert nj > 0 and ni > 0
+            assert len(origin) == 3
+            assert dxyz_dij.shape == (2, 3)
+            assert z_values.shape == (nj, ni) or z_values.shape == (nj * ni,)
+            self.nj = nj
+            self.ni = ni
+            self.regular_origin = origin
+            self.regular_dxyz_dij = np.array(dxyz_dij, dtype = float)
+            assert self.crs_uuid is not None, 'crs uuid missing'
+            self.flavour = 'regular'
+            self.full_array = None
+            _ = self.full_array_ref()
+            self.full_array[..., 2] = z_values.reshape(tuple(self.full_array.shape[:-1]))
+            self.flavour = 'reg&z'
 
-      assert self.crs_uuid is not None
-      if not self.title:
-         self.title = 'mesh'
+        assert self.crs_uuid is not None
+        if not self.title:
+            self.title = 'mesh'
 
 
 #     log.debug(f'new mesh has flavour {self.flavour}')
 
-   def _load_from_xml(self):
-      root_node = self.root
-      assert root_node is not None
-      self.surface_role = rqet.find_tag_text(root_node, 'SurfaceRole')
-      ref_node = rqet.find_tag(root_node, 'RepresentedInterpretation')
-      if ref_node is not None:
-         self.represented_interpretation_root = self.model.referenced_node(ref_node)
-      patch_node = rqet.find_tag(root_node, 'Grid2dPatch')
-      assert rqet.find_tag_int(patch_node, 'PatchIndex') == 0
-      self.ni = rqet.find_tag_int(patch_node, 'FastestAxisCount')
-      self.nj = rqet.find_tag_int(patch_node, 'SlowestAxisCount')
-      assert self.ni is not None and self.nj is not None, 'mesh extent info missing in xml'
-      geom_node = rqet.find_tag(patch_node, 'Geometry')
-      assert geom_node is not None, 'geometry missing in mesh xml'
-      self.crs_uuid = rqet.find_nested_tags_text(geom_node, ['LocalCrs', 'UUID'])
-      assert self.crs_uuid is not None, 'crs reference missing in mesh geometry xml'
-      point_node = rqet.find_tag(geom_node, 'Points')
-      assert point_node is not None, 'missing Points node in mesh geometry xml'
-      flavour = rqet.node_type(point_node)
+    def _load_from_xml(self):
+        root_node = self.root
+        assert root_node is not None
+        self.surface_role = rqet.find_tag_text(root_node, 'SurfaceRole')
+        ref_node = rqet.find_tag(root_node, 'RepresentedInterpretation')
+        if ref_node is not None:
+            self.represented_interpretation_root = self.model.referenced_node(ref_node)
+        patch_node = rqet.find_tag(root_node, 'Grid2dPatch')
+        assert rqet.find_tag_int(patch_node, 'PatchIndex') == 0
+        self.ni = rqet.find_tag_int(patch_node, 'FastestAxisCount')
+        self.nj = rqet.find_tag_int(patch_node, 'SlowestAxisCount')
+        assert self.ni is not None and self.nj is not None, 'mesh extent info missing in xml'
+        geom_node = rqet.find_tag(patch_node, 'Geometry')
+        assert geom_node is not None, 'geometry missing in mesh xml'
+        self.crs_uuid = rqet.find_nested_tags_text(geom_node, ['LocalCrs', 'UUID'])
+        assert self.crs_uuid is not None, 'crs reference missing in mesh geometry xml'
+        point_node = rqet.find_tag(geom_node, 'Points')
+        assert point_node is not None, 'missing Points node in mesh geometry xml'
+        flavour = rqet.node_type(point_node)
 
-      if flavour == 'Point3dLatticeArray':
-         self.flavour = 'regular'
-         origin_node = rqet.find_tag(point_node, 'Origin')
-         self.regular_origin = (rqet.find_tag_float(origin_node,
-                                                    'Coordinate1'), rqet.find_tag_float(origin_node, 'Coordinate2'),
-                                rqet.find_tag_float(origin_node, 'Coordinate3'))
-         assert self.regular_origin is not None, 'origin missing in xml for regular mesh (lattice)'
-         offset_nodes = rqet.list_of_tag(point_node, 'Offset')  # first occurrence for FastestAxis, ie. I; 2nd for J
-         assert len(offset_nodes) == 2, 'missing (or too many) offset nodes in xml for regular mesh (lattice)'
-         self.regular_dxyz_dij = np.empty((2, 3))
-         for j_or_i in range(2):  # 0 = J, 1 = I
-            axial_offset_node = rqet.find_tag(offset_nodes[j_or_i], 'Offset')
-            assert axial_offset_node is not None, 'missing offset offset node in xml'
-            self.regular_dxyz_dij[1 - j_or_i] = (rqet.find_tag_float(axial_offset_node, 'Coordinate1'),
-                                                 rqet.find_tag_float(axial_offset_node, 'Coordinate2'),
-                                                 rqet.find_tag_float(axial_offset_node, 'Coordinate3'))
-            if not maths.isclose(vec.dot_product(self.regular_dxyz_dij[1 - j_or_i], self.regular_dxyz_dij[1 - j_or_i]),
-                                 1.0):
-               log.warning('non-orthogonal axes and/or scaling in xml for regular mesh (lattice)')
-            spacing_node = rqet.find_tag(offset_nodes[j_or_i], 'Spacing')
-            stride = rqet.find_tag_float(spacing_node, 'Value')
-            count = rqet.find_tag_int(spacing_node, 'Count')
-            assert stride is not None and count is not None, 'missing spacing info in xml'
-            assert count == (self.nj, self.ni)[j_or_i] - 1,  \
-                   'unexpected value for count in xml spacing info for regular mesh (lattice)'
-            assert stride > 0.0, 'spacing distance is not positive in xml for regular mesh (lattice)'
-            self.regular_dxyz_dij[1 - j_or_i] *= stride
-
-      elif flavour == 'Point3dZValueArray':
-         # note: only simple, full use of supporting mesh is handled at present
-         z_ref_node = rqet.find_tag(point_node, 'ZValues')
-         self.ref_z_h5_key_pair = self.model.h5_uuid_and_path_for_node(z_ref_node, tag = 'Values')
-         support_geom_node = rqet.find_tag(point_node, 'SupportingGeometry')
-         if rqet.node_type(support_geom_node) == 'Point3dFromRepresentationLatticeArray':
-            self.flavour = 'ref&z'
-            # assert rqet.node_type(support_geom_node) == 'Point3dFromRepresentationLatticeArray'  # only this supported for now
-            self.ref_uuid = rqet.find_nested_tags_text(support_geom_node, ['SupportingRepresentation', 'UUID'])
-            assert self.ref_uuid, 'missing supporting representation info in xml for z-value mesh'
-            self.ref_mesh = Mesh(self.model, root_node = self.model.root_for_uuid(self.ref_uuid))
-            assert self.nj == self.ref_mesh.nj and self.ni == self.ref_mesh.ni  # only this supported for now
-            niosr_node = rqet.find_tag(support_geom_node, 'NodeIndicesOnSupportingRepresentation')
-            start_value = rqet.find_tag_int(niosr_node, 'StartValue')
-            assert start_value == 0, 'only full use of supporting mesh catered for at present'
-            offset_nodes = rqet.list_of_tag(niosr_node, 'Offset')  # first occurrence for FastestAxis, ie. I; 2nd for J
+        if flavour == 'Point3dLatticeArray':
+            self.flavour = 'regular'
+            origin_node = rqet.find_tag(point_node, 'Origin')
+            self.regular_origin = (rqet.find_tag_float(origin_node,
+                                                       'Coordinate1'), rqet.find_tag_float(origin_node, 'Coordinate2'),
+                                   rqet.find_tag_float(origin_node, 'Coordinate3'))
+            assert self.regular_origin is not None, 'origin missing in xml for regular mesh (lattice)'
+            offset_nodes = rqet.list_of_tag(point_node, 'Offset')  # first occurrence for FastestAxis, ie. I; 2nd for J
             assert len(offset_nodes) == 2, 'missing (or too many) offset nodes in xml for regular mesh (lattice)'
-            for j_or_i in range(2):  # 0 = J, 1 = I
-               assert rqet.node_type(offset_nodes[j_or_i]) == 'IntegerConstantArray', 'variable step not catered for'
-               assert rqet.find_tag_int(offset_nodes[j_or_i], 'Value') == 1, 'step other than 1 not catered for'
-               count = rqet.find_tag_int(offset_nodes[j_or_i], 'Count')
-               assert count == (self.nj, self.ni)[j_or_i] - 1,  \
-                       'unexpected value for count in xml spacing info for regular mesh (lattice)'
-         elif rqet.node_type(support_geom_node) == 'Point3dLatticeArray':
-            self.flavour = 'reg&z'
-            orig_node = rqet.find_tag(support_geom_node, 'Origin')
-            self.regular_origin = (rqet.find_tag_float(orig_node,
-                                                       'Coordinate1'), rqet.find_tag_float(orig_node, 'Coordinate2'),
-                                   rqet.find_tag_float(orig_node, 'Coordinate3'))
-            assert self.regular_origin is not None, 'origin missing in xml for reg&z mesh (lattice)'
-            offset_nodes = rqet.list_of_tag(support_geom_node,
-                                            'Offset')  # first occurrence for FastestAxis, ie. I; 2nd for J
-            assert len(offset_nodes) == 2, 'missing (or too many) offset nodes in xml for reg&z mesh (lattice)'
             self.regular_dxyz_dij = np.empty((2, 3))
             for j_or_i in range(2):  # 0 = J, 1 = I
-               axial_offset_node = rqet.find_tag(offset_nodes[j_or_i], 'Offset')
-               assert axial_offset_node is not None, 'missing offset offset node in xml'
-               self.regular_dxyz_dij[1 - j_or_i] = (rqet.find_tag_float(axial_offset_node, 'Coordinate1'),
-                                                    rqet.find_tag_float(axial_offset_node, 'Coordinate2'),
-                                                    rqet.find_tag_float(axial_offset_node, 'Coordinate3'))
-               if not maths.isclose(
-                     vec.dot_product(self.regular_dxyz_dij[1 - j_or_i], self.regular_dxyz_dij[1 - j_or_i]), 1.0):
-                  log.warning('non-orthogonal axes and/or scaling in xml for regular mesh (lattice)')
-               spacing_node = rqet.find_tag(offset_nodes[j_or_i], 'Spacing')
-               stride = rqet.find_tag_float(spacing_node, 'Value')
-               count = rqet.find_tag_int(spacing_node, 'Count')
-               assert stride is not None and count is not None, 'missing spacing info in xml'
-               assert count == (self.nj, self.ni)[j_or_i] - 1,  \
-                      'unexpected value for count in xml spacing info for regular mesh (lattice)'
-               assert stride > 0.0, 'spacing distance is not positive in xml for regular mesh (lattice)'
-               self.regular_dxyz_dij[1 - j_or_i] *= stride
+                axial_offset_node = rqet.find_tag(offset_nodes[j_or_i], 'Offset')
+                assert axial_offset_node is not None, 'missing offset offset node in xml'
+                self.regular_dxyz_dij[1 - j_or_i] = (rqet.find_tag_float(axial_offset_node, 'Coordinate1'),
+                                                     rqet.find_tag_float(axial_offset_node, 'Coordinate2'),
+                                                     rqet.find_tag_float(axial_offset_node, 'Coordinate3'))
+                if not maths.isclose(
+                        vec.dot_product(self.regular_dxyz_dij[1 - j_or_i], self.regular_dxyz_dij[1 - j_or_i]), 1.0):
+                    log.warning('non-orthogonal axes and/or scaling in xml for regular mesh (lattice)')
+                spacing_node = rqet.find_tag(offset_nodes[j_or_i], 'Spacing')
+                stride = rqet.find_tag_float(spacing_node, 'Value')
+                count = rqet.find_tag_int(spacing_node, 'Count')
+                assert stride is not None and count is not None, 'missing spacing info in xml'
+                assert count == (self.nj, self.ni)[j_or_i] - 1,  \
+                       'unexpected value for count in xml spacing info for regular mesh (lattice)'
+                assert stride > 0.0, 'spacing distance is not positive in xml for regular mesh (lattice)'
+                self.regular_dxyz_dij[1 - j_or_i] *= stride
 
-      elif flavour in ['Point3dHdf5Array', 'Point2dHdf5Array']:
-         self.flavour = 'explicit'
-         self.explicit_h5_key_pair = self.model.h5_uuid_and_path_for_node(point_node, tag = 'Coordinates')
-         # load full_array on demand later (see full_array_ref() method)
+        elif flavour == 'Point3dZValueArray':
+            # note: only simple, full use of supporting mesh is handled at present
+            z_ref_node = rqet.find_tag(point_node, 'ZValues')
+            self.ref_z_h5_key_pair = self.model.h5_uuid_and_path_for_node(z_ref_node, tag = 'Values')
+            support_geom_node = rqet.find_tag(point_node, 'SupportingGeometry')
+            if rqet.node_type(support_geom_node) == 'Point3dFromRepresentationLatticeArray':
+                self.flavour = 'ref&z'
+                # assert rqet.node_type(support_geom_node) == 'Point3dFromRepresentationLatticeArray'  # only this supported for now
+                self.ref_uuid = rqet.find_nested_tags_text(support_geom_node, ['SupportingRepresentation', 'UUID'])
+                assert self.ref_uuid, 'missing supporting representation info in xml for z-value mesh'
+                self.ref_mesh = Mesh(self.model, root_node = self.model.root_for_uuid(self.ref_uuid))
+                assert self.nj == self.ref_mesh.nj and self.ni == self.ref_mesh.ni  # only this supported for now
+                niosr_node = rqet.find_tag(support_geom_node, 'NodeIndicesOnSupportingRepresentation')
+                start_value = rqet.find_tag_int(niosr_node, 'StartValue')
+                assert start_value == 0, 'only full use of supporting mesh catered for at present'
+                offset_nodes = rqet.list_of_tag(niosr_node,
+                                                'Offset')  # first occurrence for FastestAxis, ie. I; 2nd for J
+                assert len(offset_nodes) == 2, 'missing (or too many) offset nodes in xml for regular mesh (lattice)'
+                for j_or_i in range(2):  # 0 = J, 1 = I
+                    assert rqet.node_type(
+                        offset_nodes[j_or_i]) == 'IntegerConstantArray', 'variable step not catered for'
+                    assert rqet.find_tag_int(offset_nodes[j_or_i], 'Value') == 1, 'step other than 1 not catered for'
+                    count = rqet.find_tag_int(offset_nodes[j_or_i], 'Count')
+                    assert count == (self.nj, self.ni)[j_or_i] - 1,  \
+                            'unexpected value for count in xml spacing info for regular mesh (lattice)'
+            elif rqet.node_type(support_geom_node) == 'Point3dLatticeArray':
+                self.flavour = 'reg&z'
+                orig_node = rqet.find_tag(support_geom_node, 'Origin')
+                self.regular_origin = (rqet.find_tag_float(orig_node, 'Coordinate1'),
+                                       rqet.find_tag_float(orig_node, 'Coordinate2'),
+                                       rqet.find_tag_float(orig_node, 'Coordinate3'))
+                assert self.regular_origin is not None, 'origin missing in xml for reg&z mesh (lattice)'
+                offset_nodes = rqet.list_of_tag(support_geom_node,
+                                                'Offset')  # first occurrence for FastestAxis, ie. I; 2nd for J
+                assert len(offset_nodes) == 2, 'missing (or too many) offset nodes in xml for reg&z mesh (lattice)'
+                self.regular_dxyz_dij = np.empty((2, 3))
+                for j_or_i in range(2):  # 0 = J, 1 = I
+                    axial_offset_node = rqet.find_tag(offset_nodes[j_or_i], 'Offset')
+                    assert axial_offset_node is not None, 'missing offset offset node in xml'
+                    self.regular_dxyz_dij[1 - j_or_i] = (rqet.find_tag_float(axial_offset_node, 'Coordinate1'),
+                                                         rqet.find_tag_float(axial_offset_node, 'Coordinate2'),
+                                                         rqet.find_tag_float(axial_offset_node, 'Coordinate3'))
+                    if not maths.isclose(
+                            vec.dot_product(self.regular_dxyz_dij[1 - j_or_i], self.regular_dxyz_dij[1 - j_or_i]), 1.0):
+                        log.warning('non-orthogonal axes and/or scaling in xml for regular mesh (lattice)')
+                    spacing_node = rqet.find_tag(offset_nodes[j_or_i], 'Spacing')
+                    stride = rqet.find_tag_float(spacing_node, 'Value')
+                    count = rqet.find_tag_int(spacing_node, 'Count')
+                    assert stride is not None and count is not None, 'missing spacing info in xml'
+                    assert count == (self.nj, self.ni)[j_or_i] - 1,  \
+                           'unexpected value for count in xml spacing info for regular mesh (lattice)'
+                    assert stride > 0.0, 'spacing distance is not positive in xml for regular mesh (lattice)'
+                    self.regular_dxyz_dij[1 - j_or_i] *= stride
 
-      else:
-         raise Exception('unrecognised flavour for mesh points')
+        elif flavour in ['Point3dHdf5Array', 'Point2dHdf5Array']:
+            self.flavour = 'explicit'
+            self.explicit_h5_key_pair = self.model.h5_uuid_and_path_for_node(point_node, tag = 'Coordinates')
+            # load full_array on demand later (see full_array_ref() method)
 
-   def set_represented_interpretation_root(self, interp_root):
-      """Makes a note of the xml root of the represented interpretation."""
+        else:
+            raise Exception('unrecognised flavour for mesh points')
 
-      self.represented_interpretation_root = interp_root
+    def set_represented_interpretation_root(self, interp_root):
+        """Makes a note of the xml root of the represented interpretation."""
 
-   def full_array_ref(self):
-      """Populates a full 2D(+1) numpy array of shape (nj, ni, 3) with xyz values, caches and returns.
+        self.represented_interpretation_root = interp_root
+
+    def full_array_ref(self):
+        """Populates a full 2D(+1) numpy array of shape (nj, ni, 3) with xyz values, caches and returns.
 
       note:
          z values may be zero or not applicable when using the mesh as support for properties.
       """
 
-      if self.full_array is not None:
-         return self.full_array
+        if self.full_array is not None:
+            return self.full_array
 
-      if self.flavour == 'explicit':
-         # load array directly from hdf5 points reference; note: could be xyz or xy data
-         assert self.explicit_h5_key_pair is not None, 'h5 key pair not established for mesh'
-         try:
-            self.model.h5_array_element(self.explicit_h5_key_pair,
-                                        cache_array = True,
-                                        object = self,
-                                        array_attribute = 'full_array',
-                                        dtype = 'float')
-            # todo: could extend with z values of zero if only xy present?
-         except Exception:
-            log.exception('hdf5 points failure for mesh')
+        if self.flavour == 'explicit':
+            # load array directly from hdf5 points reference; note: could be xyz or xy data
+            assert self.explicit_h5_key_pair is not None, 'h5 key pair not established for mesh'
+            try:
+                self.model.h5_array_element(self.explicit_h5_key_pair,
+                                            cache_array = True,
+                                            object = self,
+                                            array_attribute = 'full_array',
+                                            dtype = 'float')
+                # todo: could extend with z values of zero if only xy present?
+            except Exception:
+                log.exception('hdf5 points failure for mesh')
 
-      elif self.flavour in ['regular', 'reg&z']:
-         self.full_array = np.empty((self.nj, self.ni, 3))
-         x_i0 = np.linspace(0.0, (self.nj - 1) * self.regular_dxyz_dij[1, 0], num = self.nj)
-         y_i0 = np.linspace(0.0, (self.nj - 1) * self.regular_dxyz_dij[1, 1], num = self.nj)
-         z_i0 = np.linspace(0.0, (self.nj - 1) * self.regular_dxyz_dij[1, 2], num = self.nj)
-         x_full = np.linspace(x_i0, x_i0 + (self.ni - 1) * self.regular_dxyz_dij[0, 0], num = self.ni, axis = -1)
-         y_full = np.linspace(y_i0, y_i0 + (self.ni - 1) * self.regular_dxyz_dij[0, 1], num = self.ni, axis = -1)
-         z_full = np.linspace(z_i0, z_i0 + (self.ni - 1) * self.regular_dxyz_dij[0, 2], num = self.ni, axis = -1)
-         self.full_array = np.stack((x_full, y_full, z_full), axis = -1) + self.regular_origin
-         if self.flavour == 'reg&z':  # overwrite regular z values with explicitly stored z values
+        elif self.flavour in ['regular', 'reg&z']:
+            self.full_array = np.empty((self.nj, self.ni, 3))
+            x_i0 = np.linspace(0.0, (self.nj - 1) * self.regular_dxyz_dij[1, 0], num = self.nj)
+            y_i0 = np.linspace(0.0, (self.nj - 1) * self.regular_dxyz_dij[1, 1], num = self.nj)
+            z_i0 = np.linspace(0.0, (self.nj - 1) * self.regular_dxyz_dij[1, 2], num = self.nj)
+            x_full = np.linspace(x_i0, x_i0 + (self.ni - 1) * self.regular_dxyz_dij[0, 0], num = self.ni, axis = -1)
+            y_full = np.linspace(y_i0, y_i0 + (self.ni - 1) * self.regular_dxyz_dij[0, 1], num = self.ni, axis = -1)
+            z_full = np.linspace(z_i0, z_i0 + (self.ni - 1) * self.regular_dxyz_dij[0, 2], num = self.ni, axis = -1)
+            self.full_array = np.stack((x_full, y_full, z_full), axis = -1) + self.regular_origin
+            if self.flavour == 'reg&z':  # overwrite regular z values with explicitly stored z values
+                assert self.ref_z_h5_key_pair is not None, 'h5 key pair missing for mesh z values'
+                try:
+                    self.model.h5_array_element(self.ref_z_h5_key_pair,
+                                                cache_array = True,
+                                                object = self,
+                                                array_attribute = 'temp_z',
+                                                dtype = 'float')
+                except Exception:
+                    log.exception('hdf5 failure for mesh z values')
+                self.full_array[..., 2] = self.temp_z
+                delattr(self, 'temp_z')
+
+        elif self.flavour == 'ref&z':
+            # load array from referenced mesh and overwrite z values
+            if self.ref_mesh is None:
+                self.ref_mesh = Mesh(self.model, uuid = self.ref_uuid)
+                assert self.ref_mesh is not None, 'failed to instantiate object for referenced mesh'
+            self.full_array = self.ref_mesh.full_array_ref().copy()
             assert self.ref_z_h5_key_pair is not None, 'h5 key pair missing for mesh z values'
             try:
-               self.model.h5_array_element(self.ref_z_h5_key_pair,
-                                           cache_array = True,
-                                           object = self,
-                                           array_attribute = 'temp_z',
-                                           dtype = 'float')
+                self.model.h5_array_element(self.ref_z_h5_key_pair,
+                                            cache_array = True,
+                                            object = self,
+                                            array_attribute = 'temp_z',
+                                            dtype = 'float')
             except Exception:
-               log.exception('hdf5 failure for mesh z values')
+                log.exception('hdf5 failure for mesh z values')
             self.full_array[..., 2] = self.temp_z
+            #        if np.any(np.isnan(self.temp_z)): log.warning('z values include some NaNs')
             delattr(self, 'temp_z')
 
-      elif self.flavour == 'ref&z':
-         # load array from referenced mesh and overwrite z values
-         if self.ref_mesh is None:
-            self.ref_mesh = Mesh(self.model, uuid = self.ref_uuid)
-            assert self.ref_mesh is not None, 'failed to instantiate object for referenced mesh'
-         self.full_array = self.ref_mesh.full_array_ref().copy()
-         assert self.ref_z_h5_key_pair is not None, 'h5 key pair missing for mesh z values'
-         try:
-            self.model.h5_array_element(self.ref_z_h5_key_pair,
-                                        cache_array = True,
-                                        object = self,
-                                        array_attribute = 'temp_z',
-                                        dtype = 'float')
-         except Exception:
-            log.exception('hdf5 failure for mesh z values')
-         self.full_array[..., 2] = self.temp_z
-         #        if np.any(np.isnan(self.temp_z)): log.warning('z values include some NaNs')
-         delattr(self, 'temp_z')
+        else:
+            raise Exception(f'unrecognised mesh flavour when fetching full array: {self.flavour}')
 
-      else:
-         raise Exception(f'unrecognised mesh flavour when fetching full array: {self.flavour}')
+        return self.full_array
 
-      return self.full_array
+    def surface(self, quad_triangles = False):
+        """Returns a surface object generated from this mesh."""
 
-   def surface(self, quad_triangles = False):
-      """Returns a surface object generated from this mesh."""
+        return Surface(self.model, mesh = self, quad_triangles = quad_triangles)
 
-      return Surface(self.model, mesh = self, quad_triangles = quad_triangles)
+    def write_hdf5(self, file_name = None, mode = 'a', use_xy_only = False):
+        """Create or append to an hdf5 file, writing datasets for the mesh depending on flavour."""
 
-   def write_hdf5(self, file_name = None, mode = 'a', use_xy_only = False):
-      """Create or append to an hdf5 file, writing datasets for the mesh depending on flavour."""
+        if not file_name:
+            file_name = self.model.h5_file_name()
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
+        if self.flavour == 'regular':
+            return
+        # NB: arrays must have been set up prior to calling this function
+        h5_reg = rwh5.H5Register(self.model)
+        a = self.full_array_ref()
+        if self.flavour == 'explicit':
+            if use_xy_only:
+                h5_reg.register_dataset(self.uuid, 'points', a[..., :2])  # todo: check what others use here
+            else:
+                h5_reg.register_dataset(self.uuid, 'points', a)
+        elif self.flavour == 'ref&z' or self.flavour == 'reg&z':
+            h5_reg.register_dataset(self.uuid, 'zvalues', a[..., 2])
+        else:
+            log.error('bad mesh flavour when writing hdf5 array')
+        h5_reg.write(file_name, mode = mode)
 
-      if not file_name:
-         file_name = self.model.h5_file_name()
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
-      if self.flavour == 'regular':
-         return
-      # NB: arrays must have been set up prior to calling this function
-      h5_reg = rwh5.H5Register(self.model)
-      a = self.full_array_ref()
-      if self.flavour == 'explicit':
-         if use_xy_only:
-            h5_reg.register_dataset(self.uuid, 'points', a[..., :2])  # todo: check what others use here
-         else:
-            h5_reg.register_dataset(self.uuid, 'points', a)
-      elif self.flavour == 'ref&z' or self.flavour == 'reg&z':
-         h5_reg.register_dataset(self.uuid, 'zvalues', a[..., 2])
-      else:
-         log.error('bad mesh flavour when writing hdf5 array')
-      h5_reg.write(file_name, mode = mode)
-
-   def create_xml(self,
-                  ext_uuid = None,
-                  crs_root = None,
-                  use_xy_only = False,
-                  add_as_part = True,
-                  add_relationships = True,
-                  root = None,
-                  title = None,
-                  originator = None):
-      """Creates a grid 2d representation xml node from this mesh object and optionally adds as part of model.
+    def create_xml(self,
+                   ext_uuid = None,
+                   crs_root = None,
+                   use_xy_only = False,
+                   add_as_part = True,
+                   add_relationships = True,
+                   root = None,
+                   title = None,
+                   originator = None):
+        """Creates a grid 2d representation xml node from this mesh object and optionally adds as part of model.
 
          arguments:
             ext_uuid (uuid.UUID, optional): the uuid of the hdf5 external part holding the mesh array
@@ -2010,224 +2017,224 @@ class Mesh(_BaseSurface):
             the newly created grid 2d representation (mesh) xml node
       """
 
-      if crs_root is not None:
-         warnings.warn('crs_root argument is deprecated and ignored in Mesh.create_xml()')
+        if crs_root is not None:
+            warnings.warn('crs_root argument is deprecated and ignored in Mesh.create_xml()')
 
-      if ext_uuid is None and self.flavour != 'regular':
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None and self.flavour != 'regular':
+            ext_uuid = self.model.h5_uuid()
 
-      g2d_node = super().create_xml(add_as_part = False, title = title, originator = originator)
+        g2d_node = super().create_xml(add_as_part = False, title = title, originator = originator)
 
-      if self.represented_interpretation_root is not None:
-         interp_root = self.represented_interpretation_root
-         interp_uuid = bu.uuid_from_string(interp_root.attrib['uuid'])
-         interp_part = self.model.part_for_uuid(interp_uuid)
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
-                                    interp_uuid,
-                                    content_type = self.model.type_of_part(interp_part),
-                                    root = g2d_node)
+        if self.represented_interpretation_root is not None:
+            interp_root = self.represented_interpretation_root
+            interp_uuid = bu.uuid_from_string(interp_root.attrib['uuid'])
+            interp_part = self.model.part_for_uuid(interp_uuid)
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
+                                       interp_uuid,
+                                       content_type = self.model.type_of_part(interp_part),
+                                       root = g2d_node)
 
-      role_node = rqet.SubElement(g2d_node, ns['resqml2'] + 'SurfaceRole')
-      role_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'SurfaceRole')
-      role_node.text = self.surface_role
+        role_node = rqet.SubElement(g2d_node, ns['resqml2'] + 'SurfaceRole')
+        role_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'SurfaceRole')
+        role_node.text = self.surface_role
 
-      patch_node = rqet.SubElement(g2d_node, ns['resqml2'] + 'Grid2dPatch')
-      patch_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Grid2dPatch')
-      patch_node.text = '\n'
+        patch_node = rqet.SubElement(g2d_node, ns['resqml2'] + 'Grid2dPatch')
+        patch_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Grid2dPatch')
+        patch_node.text = '\n'
 
-      pi_node = rqet.SubElement(patch_node, ns['resqml2'] + 'PatchIndex')
-      pi_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-      pi_node.text = '0'
+        pi_node = rqet.SubElement(patch_node, ns['resqml2'] + 'PatchIndex')
+        pi_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+        pi_node.text = '0'
 
-      fast_node = rqet.SubElement(patch_node, ns['resqml2'] + 'FastestAxisCount')
-      fast_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      fast_node.text = str(self.ni)
+        fast_node = rqet.SubElement(patch_node, ns['resqml2'] + 'FastestAxisCount')
+        fast_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        fast_node.text = str(self.ni)
 
-      slow_node = rqet.SubElement(patch_node, ns['resqml2'] + 'SlowestAxisCount')
-      slow_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      slow_node.text = str(self.nj)
+        slow_node = rqet.SubElement(patch_node, ns['resqml2'] + 'SlowestAxisCount')
+        slow_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        slow_node.text = str(self.nj)
 
-      geom = rqet.SubElement(patch_node, ns['resqml2'] + 'Geometry')
-      geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
-      geom.text = '\n'
+        geom = rqet.SubElement(patch_node, ns['resqml2'] + 'Geometry')
+        geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'PointGeometry')
+        geom.text = '\n'
 
-      self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+        self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
-      p_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
-      p_node.text = '\n'
+        p_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
+        p_node.text = '\n'
 
-      ref_root = None
+        ref_root = None
 
-      if self.flavour == 'regular':
+        if self.flavour == 'regular':
 
-         assert self.regular_origin is not None and self.regular_dxyz_dij is not None
+            assert self.regular_origin is not None and self.regular_dxyz_dij is not None
 
-         p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dLatticeArray')
+            p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dLatticeArray')
 
-         self.model.create_solitary_point3d('Origin', p_node, self.regular_origin)  # todo: check xml namespace
+            self.model.create_solitary_point3d('Origin', p_node, self.regular_origin)  # todo: check xml namespace
 
-         for j_or_i in range(2):  # 0 = J, 1 = I
-            dxyz = self.regular_dxyz_dij[1 - j_or_i].copy()
-            log.debug('dxyz: ' + str(dxyz))
-            d_value = vec.dot_product(dxyz, dxyz)
-            assert d_value > 0.0
-            d_value = maths.sqrt(d_value)
-            dxyz /= d_value
-            o_node = rqet.SubElement(p_node, ns['resqml2'] + 'Offset')  # note: 1st Offset is for J axis , 2nd for I
-            o_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dOffset')
-            o_node.text = '\n'
-            self.model.create_solitary_point3d('Offset', o_node, dxyz)
-            space_node = rqet.SubElement(o_node, ns['resqml2'] + 'Spacing')
-            space_node.set(ns['xsi'] + 'type',
-                           ns['resqml2'] + 'DoubleConstantArray')  # nothing else catered for just now
-            space_node.text = '\n'
-            ov_node = rqet.SubElement(space_node, ns['resqml2'] + 'Value')
-            ov_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-            ov_node.text = str(d_value)
-            oc_node = rqet.SubElement(space_node, ns['resqml2'] + 'Count')
-            oc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-            if j_or_i:
-               oc_node.text = str(self.ni - 1)
+            for j_or_i in range(2):  # 0 = J, 1 = I
+                dxyz = self.regular_dxyz_dij[1 - j_or_i].copy()
+                log.debug('dxyz: ' + str(dxyz))
+                d_value = vec.dot_product(dxyz, dxyz)
+                assert d_value > 0.0
+                d_value = maths.sqrt(d_value)
+                dxyz /= d_value
+                o_node = rqet.SubElement(p_node, ns['resqml2'] + 'Offset')  # note: 1st Offset is for J axis , 2nd for I
+                o_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dOffset')
+                o_node.text = '\n'
+                self.model.create_solitary_point3d('Offset', o_node, dxyz)
+                space_node = rqet.SubElement(o_node, ns['resqml2'] + 'Spacing')
+                space_node.set(ns['xsi'] + 'type',
+                               ns['resqml2'] + 'DoubleConstantArray')  # nothing else catered for just now
+                space_node.text = '\n'
+                ov_node = rqet.SubElement(space_node, ns['resqml2'] + 'Value')
+                ov_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+                ov_node.text = str(d_value)
+                oc_node = rqet.SubElement(space_node, ns['resqml2'] + 'Count')
+                oc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+                if j_or_i:
+                    oc_node.text = str(self.ni - 1)
+                else:
+                    oc_node.text = str(self.nj - 1)
+
+        elif self.flavour == 'ref&z':
+
+            assert ext_uuid is not None
+            assert self.ref_uuid is not None
+
+            p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dZValueArray')
+
+            sg_node = rqet.SubElement(p_node, ns['resqml2'] + 'SupportingGeometry')
+
+            sg_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dFromRepresentationLatticeArray')
+            sg_node.text = '\n'
+
+            niosr_node = rqet.SubElement(sg_node, ns['resqml2'] + 'NodeIndicesOnSupportingRepresentation')
+            niosr_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerLatticeArray')
+            niosr_node.text = '\n'
+
+            sv_node = rqet.SubElement(niosr_node, ns['resqml2'] + 'StartValue')
+            sv_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            sv_node.text = '0'  # no other possibility cater for at present
+
+            for j_or_i in range(2):  # 0 = J, 1 = I
+                o_node = rqet.SubElement(niosr_node, ns['resqml2'] + 'Offset')
+                o_node.set(ns['xsi'] + 'type',
+                           ns['resqml2'] + 'IntegerConstantArray')  # no other possibility cater for at present
+                o_node.text = '\n'
+                ov_node = rqet.SubElement(o_node, ns['resqml2'] + 'Value')
+                ov_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+                ov_node.text = '1'  # no other possibility cater for at present
+                oc_node = rqet.SubElement(o_node, ns['resqml2'] + 'Count')
+                oc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+                if j_or_i:
+                    oc_node.text = str(self.ni - 1)
+                else:
+                    oc_node.text = str(self.nj - 1)
+
+            ref_root = self.model.root_for_uuid(self.ref_uuid)
+            self.model.create_ref_node('SupportingRepresentation',
+                                       rqet.find_nested_tags_text(ref_root, ['Citation', 'Title']),
+                                       self.ref_uuid,
+                                       content_type = 'Grid2dRepresentation',
+                                       root = sg_node)
+
+            zv_node = rqet.SubElement(p_node, ns['resqml2'] + 'ZValues')
+            zv_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+            zv_node.text = '\n'
+
+            v_node = rqet.SubElement(zv_node, ns['resqml2'] + 'Values')
+            v_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            v_node.text = '\n'
+
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'zvalues', root = v_node)
+
+        elif self.flavour == 'reg&z':
+
+            assert ext_uuid is not None
+
+            p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dZValueArray')
+
+            sg_node = rqet.SubElement(p_node, ns['resqml2'] + 'SupportingGeometry')
+
+            sg_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dLatticeArray')
+            sg_node.text = '\n'
+
+            assert self.regular_origin is not None and self.regular_dxyz_dij is not None
+
+            self.model.create_solitary_point3d('Origin', sg_node, self.regular_origin)  # todo: check xml namespace
+
+            for j_or_i in range(2):  # 0 = J, 1 = I; ie. J axis info first in xml, followed by I axis
+                dxyz = self.regular_dxyz_dij[1 - j_or_i].copy()
+                log.debug('dxyz: ' + str(dxyz))
+                d_value = vec.dot_product(dxyz, dxyz)
+                assert d_value > 0.0
+                d_value = maths.sqrt(d_value)
+                dxyz /= d_value
+                o_node = rqet.SubElement(sg_node, ns['resqml2'] + 'Offset')
+                o_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dOffset')
+                o_node.text = '\n'
+                self.model.create_solitary_point3d('Offset', o_node, dxyz)
+                space_node = rqet.SubElement(o_node, ns['resqml2'] + 'Spacing')
+                space_node.set(ns['xsi'] + 'type',
+                               ns['resqml2'] + 'DoubleConstantArray')  # nothing else catered for just now
+                space_node.text = '\n'
+                ov_node = rqet.SubElement(space_node, ns['resqml2'] + 'Value')
+                ov_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+                ov_node.text = str(d_value)
+                oc_node = rqet.SubElement(space_node, ns['resqml2'] + 'Count')
+                oc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+                if j_or_i:
+                    oc_node.text = str(self.ni - 1)
+                else:
+                    oc_node.text = str(self.nj - 1)
+
+            zv_node = rqet.SubElement(p_node, ns['resqml2'] + 'ZValues')
+            zv_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+            zv_node.text = '\n'
+
+            v_node = rqet.SubElement(zv_node, ns['resqml2'] + 'Values')
+            v_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            v_node.text = '\n'
+
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'zvalues', root = v_node)
+
+        elif self.flavour == 'explicit':
+
+            assert ext_uuid is not None
+
+            if use_xy_only:
+                p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point2dHdf5Array')
             else:
-               oc_node.text = str(self.nj - 1)
+                p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
 
-      elif self.flavour == 'ref&z':
+            coords = rqet.SubElement(p_node, ns['resqml2'] + 'Coordinates')
+            coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            coords.text = '\n'
 
-         assert ext_uuid is not None
-         assert self.ref_uuid is not None
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points', root = coords)
 
-         p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dZValueArray')
+        else:
+            log.error('mesh has bad flavour when creating xml')
+            return None
 
-         sg_node = rqet.SubElement(p_node, ns['resqml2'] + 'SupportingGeometry')
+        if root is not None:
+            root.append(g2d_node)
+        if add_as_part:
+            self.model.add_part('obj_Grid2dRepresentation', self.uuid, g2d_node)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(g2d_node, 'destinationObject', self.crs_root, 'sourceObject')
+                if self.represented_interpretation_root is not None:
+                    self.model.create_reciprocal_relationship(g2d_node, 'destinationObject',
+                                                              self.represented_interpretation_root, 'sourceObject')
+                if ref_root is not None:  # used for ref&z flavour
+                    self.model.create_reciprocal_relationship(g2d_node, 'destinationObject', ref_root, 'sourceObject')
+                if self.flavour == 'ref&z' or self.flavour == 'explicit' or self.flavour == 'reg&z':
+                    ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                    ext_node = self.model.root_for_part(ext_part)
+                    self.model.create_reciprocal_relationship(g2d_node, 'mlToExternalPartProxy', ext_node,
+                                                              'externalPartProxyToMl')
 
-         sg_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dFromRepresentationLatticeArray')
-         sg_node.text = '\n'
-
-         niosr_node = rqet.SubElement(sg_node, ns['resqml2'] + 'NodeIndicesOnSupportingRepresentation')
-         niosr_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerLatticeArray')
-         niosr_node.text = '\n'
-
-         sv_node = rqet.SubElement(niosr_node, ns['resqml2'] + 'StartValue')
-         sv_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         sv_node.text = '0'  # no other possibility cater for at present
-
-         for j_or_i in range(2):  # 0 = J, 1 = I
-            o_node = rqet.SubElement(niosr_node, ns['resqml2'] + 'Offset')
-            o_node.set(ns['xsi'] + 'type',
-                       ns['resqml2'] + 'IntegerConstantArray')  # no other possibility cater for at present
-            o_node.text = '\n'
-            ov_node = rqet.SubElement(o_node, ns['resqml2'] + 'Value')
-            ov_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-            ov_node.text = '1'  # no other possibility cater for at present
-            oc_node = rqet.SubElement(o_node, ns['resqml2'] + 'Count')
-            oc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-            if j_or_i:
-               oc_node.text = str(self.ni - 1)
-            else:
-               oc_node.text = str(self.nj - 1)
-
-         ref_root = self.model.root_for_uuid(self.ref_uuid)
-         self.model.create_ref_node('SupportingRepresentation',
-                                    rqet.find_nested_tags_text(ref_root, ['Citation', 'Title']),
-                                    self.ref_uuid,
-                                    content_type = 'Grid2dRepresentation',
-                                    root = sg_node)
-
-         zv_node = rqet.SubElement(p_node, ns['resqml2'] + 'ZValues')
-         zv_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-         zv_node.text = '\n'
-
-         v_node = rqet.SubElement(zv_node, ns['resqml2'] + 'Values')
-         v_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         v_node.text = '\n'
-
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'zvalues', root = v_node)
-
-      elif self.flavour == 'reg&z':
-
-         assert ext_uuid is not None
-
-         p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dZValueArray')
-
-         sg_node = rqet.SubElement(p_node, ns['resqml2'] + 'SupportingGeometry')
-
-         sg_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dLatticeArray')
-         sg_node.text = '\n'
-
-         assert self.regular_origin is not None and self.regular_dxyz_dij is not None
-
-         self.model.create_solitary_point3d('Origin', sg_node, self.regular_origin)  # todo: check xml namespace
-
-         for j_or_i in range(2):  # 0 = J, 1 = I; ie. J axis info first in xml, followed by I axis
-            dxyz = self.regular_dxyz_dij[1 - j_or_i].copy()
-            log.debug('dxyz: ' + str(dxyz))
-            d_value = vec.dot_product(dxyz, dxyz)
-            assert d_value > 0.0
-            d_value = maths.sqrt(d_value)
-            dxyz /= d_value
-            o_node = rqet.SubElement(sg_node, ns['resqml2'] + 'Offset')
-            o_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dOffset')
-            o_node.text = '\n'
-            self.model.create_solitary_point3d('Offset', o_node, dxyz)
-            space_node = rqet.SubElement(o_node, ns['resqml2'] + 'Spacing')
-            space_node.set(ns['xsi'] + 'type',
-                           ns['resqml2'] + 'DoubleConstantArray')  # nothing else catered for just now
-            space_node.text = '\n'
-            ov_node = rqet.SubElement(space_node, ns['resqml2'] + 'Value')
-            ov_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-            ov_node.text = str(d_value)
-            oc_node = rqet.SubElement(space_node, ns['resqml2'] + 'Count')
-            oc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-            if j_or_i:
-               oc_node.text = str(self.ni - 1)
-            else:
-               oc_node.text = str(self.nj - 1)
-
-         zv_node = rqet.SubElement(p_node, ns['resqml2'] + 'ZValues')
-         zv_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-         zv_node.text = '\n'
-
-         v_node = rqet.SubElement(zv_node, ns['resqml2'] + 'Values')
-         v_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         v_node.text = '\n'
-
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'zvalues', root = v_node)
-
-      elif self.flavour == 'explicit':
-
-         assert ext_uuid is not None
-
-         if use_xy_only:
-            p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point2dHdf5Array')
-         else:
-            p_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-
-         coords = rqet.SubElement(p_node, ns['resqml2'] + 'Coordinates')
-         coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         coords.text = '\n'
-
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'points', root = coords)
-
-      else:
-         log.error('mesh has bad flavour when creating xml')
-         return None
-
-      if root is not None:
-         root.append(g2d_node)
-      if add_as_part:
-         self.model.add_part('obj_Grid2dRepresentation', self.uuid, g2d_node)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(g2d_node, 'destinationObject', self.crs_root, 'sourceObject')
-            if self.represented_interpretation_root is not None:
-               self.model.create_reciprocal_relationship(g2d_node, 'destinationObject',
-                                                         self.represented_interpretation_root, 'sourceObject')
-            if ref_root is not None:  # used for ref&z flavour
-               self.model.create_reciprocal_relationship(g2d_node, 'destinationObject', ref_root, 'sourceObject')
-            if self.flavour == 'ref&z' or self.flavour == 'explicit' or self.flavour == 'reg&z':
-               ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-               ext_node = self.model.root_for_part(ext_part)
-               self.model.create_reciprocal_relationship(g2d_node, 'mlToExternalPartProxy', ext_node,
-                                                         'externalPartProxyToMl')
-
-      return g2d_node
+        return g2d_node

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -26,62 +26,62 @@ from resqpy.olio.xml_namespaces import curly_namespace as ns
 
 
 class TimeDuration:
-   """A thin wrapper around python's datatime timedelta objects (not a RESQML class)."""
+    """A thin wrapper around python's datatime timedelta objects (not a RESQML class)."""
 
-   def __init__(self,
-                days = None,
-                hours = None,
-                minutes = None,
-                seconds = None,
-                earlier_timestamp = None,
-                later_timestamp = None):
-      """Create a TimeDuration object either from days and seconds or from a pair of timestamps."""
+    def __init__(self,
+                 days = None,
+                 hours = None,
+                 minutes = None,
+                 seconds = None,
+                 earlier_timestamp = None,
+                 later_timestamp = None):
+        """Create a TimeDuration object either from days and seconds or from a pair of timestamps."""
 
-      # for negative durations, earlier_timestamp should be later than later_timestamp
-      # or days, hours etc. should typically all be non-positive
-      # ie. days = -1, hours = -12 will be a negative one and a half day duration
-      # whilst days = -1, hours = 12 will be a negative half day duration
-      self.duration = None
-      if earlier_timestamp is not None and later_timestamp is not None:
-         if earlier_timestamp.endswith('Z'):
-            earlier_timestamp = earlier_timestamp[:-1]  # Trailing Z is not part of iso format
-         if later_timestamp.endswith('Z'):
+        # for negative durations, earlier_timestamp should be later than later_timestamp
+        # or days, hours etc. should typically all be non-positive
+        # ie. days = -1, hours = -12 will be a negative one and a half day duration
+        # whilst days = -1, hours = 12 will be a negative half day duration
+        self.duration = None
+        if earlier_timestamp is not None and later_timestamp is not None:
+            if earlier_timestamp.endswith('Z'):
+                earlier_timestamp = earlier_timestamp[:-1]  # Trailing Z is not part of iso format
+            if later_timestamp.endswith('Z'):
+                later_timestamp = later_timestamp[:-1]
+            dt_earlier = dt.datetime.fromisoformat(earlier_timestamp)
+            dt_later = dt.datetime.fromisoformat(later_timestamp)
+            self.duration = dt_later - dt_earlier
+        else:
+            if days is None:
+                days = 0
+            if hours is None:
+                hours = 0
+            if minutes is None:
+                minutes = 0
+            if seconds is None:
+                seconds = 0
+            self.duration = dt.timedelta(days = days, hours = hours, minutes = minutes, seconds = seconds)
+
+    def timestamp_after_duration(self, earlier_timestamp):
+        """Create a new timestamp from this duration and an earlier timestamp."""
+
+        if earlier_timestamp.endswith('Z'):
+            earlier_timestamp = earlier_timestamp[:-1]
+        dt_earlier = dt.datetime.fromisoformat(earlier_timestamp)
+        dt_result = dt_earlier + self.duration
+        return dt_result.isoformat() + 'Z'
+
+    def timestamp_before_duration(self, later_timestamp):
+        """Create a new timestamp from this duration and a later timestamp."""
+
+        if later_timestamp.endswith('Z'):
             later_timestamp = later_timestamp[:-1]
-         dt_earlier = dt.datetime.fromisoformat(earlier_timestamp)
-         dt_later = dt.datetime.fromisoformat(later_timestamp)
-         self.duration = dt_later - dt_earlier
-      else:
-         if days is None:
-            days = 0
-         if hours is None:
-            hours = 0
-         if minutes is None:
-            minutes = 0
-         if seconds is None:
-            seconds = 0
-         self.duration = dt.timedelta(days = days, hours = hours, minutes = minutes, seconds = seconds)
-
-   def timestamp_after_duration(self, earlier_timestamp):
-      """Create a new timestamp from this duration and an earlier timestamp."""
-
-      if earlier_timestamp.endswith('Z'):
-         earlier_timestamp = earlier_timestamp[:-1]
-      dt_earlier = dt.datetime.fromisoformat(earlier_timestamp)
-      dt_result = dt_earlier + self.duration
-      return dt_result.isoformat() + 'Z'
-
-   def timestamp_before_duration(self, later_timestamp):
-      """Create a new timestamp from this duration and a later timestamp."""
-
-      if later_timestamp.endswith('Z'):
-         later_timestamp = later_timestamp[:-1]
-      dt_later = dt.datetime.fromisoformat(later_timestamp)
-      dt_result = dt_later - self.duration
-      return dt_result.isoformat() + 'Z'
+        dt_later = dt.datetime.fromisoformat(later_timestamp)
+        dt_result = dt_later - self.duration
+        return dt_result.isoformat() + 'Z'
 
 
 class AnyTimeSeries(BaseResqpy):
-   """Abstract class for a RESQML Time Series; use resqpy TimeSeries or GeologicTimeSeries.
+    """Abstract class for a RESQML Time Series; use resqpy TimeSeries or GeologicTimeSeries.
 
    notes:
       this class has no direct initialisation method;
@@ -91,54 +91,54 @@ class AnyTimeSeries(BaseResqpy):
       only the year offset is significant
    """
 
-   resqml_type = 'TimeSeries'
+    resqml_type = 'TimeSeries'
 
-   def _load_from_xml(self):
-      time_series_root = self.root
-      assert time_series_root is not None
-      # for human timeframe series, timestamps is an ordered list of timestamp strings in resqml/iso format
-      # for geological timeframe series, timestamps is an ordered list of ints being the year offsets from present
-      self.timestamps = []
-      for child in rqet.list_of_tag(time_series_root, 'Time'):
-         dt_text = rqet.find_tag_text(child, 'DateTime')
-         assert dt_text, 'missing DateTime field in xml for time series'
-         year_offset = rqet.find_tag_int(child, 'YearOffset')
-         if year_offset:
-            assert self.timeframe == 'geologic'
-            self.timestamps.append(year_offset)  # todo: trim and check timestamp
-         else:
-            assert self.timeframe == 'human'
-            self.timestamps.append(dt_text)  # todo: trim and check timestamp
-         self.timestamps.sort()
+    def _load_from_xml(self):
+        time_series_root = self.root
+        assert time_series_root is not None
+        # for human timeframe series, timestamps is an ordered list of timestamp strings in resqml/iso format
+        # for geological timeframe series, timestamps is an ordered list of ints being the year offsets from present
+        self.timestamps = []
+        for child in rqet.list_of_tag(time_series_root, 'Time'):
+            dt_text = rqet.find_tag_text(child, 'DateTime')
+            assert dt_text, 'missing DateTime field in xml for time series'
+            year_offset = rqet.find_tag_int(child, 'YearOffset')
+            if year_offset:
+                assert self.timeframe == 'geologic'
+                self.timestamps.append(year_offset)  # todo: trim and check timestamp
+            else:
+                assert self.timeframe == 'human'
+                self.timestamps.append(dt_text)  # todo: trim and check timestamp
+            self.timestamps.sort()
 
-   def is_equivalent(self, other_ts):
-      """Performs partial equivalence check on two time series (derived class methods finish the work)."""
+    def is_equivalent(self, other_ts):
+        """Performs partial equivalence check on two time series (derived class methods finish the work)."""
 
-      if other_ts is None:
-         return False
-      if self is other_ts:
-         return True
-      if bu.matching_uuids(self.uuid, other_ts.uuid):
-         return True
-      if self.number_of_timestamps() != other_ts.number_of_timestamps():
-         return False
-      if self.timeframe != other_ts.timeframe:
-         return False
-      return None
+        if other_ts is None:
+            return False
+        if self is other_ts:
+            return True
+        if bu.matching_uuids(self.uuid, other_ts.uuid):
+            return True
+        if self.number_of_timestamps() != other_ts.number_of_timestamps():
+            return False
+        if self.timeframe != other_ts.timeframe:
+            return False
+        return None
 
-   def set_model(self, parent_model):
-      """Associate the time series with a resqml model (does not create xml or write hdf5 data)."""
-      self.model = parent_model
+    def set_model(self, parent_model):
+        """Associate the time series with a resqml model (does not create xml or write hdf5 data)."""
+        self.model = parent_model
 
-   def number_of_timestamps(self):
-      """Returns the number of timestamps in the series.
+    def number_of_timestamps(self):
+        """Returns the number of timestamps in the series.
 
       :meta common:
       """
-      return len(self.timestamps)
+        return len(self.timestamps)
 
-   def timestamp(self, index, as_string = True):
-      """Returns an individual timestamp, indexed by its position in the series.
+    def timestamp(self, index, as_string = True):
+        """Returns an individual timestamp, indexed by its position in the series.
 
       arguments:
          index (int): the time index for which the timestamp is required
@@ -157,31 +157,31 @@ class AnyTimeSeries(BaseResqpy):
       :meta common:
       """
 
-      # individual timestamp is in iso format with a Z appended, eg: 2019-08-23T14:30:00Z
-      if not -len(self.timestamps) <= index < len(self.timestamps):
-         return None
-      stamp = self.timestamps[index]
-      if as_string and isinstance(stamp, int):
-         stamp = geologic_time_str(stamp)
-      return stamp
+        # individual timestamp is in iso format with a Z appended, eg: 2019-08-23T14:30:00Z
+        if not -len(self.timestamps) <= index < len(self.timestamps):
+            return None
+        stamp = self.timestamps[index]
+        if as_string and isinstance(stamp, int):
+            stamp = geologic_time_str(stamp)
+        return stamp
 
-   def iter_timestamps(self, as_string = True):
-      """Iterator over timestamps.
-
-      :meta common:
-      """
-      for index in len(self.timestamps):
-         yield self.timestamp(index, as_string = as_string)
-
-   def last_timestamp(self, as_string = True):
-      """Returns the last timestamp in the series.
+    def iter_timestamps(self, as_string = True):
+        """Iterator over timestamps.
 
       :meta common:
       """
-      return self.timestamp(-1, as_string = as_string) if self.timestamps else None
+        for index in len(self.timestamps):
+            yield self.timestamp(index, as_string = as_string)
 
-   def index_for_timestamp(self, timestamp):
-      """Returns the index for a given timestamp.
+    def last_timestamp(self, as_string = True):
+        """Returns the last timestamp in the series.
+
+      :meta common:
+      """
+        return self.timestamp(-1, as_string = as_string) if self.timestamps else None
+
+    def index_for_timestamp(self, timestamp):
+        """Returns the index for a given timestamp.
 
       note:
          this method uses a simplistic string or int comparison;
@@ -189,14 +189,14 @@ class AnyTimeSeries(BaseResqpy):
 
       :meta common:
       """
-      as_string = not isinstance(timestamp, int)
-      for index in range(len(self.timestamps)):
-         if self.timestamp(index, as_string = as_string) == timestamp:
-            return index
-      return None
+        as_string = not isinstance(timestamp, int)
+        for index in range(len(self.timestamps)):
+            if self.timestamp(index, as_string = as_string) == timestamp:
+                return index
+        return None
 
-   def create_xml(self, add_as_part = True, title = None, originator = None, reuse = True):
-      """Create a RESQML time series xml node from a TimeSeries or GeologicTimeSeries object, optionally add as part.
+    def create_xml(self, add_as_part = True, title = None, originator = None, reuse = True):
+        """Create a RESQML time series xml node from a TimeSeries or GeologicTimeSeries object, optionally add as part.
 
       arguments:
          add_as_part (boolean, default True): if True, the newly created xml node is added as a part
@@ -211,37 +211,37 @@ class AnyTimeSeries(BaseResqpy):
       :meta common:
       """
 
-      if reuse and self.try_reuse():
-         return self.root  # check for reusable (equivalent) object
+        if reuse and self.try_reuse():
+            return self.root  # check for reusable (equivalent) object
 
-      if self.extra_metadata is None:
-         self.extra_metadata = {}
-      self.extra_metadata['timeframe'] = self.timeframe
+        if self.extra_metadata is None:
+            self.extra_metadata = {}
+        self.extra_metadata['timeframe'] = self.timeframe
 
-      ts_node = super().create_xml(add_as_part = False, title = title, originator = originator)
+        ts_node = super().create_xml(add_as_part = False, title = title, originator = originator)
 
-      for index in range(self.number_of_timestamps()):
-         time_node = rqet.SubElement(ts_node, ns['resqml2'] + 'Time')
-         time_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Timestamp')
-         time_node.text = rqet.null_xml_text
-         dt_node = rqet.SubElement(time_node, ns['resqml2'] + 'DateTime')
-         dt_node.set(ns['xsi'] + 'type', ns['xsd'] + 'dateTime')
-         if self.timeframe == 'geologic':
-            assert isinstance(self.timestamps[index], int)
-            dt_node.text = '0000-01-01T00:00:00Z'
-            yo_node = rqet.SubElement(time_node, ns['resqml2'] + 'YearOffset')
-            yo_node.set(ns['xsi'] + 'type', ns['xsd'] + 'long')
-            yo_node.text = str(self.timestamps[index])
-         else:
-            dt_node.text = self.timestamp(index)
+        for index in range(self.number_of_timestamps()):
+            time_node = rqet.SubElement(ts_node, ns['resqml2'] + 'Time')
+            time_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Timestamp')
+            time_node.text = rqet.null_xml_text
+            dt_node = rqet.SubElement(time_node, ns['resqml2'] + 'DateTime')
+            dt_node.set(ns['xsi'] + 'type', ns['xsd'] + 'dateTime')
+            if self.timeframe == 'geologic':
+                assert isinstance(self.timestamps[index], int)
+                dt_node.text = '0000-01-01T00:00:00Z'
+                yo_node = rqet.SubElement(time_node, ns['resqml2'] + 'YearOffset')
+                yo_node.set(ns['xsi'] + 'type', ns['xsd'] + 'long')
+                yo_node.text = str(self.timestamps[index])
+            else:
+                dt_node.text = self.timestamp(index)
 
-      if add_as_part:
-         self.model.add_part('obj_TimeSeries', self.uuid, ts_node)
+        if add_as_part:
+            self.model.add_part('obj_TimeSeries', self.uuid, ts_node)
 
-      return ts_node
+        return ts_node
 
-   def create_time_index(self, time_index, root = None, check_valid_index = True):
-      """Create a time index node, including time series reference, optionally add to root.
+    def create_time_index(self, time_index, root = None, check_valid_index = True):
+        """Create a time index node, including time series reference, optionally add to root.
 
       arguments:
          time_index (int): non-negative integer index into the time series, identifying the datetime
@@ -260,46 +260,46 @@ class AnyTimeSeries(BaseResqpy):
          object
       """
 
-      assert self.uuid is not None
-      if check_valid_index:
-         assert 0 <= time_index < len(self.timestamps), 'time index out of range for time series'
+        assert self.uuid is not None
+        if check_valid_index:
+            assert 0 <= time_index < len(self.timestamps), 'time index out of range for time series'
 
-      t_node = rqet.Element(ns['resqml2'] + 'TimeIndex')
-      t_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeIndex')
-      t_node.text = rqet.null_xml_text
+        t_node = rqet.Element(ns['resqml2'] + 'TimeIndex')
+        t_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'TimeIndex')
+        t_node.text = rqet.null_xml_text
 
-      index_node = rqet.SubElement(t_node, ns['resqml2'] + 'Index')
-      index_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-      index_node.text = str(time_index)
+        index_node = rqet.SubElement(t_node, ns['resqml2'] + 'Index')
+        index_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+        index_node.text = str(time_index)
 
-      self.model.create_time_series_ref(self.uuid, root = t_node)
+        self.model.create_time_series_ref(self.uuid, root = t_node)
 
-      if root is not None:
-         root.append(t_node)
-      return t_node
+        if root is not None:
+            root.append(t_node)
+        return t_node
 
 
 class TimeSeries(AnyTimeSeries):
-   """Class for RESQML Time Series without year offsets.
+    """Class for RESQML Time Series without year offsets.
 
    notes:
       use this class for time series on a human timeframe; use the resqpy GeologicTimeSeries class
       instead if the time series is on a geological timeframe
    """
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                time_series_root = None,
-                first_timestamp = None,
-                daily = None,
-                monthly = None,
-                quarterly = None,
-                yearly = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Create a TimeSeries object, either from a time series node in parent model, or from given data.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 time_series_root = None,
+                 first_timestamp = None,
+                 daily = None,
+                 monthly = None,
+                 quarterly = None,
+                 yearly = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Create a TimeSeries object, either from a time series node in parent model, or from given data.
 
       arguments:
          parent_model (model.Model): the resqpy model to which the time series will belong
@@ -331,184 +331,184 @@ class TimeSeries(AnyTimeSeries):
       :meta common:
       """
 
-      self.timeframe = 'human'
-      self.timestamps = []  # ordered list of timestamp strings in resqml/iso format
-      if first_timestamp is not None:
-         self.timestamps.append(first_timestamp)  # todo: check format of first_timestamp
-         if daily is not None:
-            for _ in range(daily):
-               self.extend_by_days(1)
-         if monthly is not None:
-            for _ in range(monthly):
-               self.extend_by_days(30)
-         if quarterly is not None:
-            for _ in range(quarterly):
-               self.extend_by_days(90)  # could use 91
-         if yearly is not None:
-            for _ in range(yearly):
-               self.extend_by_days(365)  # could use 360
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = time_series_root)
-      if self.extra_metadata is not None and self.extra_metadata.get('timeframe') == 'geologic':
-         raise ValueError('attempt to instantiate a human timeframe time series for a geologic time series')
+        self.timeframe = 'human'
+        self.timestamps = []  # ordered list of timestamp strings in resqml/iso format
+        if first_timestamp is not None:
+            self.timestamps.append(first_timestamp)  # todo: check format of first_timestamp
+            if daily is not None:
+                for _ in range(daily):
+                    self.extend_by_days(1)
+            if monthly is not None:
+                for _ in range(monthly):
+                    self.extend_by_days(30)
+            if quarterly is not None:
+                for _ in range(quarterly):
+                    self.extend_by_days(90)  # could use 91
+            if yearly is not None:
+                for _ in range(yearly):
+                    self.extend_by_days(365)  # could use 360
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = time_series_root)
+        if self.extra_metadata is not None and self.extra_metadata.get('timeframe') == 'geologic':
+            raise ValueError('attempt to instantiate a human timeframe time series for a geologic time series')
 
-   def is_equivalent(self, other_ts, tol_seconds = 1):
-      """Returns True if the this timestep series is essentially identical to the other; otherwise False."""
+    def is_equivalent(self, other_ts, tol_seconds = 1):
+        """Returns True if the this timestep series is essentially identical to the other; otherwise False."""
 
-      super_equivalence = super().is_equivalent(other_ts)
-      if super_equivalence is not None:
-         return super_equivalence
-      tolerance = TimeDuration(seconds = tol_seconds)
-      for t_index in range(self.number_of_timestamps()):
-         diff = TimeDuration(earlier_timestamp = self.timestamps[t_index],
-                             later_timestamp = other_ts.timestamps[t_index])
-         if abs(diff.duration) > tolerance.duration:
-            return False
-      return True
+        super_equivalence = super().is_equivalent(other_ts)
+        if super_equivalence is not None:
+            return super_equivalence
+        tolerance = TimeDuration(seconds = tol_seconds)
+        for t_index in range(self.number_of_timestamps()):
+            diff = TimeDuration(earlier_timestamp = self.timestamps[t_index],
+                                later_timestamp = other_ts.timestamps[t_index])
+            if abs(diff.duration) > tolerance.duration:
+                return False
+        return True
 
-   def index_for_timestamp_not_later_than(self, timestamp):
-      """Returns the index of the latest timestamp that is not later than the specified date.
-
-      :meta common:
-      """
-      index = len(self.timestamps) - 1
-      while (index >= 0) and (self.timestamps[index] > timestamp):
-         index -= 1
-      if index < 0:
-         return None
-      return index
-
-   def index_for_timestamp_not_earlier_than(self, timestamp):
-      """Returns the index of the earliest timestamp that is not earlier than the specified date.
+    def index_for_timestamp_not_later_than(self, timestamp):
+        """Returns the index of the latest timestamp that is not later than the specified date.
 
       :meta common:
       """
-      index = 0
-      while (index < len(self.timestamps)) and (self.timestamps[index] < timestamp):
-         index += 1
-      if index >= len(self.timestamps):
-         return None
-      return index
+        index = len(self.timestamps) - 1
+        while (index >= 0) and (self.timestamps[index] > timestamp):
+            index -= 1
+        if index < 0:
+            return None
+        return index
 
-   def index_for_timestamp_closest_to(self, timestamp):
-      """Returns the index of the timestamp that is closest to the specified date.
-
-      :meta common:
-      """
-      if not self.timestamps:
-         return None
-      before = self.index_for_timestamp_not_later_than(self, timestamp)
-      if not before:
-         return 0
-      if before == len(self.timestamps) - 1 or self.timestamps[before] == timestamp:
-         return before
-      after = before + 1
-      early_delta = TimeDuration(earlier_timestamp = self.timestamps[before], later_timestamp = timestamp)
-      later_delta = TimeDuration(earlier_timestamp = timestamp, later_timestamp = self.timestamps[after])
-      return before if early_delta <= later_delta else after
-
-   def duration_between_timestamps(self, earlier_index, later_index):
-      """Returns the duration between a pair of timestamps.
+    def index_for_timestamp_not_earlier_than(self, timestamp):
+        """Returns the index of the earliest timestamp that is not earlier than the specified date.
 
       :meta common:
       """
-      if earlier_index < 0 or later_index >= len(self.timestamps) or later_index < earlier_index:
-         return None
-      return TimeDuration(earlier_timestamp = self.timestamps[earlier_index],
-                          later_timestamp = self.timestamps[later_index])
-
-   def days_between_timestamps(self, earlier_index, later_index):
-      """Returns the number of whole days between a pair of timestamps, as an integer."""
-      delta = self.duration_between_timestamps(earlier_index, later_index)
-      if delta is None:
-         return None
-      return delta.duration.days
-
-   def duration_since_start(self, index):
-      """Returns the duration between the start of the time series and the indexed timestamp.
-
-      :meta common:
-      """
-      if index < 0 or index >= len(self.timestamps):
-         return None
-      return self.duration_between_timestamps(0, index)
-
-   def days_since_start(self, index):
-      """Returns the number of days between the start of the time series and the indexed timestamp."""
-      return self.duration_since_start(index).duration.days
-
-   def step_duration(self, index):
-      """Returns the duration of the time step between the indexed timestamp and preceeding one.
-
-      :meta common:
-      """
-      if index < 1 or index >= len(self.timestamps):
-         return None
-      return self.duration_between_timestamps(index - 1, index)
-
-   def step_days(self, index):
-      """Returns the number of days between the indexed timestamp and preceeding one."""
-      delta = self.step_duration(index)
-      if delta is None:
-         return None
-      return delta.duration.days
-
-   # NB: Following functions modify the time series, which is dangerous if the series is in use by a model
-   # Could check for relationships involving the time series and disallow changes if any found?
-   def add_timestamp(self, new_timestamp, allow_insertion = False):
-      """Inserts a new timestamp into the time series."""
-      # todo: check that new_timestamp is in valid format (iso format + 'Z')
-      if allow_insertion:
-         # NB: This can insert a timestamp anywhere in the series, which will invalidate indices, possibly corrupting model
-         index = self.index_for_timestamp_not_later_than(new_timestamp)
-         if index is None:
-            index = 0
-         else:
+        index = 0
+        while (index < len(self.timestamps)) and (self.timestamps[index] < timestamp):
             index += 1
-         self.timestamps.insert(new_timestamp, index)
-      else:
-         last = self.last_timestamp()
-         if last is not None:
-            assert (new_timestamp > self.last_timestamp())
-         self.timestamps.append(new_timestamp)
+        if index >= len(self.timestamps):
+            return None
+        return index
 
-   def extend_by_duration(self, duration):
-      """Adds a timestamp to the end of the series, at duration beyond the last timestamp."""
-      assert (duration.duration.days >= 0)  # duration may not be negative
-      assert (len(self.timestamps) > 0)  # there must be something to extend from
-      self.timestamps.append(duration.timestamp_after_duration(self.last_timestamp()))
+    def index_for_timestamp_closest_to(self, timestamp):
+        """Returns the index of the timestamp that is closest to the specified date.
 
-   def extend_by_days(self, days):
-      """Adds a timestamp to the end of the series, at a duration of days beyond the last timestamp."""
-      duration = TimeDuration(days = days)
-      self.extend_by_duration(duration)
+      :meta common:
+      """
+        if not self.timestamps:
+            return None
+        before = self.index_for_timestamp_not_later_than(self, timestamp)
+        if not before:
+            return 0
+        if before == len(self.timestamps) - 1 or self.timestamps[before] == timestamp:
+            return before
+        after = before + 1
+        early_delta = TimeDuration(earlier_timestamp = self.timestamps[before], later_timestamp = timestamp)
+        later_delta = TimeDuration(earlier_timestamp = timestamp, later_timestamp = self.timestamps[after])
+        return before if early_delta <= later_delta else after
 
-   def datetimes(self):
-      """Returns the timestamps as a list of python-datetime objects."""
-      return [dt.datetime.fromisoformat(t.rstrip('Z')) for t in self.timestamps]
+    def duration_between_timestamps(self, earlier_index, later_index):
+        """Returns the duration between a pair of timestamps.
 
-   @property
-   def time_series_root(self):
-      """DEPRECATED. Alias for root"""
-      warnings.warn("Attribute 'time_series_root' is deprecated. Use 'root'", DeprecationWarning)
-      return self.root
+      :meta common:
+      """
+        if earlier_index < 0 or later_index >= len(self.timestamps) or later_index < earlier_index:
+            return None
+        return TimeDuration(earlier_timestamp = self.timestamps[earlier_index],
+                            later_timestamp = self.timestamps[later_index])
+
+    def days_between_timestamps(self, earlier_index, later_index):
+        """Returns the number of whole days between a pair of timestamps, as an integer."""
+        delta = self.duration_between_timestamps(earlier_index, later_index)
+        if delta is None:
+            return None
+        return delta.duration.days
+
+    def duration_since_start(self, index):
+        """Returns the duration between the start of the time series and the indexed timestamp.
+
+      :meta common:
+      """
+        if index < 0 or index >= len(self.timestamps):
+            return None
+        return self.duration_between_timestamps(0, index)
+
+    def days_since_start(self, index):
+        """Returns the number of days between the start of the time series and the indexed timestamp."""
+        return self.duration_since_start(index).duration.days
+
+    def step_duration(self, index):
+        """Returns the duration of the time step between the indexed timestamp and preceeding one.
+
+      :meta common:
+      """
+        if index < 1 or index >= len(self.timestamps):
+            return None
+        return self.duration_between_timestamps(index - 1, index)
+
+    def step_days(self, index):
+        """Returns the number of days between the indexed timestamp and preceeding one."""
+        delta = self.step_duration(index)
+        if delta is None:
+            return None
+        return delta.duration.days
+
+    # NB: Following functions modify the time series, which is dangerous if the series is in use by a model
+    # Could check for relationships involving the time series and disallow changes if any found?
+    def add_timestamp(self, new_timestamp, allow_insertion = False):
+        """Inserts a new timestamp into the time series."""
+        # todo: check that new_timestamp is in valid format (iso format + 'Z')
+        if allow_insertion:
+            # NB: This can insert a timestamp anywhere in the series, which will invalidate indices, possibly corrupting model
+            index = self.index_for_timestamp_not_later_than(new_timestamp)
+            if index is None:
+                index = 0
+            else:
+                index += 1
+            self.timestamps.insert(new_timestamp, index)
+        else:
+            last = self.last_timestamp()
+            if last is not None:
+                assert (new_timestamp > self.last_timestamp())
+            self.timestamps.append(new_timestamp)
+
+    def extend_by_duration(self, duration):
+        """Adds a timestamp to the end of the series, at duration beyond the last timestamp."""
+        assert (duration.duration.days >= 0)  # duration may not be negative
+        assert (len(self.timestamps) > 0)  # there must be something to extend from
+        self.timestamps.append(duration.timestamp_after_duration(self.last_timestamp()))
+
+    def extend_by_days(self, days):
+        """Adds a timestamp to the end of the series, at a duration of days beyond the last timestamp."""
+        duration = TimeDuration(days = days)
+        self.extend_by_duration(duration)
+
+    def datetimes(self):
+        """Returns the timestamps as a list of python-datetime objects."""
+        return [dt.datetime.fromisoformat(t.rstrip('Z')) for t in self.timestamps]
+
+    @property
+    def time_series_root(self):
+        """DEPRECATED. Alias for root"""
+        warnings.warn("Attribute 'time_series_root' is deprecated. Use 'root'", DeprecationWarning)
+        return self.root
 
 
 class GeologicTimeSeries(AnyTimeSeries):
-   """Class for RESQML Time Series using only year offsets (for geological time frames)."""
+    """Class for RESQML Time Series using only year offsets (for geological time frames)."""
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                time_series_root = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Create a GeologicTimeSeries object, either from a time series node in parent model, or empty.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 time_series_root = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Create a GeologicTimeSeries object, either from a time series node in parent model, or empty.
 
       arguments:
          parent_model (model.Model): the resqpy model to which the time series will belong
@@ -529,20 +529,20 @@ class GeologicTimeSeries(AnyTimeSeries):
 
       :meta common:
       """
-      self.timeframe = 'geologic'
-      self.timestamps = []  # ordered list of (large negative) ints being year offsets from present
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = time_series_root)
-      if self.extra_metadata is not None and self.extra_metadata.get('timeframe') == 'human':
-         raise ValueError('attempt to instantiate a geologic time series for a human timeframe time series')
+        self.timeframe = 'geologic'
+        self.timestamps = []  # ordered list of (large negative) ints being year offsets from present
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = time_series_root)
+        if self.extra_metadata is not None and self.extra_metadata.get('timeframe') == 'human':
+            raise ValueError('attempt to instantiate a geologic time series for a human timeframe time series')
 
-   @classmethod
-   def from_year_list(cls, parent_model, year_list, title = None, originator = None, extra_metadata = {}):
-      """Creates a new GeologicTimeSeries from a list of large integers representing years before present.
+    @classmethod
+    def from_year_list(cls, parent_model, year_list, title = None, originator = None, extra_metadata = {}):
+        """Creates a new GeologicTimeSeries from a list of large integers representing years before present.
 
       note:
          the years will be converted to negative numbers if positive, and sorted from oldest (most negative)
@@ -551,225 +551,225 @@ class GeologicTimeSeries(AnyTimeSeries):
       :meta common:
       """
 
-      assert isinstance(year_list, list) and len(year_list) > 0
-      negative_list = []
-      for year in year_list:
-         assert isinstance(year, int)
-         if year > 0:
-            negative_list.append(-year)
-         else:
-            negative_list.append(year)
+        assert isinstance(year_list, list) and len(year_list) > 0
+        negative_list = []
+        for year in year_list:
+            assert isinstance(year, int)
+            if year > 0:
+                negative_list.append(-year)
+            else:
+                negative_list.append(year)
 
-      gts = cls(parent_model, title = title, originator = originator, extra_metadata = extra_metadata)
+        gts = cls(parent_model, title = title, originator = originator, extra_metadata = extra_metadata)
 
-      gts.timestamps = sorted(negative_list)
+        gts.timestamps = sorted(negative_list)
 
-      return gts
+        return gts
 
-   def is_equivalent(self, other_ts):
-      """Returns True if the this geologic time series is essentially identical to the other; otherwise False."""
+    def is_equivalent(self, other_ts):
+        """Returns True if the this geologic time series is essentially identical to the other; otherwise False."""
 
-      super_equivalence = super().is_equivalent(other_ts)
-      if super_equivalence is not None:
-         return super_equivalence
-      return self.timestamps == other_ts.timestamps  # has no tolerance of small differences
+        super_equivalence = super().is_equivalent(other_ts)
+        if super_equivalence is not None:
+            return super_equivalence
+        return self.timestamps == other_ts.timestamps  # has no tolerance of small differences
 
 
 def selected_time_series(full_series, indices_list, title = None):
-   """Returns a new TimeSeries or GeologicTimeSeries object with timestamps selected from the full series by a list of indices."""
+    """Returns a new TimeSeries or GeologicTimeSeries object with timestamps selected from the full series by a list of indices."""
 
-   if isinstance(full_series, TimeSeries):
-      selected_ts = TimeSeries(full_series.model, title = title)
-   else:
-      assert isinstance(full_series, GeologicTimeSeries)
-      selected_ts = GeologicTimeSeries(full_series.model, title = title)
-   selected_ts.timestamps = [full_series.timestamps[i] for i in sorted(indices_list)]
-   return selected_ts
+    if isinstance(full_series, TimeSeries):
+        selected_ts = TimeSeries(full_series.model, title = title)
+    else:
+        assert isinstance(full_series, GeologicTimeSeries)
+        selected_ts = GeologicTimeSeries(full_series.model, title = title)
+    selected_ts.timestamps = [full_series.timestamps[i] for i in sorted(indices_list)]
+    return selected_ts
 
 
 def simplified_timestamp(timestamp):
-   """Return a more readable version of the timestamp."""
+    """Return a more readable version of the timestamp."""
 
-   if timestamp is None:
-      return None
-   if isinstance(timestamp, int):
-      return geologic_time_str(int)
-   timestamp = cleaned_timestamp(timestamp)
-   if len(timestamp) > 10:
-      timestamp = timestamp[:10] + ' ' + timestamp[11:]
-   return timestamp[:19]
+    if timestamp is None:
+        return None
+    if isinstance(timestamp, int):
+        return geologic_time_str(int)
+    timestamp = cleaned_timestamp(timestamp)
+    if len(timestamp) > 10:
+        timestamp = timestamp[:10] + ' ' + timestamp[11:]
+    return timestamp[:19]
 
 
 def cleaned_timestamp(timestamp):
-   """Return a cleaned version of the timestamp."""
+    """Return a cleaned version of the timestamp."""
 
-   if timestamp is None:
-      return None
-   if isinstance(timestamp, int):
-      return geologic_time_str(int)
-   timestamp = str(timestamp)
-   if len(timestamp) < 19 or timestamp[11:19] == '00:00:00':
-      return timestamp[:10]
-   return timestamp[:10] + 'T' + timestamp[11:19] + 'Z'
+    if timestamp is None:
+        return None
+    if isinstance(timestamp, int):
+        return geologic_time_str(int)
+    timestamp = str(timestamp)
+    if len(timestamp) < 19 or timestamp[11:19] == '00:00:00':
+        return timestamp[:10]
+    return timestamp[:10] + 'T' + timestamp[11:19] + 'Z'
 
 
 def time_series_from_list(timestamp_list, parent_model = None, title = None):
-   """Create a TimeSeries object from a list of timestamps (model and node set to None).
+    """Create a TimeSeries object from a list of timestamps (model and node set to None).
 
    note:
       timestamps in the list should be in the correct string format for human timeframe series,
       or large negative integers for geologic timeframe series
    """
 
-   assert (len(timestamp_list) > 0)
-   sorted_timestamps = sorted(timestamp_list)
-   if isinstance(sorted_timestamps[0], int):
-      sorted_timestamps = sorted([-t if t > 0 else t for t in timestamp_list])
-      time_series = GeologicTimeSeries(parent_model = parent_model, title = title)
-      time_series.timestamps = sorted_timestamps
-   else:
-      sorted_timestamps = sorted(timestamp_list)
-      time_series = TimeSeries(parent_model = parent_model,
-                               first_timestamp = cleaned_timestamp(sorted_timestamps[0]),
-                               title = title)
-      for raw_timestamp in sorted_timestamps[1:]:
-         timestamp = cleaned_timestamp(raw_timestamp)
-         time_series.add_timestamp(timestamp)
-   return time_series
+    assert (len(timestamp_list) > 0)
+    sorted_timestamps = sorted(timestamp_list)
+    if isinstance(sorted_timestamps[0], int):
+        sorted_timestamps = sorted([-t if t > 0 else t for t in timestamp_list])
+        time_series = GeologicTimeSeries(parent_model = parent_model, title = title)
+        time_series.timestamps = sorted_timestamps
+    else:
+        sorted_timestamps = sorted(timestamp_list)
+        time_series = TimeSeries(parent_model = parent_model,
+                                 first_timestamp = cleaned_timestamp(sorted_timestamps[0]),
+                                 title = title)
+        for raw_timestamp in sorted_timestamps[1:]:
+            timestamp = cleaned_timestamp(raw_timestamp)
+            time_series.add_timestamp(timestamp)
+    return time_series
 
 
 def merge_timeseries_from_uuid(model, timeseries_uuid_iter):
-   """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). The new timeseries is sorted in ascending order. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
+    """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). The new timeseries is sorted in ascending order. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
 
-   reverse = False
+    reverse = False
 
-   alltimestamps = set({})
-   timeserieslist = []
-   timeframe = None
-   for timeseries_uuid in timeseries_uuid_iter:
-      timeseriesroot = model.root(uuid = timeseries_uuid)
-      assert (rqet.node_type(timeseriesroot) == 'obj_TimeSeries')
+    alltimestamps = set({})
+    timeserieslist = []
+    timeframe = None
+    for timeseries_uuid in timeseries_uuid_iter:
+        timeseriesroot = model.root(uuid = timeseries_uuid)
+        assert (rqet.node_type(timeseriesroot) == 'obj_TimeSeries')
 
-      singlets = any_time_series(model, uuid = timeseries_uuid)
-      if timeframe is None:
-         timeframe = singlets.timeframe
-      else:
-         assert timeframe == singlets.timeframe, 'attempt to merge human and geologic timeframe time series'
+        singlets = any_time_series(model, uuid = timeseries_uuid)
+        if timeframe is None:
+            timeframe = singlets.timeframe
+        else:
+            assert timeframe == singlets.timeframe, 'attempt to merge human and geologic timeframe time series'
 
-      timeserieslist.append(singlets)
-      #alltimestamps.update( set(singlets.timestamps) )
-      alltimestamps.update(set(singlets.datetimes()))
+        timeserieslist.append(singlets)
+        #alltimestamps.update( set(singlets.timestamps) )
+        alltimestamps.update(set(singlets.datetimes()))
 
-   sortedtimestamps = sorted(list(alltimestamps), reverse = reverse)
+    sortedtimestamps = sorted(list(alltimestamps), reverse = reverse)
 
-   new_time_series = time_series_from_list(sortedtimestamps, parent_model = model)
-   new_time_series_uuid = new_time_series.uuid
-   return (new_time_series, new_time_series_uuid, timeserieslist)
+    new_time_series = time_series_from_list(sortedtimestamps, parent_model = model)
+    new_time_series_uuid = new_time_series.uuid
+    return (new_time_series, new_time_series_uuid, timeserieslist)
 
 
 def time_series_from_nexus_summary(summary_file, parent_model = None):
-   """Create a TimeSeries object based on time steps reported in a nexus summary file (.sum)."""
+    """Create a TimeSeries object based on time steps reported in a nexus summary file (.sum)."""
 
-   if not summary_file:
-      return None
-   if not os.path.isfile(summary_file):
-      log.warning('Summary file not found: ' + summary_file)
-      return None
-   try:
-      us_date_format = True
-      date_format = 'MM/DD/YYYY'
-      summary_entries = []  # list of (time step no., cumulative time (days), date (dd/mm/yyyy))
-      with open(summary_file, "r") as fp:
-         while True:
-            line = fp.readline()
-            if len(line) == 0:
-               break  # end of file
-            words = line.split()
-            if len(words) < 5:
-               continue
-            if not words[0].isdigit():
-               if words[0].upper() == 'NO.' and len(words[4]) == 10:
-                  date_format = words[4].upper()
-                  us_date_format = (date_format == 'MM/DD/YYYY')
-                  if not us_date_format:
-                     assert date_format == 'DD/MM/YYYY'
-               continue
-            ts_number = int(words[0])
-            time_in_days = float(words[3])
-            date_str = words[4]
-            assert 9 <= len(date_str) <= 10, 'invalid date string length in summary file: ' + date_str
-            if us_date_format:
-               date = dt.date(int(date_str[-4:]), int(date_str[:-8]), int(date_str[-7:-5]))
+    if not summary_file:
+        return None
+    if not os.path.isfile(summary_file):
+        log.warning('Summary file not found: ' + summary_file)
+        return None
+    try:
+        us_date_format = True
+        date_format = 'MM/DD/YYYY'
+        summary_entries = []  # list of (time step no., cumulative time (days), date (dd/mm/yyyy))
+        with open(summary_file, "r") as fp:
+            while True:
+                line = fp.readline()
+                if len(line) == 0:
+                    break  # end of file
+                words = line.split()
+                if len(words) < 5:
+                    continue
+                if not words[0].isdigit():
+                    if words[0].upper() == 'NO.' and len(words[4]) == 10:
+                        date_format = words[4].upper()
+                        us_date_format = (date_format == 'MM/DD/YYYY')
+                        if not us_date_format:
+                            assert date_format == 'DD/MM/YYYY'
+                    continue
+                ts_number = int(words[0])
+                time_in_days = float(words[3])
+                date_str = words[4]
+                assert 9 <= len(date_str) <= 10, 'invalid date string length in summary file: ' + date_str
+                if us_date_format:
+                    date = dt.date(int(date_str[-4:]), int(date_str[:-8]), int(date_str[-7:-5]))
+                else:
+                    date = dt.date(int(date_str[-4:]), int(date_str[-7:-5]), int(date_str[:-8]))
+                summary_entries.append((ts_number, time_in_days, date))
+        if len(summary_entries) == 0:
+            return None  # no entries extracted from summary file, could raise error?
+        summary_entries.sort()
+        if summary_entries[0][0] == 0:  # first entry is for time zero
+            tz_date = summary_entries[0][2]
+            summary_entries.pop(0)
+        else:  # back calculate time zero from first entry
+            delta = dt.timedelta(days = summary_entries[0][1])
+            tz_date = summary_entries[0][2] - delta
+        time_series = TimeSeries(parent_model = parent_model, first_timestamp = tz_date.isoformat() + 'T00:00:00Z')
+        last_timestep = 0
+        last_cumulative_time = 0.0
+        for entry in summary_entries:
+            if entry[0] <= last_timestep:
+                log.warning('ignoring out of sequence time step in summary file: ' + str(entry[0]))
+                continue
+            while entry[0] > last_timestep + 1:  # add filler steps
+                time_series.extend_by_days(0)
+                last_timestep += 1
+            if entry[1] < last_cumulative_time:  # should never happen
+                time_series.extend_by_days(0)
             else:
-               date = dt.date(int(date_str[-4:]), int(date_str[-7:-5]), int(date_str[:-8]))
-            summary_entries.append((ts_number, time_in_days, date))
-      if len(summary_entries) == 0:
-         return None  # no entries extracted from summary file, could raise error?
-      summary_entries.sort()
-      if summary_entries[0][0] == 0:  # first entry is for time zero
-         tz_date = summary_entries[0][2]
-         summary_entries.pop(0)
-      else:  # back calculate time zero from first entry
-         delta = dt.timedelta(days = summary_entries[0][1])
-         tz_date = summary_entries[0][2] - delta
-      time_series = TimeSeries(parent_model = parent_model, first_timestamp = tz_date.isoformat() + 'T00:00:00Z')
-      last_timestep = 0
-      last_cumulative_time = 0.0
-      for entry in summary_entries:
-         if entry[0] <= last_timestep:
-            log.warning('ignoring out of sequence time step in summary file: ' + str(entry[0]))
-            continue
-         while entry[0] > last_timestep + 1:  # add filler steps
-            time_series.extend_by_days(0)
+                time_series.extend_by_days(entry[1] - last_cumulative_time)
+                last_cumulative_time = entry[1]
             last_timestep += 1
-         if entry[1] < last_cumulative_time:  # should never happen
-            time_series.extend_by_days(0)
-         else:
-            time_series.extend_by_days(entry[1] - last_cumulative_time)
-            last_cumulative_time = entry[1]
-         last_timestep += 1
-      return time_series
-   except Exception:
-      log.exception('failed to create TimeSeries object from summary file: ' + summary_file)
-   return None
+        return time_series
+    except Exception:
+        log.exception('failed to create TimeSeries object from summary file: ' + summary_file)
+    return None
 
 
 def geologic_time_str(years):
-   """Returns a string representing a geological time for a large int representing number of years before present."""
+    """Returns a string representing a geological time for a large int representing number of years before present."""
 
-   assert isinstance(years, int)
-   years = abs(years)  # positive and negative values are both interpreted as the same: years before present
-   if years < 10000000 and years % 1000000:
-      stamp = f'{float(-years) / 1.0e6:.3f} Ma'
-   else:
-      stamp = f'{-years // 1000000} Ma'
-   return stamp
+    assert isinstance(years, int)
+    years = abs(years)  # positive and negative values are both interpreted as the same: years before present
+    if years < 10000000 and years % 1000000:
+        stamp = f'{float(-years) / 1.0e6:.3f} Ma'
+    else:
+        stamp = f'{-years // 1000000} Ma'
+    return stamp
 
 
 def timeframe_for_time_series_uuid(model, uuid):
-   """Returns string 'human' or 'geologic' indicating timeframe of the RESQML time series with a given uuid."""
+    """Returns string 'human' or 'geologic' indicating timeframe of the RESQML time series with a given uuid."""
 
-   assert model.type_of_uuid(uuid = uuid, strip_obj = True) == 'TimeSeries'
+    assert model.type_of_uuid(uuid = uuid, strip_obj = True) == 'TimeSeries'
 
-   root = model.root(uuid = uuid)
+    root = model.root(uuid = uuid)
 
-   em = rqet.load_metadata_from_xml(root)
-   if em is not None:
-      timeframe = em['timeframe']
-      if timeframe:
-         return timeframe
+    em = rqet.load_metadata_from_xml(root)
+    if em is not None:
+        timeframe = em['timeframe']
+        if timeframe:
+            return timeframe
 
-   t_node = rqet.find_tag(root, 'Time')
-   assert t_node is not None
+    t_node = rqet.find_tag(root, 'Time')
+    assert t_node is not None
 
-   return 'human' if rqet.find_tag(t_node, 'YearOffset') is None else 'geologic'
+    return 'human' if rqet.find_tag(t_node, 'YearOffset') is None else 'geologic'
 
 
 def any_time_series(parent_model, uuid):
-   """Returns a resqpy TimeSeries or GeologicTimeSeries object for an existing RESQML time series with a given uuid."""
+    """Returns a resqpy TimeSeries or GeologicTimeSeries object for an existing RESQML time series with a given uuid."""
 
-   timeframe = timeframe_for_time_series_uuid(parent_model, uuid)
-   if timeframe == 'human':
-      return TimeSeries(parent_model, uuid = uuid)
-   assert timeframe == 'geologic'
-   return GeologicTimeSeries(parent_model, uuid = uuid)
+    timeframe = timeframe_for_time_series_uuid(parent_model, uuid)
+    if timeframe == 'human':
+        return TimeSeries(parent_model, uuid = uuid)
+    assert timeframe == 'geologic'
+    return GeologicTimeSeries(parent_model, uuid = uuid)

--- a/resqpy/unstructured.py
+++ b/resqpy/unstructured.py
@@ -32,21 +32,21 @@ valid_cell_shapes = ['polyhedral', 'tetrahedral', 'pyramidal', 'prism', 'hexahed
 
 
 class UnstructuredGrid(BaseResqpy):
-   """Class for RESQML Unstructured Grid objects."""
+    """Class for RESQML Unstructured Grid objects."""
 
-   resqml_type = 'UnstructuredGridRepresentation'
+    resqml_type = 'UnstructuredGridRepresentation'
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                find_properties = True,
-                geometry_required = True,
-                cache_geometry = False,
-                cell_shape = 'polyhedral',
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Create an Unstructured Grid object and optionally populate from xml tree.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 find_properties = True,
+                 geometry_required = True,
+                 cache_geometry = False,
+                 cell_shape = 'polyhedral',
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Create an Unstructured Grid object and optionally populate from xml tree.
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -79,69 +79,69 @@ class UnstructuredGrid(BaseResqpy):
       :meta common:
       """
 
-      if cell_shape is not None:
-         assert cell_shape in valid_cell_shapes, f'invalid cell shape {cell_shape} for unstructured grid'
+        if cell_shape is not None:
+            assert cell_shape in valid_cell_shapes, f'invalid cell shape {cell_shape} for unstructured grid'
 
-      self.cell_count = None  #: the number of cells in the grid
-      self.cell_shape = cell_shape  #: the shape of cells within the grid
-      self.crs_uuid = None  #: uuid of the coordinate reference system used by the grid's geometry
-      self.points_cached = None  #: numpy array of raw points data; loaded on demand
-      self.node_count = None  #: number of distinct points used in geometry; None if no geometry present
-      self.face_count = None  #: number of distinct faces used in geometry; None if no geometry present
-      self.nodes_per_face = None
-      self.nodes_per_face_cl = None
-      self.faces_per_cell = None
-      self.cell_face_is_right_handed = None
-      self.faces_per_cell_cl = None
-      self.inactive = None  #: numpy boolean array indicating which cells are inactive in flow simulation
-      self.all_inactive = None  #: boolean indicating whether all cells are inactive
-      self.active_property_uuid = None  #: uuid of property holding active cell boolean array (used to populate inactive)
-      self.grid_representation = 'UnstructuredGrid'  #: flavour of grid, 'UnstructuredGrid'; not much used
-      self.geometry_root = None  #: xml node at root of geometry sub-tree, if present
-      self.property_collection = None  #: collection of properties for which this grid is the supporting representation
-      self.crs_is_right_handed = None  #: cached boolean indicating handedness of crs axes
-      self.cells_per_face = None  #: numpy int array of shape (face_count, 2) holding cells for faces; -1 is null value
-      self.xyz_box_cached = None
+        self.cell_count = None  #: the number of cells in the grid
+        self.cell_shape = cell_shape  #: the shape of cells within the grid
+        self.crs_uuid = None  #: uuid of the coordinate reference system used by the grid's geometry
+        self.points_cached = None  #: numpy array of raw points data; loaded on demand
+        self.node_count = None  #: number of distinct points used in geometry; None if no geometry present
+        self.face_count = None  #: number of distinct faces used in geometry; None if no geometry present
+        self.nodes_per_face = None
+        self.nodes_per_face_cl = None
+        self.faces_per_cell = None
+        self.cell_face_is_right_handed = None
+        self.faces_per_cell_cl = None
+        self.inactive = None  #: numpy boolean array indicating which cells are inactive in flow simulation
+        self.all_inactive = None  #: boolean indicating whether all cells are inactive
+        self.active_property_uuid = None  #: uuid of property holding active cell boolean array (used to populate inactive)
+        self.grid_representation = 'UnstructuredGrid'  #: flavour of grid, 'UnstructuredGrid'; not much used
+        self.geometry_root = None  #: xml node at root of geometry sub-tree, if present
+        self.property_collection = None  #: collection of properties for which this grid is the supporting representation
+        self.crs_is_right_handed = None  #: cached boolean indicating handedness of crs axes
+        self.cells_per_face = None  #: numpy int array of shape (face_count, 2) holding cells for faces; -1 is null value
+        self.xyz_box_cached = None
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata)
 
-      if not self.title:
-         self.title = 'ROOT'
+        if not self.title:
+            self.title = 'ROOT'
 
-      if uuid is not None:
-         if geometry_required:
-            assert self.geometry_root is not None, 'unstructured grid geometry not present in xml'
-         if cache_geometry and self.geometry_root is not None:
-            self.cache_all_geometry_arrays()
-         if find_properties:
-            self.extract_property_collection()
+        if uuid is not None:
+            if geometry_required:
+                assert self.geometry_root is not None, 'unstructured grid geometry not present in xml'
+            if cache_geometry and self.geometry_root is not None:
+                self.cache_all_geometry_arrays()
+            if find_properties:
+                self.extract_property_collection()
 
-   def _load_from_xml(self):
-      # Extract simple attributes from xml and set as attributes in this resqpy object
-      grid_root = self.root
-      assert grid_root is not None
-      self.cell_count = rqet.find_tag_int(grid_root, 'CellCount')
-      assert self.cell_count > 0
-      self.geometry_root = rqet.find_tag(grid_root, 'Geometry')
-      if self.geometry_root is None:
-         self.cell_shape = None
-      else:
-         self.extract_crs_uuid()
-         self.cell_shape = rqet.find_tag_text(self.geometry_root, 'CellShape')
-         assert self.cell_shape in valid_cell_shapes
-         self.node_count = rqet.find_tag_int(self.geometry_root, 'NodeCount')
-         assert self.node_count > 3
-         self.face_count = rqet.find_tag_int(self.geometry_root, 'FaceCount')
-         assert self.face_count > 3
-      self.extract_inactive_mask()
-      # note: geometry arrays not loaded until demanded; see cache_all_geometry_arrays()
+    def _load_from_xml(self):
+        # Extract simple attributes from xml and set as attributes in this resqpy object
+        grid_root = self.root
+        assert grid_root is not None
+        self.cell_count = rqet.find_tag_int(grid_root, 'CellCount')
+        assert self.cell_count > 0
+        self.geometry_root = rqet.find_tag(grid_root, 'Geometry')
+        if self.geometry_root is None:
+            self.cell_shape = None
+        else:
+            self.extract_crs_uuid()
+            self.cell_shape = rqet.find_tag_text(self.geometry_root, 'CellShape')
+            assert self.cell_shape in valid_cell_shapes
+            self.node_count = rqet.find_tag_int(self.geometry_root, 'NodeCount')
+            assert self.node_count > 3
+            self.face_count = rqet.find_tag_int(self.geometry_root, 'FaceCount')
+            assert self.face_count > 3
+        self.extract_inactive_mask()
+        # note: geometry arrays not loaded until demanded; see cache_all_geometry_arrays()
 
-   def set_cell_count(self, n: int):
-      """Set the number of cells in the grid.
+    def set_cell_count(self, n: int):
+        """Set the number of cells in the grid.
 
       arguments:
          n (int): the number of cells in the unstructured grid
@@ -149,17 +149,17 @@ class UnstructuredGrid(BaseResqpy):
       note:
          only call this method when creating a new grid, not when working from an existing RESQML grid
       """
-      assert self.cell_count is None or self.cell_count == n
-      self.cell_count = n
+        assert self.cell_count is None or self.cell_count == n
+        self.cell_count = n
 
-   def active_cell_count(self):
-      """Returns the number of cells deemed to be active for flow simulation purposes."""
-      if self.inactive is None:
-         return self.cell_count
-      return self.cell_count - np.count_nonzero(self.inactive)
+    def active_cell_count(self):
+        """Returns the number of cells deemed to be active for flow simulation purposes."""
+        if self.inactive is None:
+            return self.cell_count
+        return self.cell_count - np.count_nonzero(self.inactive)
 
-   def cache_all_geometry_arrays(self):
-      """Loads from hdf5 into memory all the arrays defining the grid geometry.
+    def cache_all_geometry_arrays(self):
+        """Loads from hdf5 into memory all the arrays defining the grid geometry.
 
       returns:
          None
@@ -173,72 +173,72 @@ class UnstructuredGrid(BaseResqpy):
       :meta common:
       """
 
-      assert self.node_count is not None and self.face_count is not None
+        assert self.node_count is not None and self.face_count is not None
 
-      self.points_ref()
+        self.points_ref()
 
-      if self.nodes_per_face is None:
-         self._load_jagged_array('NodesPerFace', 'nodes_per_face')
-         assert len(self.nodes_per_face_cl) == self.face_count
+        if self.nodes_per_face is None:
+            self._load_jagged_array('NodesPerFace', 'nodes_per_face')
+            assert len(self.nodes_per_face_cl) == self.face_count
 
-      if self.faces_per_cell is None:
-         self._load_jagged_array('FacesPerCell', 'faces_per_cell')
-         assert len(self.faces_per_cell_cl) == self.cell_count
+        if self.faces_per_cell is None:
+            self._load_jagged_array('FacesPerCell', 'faces_per_cell')
+            assert len(self.faces_per_cell_cl) == self.cell_count
 
-      if self.cell_face_is_right_handed is None:
-         assert self.geometry_root is not None
-         cfirh_node = rqet.find_tag(self.geometry_root, 'CellFaceIsRightHanded')
-         assert cfirh_node is not None
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(cfirh_node)
-         self.model.h5_array_element(h5_key_pair,
-                                     index = None,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'cell_face_is_right_handed',
-                                     required_shape = (len(self.faces_per_cell),),
-                                     dtype = 'bool')
+        if self.cell_face_is_right_handed is None:
+            assert self.geometry_root is not None
+            cfirh_node = rqet.find_tag(self.geometry_root, 'CellFaceIsRightHanded')
+            assert cfirh_node is not None
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(cfirh_node)
+            self.model.h5_array_element(h5_key_pair,
+                                        index = None,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'cell_face_is_right_handed',
+                                        required_shape = (len(self.faces_per_cell),),
+                                        dtype = 'bool')
 
-   def _load_jagged_array(self, tag, main_attribute):
-      # jagged arrays are used by RESQML to efficiantly pack arrays of lists of numbers
-      assert self.geometry_root is not None
-      root_node = rqet.find_tag(self.geometry_root, tag)
-      assert root_node is not None
-      elements_root = rqet.find_tag(root_node, 'Elements')
-      h5_key_pair = self.model.h5_uuid_and_path_for_node(elements_root)
-      self.model.h5_array_element(h5_key_pair,
-                                  index = None,
-                                  cache_array = True,
-                                  object = self,
-                                  array_attribute = main_attribute,
-                                  dtype = 'int')
-      cum_length_root = rqet.find_tag(root_node, 'CumulativeLength')
-      h5_key_pair = self.model.h5_uuid_and_path_for_node(cum_length_root)
-      self.model.h5_array_element(h5_key_pair,
-                                  index = None,
-                                  cache_array = True,
-                                  object = self,
-                                  array_attribute = main_attribute + '_cl',
-                                  dtype = 'int')
+    def _load_jagged_array(self, tag, main_attribute):
+        # jagged arrays are used by RESQML to efficiantly pack arrays of lists of numbers
+        assert self.geometry_root is not None
+        root_node = rqet.find_tag(self.geometry_root, tag)
+        assert root_node is not None
+        elements_root = rqet.find_tag(root_node, 'Elements')
+        h5_key_pair = self.model.h5_uuid_and_path_for_node(elements_root)
+        self.model.h5_array_element(h5_key_pair,
+                                    index = None,
+                                    cache_array = True,
+                                    object = self,
+                                    array_attribute = main_attribute,
+                                    dtype = 'int')
+        cum_length_root = rqet.find_tag(root_node, 'CumulativeLength')
+        h5_key_pair = self.model.h5_uuid_and_path_for_node(cum_length_root)
+        self.model.h5_array_element(h5_key_pair,
+                                    index = None,
+                                    cache_array = True,
+                                    object = self,
+                                    array_attribute = main_attribute + '_cl',
+                                    dtype = 'int')
 
-   def extract_crs_uuid(self):
-      """Returns uuid for coordinate reference system, as stored in geometry xml tree.
+    def extract_crs_uuid(self):
+        """Returns uuid for coordinate reference system, as stored in geometry xml tree.
 
       returns:
          uuid.UUID object
       """
 
-      if self.crs_uuid is not None:
-         return self.crs_uuid
-      if self.geometry_root is None:
-         return None
-      uuid_str = rqet.find_nested_tags_text(self.geometry_root, ['LocalCrs', 'UUID'])
-      if uuid_str:
-         self.crs_uuid = bu.uuid_from_string(uuid_str)
-         self._set_crs_handedness()
-      return self.crs_uuid
+        if self.crs_uuid is not None:
+            return self.crs_uuid
+        if self.geometry_root is None:
+            return None
+        uuid_str = rqet.find_nested_tags_text(self.geometry_root, ['LocalCrs', 'UUID'])
+        if uuid_str:
+            self.crs_uuid = bu.uuid_from_string(uuid_str)
+            self._set_crs_handedness()
+        return self.crs_uuid
 
-   def extract_inactive_mask(self):
-      """Returns boolean numpy array indicating which cells are inactive, if (in)active property found for this grid.
+    def extract_inactive_mask(self):
+        """Returns boolean numpy array indicating which cells are inactive, if (in)active property found for this grid.
 
       returns:
          numpy array of booleans, of shape (cell_count,) being True for cells which are inactive; False for active
@@ -249,32 +249,32 @@ class UnstructuredGrid(BaseResqpy):
          attribute for the grid object, which is a boolean numpy array indicating which cells are inactive
       """
 
-      if self.inactive is not None:
-         return self.inactive
-      self.inactive = np.zeros((self.cell_count,), dtype = bool)  # ie. all active
-      self.all_inactive = False
-      gpc = self.extract_property_collection()
-      if gpc is None:
-         return self.inactive
-      active_gpc = rqp.PropertyCollection()
-      # note: use of bespoke (local) property kind 'active' as suggested in resqml usage guide
-      active_gpc.inherit_parts_selectively_from_other_collection(other = gpc,
-                                                                 property_kind = 'active',
-                                                                 continuous = False)
-      if active_gpc.number_of_parts() > 0:
-         if active_gpc.number_of_parts() > 1:
-            log.warning('more than one property found with bespoke kind "active", using last encountered')
-         active_part = active_gpc.parts()[-1]
-         active_array = active_gpc.cached_part_array_ref(active_part, dtype = 'bool')
-         self.inactive = np.logical_not(active_array)
-         self.active_property_uuid = active_gpc.uuid_for_part(active_part)
-         active_gpc.uncache_part_array(active_part)
-         self.all_inactive = np.all(self.inactive)
+        if self.inactive is not None:
+            return self.inactive
+        self.inactive = np.zeros((self.cell_count,), dtype = bool)  # ie. all active
+        self.all_inactive = False
+        gpc = self.extract_property_collection()
+        if gpc is None:
+            return self.inactive
+        active_gpc = rqp.PropertyCollection()
+        # note: use of bespoke (local) property kind 'active' as suggested in resqml usage guide
+        active_gpc.inherit_parts_selectively_from_other_collection(other = gpc,
+                                                                   property_kind = 'active',
+                                                                   continuous = False)
+        if active_gpc.number_of_parts() > 0:
+            if active_gpc.number_of_parts() > 1:
+                log.warning('more than one property found with bespoke kind "active", using last encountered')
+            active_part = active_gpc.parts()[-1]
+            active_array = active_gpc.cached_part_array_ref(active_part, dtype = 'bool')
+            self.inactive = np.logical_not(active_array)
+            self.active_property_uuid = active_gpc.uuid_for_part(active_part)
+            active_gpc.uncache_part_array(active_part)
+            self.all_inactive = np.all(self.inactive)
 
-      return self.inactive
+        return self.inactive
 
-   def extract_property_collection(self):
-      """Load grid property collection object holding lists of all properties in model that relate to this grid.
+    def extract_property_collection(self):
+        """Load grid property collection object holding lists of all properties in model that relate to this grid.
 
       returns:
          resqml_property.PropertyCollection object
@@ -285,13 +285,13 @@ class UnstructuredGrid(BaseResqpy):
          would need to be reset to None elsewhere before calling this method again
       """
 
-      if self.property_collection is not None:
-         return self.property_collection
-      self.property_collection = rqp.PropertyCollection(support = self)
-      return self.property_collection
+        if self.property_collection is not None:
+            return self.property_collection
+        self.property_collection = rqp.PropertyCollection(support = self)
+        return self.property_collection
 
-   def set_cells_per_face(self, check_all_faces_used = True):
-      """Sets and returns the cells_per_face array showing which cells are using each face.
+    def set_cells_per_face(self, check_all_faces_used = True):
+        """Sets and returns the cells_per_face array showing which cells are using each face.
 
       arguments:
          check_all_faces_used (boolean, default True): if True, an assertion error is raised if there are any
@@ -302,23 +302,23 @@ class UnstructuredGrid(BaseResqpy):
          null value; if only one cell uses a face, its index is always in position 0 of the second axis
       """
 
-      if self.cells_per_face is not None:
-         return self.cells_per_face
-      assert self.face_count is not None
-      self.cells_per_face = -np.ones((self.face_count, 2), dtype = int)  # -1 is used here as a null value
-      for cell in range(self.cell_count):
-         for face in self.face_indices_for_cell(cell):
-            if self.cells_per_face[face, 0] == -1:
-               self.cells_per_face[face, 0] = cell
-            else:
-               assert self.cells_per_face[face, 1] == -1, f'more than two cells use face with index {face}'
-               self.cells_per_face[face, 1] = cell
-      if check_all_faces_used:
-         assert np.all(self.cells_per_face[:, 0] >= 0), 'not all faces used by cells'
-      return self.cells_per_face
+        if self.cells_per_face is not None:
+            return self.cells_per_face
+        assert self.face_count is not None
+        self.cells_per_face = -np.ones((self.face_count, 2), dtype = int)  # -1 is used here as a null value
+        for cell in range(self.cell_count):
+            for face in self.face_indices_for_cell(cell):
+                if self.cells_per_face[face, 0] == -1:
+                    self.cells_per_face[face, 0] = cell
+                else:
+                    assert self.cells_per_face[face, 1] == -1, f'more than two cells use face with index {face}'
+                    self.cells_per_face[face, 1] = cell
+        if check_all_faces_used:
+            assert np.all(self.cells_per_face[:, 0] >= 0), 'not all faces used by cells'
+        return self.cells_per_face
 
-   def masked_cells_per_face(self, exclude_cell_mask):
-      """Sets and returns the cells_per_face array showing which cells are using each face.
+    def masked_cells_per_face(self, exclude_cell_mask):
+        """Sets and returns the cells_per_face array showing which cells are using each face.
 
       arguments:
          exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
@@ -332,31 +332,31 @@ class UnstructuredGrid(BaseResqpy):
          this method recomputes the result on every call - nothing extra is cached in the grid
       """
 
-      assert self.face_count is not None
-      result = -np.ones((self.face_count, 2), dtype = int)  # -1 is used here as a null value
-      for cell in range(self.cell_count):
-         if exclude_cell_mask[cell]:
-            continue
-         for face in self.face_indices_for_cell(cell):
-            if result[face, 0] == -1:
-               result[face, 0] = cell
-            else:
-               assert result[face, 1] == -1, f'more than two cells use face with index {face}'
-               result[face, 1] = cell
-      return result
+        assert self.face_count is not None
+        result = -np.ones((self.face_count, 2), dtype = int)  # -1 is used here as a null value
+        for cell in range(self.cell_count):
+            if exclude_cell_mask[cell]:
+                continue
+            for face in self.face_indices_for_cell(cell):
+                if result[face, 0] == -1:
+                    result[face, 0] = cell
+                else:
+                    assert result[face, 1] == -1, f'more than two cells use face with index {face}'
+                    result[face, 1] = cell
+        return result
 
-   def external_face_indices(self):
-      """Returns a numpy int vector listing the indices of faces which are only used by one cell.
+    def external_face_indices(self):
+        """Returns a numpy int vector listing the indices of faces which are only used by one cell.
 
       note:
          resulting array is ordered by face index
       """
 
-      self.set_cells_per_face()
-      return np.where(self.cells_per_face[:, 1] == -1)[0]
+        self.set_cells_per_face()
+        return np.where(self.cells_per_face[:, 1] == -1)[0]
 
-   def external_face_indices_for_masked_cells(self, exclude_cell_mask):
-      """Returns a numpy int vector listing the indices of faces which are used by exactly one of masked cells.
+    def external_face_indices_for_masked_cells(self, exclude_cell_mask):
+        """Returns a numpy int vector listing the indices of faces which are used by exactly one of masked cells.
 
       arguments:
          exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
@@ -366,11 +366,11 @@ class UnstructuredGrid(BaseResqpy):
          resulting array is ordered by face index
       """
 
-      cpf = self.masked_cells_per_face(exclude_cell_mask)
-      return np.where(np.logical_and(cpf[:, 0] >= 0, cpf[:, 1] == -1))[0]
+        cpf = self.masked_cells_per_face(exclude_cell_mask)
+        return np.where(np.logical_and(cpf[:, 0] >= 0, cpf[:, 1] == -1))[0]
 
-   def internal_face_indices_for_masked_cells(self, exclude_cell_mask):
-      """Returns a numpy int vector listing the indices of faces which are used by two of masked cells.
+    def internal_face_indices_for_masked_cells(self, exclude_cell_mask):
+        """Returns a numpy int vector listing the indices of faces which are used by two of masked cells.
 
       arguments:
          exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
@@ -380,11 +380,11 @@ class UnstructuredGrid(BaseResqpy):
          resulting array is ordered by face index
       """
 
-      cpf = self.masked_cells_per_face(exclude_cell_mask)
-      return np.where(np.logical_and(cpf[:, 0] >= 0, cpf[:, 1] >= 0))[0]
+        cpf = self.masked_cells_per_face(exclude_cell_mask)
+        return np.where(np.logical_and(cpf[:, 0] >= 0, cpf[:, 1] >= 0))[0]
 
-   def points_ref(self):
-      """Returns an in-memory numpy array containing the xyz data for points used in the grid geometry.
+    def points_ref(self):
+        """Returns an in-memory numpy array containing the xyz data for points used in the grid geometry.
 
       returns:
          numpy array of shape (node_count, 3)
@@ -396,31 +396,31 @@ class UnstructuredGrid(BaseResqpy):
       :meta common:
       """
 
-      if self.points_cached is None:
+        if self.points_cached is None:
 
-         assert self.node_count is not None
+            assert self.node_count is not None
 
-         p_root = rqet.find_tag(self.geometry_root, 'Points')
-         if p_root is None:
-            log.debug('points_ref() returning None as geometry not present')
-            return None  # geometry not present
+            p_root = rqet.find_tag(self.geometry_root, 'Points')
+            if p_root is None:
+                log.debug('points_ref() returning None as geometry not present')
+                return None  # geometry not present
 
-         assert rqet.node_type(p_root) == 'Point3dHdf5Array'
-         h5_key_pair = self.model.h5_uuid_and_path_for_node(p_root, tag = 'Coordinates')
-         if h5_key_pair is None:
-            return None
+            assert rqet.node_type(p_root) == 'Point3dHdf5Array'
+            h5_key_pair = self.model.h5_uuid_and_path_for_node(p_root, tag = 'Coordinates')
+            if h5_key_pair is None:
+                return None
 
-         self.model.h5_array_element(h5_key_pair,
-                                     index = None,
-                                     cache_array = True,
-                                     object = self,
-                                     array_attribute = 'points_cached',
-                                     required_shape = (self.node_count, 3))
+            self.model.h5_array_element(h5_key_pair,
+                                        index = None,
+                                        cache_array = True,
+                                        object = self,
+                                        array_attribute = 'points_cached',
+                                        required_shape = (self.node_count, 3))
 
-      return self.points_cached
+        return self.points_cached
 
-   def xyz_box(self):
-      """Returns the minimum and maximum xyz for the grid geometry.
+    def xyz_box(self):
+        """Returns the minimum and maximum xyz for the grid geometry.
 
       returns:
          numpy array of float of shape (2, 3); the first axis is minimum, maximum; the second axis is x, y, z
@@ -428,16 +428,16 @@ class UnstructuredGrid(BaseResqpy):
       :meta common:
       """
 
-      if self.xyz_box_cached is None:
-         self.xyz_box_cached = np.empty((2, 3), dtype = float)
-         p = self.points_ref()
-         self.xyz_box_cached[0] = np.min(p, axis = 0)
-         self.xyz_box_cached[1] = np.max(p, axis = 0)
+        if self.xyz_box_cached is None:
+            self.xyz_box_cached = np.empty((2, 3), dtype = float)
+            p = self.points_ref()
+            self.xyz_box_cached[0] = np.min(p, axis = 0)
+            self.xyz_box_cached[1] = np.max(p, axis = 0)
 
-      return self.xyz_box_cached
+        return self.xyz_box_cached
 
-   def face_centre_point(self, face_index):
-      """Returns a nominal centre point for a single face calculated as the mean position of its nodes.
+    def face_centre_point(self, face_index):
+        """Returns a nominal centre point for a single face calculated as the mean position of its nodes.
 
       arguments:
          face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
@@ -450,36 +450,36 @@ class UnstructuredGrid(BaseResqpy):
          its barycentre
       """
 
-      return np.mean(self.points_cached[self.node_indices_for_face(face_index)], axis = 0)
+        return np.mean(self.points_cached[self.node_indices_for_face(face_index)], axis = 0)
 
-   def face_count_for_cell(self, cell):
-      """Returns the number of faces for a particular cell."""
+    def face_count_for_cell(self, cell):
+        """Returns the number of faces for a particular cell."""
 
-      self.cache_all_geometry_arrays()
-      start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
-      return self.faces_per_cell_cl[cell] - start
+        self.cache_all_geometry_arrays()
+        start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
+        return self.faces_per_cell_cl[cell] - start
 
-   def max_face_count_for_any_cell(self):
-      """Returns the largest number of faces in use by any one cell."""
+    def max_face_count_for_any_cell(self):
+        """Returns the largest number of faces in use by any one cell."""
 
-      self.cache_all_geometry_arrays()
-      return max(self.faces_per_cell_cl[0], np.max(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1]))
+        self.cache_all_geometry_arrays()
+        return max(self.faces_per_cell_cl[0], np.max(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1]))
 
-   def node_count_for_face(self, face_index):
-      """Returns the number of nodes for a particular face."""
+    def node_count_for_face(self, face_index):
+        """Returns the number of nodes for a particular face."""
 
-      self.cache_all_geometry_arrays()
-      start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
-      return self.nodes_per_face_cl[face_index] - start
+        self.cache_all_geometry_arrays()
+        start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
+        return self.nodes_per_face_cl[face_index] - start
 
-   def max_node_count_for_any_face(self):
-      """Returns the largest number of nodes in use by any one face."""
+    def max_node_count_for_any_face(self):
+        """Returns the largest number of nodes in use by any one face."""
 
-      self.cache_all_geometry_arrays()
-      return max(self.nodes_per_face_cl[0], np.max(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1]))
+        self.cache_all_geometry_arrays()
+        return max(self.nodes_per_face_cl[0], np.max(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1]))
 
-   def node_indices_for_face(self, face_index):
-      """Returns numpy list of node indices for a single face.
+    def node_indices_for_face(self, face_index):
+        """Returns numpy list of node indices for a single face.
 
       arguments:
          face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
@@ -493,12 +493,12 @@ class UnstructuredGrid(BaseResqpy):
          as indicated by the entry in the cell_face_is_right_handed array
       """
 
-      self.cache_all_geometry_arrays()
-      start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
-      return self.nodes_per_face[start:self.nodes_per_face_cl[face_index]].copy()
+        self.cache_all_geometry_arrays()
+        start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
+        return self.nodes_per_face[start:self.nodes_per_face_cl[face_index]].copy()
 
-   def distinct_node_indices_for_cell(self, cell):
-      """Returns a numpy list of distinct node indices used by the faces of a single cell.
+    def distinct_node_indices_for_cell(self, cell):
+        """Returns a numpy list of distinct node indices used by the faces of a single cell.
 
       arguments:
          cell (int): the index of the cell for which distinct node indices are required
@@ -510,14 +510,14 @@ class UnstructuredGrid(BaseResqpy):
          the returned array is sorted by increasing node index
       """
 
-      face_indices = self.face_indices_for_cell(cell)
-      node_set = self.node_indices_for_face(face_indices[0])
-      for face_index in face_indices[1:]:
-         node_set = np.union1d(node_set, self.node_indices_for_face(face_index))
-      return node_set
+        face_indices = self.face_indices_for_cell(cell)
+        node_set = self.node_indices_for_face(face_indices[0])
+        for face_index in face_indices[1:]:
+            node_set = np.union1d(node_set, self.node_indices_for_face(face_index))
+        return node_set
 
-   def face_indices_for_cell(self, cell):
-      """Returns numpy list of face indices for a single cell.
+    def face_indices_for_cell(self, cell):
+        """Returns numpy list of face indices for a single cell.
 
       arguments:
          cell (int): the index of the cell for which face indices are required
@@ -530,12 +530,12 @@ class UnstructuredGrid(BaseResqpy):
          shared faces
       """
 
-      self.cache_all_geometry_arrays()
-      start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
-      return self.faces_per_cell[start:self.faces_per_cell_cl[cell]].copy()
+        self.cache_all_geometry_arrays()
+        start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
+        return self.faces_per_cell[start:self.faces_per_cell_cl[cell]].copy()
 
-   def face_indices_and_handedness_for_cell(self, cell):
-      """Returns numpy list of face indices for a single cell, and numpy boolean list of face right handedness.
+    def face_indices_and_handedness_for_cell(self, cell):
+        """Returns numpy list of face indices for a single cell, and numpy boolean list of face right handedness.
 
       arguments:
          cell (int): the index of the cell for which face indices are required
@@ -551,13 +551,13 @@ class UnstructuredGrid(BaseResqpy):
          some processing of geometry such as volume calculations
       """
 
-      self.cache_all_geometry_arrays()
-      start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
-      return (self.faces_per_cell[start:self.faces_per_cell_cl[cell]].copy(),
-              self.cell_face_is_right_handed[start:self.faces_per_cell_cl[cell]].copy())
+        self.cache_all_geometry_arrays()
+        start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
+        return (self.faces_per_cell[start:self.faces_per_cell_cl[cell]].copy(),
+                self.cell_face_is_right_handed[start:self.faces_per_cell_cl[cell]].copy())
 
-   def edges_for_face(self, face_index):
-      """Returns numpy list of pairs of node indices, each pair being one edge of the face.
+    def edges_for_face(self, face_index):
+        """Returns numpy list of pairs of node indices, each pair being one edge of the face.
 
       arguments:
          face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
@@ -570,11 +570,11 @@ class UnstructuredGrid(BaseResqpy):
          order of the two node indices also follows the order of the nodes for the face
       """
 
-      face_nodes = self.node_indices_for_face(face_index)
-      return np.array([(face_nodes[i - 1], face_nodes[i]) for i in range(len(face_nodes))], dtype = int)
+        face_nodes = self.node_indices_for_face(face_index)
+        return np.array([(face_nodes[i - 1], face_nodes[i]) for i in range(len(face_nodes))], dtype = int)
 
-   def edges_for_face_with_node_indices_ordered_within_pairs(self, face_index):
-      """Returns numpy list of pairs of node indices, each pair being one edge of the face.
+    def edges_for_face_with_node_indices_ordered_within_pairs(self, face_index):
+        """Returns numpy list of pairs of node indices, each pair being one edge of the face.
 
       arguments:
          face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
@@ -587,15 +587,15 @@ class UnstructuredGrid(BaseResqpy):
          two node indices are ordered with the lower index first
       """
 
-      edges = self.edges_for_face(face_index)
-      for i in range(len(edges)):
-         a, b = edges[i]
-         if b < a:
-            edges[i] = (b, a)
-      return edges
+        edges = self.edges_for_face(face_index)
+        for i in range(len(edges)):
+            a, b = edges[i]
+            if b < a:
+                edges[i] = (b, a)
+        return edges
 
-   def distinct_edges_for_cell(self, cell):
-      """Returns numpy list of pairs of node indices, each pair being one distinct edge of the cell.
+    def distinct_edges_for_cell(self, cell):
+        """Returns numpy list of pairs of node indices, each pair being one distinct edge of the cell.
 
       arguments:
          cell (int): the index of the cell
@@ -607,17 +607,17 @@ class UnstructuredGrid(BaseResqpy):
          within each pair, the two node indices are ordered with the lower index first
       """
 
-      edge_list = []
-      for face_index in self.face_indices_for_cell(cell):
-         for a, b in self.edges_for_face(face_index):
-            if b < a:
-               a, b = b, a
-            if (a, b) not in edge_list:
-               edge_list.append((a, b))
-      return np.array(edge_list, dtype = int)
+        edge_list = []
+        for face_index in self.face_indices_for_cell(cell):
+            for a, b in self.edges_for_face(face_index):
+                if b < a:
+                    a, b = b, a
+                if (a, b) not in edge_list:
+                    edge_list.append((a, b))
+        return np.array(edge_list, dtype = int)
 
-   def cell_face_centre_points(self, cell):
-      """Returns a numpy array of centre points of the faces for a single cell.
+    def cell_face_centre_points(self, cell):
+        """Returns a numpy array of centre points of the faces for a single cell.
 
       arguments:
          cell (int): the index of the cell for which face centre points are required
@@ -631,14 +631,14 @@ class UnstructuredGrid(BaseResqpy):
          are not generally their barycentres
       """
 
-      face_indices = self.face_indices_for_cell(cell)
-      face_centres = np.empty((len(face_indices), 3))
-      for fi, face_index in enumerate(face_indices):  # todo: vectorise?
-         face_centres[fi] = self.face_centre_point(face_index)
-      return face_centres
+        face_indices = self.face_indices_for_cell(cell)
+        face_centres = np.empty((len(face_indices), 3))
+        for fi, face_index in enumerate(face_indices):  # todo: vectorise?
+            face_centres[fi] = self.face_centre_point(face_index)
+        return face_centres
 
-   def face_normal(self, face_index):
-      """Returns a unit vector normal to a planar approximation of the face.
+    def face_normal(self, face_index):
+        """Returns a unit vector normal to a planar approximation of the face.
 
       arguments:
          face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
@@ -652,24 +652,24 @@ class UnstructuredGrid(BaseResqpy):
          cell face
       """
 
-      self.cache_all_geometry_arrays()
-      vertices = self.points_cached[self.node_indices_for_face(face_index)]
-      centre = self.face_centre_point(face_index)
-      normal_sum = np.zeros(3)
+        self.cache_all_geometry_arrays()
+        vertices = self.points_cached[self.node_indices_for_face(face_index)]
+        centre = self.face_centre_point(face_index)
+        normal_sum = np.zeros(3)
 
-      for e in range(len(vertices)):
-         edge = vertices[e] - vertices[e - 1]
-         radial = centre - 0.5 * (vertices[e] + vertices[e - 1])
-         weight = vec.naive_length(edge)
-         if weight == 0.0:
-            continue
-         edge_normal = vec.unit_vector(vec.cross_product(edge, radial))
-         normal_sum += weight * edge_normal
+        for e in range(len(vertices)):
+            edge = vertices[e] - vertices[e - 1]
+            radial = centre - 0.5 * (vertices[e] + vertices[e - 1])
+            weight = vec.naive_length(edge)
+            if weight == 0.0:
+                continue
+            edge_normal = vec.unit_vector(vec.cross_product(edge, radial))
+            normal_sum += weight * edge_normal
 
-      return vec.unit_vector(normal_sum)
+        return vec.unit_vector(normal_sum)
 
-   def planar_face_points(self, face_index, xy_plane = False):
-      """Returns points for a planar approximation of a face.
+    def planar_face_points(self, face_index, xy_plane = False):
+        """Returns points for a planar approximation of a face.
 
       arguments:
          face_index (int): the index of the face for which a planar approximation is required
@@ -682,24 +682,24 @@ class UnstructuredGrid(BaseResqpy):
          N nodes of the original face, in the same order
       """
 
-      self.cache_all_geometry_arrays()
-      face_centre = self.face_centre_point(face_index)
-      assert np.all(self.node_indices_for_face(face_index) >= 0)  # debug
-      assert np.all(self.node_indices_for_face(face_index) < self.node_count)  # debug
-      face_points = self.points_cached[self.node_indices_for_face(face_index), :].copy()
-      normal = self.face_normal(face_index)
-      az = vec.azimuth(normal)
-      incl = vec.inclination(normal)
-      vec.tilt_points(face_centre, az, -incl, face_points)  # modifies face_points in situ
-      if xy_plane:
-         face_points[..., 2] = 0.0
-      else:
-         face_points[..., 2] = face_centre[2]
-         vec.tilt_points(face_centre, az, incl, face_points)  # tilt back to original average normal
-      return face_points
+        self.cache_all_geometry_arrays()
+        face_centre = self.face_centre_point(face_index)
+        assert np.all(self.node_indices_for_face(face_index) >= 0)  # debug
+        assert np.all(self.node_indices_for_face(face_index) < self.node_count)  # debug
+        face_points = self.points_cached[self.node_indices_for_face(face_index), :].copy()
+        normal = self.face_normal(face_index)
+        az = vec.azimuth(normal)
+        incl = vec.inclination(normal)
+        vec.tilt_points(face_centre, az, -incl, face_points)  # modifies face_points in situ
+        if xy_plane:
+            face_points[..., 2] = 0.0
+        else:
+            face_points[..., 2] = face_centre[2]
+            vec.tilt_points(face_centre, az, incl, face_points)  # tilt back to original average normal
+        return face_points
 
-   def face_triangulation(self, face_index, local_nodes = False):
-      """Returns a Delauney triangulation of (a planar approximation of) a face.
+    def face_triangulation(self, face_index, local_nodes = False):
+        """Returns a Delauney triangulation of (a planar approximation of) a face.
 
       arguments:
          face_index (int): the index of the face for which a triangulation is required
@@ -712,15 +712,16 @@ class UnstructuredGrid(BaseResqpy):
          of nodes defining the face
       """
 
-      face_points = self.planar_face_points(face_index, xy_plane = True)
-      local_triangulation = tri.dt(face_points)  # returns int array of shape (M, 3)
-      assert len(local_triangulation) == len(face_points) - 2, 'face triangulation failure (concave edges when planar?)'
-      if local_nodes:
-         return local_triangulation
-      return self.node_indices_for_face(face_index)[local_triangulation]
+        face_points = self.planar_face_points(face_index, xy_plane = True)
+        local_triangulation = tri.dt(face_points)  # returns int array of shape (M, 3)
+        assert len(
+            local_triangulation) == len(face_points) - 2, 'face triangulation failure (concave edges when planar?)'
+        if local_nodes:
+            return local_triangulation
+        return self.node_indices_for_face(face_index)[local_triangulation]
 
-   def area_of_face(self, face_index, in_plane = False):
-      """Returns the area of a face.
+    def area_of_face(self, face_index, in_plane = False):
+        """Returns the area of a face.
 
       arguments:
          face_index (int): the index of the face for which the area is required
@@ -735,21 +736,21 @@ class UnstructuredGrid(BaseResqpy):
          units of measure of the area is implied by the units of the crs in use by the grid
       """
 
-      if in_plane:
-         face_points = self.planar_face_points(face_index, xy_plane = True)
-         local_triangulation = tri.dt(face_points)
-         triangulated_points = face_points[local_triangulation]
-      else:
-         global_triangulation = self.face_triangulation(face_index)
-         triangulated_points = self.points_cached[global_triangulation]
-      assert triangulated_points.ndim == 3 and triangulated_points.shape[1:] == (3, 3)
-      area = 0.0
-      for tp in triangulated_points:
-         area += vec.area_of_triangle(tp[0], tp[1], tp[2])
-      return area
+        if in_plane:
+            face_points = self.planar_face_points(face_index, xy_plane = True)
+            local_triangulation = tri.dt(face_points)
+            triangulated_points = face_points[local_triangulation]
+        else:
+            global_triangulation = self.face_triangulation(face_index)
+            triangulated_points = self.points_cached[global_triangulation]
+        assert triangulated_points.ndim == 3 and triangulated_points.shape[1:] == (3, 3)
+        area = 0.0
+        for tp in triangulated_points:
+            area += vec.area_of_triangle(tp[0], tp[1], tp[2])
+        return area
 
-   def cell_centre_point(self, cell):
-      """Returns centre point of a single cell calculated as the mean position of the centre points of its faces.
+    def cell_centre_point(self, cell):
+        """Returns centre point of a single cell calculated as the mean position of the centre points of its faces.
 
       arguments:
          cell (int): the index of the cell for which the centre point is required
@@ -762,10 +763,10 @@ class UnstructuredGrid(BaseResqpy):
          the barycentre of the cell
       """
 
-      return np.mean(self.cell_face_centre_points(cell), axis = 0)
+        return np.mean(self.cell_face_centre_points(cell), axis = 0)
 
-   def centre_point(self, cell = None, cache_centre_array = False):
-      """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all cells.
+    def centre_point(self, cell = None, cache_centre_array = False):
+        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all cells.
 
       arguments:
          cell (optional): if present, the cell number of the individual cell for which the
@@ -785,31 +786,31 @@ class UnstructuredGrid(BaseResqpy):
       :meta common:
       """
 
-      if cell is None:
-         cache_centre_array = True
+        if cell is None:
+            cache_centre_array = True
 
-      if hasattr(self, 'array_centre_point') and self.array_centre_point is not None:
-         if cell is None:
-            return self.array_centre_point
-         return self.array_centre_point[cell]  # could check for nan here and return None
+        if hasattr(self, 'array_centre_point') and self.array_centre_point is not None:
+            if cell is None:
+                return self.array_centre_point
+            return self.array_centre_point[cell]  # could check for nan here and return None
 
-      if self.node_count is None:  # no geometry present
-         return None
+        if self.node_count is None:  # no geometry present
+            return None
 
-      if cache_centre_array:  # calculate for all cells and cache
-         self.array_centre_point = np.empty((self.cell_count, 3))
-         for cell_index in range(self.cell_count):  # todo: vectorise
-            self.array_centre_point[cell_index] = self.cell_centre_point(cell_index)
-         if cell is None:
-            return self.array_centre_point
-         else:
-            return self.array_centre_point[cell]
+        if cache_centre_array:  # calculate for all cells and cache
+            self.array_centre_point = np.empty((self.cell_count, 3))
+            for cell_index in range(self.cell_count):  # todo: vectorise
+                self.array_centre_point[cell_index] = self.cell_centre_point(cell_index)
+            if cell is None:
+                return self.array_centre_point
+            else:
+                return self.array_centre_point[cell]
 
-      else:
-         return self.cell_centre_point(cell)
+        else:
+            return self.cell_centre_point(cell)
 
-   def volume(self, cell):
-      """Returns the volume of a single cell.
+    def volume(self, cell):
+        """Returns the volume of a single cell.
 
       arguments:
          cell (int): the index of the cell for which the volume is required
@@ -821,109 +822,115 @@ class UnstructuredGrid(BaseResqpy):
          this is a computationally expensive method
       """
 
-      tetra = TetraGrid.from_unstructured_cell(self, cell, set_handedness = False)
-      assert tetra is not None
-      return tetra.grid_volume()
+        tetra = TetraGrid.from_unstructured_cell(self, cell, set_handedness = False)
+        assert tetra is not None
+        return tetra.grid_volume()
 
-   def check_indices(self):
-      """Asserts that all node and face indices are within range."""
+    def check_indices(self):
+        """Asserts that all node and face indices are within range."""
 
-      self.cache_all_geometry_arrays()
-      assert self.cell_count > 0
-      assert self.face_count >= 4
-      assert self.node_count >= 4
-      assert np.all(self.faces_per_cell >= 0) and np.all(self.faces_per_cell < self.face_count)
-      assert self.faces_per_cell_cl[0] >= 4
-      assert np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] >= 4)
-      assert len(self.faces_per_cell_cl) == self.cell_count
-      assert np.all(self.nodes_per_face >= 0) and np.all(self.nodes_per_face < self.node_count)
-      assert self.nodes_per_face_cl[0] >= 3
-      assert np.all(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1] >= 3)
-      assert len(self.nodes_per_face_cl) == self.face_count
+        self.cache_all_geometry_arrays()
+        assert self.cell_count > 0
+        assert self.face_count >= 4
+        assert self.node_count >= 4
+        assert np.all(self.faces_per_cell >= 0) and np.all(self.faces_per_cell < self.face_count)
+        assert self.faces_per_cell_cl[0] >= 4
+        assert np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] >= 4)
+        assert len(self.faces_per_cell_cl) == self.cell_count
+        assert np.all(self.nodes_per_face >= 0) and np.all(self.nodes_per_face < self.node_count)
+        assert self.nodes_per_face_cl[0] >= 3
+        assert np.all(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1] >= 3)
+        assert len(self.nodes_per_face_cl) == self.face_count
 
-   def xy_units(self):
-      """Returns the projected view (x, y) units of measure of the coordinate reference system for the grid.
-
-      :meta common:
-      """
-
-      return rqet.find_tag(self._crs_root(), 'ProjectedUom').text
-
-   def z_units(self):
-      """Returns the vertical (z) units of measure of the coordinate reference system for the grid.
+    def xy_units(self):
+        """Returns the projected view (x, y) units of measure of the coordinate reference system for the grid.
 
       :meta common:
       """
 
-      return rqet.find_tag(self._crs_root(), 'VerticalUom').text
+        return rqet.find_tag(self._crs_root(), 'ProjectedUom').text
 
-   def write_hdf5(self, file = None, geometry = True, imported_properties = None, write_active = None):
-      """Write to an hdf5 file the datasets for the grid geometry and optionally properties from cached arrays.
+    def z_units(self):
+        """Returns the vertical (z) units of measure of the coordinate reference system for the grid.
 
       :meta common:
       """
 
-      # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
-      # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
-      # xml is not created here for property objects
+        return rqet.find_tag(self._crs_root(), 'VerticalUom').text
 
-      if geometry:
-         assert self.node_count > 0 and self.face_count > 0, 'geometry not present when writing unstructured grid to hdf5'
+    def write_hdf5(self, file = None, geometry = True, imported_properties = None, write_active = None):
+        """Write to an hdf5 file the datasets for the grid geometry and optionally properties from cached arrays.
 
-      if write_active is None:
-         write_active = geometry
+      :meta common:
+      """
 
-      self.cache_all_geometry_arrays()
+        # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
+        # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
+        # xml is not created here for property objects
 
-      if not file:
-         file = self.model.h5_file_name()
-      h5_reg = rwh5.H5Register(self.model)
+        if geometry:
+            assert self.node_count > 0 and self.face_count > 0, 'geometry not present when writing unstructured grid to hdf5'
 
-      if geometry:
-         h5_reg.register_dataset(self.uuid, 'Points', self.points_cached)
-         h5_reg.register_dataset(self.uuid, 'NodesPerFace/elements', self.nodes_per_face, dtype = 'uint32')
-         h5_reg.register_dataset(self.uuid, 'NodesPerFace/cumulativeLength', self.nodes_per_face_cl, dtype = 'uint32')
-         h5_reg.register_dataset(self.uuid, 'FacesPerCell/elements', self.faces_per_cell, dtype = 'uint32')
-         h5_reg.register_dataset(self.uuid, 'FacesPerCell/cumulativeLength', self.faces_per_cell_cl, dtype = 'uint32')
-         h5_reg.register_dataset(self.uuid, 'CellFaceIsRightHanded', self.cell_face_is_right_handed, dtype = 'uint8')
+        if write_active is None:
+            write_active = geometry
 
-      if write_active and self.inactive is not None:
-         if imported_properties is None:
-            imported_properties = rqp.PropertyCollection()
-            imported_properties.set_support(support = self)
-         else:
-            filtered_list = []
+        self.cache_all_geometry_arrays()
+
+        if not file:
+            file = self.model.h5_file_name()
+        h5_reg = rwh5.H5Register(self.model)
+
+        if geometry:
+            h5_reg.register_dataset(self.uuid, 'Points', self.points_cached)
+            h5_reg.register_dataset(self.uuid, 'NodesPerFace/elements', self.nodes_per_face, dtype = 'uint32')
+            h5_reg.register_dataset(self.uuid,
+                                    'NodesPerFace/cumulativeLength',
+                                    self.nodes_per_face_cl,
+                                    dtype = 'uint32')
+            h5_reg.register_dataset(self.uuid, 'FacesPerCell/elements', self.faces_per_cell, dtype = 'uint32')
+            h5_reg.register_dataset(self.uuid,
+                                    'FacesPerCell/cumulativeLength',
+                                    self.faces_per_cell_cl,
+                                    dtype = 'uint32')
+            h5_reg.register_dataset(self.uuid, 'CellFaceIsRightHanded', self.cell_face_is_right_handed, dtype = 'uint8')
+
+        if write_active and self.inactive is not None:
+            if imported_properties is None:
+                imported_properties = rqp.PropertyCollection()
+                imported_properties.set_support(support = self)
+            else:
+                filtered_list = []
+                for entry in imported_properties.imported_list:
+                    if entry[2].upper() == 'ACTIVE' or entry[10] == 'active':
+                        continue  # keyword or property kind
+                    filtered_list.append(entry)
+                imported_properties.imported_list = filtered_list  # might have unintended side effects elsewhere
+            active_mask = np.logical_not(self.inactive)
+            imported_properties.add_cached_array_to_imported_list(active_mask,
+                                                                  'active cell mask',
+                                                                  'ACTIVE',
+                                                                  discrete = True,
+                                                                  property_kind = 'active')
+
+        if imported_properties is not None and imported_properties.imported_list is not None:
             for entry in imported_properties.imported_list:
-               if entry[2].upper() == 'ACTIVE' or entry[10] == 'active':
-                  continue  # keyword or property kind
-               filtered_list.append(entry)
-            imported_properties.imported_list = filtered_list  # might have unintended side effects elsewhere
-         active_mask = np.logical_not(self.inactive)
-         imported_properties.add_cached_array_to_imported_list(active_mask,
-                                                               'active cell mask',
-                                                               'ACTIVE',
-                                                               discrete = True,
-                                                               property_kind = 'active')
+                if hasattr(imported_properties, entry[3]):  # otherwise constant array
+                    h5_reg.register_dataset(entry[0], 'values_patch0', imported_properties.__dict__[entry[3]])
+                if entry[10] == 'active':
+                    self.active_property_uuid = entry[0]
 
-      if imported_properties is not None and imported_properties.imported_list is not None:
-         for entry in imported_properties.imported_list:
-            if hasattr(imported_properties, entry[3]):  # otherwise constant array
-               h5_reg.register_dataset(entry[0], 'values_patch0', imported_properties.__dict__[entry[3]])
-            if entry[10] == 'active':
-               self.active_property_uuid = entry[0]
+        h5_reg.write(file, mode = 'a')
 
-      h5_reg.write(file, mode = 'a')
-
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  title = None,
-                  originator = None,
-                  write_active = True,
-                  write_geometry = True,
-                  extra_metadata = {}):
-      """Creates an unstructured grid node and optionally adds as a part in the model.
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   title = None,
+                   originator = None,
+                   write_active = True,
+                   write_geometry = True,
+                   extra_metadata = {}):
+        """Creates an unstructured grid node and optionally adds as a part in the model.
 
       arguments:
          ext_uuid (uuid.UUID, optional): the uuid of the hdf5 external part holding the array data for the grid geometry
@@ -953,157 +960,158 @@ class UnstructuredGrid(BaseResqpy):
       :meta common:
       """
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
-      if title:
-         self.title = title
-      if not self.title:
-         self.title = 'ROOT'
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
+        if title:
+            self.title = title
+        if not self.title:
+            self.title = 'ROOT'
 
-      ug = super().create_xml(add_as_part = False, originator = originator, extra_metadata = extra_metadata)
+        ug = super().create_xml(add_as_part = False, originator = originator, extra_metadata = extra_metadata)
 
-      if self.grid_representation and not write_geometry:
-         rqet.create_metadata_xml(node = ug, extra_metadata = {'grid_flavour': self.grid_representation})
+        if self.grid_representation and not write_geometry:
+            rqet.create_metadata_xml(node = ug, extra_metadata = {'grid_flavour': self.grid_representation})
 
-      cc_node = rqet.SubElement(ug, ns['resqml2'] + 'CellCount')
-      cc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      cc_node.text = str(self.cell_count)
+        cc_node = rqet.SubElement(ug, ns['resqml2'] + 'CellCount')
+        cc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        cc_node.text = str(self.cell_count)
 
-      if write_geometry:
+        if write_geometry:
 
-         geom = rqet.SubElement(ug, ns['resqml2'] + 'Geometry')
-         geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'UnstructuredGridGeometry')
-         geom.text = '\n'
+            geom = rqet.SubElement(ug, ns['resqml2'] + 'Geometry')
+            geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'UnstructuredGridGeometry')
+            geom.text = '\n'
 
-         # the remainder of this function is populating the geometry node
-         self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+            # the remainder of this function is populating the geometry node
+            self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
-         points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
-         points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-         points_node.text = '\n'
+            points_node = rqet.SubElement(geom, ns['resqml2'] + 'Points')
+            points_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+            points_node.text = '\n'
 
-         coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
-         coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         coords.text = '\n'
+            coords = rqet.SubElement(points_node, ns['resqml2'] + 'Coordinates')
+            coords.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            coords.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Points', root = coords)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Points', root = coords)
 
-         shape_node = rqet.SubElement(geom, ns['resqml2'] + 'CellShape')
-         shape_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'CellShape')
-         shape_node.text = self.cell_shape
+            shape_node = rqet.SubElement(geom, ns['resqml2'] + 'CellShape')
+            shape_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'CellShape')
+            shape_node.text = self.cell_shape
 
-         nc_node = rqet.SubElement(geom, ns['resqml2'] + 'NodeCount')
-         nc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         nc_node.text = str(self.node_count)
+            nc_node = rqet.SubElement(geom, ns['resqml2'] + 'NodeCount')
+            nc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            nc_node.text = str(self.node_count)
 
-         fc_node = rqet.SubElement(geom, ns['resqml2'] + 'FaceCount')
-         fc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         fc_node.text = str(self.face_count)
+            fc_node = rqet.SubElement(geom, ns['resqml2'] + 'FaceCount')
+            fc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            fc_node.text = str(self.face_count)
 
-         self._create_jagged_array_xml(geom, 'NodesPerFace', ext_uuid)
+            self._create_jagged_array_xml(geom, 'NodesPerFace', ext_uuid)
 
-         self._create_jagged_array_xml(geom, 'FacesPerCell', ext_uuid)
+            self._create_jagged_array_xml(geom, 'FacesPerCell', ext_uuid)
 
-         cfirh_node = rqet.SubElement(geom, ns['resqml2'] + 'CellFaceIsRightHanded')
-         cfirh_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
-         cfirh_node.text = '\n'
+            cfirh_node = rqet.SubElement(geom, ns['resqml2'] + 'CellFaceIsRightHanded')
+            cfirh_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'BooleanHdf5Array')
+            cfirh_node.text = '\n'
 
-         cfirh_values = rqet.SubElement(cfirh_node, ns['resqml2'] + 'Values')
-         cfirh_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         cfirh_values.text = '\n'
+            cfirh_values = rqet.SubElement(cfirh_node, ns['resqml2'] + 'Values')
+            cfirh_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            cfirh_values.text = '\n'
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellFaceIsRightHanded', root = cfirh_values)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellFaceIsRightHanded', root = cfirh_values)
 
-         self.geometry_root = geom
+            self.geometry_root = geom
 
-      if add_as_part:
-         self.model.add_part('obj_UnstructuredGridRepresentation', self.uuid, ug)
-         if add_relationships:
-            if write_geometry:
-               # create 2 way relationship between UnstructuredGrid and Crs
-               self.model.create_reciprocal_relationship(ug, 'destinationObject', self.model.root(uuid = self.crs_uuid),
-                                                         'sourceObject')
-               # create 2 way relationship between UnstructuredGrid and Ext
-               ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-               ext_node = self.model.root_for_part(ext_part)
-               self.model.create_reciprocal_relationship(ug, 'mlToExternalPartProxy', ext_node, 'externalPartProxyToMl')
+        if add_as_part:
+            self.model.add_part('obj_UnstructuredGridRepresentation', self.uuid, ug)
+            if add_relationships:
+                if write_geometry:
+                    # create 2 way relationship between UnstructuredGrid and Crs
+                    self.model.create_reciprocal_relationship(ug, 'destinationObject',
+                                                              self.model.root(uuid = self.crs_uuid), 'sourceObject')
+                    # create 2 way relationship between UnstructuredGrid and Ext
+                    ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                    ext_node = self.model.root_for_part(ext_part)
+                    self.model.create_reciprocal_relationship(ug, 'mlToExternalPartProxy', ext_node,
+                                                              'externalPartProxyToMl')
 
-      if write_active and self.active_property_uuid is not None and self.model.part(
-            uuid = self.active_property_uuid) is None:
-         active_collection = rqp.PropertyCollection()
-         active_collection.set_support(support = self)
-         active_collection.create_xml(None,
-                                      None,
-                                      'ACTIVE',
-                                      'active',
-                                      p_uuid = self.active_property_uuid,
-                                      discrete = True,
-                                      add_min_max = False,
-                                      find_local_property_kinds = True)
+        if write_active and self.active_property_uuid is not None and self.model.part(
+                uuid = self.active_property_uuid) is None:
+            active_collection = rqp.PropertyCollection()
+            active_collection.set_support(support = self)
+            active_collection.create_xml(None,
+                                         None,
+                                         'ACTIVE',
+                                         'active',
+                                         p_uuid = self.active_property_uuid,
+                                         discrete = True,
+                                         add_min_max = False,
+                                         find_local_property_kinds = True)
 
-      return ug
+        return ug
 
-   def _create_jagged_array_xml(self, parent_node, tag, ext_uuid, null_value = -1):
+    def _create_jagged_array_xml(self, parent_node, tag, ext_uuid, null_value = -1):
 
-      j_node = rqet.SubElement(parent_node, ns['resqml2'] + tag)
-      j_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlJaggedArray')
-      j_node.text = '\n'
+        j_node = rqet.SubElement(parent_node, ns['resqml2'] + tag)
+        j_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'ResqmlJaggedArray')
+        j_node.text = '\n'
 
-      elements = rqet.SubElement(j_node, ns['resqml2'] + 'Elements')
-      elements.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      elements.text = '\n'
+        elements = rqet.SubElement(j_node, ns['resqml2'] + 'Elements')
+        elements.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        elements.text = '\n'
 
-      el_null = rqet.SubElement(elements, ns['resqml2'] + 'NullValue')
-      el_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      el_null.text = str(null_value)
+        el_null = rqet.SubElement(elements, ns['resqml2'] + 'NullValue')
+        el_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        el_null.text = str(null_value)
 
-      el_values = rqet.SubElement(elements, ns['resqml2'] + 'Values')
-      el_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      el_values.text = '\n'
+        el_values = rqet.SubElement(elements, ns['resqml2'] + 'Values')
+        el_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        el_values.text = '\n'
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, tag + '/elements', root = el_values)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, tag + '/elements', root = el_values)
 
-      c_length = rqet.SubElement(j_node, ns['resqml2'] + 'CumulativeLength')
-      c_length.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      c_length.text = '\n'
+        c_length = rqet.SubElement(j_node, ns['resqml2'] + 'CumulativeLength')
+        c_length.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        c_length.text = '\n'
 
-      cl_null = rqet.SubElement(c_length, ns['resqml2'] + 'NullValue')
-      cl_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      cl_null.text = '0'
+        cl_null = rqet.SubElement(c_length, ns['resqml2'] + 'NullValue')
+        cl_null.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        cl_null.text = '0'
 
-      cl_values = rqet.SubElement(c_length, ns['resqml2'] + 'Values')
-      cl_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      cl_values.text = '\n'
+        cl_values = rqet.SubElement(c_length, ns['resqml2'] + 'Values')
+        cl_values.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        cl_values.text = '\n'
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, tag + '/cumulativeLength', root = cl_values)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, tag + '/cumulativeLength', root = cl_values)
 
-   def _set_crs_handedness(self):
-      if self.crs_is_right_handed is not None:
-         return
-      assert self.crs_uuid is not None
-      crs = rqc.Crs(self.model, uuid = self.crs_uuid)
-      self.crs_is_right_handed = crs.is_right_handed_xyz()
+    def _set_crs_handedness(self):
+        if self.crs_is_right_handed is not None:
+            return
+        assert self.crs_uuid is not None
+        crs = rqc.Crs(self.model, uuid = self.crs_uuid)
+        self.crs_is_right_handed = crs.is_right_handed_xyz()
 
-   def _crs_root(self):
-      """Returns xml root node for the crs object referred to by this grid."""
+    def _crs_root(self):
+        """Returns xml root node for the crs object referred to by this grid."""
 
-      if self.crs_uuid is None:
-         return None
-      return self.model.root(uuid = self.crs_uuid)
+        if self.crs_uuid is None:
+            return None
+        return self.model.root(uuid = self.crs_uuid)
 
 
 class TetraGrid(UnstructuredGrid):
-   """Class for unstructured grids where every cell is a tetrahedron."""
+    """Class for unstructured grids where every cell is a tetrahedron."""
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                find_properties = True,
-                cache_geometry = False,
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Creates a new resqpy TetraGrid object (RESQML UnstructuredGrid with cell shape tetrahedral)
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 find_properties = True,
+                 cache_geometry = False,
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Creates a new resqpy TetraGrid object (RESQML UnstructuredGrid with cell shape tetrahedral)
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -1123,44 +1131,44 @@ class TetraGrid(UnstructuredGrid):
          a newly created TetraGrid object
       """
 
-      super().__init__(parent_model = parent_model,
-                       uuid = uuid,
-                       find_properties = find_properties,
-                       geometry_required = True,
-                       cache_geometry = cache_geometry,
-                       cell_shape = 'tetrahedral',
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata)
+        super().__init__(parent_model = parent_model,
+                         uuid = uuid,
+                         find_properties = find_properties,
+                         geometry_required = True,
+                         cache_geometry = cache_geometry,
+                         cell_shape = 'tetrahedral',
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata)
 
-      if self.root is not None:
-         assert grr.grid_flavour(self.root) == 'TetraGrid'
-         self.check_tetra()
+        if self.root is not None:
+            assert grr.grid_flavour(self.root) == 'TetraGrid'
+            self.check_tetra()
 
-      self.grid_representation = 'TetraGrid'  #: flavour of grid; not much used
+        self.grid_representation = 'TetraGrid'  #: flavour of grid; not much used
 
-   def check_tetra(self):
-      """Checks that each cell has 4 faces and each face has 3 nodes."""
+    def check_tetra(self):
+        """Checks that each cell has 4 faces and each face has 3 nodes."""
 
-      assert self.cell_shape == 'tetrahedral'
-      self.cache_all_geometry_arrays()
-      assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
-      assert self.faces_per_cell_cl[0] == 4 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 4)
-      assert self.nodes_per_face_cl[0] == 3 and np.all(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1] == 3)
+        assert self.cell_shape == 'tetrahedral'
+        self.cache_all_geometry_arrays()
+        assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
+        assert self.faces_per_cell_cl[0] == 4 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 4)
+        assert self.nodes_per_face_cl[0] == 3 and np.all(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1] == 3)
 
-   def face_centre_point(self, face_index):
-      """Returns a nominal centre point for a single face calculated as the mean position of its nodes.
+    def face_centre_point(self, face_index):
+        """Returns a nominal centre point for a single face calculated as the mean position of its nodes.
 
       note:
          this is a nominal centre point for a face and not generally its barycentre
       """
 
-      self.cache_all_geometry_arrays()
-      start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
-      return np.mean(self.points_cached[self.nodes_per_face[start:start + 3]], axis = 0)
+        self.cache_all_geometry_arrays()
+        start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
+        return np.mean(self.points_cached[self.nodes_per_face[start:start + 3]], axis = 0)
 
-   def volume(self, cell):
-      """Returns the volume of a single cell.
+    def volume(self, cell):
+        """Returns the volume of a single cell.
 
       arguments:
          cell (int): the index of the cell for which the volume is required
@@ -1169,145 +1177,145 @@ class TetraGrid(UnstructuredGrid):
          float being the volume of the tetrahedral cell; units of measure is implied by crs units
       """
 
-      self.cache_all_geometry_arrays()
-      abcd = self.points_cached[self.distinct_node_indices_for_cell(cell)]
-      assert abcd.shape == (4, 3)
-      return vol.tetrahedron_volume(abcd[0], abcd[1], abcd[2], abcd[3])
+        self.cache_all_geometry_arrays()
+        abcd = self.points_cached[self.distinct_node_indices_for_cell(cell)]
+        assert abcd.shape == (4, 3)
+        return vol.tetrahedron_volume(abcd[0], abcd[1], abcd[2], abcd[3])
 
-   def grid_volume(self):
-      """Returns the sum of the volumes of all the cells in the grid.
+    def grid_volume(self):
+        """Returns the sum of the volumes of all the cells in the grid.
 
       returns:
          float being the total volume of the grid; units of measure is implied by crs units
       """
 
-      v = 0.0
-      for cell in range(self.cell_count):
-         v += self.volume(cell)
-      return v
+        v = 0.0
+        for cell in range(self.cell_count):
+            v += self.volume(cell)
+        return v
 
-   @classmethod
-   def from_unstructured_cell(cls, u_grid, cell, title = None, extra_metadata = {}, set_handedness = False):
-      """Instantiates a small TetraGrid representing a single cell from an UnstructuredGrid as a set of tetrahedra."""
+    @classmethod
+    def from_unstructured_cell(cls, u_grid, cell, title = None, extra_metadata = {}, set_handedness = False):
+        """Instantiates a small TetraGrid representing a single cell from an UnstructuredGrid as a set of tetrahedra."""
 
-      def _min_max(a, b):
-         if a < b:
-            return (a, b)
-         else:
-            return (b, a)
+        def _min_max(a, b):
+            if a < b:
+                return (a, b)
+            else:
+                return (b, a)
 
-      if not title:
-         title = str(u_grid.title) + f'_cell_{cell}'
+        if not title:
+            title = str(u_grid.title) + f'_cell_{cell}'
 
-      assert u_grid.cell_shape in valid_cell_shapes
-      u_grid.cache_all_geometry_arrays()
-      u_cell_faces = u_grid.face_indices_for_cell(cell)
-      u_cell_nodes = u_grid.distinct_node_indices_for_cell(cell)
+        assert u_grid.cell_shape in valid_cell_shapes
+        u_grid.cache_all_geometry_arrays()
+        u_cell_faces = u_grid.face_indices_for_cell(cell)
+        u_cell_nodes = u_grid.distinct_node_indices_for_cell(cell)
 
-      # create an empty TetreGrid
-      tetra = cls(u_grid.model, title = title, extra_metadata = extra_metadata)
-      tetra.crs_uuid = u_grid.crs_uuid
+        # create an empty TetreGrid
+        tetra = cls(u_grid.model, title = title, extra_metadata = extra_metadata)
+        tetra.crs_uuid = u_grid.crs_uuid
 
-      u_cell_node_count = len(u_cell_nodes)
-      assert u_cell_node_count >= 4
-      u_cell_face_count = len(u_cell_faces)
-      assert u_cell_face_count >= 4
+        u_cell_node_count = len(u_cell_nodes)
+        assert u_cell_node_count >= 4
+        u_cell_face_count = len(u_cell_faces)
+        assert u_cell_face_count >= 4
 
-      # build attributes, depending on the shape of the individual unstructured cell
+        # build attributes, depending on the shape of the individual unstructured cell
 
-      if u_cell_node_count == 4:  # cell is tetrahedral
+        if u_cell_node_count == 4:  # cell is tetrahedral
 
-         assert u_cell_face_count == 4
-         tetra.set_cell_count(1)
-         tetra.face_count = 4
-         tetra.faces_per_cell_cl = np.array((4,), dtype = int)
-         tetra.faces_per_cell = np.arange(4, dtype = int)
-         tetra.node_count = 4
-         tetra.nodes_per_face_cl = np.arange(3, 3 * 4 + 1, 3, dtype = int)
-         tetra.nodes_per_face = np.array((0, 1, 2, 0, 3, 1, 1, 3, 2, 2, 3, 0), dtype = int)
-         tetra.cell_face_is_right_handed = np.ones(4, dtype = bool)
-         tetra.points_cached = u_grid.points_cached[u_cell_nodes].copy()
+            assert u_cell_face_count == 4
+            tetra.set_cell_count(1)
+            tetra.face_count = 4
+            tetra.faces_per_cell_cl = np.array((4,), dtype = int)
+            tetra.faces_per_cell = np.arange(4, dtype = int)
+            tetra.node_count = 4
+            tetra.nodes_per_face_cl = np.arange(3, 3 * 4 + 1, 3, dtype = int)
+            tetra.nodes_per_face = np.array((0, 1, 2, 0, 3, 1, 1, 3, 2, 2, 3, 0), dtype = int)
+            tetra.cell_face_is_right_handed = np.ones(4, dtype = bool)
+            tetra.points_cached = u_grid.points_cached[u_cell_nodes].copy()
 
-      # todo: add optimised code for pyramidal (and hexahedral?) cells
+        # todo: add optimised code for pyramidal (and hexahedral?) cells
 
-      else:  # generic case: add a node at centre of unstructured cell and divide faces into triangles
+        else:  # generic case: add a node at centre of unstructured cell and divide faces into triangles
 
-         tetra.node_count = u_cell_node_count + 1
-         tetra.points_cached = np.empty((tetra.node_count, 3))
-         tetra.points_cached[:-1] = u_grid.points_cached[u_cell_nodes].copy()
-         tetra.points_cached[-1] = u_grid.centre_point(cell = cell)
-         centre_node = tetra.node_count - 1
+            tetra.node_count = u_cell_node_count + 1
+            tetra.points_cached = np.empty((tetra.node_count, 3))
+            tetra.points_cached[:-1] = u_grid.points_cached[u_cell_nodes].copy()
+            tetra.points_cached[-1] = u_grid.centre_point(cell = cell)
+            centre_node = tetra.node_count - 1
 
-         u_cell_nodes = list(u_cell_nodes)  # to allow simple index usage below
+            u_cell_nodes = list(u_cell_nodes)  # to allow simple index usage below
 
-         # build list of distinct edges used by cell
-         u_cell_edge_list = u_grid.distinct_edges_for_cell(cell)
-         u_edge_count = len(u_cell_edge_list)
-         assert u_edge_count >= 4
+            # build list of distinct edges used by cell
+            u_cell_edge_list = u_grid.distinct_edges_for_cell(cell)
+            u_edge_count = len(u_cell_edge_list)
+            assert u_edge_count >= 4
 
-         t_cell_list = []  # list of 4-tuples of ints, being local face indices for tetra cells
+            t_cell_list = []  # list of 4-tuples of ints, being local face indices for tetra cells
 
-         # create an internal tetra face for each edge, using centre point as third node
-         # note: u_a, u_b are a sorted pair, and u_cell_nodes is also aorted, so t_a, t_b are a sorted pair
-         t_face_list = []  # list of triple ints each triplet being local node indices for a triangular face
-         for u_a, u_b in u_cell_edge_list:
-            t_a, t_b = u_cell_nodes.index(u_a), u_cell_nodes.index(u_b)
-            t_face_list.append((t_a, t_b, centre_node))
+            # create an internal tetra face for each edge, using centre point as third node
+            # note: u_a, u_b are a sorted pair, and u_cell_nodes is also aorted, so t_a, t_b are a sorted pair
+            t_face_list = []  # list of triple ints each triplet being local node indices for a triangular face
+            for u_a, u_b in u_cell_edge_list:
+                t_a, t_b = u_cell_nodes.index(u_a), u_cell_nodes.index(u_b)
+                t_face_list.append((t_a, t_b, centre_node))
 
-         # for each unstructured face, create a Delauney triangulation; create a tetra face for each
-         # triangle in the triangulation; create internal tetra faces for each of the internal edges in
-         # the triangulation; and create a tetra cell for each triangle in the triangulation
-         # note: the resqpy Delauney triangulation is for a 2D system, so here the unstructured face
-         # is projected onto a planar approximation defined by the face centre point and an average
-         # normal vector
-         for fi in u_cell_faces:
-            triangulated_face = u_grid.face_triangulation(fi)
-            for u_a, u_b, u_c in triangulated_face:
-               t_a, t_b, t_c = u_cell_nodes.index(u_a), u_cell_nodes.index(u_b), u_cell_nodes.index(u_c)
-               t_cell_faces = [len(t_face_list)]  # local face index for this triangle
-               t_face_list.append((t_a, t_b, t_c))
-               tri_edges = np.array([_min_max(t_a, t_b), _min_max(t_b, t_c), _min_max(t_c, t_a)], dtype = int)
-               for e_a, e_b in tri_edges:
-                  try:
-                     pos = t_face_list.index((e_a, e_b, centre_node))
-                  except ValueError:
-                     pos = len(t_face_list)
-                     t_face_list.append((e_a, e_b, centre_node))
-                  t_cell_faces.append(pos)
-               t_cell_list.append(tuple(t_cell_faces))
+            # for each unstructured face, create a Delauney triangulation; create a tetra face for each
+            # triangle in the triangulation; create internal tetra faces for each of the internal edges in
+            # the triangulation; and create a tetra cell for each triangle in the triangulation
+            # note: the resqpy Delauney triangulation is for a 2D system, so here the unstructured face
+            # is projected onto a planar approximation defined by the face centre point and an average
+            # normal vector
+            for fi in u_cell_faces:
+                triangulated_face = u_grid.face_triangulation(fi)
+                for u_a, u_b, u_c in triangulated_face:
+                    t_a, t_b, t_c = u_cell_nodes.index(u_a), u_cell_nodes.index(u_b), u_cell_nodes.index(u_c)
+                    t_cell_faces = [len(t_face_list)]  # local face index for this triangle
+                    t_face_list.append((t_a, t_b, t_c))
+                    tri_edges = np.array([_min_max(t_a, t_b), _min_max(t_b, t_c), _min_max(t_c, t_a)], dtype = int)
+                    for e_a, e_b in tri_edges:
+                        try:
+                            pos = t_face_list.index((e_a, e_b, centre_node))
+                        except ValueError:
+                            pos = len(t_face_list)
+                            t_face_list.append((e_a, e_b, centre_node))
+                        t_cell_faces.append(pos)
+                    t_cell_list.append(tuple(t_cell_faces))
 
-         # everything is now ready to populate the tetra grid attributes (apart from handedness)
-         tetra.set_cell_count(len(t_cell_list))
-         tetra.face_count = len(t_face_list)
-         tetra.faces_per_cell_cl = np.arange(4, 4 * tetra.cell_count + 1, 4, dtype = int)
-         tetra.faces_per_cell = np.array(t_cell_list, dtype = int).flatten()
-         tetra.nodes_per_face_cl = np.arange(3, 3 * tetra.face_count + 1, 3, dtype = int)
-         tetra.nodes_per_face = np.array(t_face_list, dtype = int).flatten()
+            # everything is now ready to populate the tetra grid attributes (apart from handedness)
+            tetra.set_cell_count(len(t_cell_list))
+            tetra.face_count = len(t_face_list)
+            tetra.faces_per_cell_cl = np.arange(4, 4 * tetra.cell_count + 1, 4, dtype = int)
+            tetra.faces_per_cell = np.array(t_cell_list, dtype = int).flatten()
+            tetra.nodes_per_face_cl = np.arange(3, 3 * tetra.face_count + 1, 3, dtype = int)
+            tetra.nodes_per_face = np.array(t_face_list, dtype = int).flatten()
 
-         tetra.cell_face_is_right_handed = np.ones(len(tetra.faces_per_cell), dtype = bool)
-         if set_handedness:
-            # TODO: set handedness correctly and make default for set_handedness True
-            raise NotImplementedError('code not written to set handedness for tetra from unstructured cell')
+            tetra.cell_face_is_right_handed = np.ones(len(tetra.faces_per_cell), dtype = bool)
+            if set_handedness:
+                # TODO: set handedness correctly and make default for set_handedness True
+                raise NotImplementedError('code not written to set handedness for tetra from unstructured cell')
 
-      tetra.check_tetra()
+        tetra.check_tetra()
 
-      return tetra
+        return tetra
 
-   # todo: add tetra specific method for centre_point()
+    # todo: add tetra specific method for centre_point()
 
 
 class PyramidGrid(UnstructuredGrid):
-   """Class for unstructured grids where every cell is a quadrilateral pyramid."""
+    """Class for unstructured grids where every cell is a quadrilateral pyramid."""
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                find_properties = True,
-                cache_geometry = False,
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Creates a new resqpy PyramidGrid object (RESQML UnstructuredGrid with cell shape pyramidal)
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 find_properties = True,
+                 cache_geometry = False,
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Creates a new resqpy PyramidGrid object (RESQML UnstructuredGrid with cell shape pyramidal)
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -1327,41 +1335,41 @@ class PyramidGrid(UnstructuredGrid):
          a newly created PyramidGrid object
       """
 
-      super().__init__(parent_model = parent_model,
-                       uuid = uuid,
-                       find_properties = find_properties,
-                       geometry_required = True,
-                       cache_geometry = cache_geometry,
-                       cell_shape = 'pyramidal',
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata)
+        super().__init__(parent_model = parent_model,
+                         uuid = uuid,
+                         find_properties = find_properties,
+                         geometry_required = True,
+                         cache_geometry = cache_geometry,
+                         cell_shape = 'pyramidal',
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata)
 
-      if self.root is not None:
-         assert grr.grid_flavour(self.root) == 'PyramidGrid'
-         self.check_pyramidal()
+        if self.root is not None:
+            assert grr.grid_flavour(self.root) == 'PyramidGrid'
+            self.check_pyramidal()
 
-      self.grid_representation = 'PyramidGrid'  #: flavour of grid; not much used
+        self.grid_representation = 'PyramidGrid'  #: flavour of grid; not much used
 
-   def check_pyramidal(self):
-      """Checks that each cell has 5 faces and each face has 3 or 4 nodes.
+    def check_pyramidal(self):
+        """Checks that each cell has 5 faces and each face has 3 or 4 nodes.
 
       note:
          currently only performs a cursory check, without checking nodes are shared or that there is exactly one
          quadrilateral face
       """
 
-      assert self.cell_shape == 'pyramidal'
-      self.cache_all_geometry_arrays()
-      assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
-      assert self.faces_per_cell_cl[0] == 5 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 5)
-      nodes_per_face_count = np.empty(self.face_count)
-      nodes_per_face_count[0] = self.nodes_per_face_cl[0]
-      nodes_per_face_count[1:] = self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1]
-      assert np.all(np.logical_or(nodes_per_face_count == 3, nodes_per_face_count == 4))
+        assert self.cell_shape == 'pyramidal'
+        self.cache_all_geometry_arrays()
+        assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
+        assert self.faces_per_cell_cl[0] == 5 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 5)
+        nodes_per_face_count = np.empty(self.face_count)
+        nodes_per_face_count[0] = self.nodes_per_face_cl[0]
+        nodes_per_face_count[1:] = self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1]
+        assert np.all(np.logical_or(nodes_per_face_count == 3, nodes_per_face_count == 4))
 
-   def face_indices_for_cell(self, cell):
-      """Returns numpy list of face indices for a single cell.
+    def face_indices_for_cell(self, cell):
+        """Returns numpy list of face indices for a single cell.
 
       arguments:
          cell (int): the index of the cell for which face indices are required
@@ -1375,24 +1383,24 @@ class PyramidGrid(UnstructuredGrid):
          shared faces
       """
 
-      faces = super().face_indices_for_cell(cell)
-      assert len(faces) == 5
-      result = -np.ones(5, dtype = int)
-      i = 1
-      for f in range(5):
-         nc = self.node_count_for_face(faces[f])
-         if nc == 3:
-            assert i < 5, 'too many triangular faces for cell in pyramid grid'
-            result[i] = faces[f]
-            i += 1
-         else:
-            assert nc == 4, 'pyramid grid includes a face that is neither triangle nor quadrilateral'
-            assert result[0] == -1, 'more than one quadrilateral face for cell in pyramid grid'
-            result[0] = faces[f]
-      return result
+        faces = super().face_indices_for_cell(cell)
+        assert len(faces) == 5
+        result = -np.ones(5, dtype = int)
+        i = 1
+        for f in range(5):
+            nc = self.node_count_for_face(faces[f])
+            if nc == 3:
+                assert i < 5, 'too many triangular faces for cell in pyramid grid'
+                result[i] = faces[f]
+                i += 1
+            else:
+                assert nc == 4, 'pyramid grid includes a face that is neither triangle nor quadrilateral'
+                assert result[0] == -1, 'more than one quadrilateral face for cell in pyramid grid'
+                result[0] = faces[f]
+        return result
 
-   def face_indices_and_handedness_for_cell(self, cell):
-      """Returns numpy list of face indices for a single cell, and numpy boolean list of face right handedness.
+    def face_indices_and_handedness_for_cell(self, cell):
+        """Returns numpy list of face indices for a single cell, and numpy boolean list of face right handedness.
 
       arguments:
          cell (int): the index of the cell for which face indices are required
@@ -1409,27 +1417,27 @@ class PyramidGrid(UnstructuredGrid):
          some processing of geometry such as volume calculations
       """
 
-      faces, handednesses = super().face_indices_and_handedness_for_cell(cell)
-      assert len(faces) == 5 and len(handednesses) == 5
-      f_result = -np.ones(5, dtype = int)
-      h_result = np.empty(5, dtype = bool)
-      i = 1
-      for f in range(5):
-         nc = self.node_count_for_face(faces[f])
-         if nc == 3:
-            assert i < 5, 'too many triangular faces for cell in pyramid grid'
-            f_result[i] = faces[f]
-            h_result[i] = handednesses[f]
-            i += 1
-         else:
-            assert nc == 4, 'pyramid grid includes a face that is neither triangle nor quadrilateral'
-            assert f_result[0] == -1, 'more than one quadrilateral face for cell in pyramid grid'
-            f_result[0] = faces[f]
-            h_result[0] = handednesses[f]
-      return f_result, h_result
+        faces, handednesses = super().face_indices_and_handedness_for_cell(cell)
+        assert len(faces) == 5 and len(handednesses) == 5
+        f_result = -np.ones(5, dtype = int)
+        h_result = np.empty(5, dtype = bool)
+        i = 1
+        for f in range(5):
+            nc = self.node_count_for_face(faces[f])
+            if nc == 3:
+                assert i < 5, 'too many triangular faces for cell in pyramid grid'
+                f_result[i] = faces[f]
+                h_result[i] = handednesses[f]
+                i += 1
+            else:
+                assert nc == 4, 'pyramid grid includes a face that is neither triangle nor quadrilateral'
+                assert f_result[0] == -1, 'more than one quadrilateral face for cell in pyramid grid'
+                f_result[0] = faces[f]
+                h_result[0] = handednesses[f]
+        return f_result, h_result
 
-   def volume(self, cell):
-      """Returns the volume of a single cell.
+    def volume(self, cell):
+        """Returns the volume of a single cell.
 
       arguments:
          cell (int): the index of the cell for which the volume is required
@@ -1438,46 +1446,46 @@ class PyramidGrid(UnstructuredGrid):
          float being the volume of the pyramidal cell; units of measure is implied by crs units
       """
 
-      self._set_crs_handedness()
-      self.cache_all_geometry_arrays()
-      faces, hands = self.face_indices_and_handedness_for_cell(cell)
-      nodes = self.distinct_node_indices_for_cell(cell)
-      base_nodes = self.node_indices_for_face(faces[0])
-      for node in nodes:
-         if node not in base_nodes:
-            apex_node = node
-            break
-      else:
-         raise Exception('apex node not found for cell in pyramid grid')
-      apex = self.points_cached[apex_node]
-      abcd = self.points_cached[base_nodes]
+        self._set_crs_handedness()
+        self.cache_all_geometry_arrays()
+        faces, hands = self.face_indices_and_handedness_for_cell(cell)
+        nodes = self.distinct_node_indices_for_cell(cell)
+        base_nodes = self.node_indices_for_face(faces[0])
+        for node in nodes:
+            if node not in base_nodes:
+                apex_node = node
+                break
+        else:
+            raise Exception('apex node not found for cell in pyramid grid')
+        apex = self.points_cached[apex_node]
+        abcd = self.points_cached[base_nodes]
 
-      return vol.pyramid_volume(apex,
-                                abcd[0],
-                                abcd[1],
-                                abcd[2],
-                                abcd[3],
-                                crs_is_right_handed = (self.crs_is_right_handed == hands[0]))
+        return vol.pyramid_volume(apex,
+                                  abcd[0],
+                                  abcd[1],
+                                  abcd[2],
+                                  abcd[3],
+                                  crs_is_right_handed = (self.crs_is_right_handed == hands[0]))
 
-   # todo: add pyramidal specific method for centre_point()
+    # todo: add pyramidal specific method for centre_point()
 
 
 class PrismGrid(UnstructuredGrid):
-   """Class for unstructured grids where every cell is a triangular prism.
+    """Class for unstructured grids where every cell is a triangular prism.
 
    note:
       prism cells are not constrained to have a fixed cross-section, though in practice they often will
    """
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                find_properties = True,
-                cache_geometry = False,
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Creates a new resqpy PrismGrid object (RESQML UnstructuredGrid with cell shape trisngular prism)
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 find_properties = True,
+                 cache_geometry = False,
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Creates a new resqpy PrismGrid object (RESQML UnstructuredGrid with cell shape trisngular prism)
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -1497,44 +1505,44 @@ class PrismGrid(UnstructuredGrid):
          a newly created PrismGrid object
       """
 
-      super().__init__(parent_model = parent_model,
-                       uuid = uuid,
-                       find_properties = find_properties,
-                       geometry_required = True,
-                       cache_geometry = cache_geometry,
-                       cell_shape = 'prism',
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata)
+        super().__init__(parent_model = parent_model,
+                         uuid = uuid,
+                         find_properties = find_properties,
+                         geometry_required = True,
+                         cache_geometry = cache_geometry,
+                         cell_shape = 'prism',
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata)
 
-      if self.root is not None:
-         assert grr.grid_flavour(self.root) in ['PrismGrid', 'VerticalPrismGrid']
-         self.check_prism()
+        if self.root is not None:
+            assert grr.grid_flavour(self.root) in ['PrismGrid', 'VerticalPrismGrid']
+            self.check_prism()
 
-      self.grid_representation = 'PrismGrid'  #: flavour of grid; not much used
+        self.grid_representation = 'PrismGrid'  #: flavour of grid; not much used
 
-   def check_prism(self):
-      """Checks that each cell has 5 faces and each face has 3 or 4 nodes.
+    def check_prism(self):
+        """Checks that each cell has 5 faces and each face has 3 or 4 nodes.
 
       note:
          currently only performs a cursory check, without checking nodes are shared or that there are exactly two
          triangular faces without shared nodes
       """
 
-      assert self.cell_shape == 'prism'
-      self.cache_all_geometry_arrays()
-      assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
-      assert self.faces_per_cell_cl[0] == 5 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 5)
-      nodes_per_face_count = np.empty(self.face_count)
-      nodes_per_face_count[0] = self.nodes_per_face_cl[0]
-      nodes_per_face_count[1:] = self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1]
-      assert np.all(np.logical_or(nodes_per_face_count == 3, nodes_per_face_count == 4))
+        assert self.cell_shape == 'prism'
+        self.cache_all_geometry_arrays()
+        assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
+        assert self.faces_per_cell_cl[0] == 5 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 5)
+        nodes_per_face_count = np.empty(self.face_count)
+        nodes_per_face_count[0] = self.nodes_per_face_cl[0]
+        nodes_per_face_count[1:] = self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1]
+        assert np.all(np.logical_or(nodes_per_face_count == 3, nodes_per_face_count == 4))
 
-   # todo: add prism specific methods for centre_point(), volume()
+    # todo: add prism specific methods for centre_point(), volume()
 
 
 class VerticalPrismGrid(PrismGrid):
-   """Class for unstructured grids where every cell is a vertical triangular prism.
+    """Class for unstructured grids where every cell is a vertical triangular prism.
 
    notes:
       vertical prism cells are constrained to have a fixed triangular horzontal cross-section, though top and base
@@ -1545,15 +1553,15 @@ class VerticalPrismGrid(PrismGrid):
       within a column
    """
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                find_properties = True,
-                cache_geometry = False,
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Creates a new resqpy VerticalPrismGrid object.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 find_properties = True,
+                 cache_geometry = False,
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Creates a new resqpy VerticalPrismGrid object.
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -1573,35 +1581,35 @@ class VerticalPrismGrid(PrismGrid):
          a newly created VerticalPrismGrid object
       """
 
-      self.nk = None  #: number of layers when constructed as a layered grid
+        self.nk = None  #: number of layers when constructed as a layered grid
 
-      super().__init__(parent_model = parent_model,
-                       uuid = uuid,
-                       find_properties = find_properties,
-                       cache_geometry = cache_geometry,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata)
+        super().__init__(parent_model = parent_model,
+                         uuid = uuid,
+                         find_properties = find_properties,
+                         cache_geometry = cache_geometry,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata)
 
-      if self.root is not None:
-         assert grr.grid_flavour(self.root) in ['VerticalPrismGrid', 'PrismGrid']
-         self.check_prism()
-         if 'layer count' in self.extra_metadata:
-            self.nk = int(self.extra_metadata['layer count'])
+        if self.root is not None:
+            assert grr.grid_flavour(self.root) in ['VerticalPrismGrid', 'PrismGrid']
+            self.check_prism()
+            if 'layer count' in self.extra_metadata:
+                self.nk = int(self.extra_metadata['layer count'])
 
-      self.grid_representation = 'VerticalPrismGrid'  #: flavour of grid; not much used
+        self.grid_representation = 'VerticalPrismGrid'  #: flavour of grid; not much used
 
-   @classmethod
-   def from_surfaces(cls,
-                     parent_model,
-                     surfaces,
-                     column_points = None,
-                     column_triangles = None,
-                     title = None,
-                     originator = None,
-                     extra_metadata = {},
-                     set_handedness = False):
-      """Create a layered vertical prism grid from an ordered list of untorn surfaces.
+    @classmethod
+    def from_surfaces(cls,
+                      parent_model,
+                      surfaces,
+                      column_points = None,
+                      column_triangles = None,
+                      title = None,
+                      originator = None,
+                      extra_metadata = {},
+                      set_handedness = False):
+        """Create a layered vertical prism grid from an ordered list of untorn surfaces.
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -1634,170 +1642,171 @@ class VerticalPrismGrid(PrismGrid):
          convert from a resqpy VerticalPrismGrid
       """
 
-      def find_pair(a, pair):
-         # for sorted array a of shape (N, 2) returns index in first axis of a pair
+        def find_pair(a, pair):
+            # for sorted array a of shape (N, 2) returns index in first axis of a pair
 
-         def frp(a, pair, b, c):
-            m = b + ((c - b) // 2)
-            assert m < len(a), 'pair not found in sorted array'
-            if np.all(a[m] == pair):
-               return m
-            assert c > b, 'pair not found in sorted array'
-            if a[m, 0] < pair[0]:
-               return frp(a, pair, m + 1, c)
-            elif a[m, 0] > pair[0]:
-               return frp(a, pair, b, m)
-            elif a[m, 1] < pair[1]:
-               return frp(a, pair, m + 1, c)
+            def frp(a, pair, b, c):
+                m = b + ((c - b) // 2)
+                assert m < len(a), 'pair not found in sorted array'
+                if np.all(a[m] == pair):
+                    return m
+                assert c > b, 'pair not found in sorted array'
+                if a[m, 0] < pair[0]:
+                    return frp(a, pair, m + 1, c)
+                elif a[m, 0] > pair[0]:
+                    return frp(a, pair, b, m)
+                elif a[m, 1] < pair[1]:
+                    return frp(a, pair, m + 1, c)
+                else:
+                    return frp(a, pair, b, m)
+
+            return frp(a, pair, 0, len(a))
+
+        assert (column_points is None) == (column_triangles is None)
+        assert len(surfaces) > 1
+        for s in surfaces:
+            assert isinstance(s, rqs.Surface)
+
+        vpg = cls(parent_model, title = title, originator = originator, extra_metadata = extra_metadata)
+        assert vpg is not None
+
+        top = surfaces[0]
+
+        # set and check consistency of crs
+        vpg.crs_uuid = top.crs_uuid
+        for s in surfaces[1:]:
+            if not bu.matching_uuids(vpg.crs_uuid, s.crs_uuid):
+                # check for equivalence
+                assert rqc.Crs(parent_model,
+                               uuid = vpg.crs_uuid) == rqc.Crs(parent_model,
+                                                               uuid = s.crs_uuid), 'mismatching surface crs'
+
+        # fetch the data for the top surface, to be used as the master for the triangular pattern
+        if column_triangles is None:
+            top_triangles, top_points = top.triangles_and_points()
+            column_edges = top.distinct_edges()  # ordered pairs of node indices
+        else:
+            top_triangles = column_triangles
+            if column_points.shape[1] == 3:
+                top_points = column_points
             else:
-               return frp(a, pair, b, m)
+                top_points = np.zeros((len(column_points), 3))
+                top_points[:, :column_points.shape[1]] = column_points
+            column_surf = rqs.Surface(parent_model, crs_uuid = vpg.crs_uuid)
+            column_surf.set_from_triangles_and_points(column_triangles, column_points)
+            column_edges = column_surf.distinct_edges()
+        assert top_triangles.ndim == 2 and top_triangles.shape[1] == 3
+        assert top_points.ndim == 2 and top_points.shape[1] in [2, 3]
+        assert len(top_triangles) > 0
+        p_count = len(top_points)
+        bad_points = np.zeros(p_count, dtype = bool)
 
-         return frp(a, pair, 0, len(a))
+        # setup size of arrays for the vertical prism grid
+        column_count = top_triangles.shape[0]
+        surface_count = len(surfaces)
+        layer_count = surface_count - 1
+        column_edge_count = len(column_edges)
+        vpg.cell_count = column_count * layer_count
+        vpg.node_count = p_count * surface_count
+        vpg.face_count = column_count * surface_count + column_edge_count * layer_count
+        vpg.nk = layer_count
+        if vpg.extra_metadata is None:
+            vpg.extra_metadata = {}
+        vpg.extra_metadata['layer count'] = vpg.nk
 
-      assert (column_points is None) == (column_triangles is None)
-      assert len(surfaces) > 1
-      for s in surfaces:
-         assert isinstance(s, rqs.Surface)
+        # setup points with copies of points for top surface, z values to be updated later
+        points = np.zeros((surface_count, p_count, 3))
+        points[:, :, :] = top_points
 
-      vpg = cls(parent_model, title = title, originator = originator, extra_metadata = extra_metadata)
-      assert vpg is not None
+        # arrange faces with all triangles first, followed by the vertical quadrilaterals
+        vpg.nodes_per_face_cl = np.zeros(vpg.face_count, dtype = int)
+        vpg.nodes_per_face_cl[:column_count * surface_count] =  \
+           np.arange(3, 3 * column_count * surface_count + 1, 3, dtype = int)
+        quad_start = vpg.nodes_per_face_cl[column_count * surface_count - 1] + 4
+        vpg.nodes_per_face_cl[column_count * surface_count:] =  \
+           np.arange(quad_start, quad_start + 4 * column_edge_count * layer_count, 4)
+        assert vpg.nodes_per_face_cl[-1] == 3 * column_count * surface_count + 4 * column_edge_count * layer_count
+        # populate nodes per face for triangular faces
+        vpg.nodes_per_face = np.zeros(vpg.nodes_per_face_cl[-1], dtype = int)
+        for surface_index in range(surface_count):
+            vpg.nodes_per_face[surface_index * 3 * column_count : (surface_index + 1) * 3 * column_count] =  \
+               top_triangles.flatten() + surface_index * p_count
+        # populate nodes per face for quadrilateral faces
+        quad_nodes = np.empty((layer_count, column_edge_count, 2, 2), dtype = int)
+        for layer in range(layer_count):
+            quad_nodes[layer, :, 0, :] = column_edges + layer * p_count
+            # reverse order of base pairs to maintain cyclic ordering of nodes per face
+            quad_nodes[layer, :, 1, 0] = column_edges[:, 1] + (layer + 1) * p_count
+            quad_nodes[layer, :, 1, 1] = column_edges[:, 0] + (layer + 1) * p_count
+        vpg.nodes_per_face[3 * surface_count * column_count:] = quad_nodes.flatten()
+        assert vpg.nodes_per_face[-1] > 0
 
-      top = surfaces[0]
+        # set up faces per cell
+        vpg.faces_per_cell = np.zeros(5 * vpg.cell_count, dtype = int)
+        vpg.faces_per_cell_cl = np.arange(5, 5 * vpg.cell_count + 1, 5, dtype = int)
+        assert len(vpg.faces_per_cell_cl) == vpg.cell_count
+        # set cell top triangle indices
+        for layer in range(layer_count):
+            # top triangular faces of cells
+            vpg.faces_per_cell[5 * layer * column_count : (layer + 1) * 5 * column_count : 5] =  \
+               layer * column_count + np.arange(column_count)
+            # base triangular faces of cells
+            vpg.faces_per_cell[layer * 5 * column_count + 1: (layer + 1) * 5 * column_count : 5] =  \
+               (layer + 1) * column_count + np.arange(column_count)
+        # todo: some clever numpy indexing to irradicate the following for loop
+        for col in range(column_count):
+            t_nodes = top_triangles[col]
+            for t_edge in range(3):
+                a, b = t_nodes[t_edge - 1], t_nodes[t_edge]
+                if b < a:
+                    a, b = b, a
+                edge = find_pair(column_edges, (a, b))  # returns index into first axis of column edges
+                # set quadrilateral faces of cells in column, for this edge
+                vpg.faces_per_cell[5 * col + t_edge + 2 : 5 * vpg.cell_count : 5 * column_count] =  \
+                   np.arange(column_count * surface_count + edge, vpg.face_count, column_edge_count)
+        # check full population of faces_per_cell (face zero is a top triangle, only used once)
+        assert np.count_nonzero(vpg.faces_per_cell) == vpg.faces_per_cell.size - 1
 
-      # set and check consistency of crs
-      vpg.crs_uuid = top.crs_uuid
-      for s in surfaces[1:]:
-         if not bu.matching_uuids(vpg.crs_uuid, s.crs_uuid):
-            # check for equivalence
-            assert rqc.Crs(parent_model, uuid = vpg.crs_uuid) == rqc.Crs(parent_model,
-                                                                         uuid = s.crs_uuid), 'mismatching surface crs'
+        vpg.cell_face_is_right_handed = np.ones(len(vpg.faces_per_cell), dtype = bool)
+        if set_handedness:
+            # TODO: set handedness correctly and make default for set_handedness True
+            raise NotImplementedError('code not written to set handedness for vertical prism grid from surfaces')
 
-      # fetch the data for the top surface, to be used as the master for the triangular pattern
-      if column_triangles is None:
-         top_triangles, top_points = top.triangles_and_points()
-         column_edges = top.distinct_edges()  # ordered pairs of node indices
-      else:
-         top_triangles = column_triangles
-         if column_points.shape[1] == 3:
-            top_points = column_points
-         else:
-            top_points = np.zeros((len(column_points), 3))
-            top_points[:, :column_points.shape[1]] = column_points
-         column_surf = rqs.Surface(parent_model, crs_uuid = vpg.crs_uuid)
-         column_surf.set_from_triangles_and_points(column_triangles, column_points)
-         column_edges = column_surf.distinct_edges()
-      assert top_triangles.ndim == 2 and top_triangles.shape[1] == 3
-      assert top_points.ndim == 2 and top_points.shape[1] in [2, 3]
-      assert len(top_triangles) > 0
-      p_count = len(top_points)
-      bad_points = np.zeros(p_count, dtype = bool)
+        # instersect gravity vectors from column points with other surfaces, and update z values in points
+        gravity = np.zeros((p_count, 3))
+        gravity[:, 2] = 1.0  # up/down does not matter for the intersection function used below
+        start = 1 if top_triangles is None else 0
+        for surf in range(start, surface_count):
+            surf_triangles, surf_points = surfaces[surf].triangles_and_points()
+            intersects = meet.line_set_triangles_intersects(top_points, gravity, surf_points[surf_triangles])
+            single_intersects = meet.last_intersects(intersects)  # will be triple NaN where no intersection occurs
+            # inherit point from surface above where no intersection has occurred
+            nan_lines = np.isnan(single_intersects[:, 0])
+            if surf == 0:
+                # allow NaN entries to handle unused distant circumcentres in Voronoi graph data
+                # assert not np.any(nan_lines), 'top surface does not cover all column points'
+                single_intersects[nan_lines] = np.NaN
+            else:
+                single_intersects[nan_lines] = points[surf - 1][nan_lines]
+            # populate z values for layer of points
+            points[surf, :, 2] = single_intersects[:, 2]
 
-      # setup size of arrays for the vertical prism grid
-      column_count = top_triangles.shape[0]
-      surface_count = len(surfaces)
-      layer_count = surface_count - 1
-      column_edge_count = len(column_edges)
-      vpg.cell_count = column_count * layer_count
-      vpg.node_count = p_count * surface_count
-      vpg.face_count = column_count * surface_count + column_edge_count * layer_count
-      vpg.nk = layer_count
-      if vpg.extra_metadata is None:
-         vpg.extra_metadata = {}
-      vpg.extra_metadata['layer count'] = vpg.nk
+        vpg.points_cached = points.reshape((-1, 3))
+        assert np.all(vpg.nodes_per_face < len(vpg.points_cached))
 
-      # setup points with copies of points for top surface, z values to be updated later
-      points = np.zeros((surface_count, p_count, 3))
-      points[:, :, :] = top_points
+        return vpg
 
-      # arrange faces with all triangles first, followed by the vertical quadrilaterals
-      vpg.nodes_per_face_cl = np.zeros(vpg.face_count, dtype = int)
-      vpg.nodes_per_face_cl[:column_count * surface_count] =  \
-         np.arange(3, 3 * column_count * surface_count + 1, 3, dtype = int)
-      quad_start = vpg.nodes_per_face_cl[column_count * surface_count - 1] + 4
-      vpg.nodes_per_face_cl[column_count * surface_count:] =  \
-         np.arange(quad_start, quad_start + 4 * column_edge_count * layer_count, 4)
-      assert vpg.nodes_per_face_cl[-1] == 3 * column_count * surface_count + 4 * column_edge_count * layer_count
-      # populate nodes per face for triangular faces
-      vpg.nodes_per_face = np.zeros(vpg.nodes_per_face_cl[-1], dtype = int)
-      for surface_index in range(surface_count):
-         vpg.nodes_per_face[surface_index * 3 * column_count : (surface_index + 1) * 3 * column_count] =  \
-            top_triangles.flatten() + surface_index * p_count
-      # populate nodes per face for quadrilateral faces
-      quad_nodes = np.empty((layer_count, column_edge_count, 2, 2), dtype = int)
-      for layer in range(layer_count):
-         quad_nodes[layer, :, 0, :] = column_edges + layer * p_count
-         # reverse order of base pairs to maintain cyclic ordering of nodes per face
-         quad_nodes[layer, :, 1, 0] = column_edges[:, 1] + (layer + 1) * p_count
-         quad_nodes[layer, :, 1, 1] = column_edges[:, 0] + (layer + 1) * p_count
-      vpg.nodes_per_face[3 * surface_count * column_count:] = quad_nodes.flatten()
-      assert vpg.nodes_per_face[-1] > 0
-
-      # set up faces per cell
-      vpg.faces_per_cell = np.zeros(5 * vpg.cell_count, dtype = int)
-      vpg.faces_per_cell_cl = np.arange(5, 5 * vpg.cell_count + 1, 5, dtype = int)
-      assert len(vpg.faces_per_cell_cl) == vpg.cell_count
-      # set cell top triangle indices
-      for layer in range(layer_count):
-         # top triangular faces of cells
-         vpg.faces_per_cell[5 * layer * column_count : (layer + 1) * 5 * column_count : 5] =  \
-            layer * column_count + np.arange(column_count)
-         # base triangular faces of cells
-         vpg.faces_per_cell[layer * 5 * column_count + 1: (layer + 1) * 5 * column_count : 5] =  \
-            (layer + 1) * column_count + np.arange(column_count)
-      # todo: some clever numpy indexing to irradicate the following for loop
-      for col in range(column_count):
-         t_nodes = top_triangles[col]
-         for t_edge in range(3):
-            a, b = t_nodes[t_edge - 1], t_nodes[t_edge]
-            if b < a:
-               a, b = b, a
-            edge = find_pair(column_edges, (a, b))  # returns index into first axis of column edges
-            # set quadrilateral faces of cells in column, for this edge
-            vpg.faces_per_cell[5 * col + t_edge + 2 : 5 * vpg.cell_count : 5 * column_count] =  \
-               np.arange(column_count * surface_count + edge, vpg.face_count, column_edge_count)
-      # check full population of faces_per_cell (face zero is a top triangle, only used once)
-      assert np.count_nonzero(vpg.faces_per_cell) == vpg.faces_per_cell.size - 1
-
-      vpg.cell_face_is_right_handed = np.ones(len(vpg.faces_per_cell), dtype = bool)
-      if set_handedness:
-         # TODO: set handedness correctly and make default for set_handedness True
-         raise NotImplementedError('code not written to set handedness for vertical prism grid from surfaces')
-
-      # instersect gravity vectors from column points with other surfaces, and update z values in points
-      gravity = np.zeros((p_count, 3))
-      gravity[:, 2] = 1.0  # up/down does not matter for the intersection function used below
-      start = 1 if top_triangles is None else 0
-      for surf in range(start, surface_count):
-         surf_triangles, surf_points = surfaces[surf].triangles_and_points()
-         intersects = meet.line_set_triangles_intersects(top_points, gravity, surf_points[surf_triangles])
-         single_intersects = meet.last_intersects(intersects)  # will be triple NaN where no intersection occurs
-         # inherit point from surface above where no intersection has occurred
-         nan_lines = np.isnan(single_intersects[:, 0])
-         if surf == 0:
-            # allow NaN entries to handle unused distant circumcentres in Voronoi graph data
-            # assert not np.any(nan_lines), 'top surface does not cover all column points'
-            single_intersects[nan_lines] = np.NaN
-         else:
-            single_intersects[nan_lines] = points[surf - 1][nan_lines]
-         # populate z values for layer of points
-         points[surf, :, 2] = single_intersects[:, 2]
-
-      vpg.points_cached = points.reshape((-1, 3))
-      assert np.all(vpg.nodes_per_face < len(vpg.points_cached))
-
-      return vpg
-
-   @classmethod
-   def from_seed_points_and_surfaces(cls,
-                                     parent_model,
-                                     seed_xy,
-                                     surfaces,
-                                     area_of_interest,
-                                     title = None,
-                                     originator = None,
-                                     extra_metadata = {},
-                                     set_handedness = False):
-      """Create a layered vertical prism grid from seed points and an ordered list of untorn surfaces.
+    @classmethod
+    def from_seed_points_and_surfaces(cls,
+                                      parent_model,
+                                      seed_xy,
+                                      surfaces,
+                                      area_of_interest,
+                                      title = None,
+                                      originator = None,
+                                      extra_metadata = {},
+                                      set_handedness = False):
+        """Create a layered vertical prism grid from seed points and an ordered list of untorn surfaces.
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -1825,41 +1834,41 @@ class VerticalPrismGrid(PrismGrid):
          Grid2dRepresentation), or for a horizontal plane
       """
 
-      assert seed_xy.ndim == 2 and seed_xy.shape[1] in [2, 3]
-      assert area_of_interest.isclosed and area_of_interest.is_convex()
+        assert seed_xy.ndim == 2 and seed_xy.shape[1] in [2, 3]
+        assert area_of_interest.isclosed and area_of_interest.is_convex()
 
-      # compute Delauney triangulation
-      delauney_t, hull_indices = tri.dt(seed_xy, return_hull = True)
+        # compute Delauney triangulation
+        delauney_t, hull_indices = tri.dt(seed_xy, return_hull = True)
 
-      # construct Voronoi graph
-      voronoi_points, voronoi_indices = tri.voronoi(seed_xy, delauney_t, hull_indices, area_of_interest)
+        # construct Voronoi graph
+        voronoi_points, voronoi_indices = tri.voronoi(seed_xy, delauney_t, hull_indices, area_of_interest)
 
-      # re-triangulate Voronoi cells
-      points, triangles = tri.triangulated_polygons(voronoi_points, voronoi_indices, centres = seed_xy[:, :2])
+        # re-triangulate Voronoi cells
+        points, triangles = tri.triangulated_polygons(voronoi_points, voronoi_indices, centres = seed_xy[:, :2])
 
-      vpg = cls.from_surfaces(parent_model,
-                              surfaces,
-                              column_points = points,
-                              column_triangles = triangles,
-                              title = title,
-                              originator = originator,
-                              extra_metadata = extra_metadata,
-                              set_handedness = set_handedness)
+        vpg = cls.from_surfaces(parent_model,
+                                surfaces,
+                                column_points = points,
+                                column_triangles = triangles,
+                                title = title,
+                                originator = originator,
+                                extra_metadata = extra_metadata,
+                                set_handedness = set_handedness)
 
-      # TODO: store information relating columns to seed points, and seed points to top layer points?
+        # TODO: store information relating columns to seed points, and seed points to top layer points?
 
-      return vpg
+        return vpg
 
-   def column_count(self):
-      """Returns the number of columns in the grid."""
+    def column_count(self):
+        """Returns the number of columns in the grid."""
 
-      assert self.nk > 1, 'no layer information set for vertical prism grid'
-      n_col, remainder = divmod(self.cell_count, self.nk)
-      assert remainder == 0, 'code failure for vertical prism grid: cell and layer counts not compatible'
-      return n_col
+        assert self.nk > 1, 'no layer information set for vertical prism grid'
+        n_col, remainder = divmod(self.cell_count, self.nk)
+        assert remainder == 0, 'code failure for vertical prism grid: cell and layer counts not compatible'
+        return n_col
 
-   def cell_centre_point(self, cell = None):
-      """Returns centre point of a single cell (or all cells) calculated as the mean position of its 6 nodes.
+    def cell_centre_point(self, cell = None):
+        """Returns centre point of a single cell (or all cells) calculated as the mean position of its 6 nodes.
 
       arguments:
          cell (int): the index of the cell for which the centre point is required
@@ -1868,11 +1877,11 @@ class VerticalPrismGrid(PrismGrid):
          numpy float array of shape (3,) being the xyz location of the centre point of the cell
       """
 
-      cp = self.corner_points(cell = cell)
-      return np.mean(cp.reshape((-1, 6, 3)), axis = (1))
+        cp = self.corner_points(cell = cell)
+        return np.mean(cp.reshape((-1, 6, 3)), axis = (1))
 
-   def corner_points(self, cell = None):
-      """Returns corner points for all cells or for a single cell.
+    def corner_points(self, cell = None):
+        """Returns corner points for all cells or for a single cell.
 
       arguments:
          cell (int, optional): cell index of single cell for which corner points are required;
@@ -1883,63 +1892,63 @@ class VerticalPrismGrid(PrismGrid):
          numpy float array of shape (N, 2, 3, 3) being xyz points for top & base points for all cells
       """
 
-      if hasattr(self, 'array_corner_points'):
-         if cell is None:
-            return self.array_corner_points
-         return self.array_corner_points[cell]
+        if hasattr(self, 'array_corner_points'):
+            if cell is None:
+                return self.array_corner_points
+            return self.array_corner_points[cell]
 
-      p = self.points_ref()
-      if cell is None:
-         cp = np.empty((self.cell_count, 2, 3, 3), dtype = float)
-         top_fi = self.faces_per_cell.reshape((-1, 5))[:, 0]
-         top_npfi_start = np.where(top_fi == 0, 0, self.nodes_per_face_cl[top_fi - 1])
-         top_npfi_end = self.nodes_per_face_cl[top_fi]
-         base_fi = self.faces_per_cell.reshape((-1, 5))[:, 1]
-         base_npfi_start = self.nodes_per_face_cl[base_fi - 1]
-         base_npfi_end = self.nodes_per_face_cl[base_fi]
-         for cell in range(self.cell_count):
-            cp[cell, 0] = p[self.nodes_per_face[top_npfi_start[cell]:top_npfi_end[cell]]]
-            cp[cell, 1] = p[self.nodes_per_face[base_npfi_start[cell]:base_npfi_end[cell]]]
-         self.array_corner_points = cp
-         return cp
+        p = self.points_ref()
+        if cell is None:
+            cp = np.empty((self.cell_count, 2, 3, 3), dtype = float)
+            top_fi = self.faces_per_cell.reshape((-1, 5))[:, 0]
+            top_npfi_start = np.where(top_fi == 0, 0, self.nodes_per_face_cl[top_fi - 1])
+            top_npfi_end = self.nodes_per_face_cl[top_fi]
+            base_fi = self.faces_per_cell.reshape((-1, 5))[:, 1]
+            base_npfi_start = self.nodes_per_face_cl[base_fi - 1]
+            base_npfi_end = self.nodes_per_face_cl[base_fi]
+            for cell in range(self.cell_count):
+                cp[cell, 0] = p[self.nodes_per_face[top_npfi_start[cell]:top_npfi_end[cell]]]
+                cp[cell, 1] = p[self.nodes_per_face[base_npfi_start[cell]:base_npfi_end[cell]]]
+            self.array_corner_points = cp
+            return cp
 
-      top_fi, base_fi = self.faces_per_cell.reshape((-1, 5))[cell, :2]
-      top_npfi_start = 0 if top_fi == 0 else self.nodes_per_face_cl[top_fi - 1]
-      base_npfi_start = self.nodes_per_face_cl[base_fi - 1]
-      cp = np.empty((2, 3, 3), dtype = float)
-      cp[0] = p[self.nodes_per_face[top_npfi_start:self.nodes_per_face_cl[top_fi]]]
-      cp[1] = p[self.nodes_per_face[base_npfi_start:self.nodes_per_face_cl[base_fi]]]
-      return cp
+        top_fi, base_fi = self.faces_per_cell.reshape((-1, 5))[cell, :2]
+        top_npfi_start = 0 if top_fi == 0 else self.nodes_per_face_cl[top_fi - 1]
+        base_npfi_start = self.nodes_per_face_cl[base_fi - 1]
+        cp = np.empty((2, 3, 3), dtype = float)
+        cp[0] = p[self.nodes_per_face[top_npfi_start:self.nodes_per_face_cl[top_fi]]]
+        cp[1] = p[self.nodes_per_face[base_npfi_start:self.nodes_per_face_cl[base_fi]]]
+        return cp
 
-   def thickness(self, cell = None):
-      """Returns array of thicknesses of all cells or a single cell.
+    def thickness(self, cell = None):
+        """Returns array of thicknesses of all cells or a single cell.
 
       note:
          units are z units of crs used by this grid
       """
 
-      if hasattr(self, 'array_thickness'):
-         if cell is None:
-            return self.array_thickness
-         return self.array_thickness[cell]
+        if hasattr(self, 'array_thickness'):
+            if cell is None:
+                return self.array_thickness
+            return self.array_thickness[cell]
 
-      cp = self.corner_points(cell = cell)
+        cp = self.corner_points(cell = cell)
 
-      if cell is None:
-         thick = np.mean(cp[:, 1, :, 2] - cp[:, 0, :, 2], axis = -1)
-         self.array_thickness = thick
-      else:
-         thick = np.mean(cp[1, :, 2] - cp[0, :, 2])
+        if cell is None:
+            thick = np.mean(cp[:, 1, :, 2] - cp[:, 0, :, 2], axis = -1)
+            self.array_thickness = thick
+        else:
+            thick = np.mean(cp[1, :, 2] - cp[0, :, 2])
 
-      return thick
+        return thick
 
-   def top_faces(self):
-      """Returns the global face indices for the top triangular faces of the top layer of cells."""
+    def top_faces(self):
+        """Returns the global face indices for the top triangular faces of the top layer of cells."""
 
-      return self.faces_per_cell[:self.column_count() * 5].reshape(-1, 5)[:, 0]
+        return self.faces_per_cell[:self.column_count() * 5].reshape(-1, 5)[:, 0]
 
-   def triangulation(self):
-      """Returns triangulation used by this vertical prism grid.
+    def triangulation(self):
+        """Returns triangulation used by this vertical prism grid.
 
       returns:
          numpy int array of shape (M, 3) being the indices into the grid points of the triangles forming
@@ -1951,15 +1960,15 @@ class VerticalPrismGrid(PrismGrid):
          within cell related data
       """
 
-      n_col = self.column_count()
-      top_face_indices = self.top_faces()
-      top_nodes = np.empty((n_col, 3), dtype = int)
-      for column in range(n_col):  # also used as cell number
-         top_nodes[column] = self.node_indices_for_face(top_face_indices[column])
-      return top_nodes
+        n_col = self.column_count()
+        top_face_indices = self.top_faces()
+        top_nodes = np.empty((n_col, 3), dtype = int)
+        for column in range(n_col):  # also used as cell number
+            top_nodes[column] = self.node_indices_for_face(top_face_indices[column])
+        return top_nodes
 
-   def triple_horizontal_permeability(self, primary_k, orthogonal_k, primary_azimuth = 0.0):
-      """Returns array of triple horizontal permeabilities derived from a pair of permeability properties
+    def triple_horizontal_permeability(self, primary_k, orthogonal_k, primary_azimuth = 0.0):
+        """Returns array of triple horizontal permeabilities derived from a pair of permeability properties
 
       arguments:
          primary_k (numpy float array of shape (N,) being the primary horizontal permeability for each cell
@@ -1980,47 +1989,47 @@ class VerticalPrismGrid(PrismGrid):
          opposing vertical face; no net to gross ratio modification is applied here;
       """
 
-      assert primary_k.size == self.cell_count and orthogonal_k.size == self.cell_count
-      azimuth_is_constant = isinstance(primary_azimuth, float) or isinstance(primary_azimuth, int)
-      if not azimuth_is_constant:
-         assert primary_azimuth.size == self.cell_count
+        assert primary_k.size == self.cell_count and orthogonal_k.size == self.cell_count
+        azimuth_is_constant = isinstance(primary_azimuth, float) or isinstance(primary_azimuth, int)
+        if not azimuth_is_constant:
+            assert primary_azimuth.size == self.cell_count
 
-      p = self.points_ref()
-      t = self.triangulation()
-      # mid point of triangle edges
-      m = np.empty((t.shape[0], 3, 3), dtype = float)
-      for e in range(3):
-         m[:, e, :] = 0.5 * (p[t[:, e]] + p[t[:, e - 1]])
-      # cell centre points
-      c = self.centre_point()
-      # todo: decide which directions to use: cell centre to face centre; or face normal?
-      # vectors with direction cell centre to face centre (for one layer only)
-      v = m - c.reshape((self.nk, -1, 1, 3))[0]
-      # compass directions of those vectors
-      a = vec.azimuths(v)
-      # vector directions relative to primary permeability direction (per cell)
-      if azimuth_is_constant:
-         # work with one layer only
-         ap_rad = np.radians(a - primary_azimuth)
-      else:
-         # value per face per cell in whole grid
-         ap_rad = np.radians(
-            np.repeat(a.reshape((1, -1, 3)), self.nk, axis = 0).reshape((-1, 3)) - primary_azimuth.reshape((-1, 1)))
-      cos_ap = np.cos(ap_rad)
-      sin_ap = np.sin(ap_rad)
-      cos_sqr_ap = cos_ap * cos_ap
-      sin_sqr_ap = sin_ap * sin_ap
-      if azimuth_is_constant:
-         cos_sqr_ap = np.repeat(cos_sqr_ap.reshape(1, -1, 3), self.nk, axis = 0).reshape((-1, 3))
-         sin_sqr_ap = np.repeat(sin_sqr_ap.reshape(1, -1, 3), self.nk, axis = 0).reshape((-1, 3))
-      # local elliptical permeability projected in directions of azimuths
-      k = np.sqrt((primary_k * primary_k).reshape((-1, 1)) * cos_sqr_ap +
-                  (orthogonal_k * orthogonal_k).reshape((-1, 1)) * sin_sqr_ap)
+        p = self.points_ref()
+        t = self.triangulation()
+        # mid point of triangle edges
+        m = np.empty((t.shape[0], 3, 3), dtype = float)
+        for e in range(3):
+            m[:, e, :] = 0.5 * (p[t[:, e]] + p[t[:, e - 1]])
+        # cell centre points
+        c = self.centre_point()
+        # todo: decide which directions to use: cell centre to face centre; or face normal?
+        # vectors with direction cell centre to face centre (for one layer only)
+        v = m - c.reshape((self.nk, -1, 1, 3))[0]
+        # compass directions of those vectors
+        a = vec.azimuths(v)
+        # vector directions relative to primary permeability direction (per cell)
+        if azimuth_is_constant:
+            # work with one layer only
+            ap_rad = np.radians(a - primary_azimuth)
+        else:
+            # value per face per cell in whole grid
+            ap_rad = np.radians(
+                np.repeat(a.reshape((1, -1, 3)), self.nk, axis = 0).reshape((-1, 3)) - primary_azimuth.reshape((-1, 1)))
+        cos_ap = np.cos(ap_rad)
+        sin_ap = np.sin(ap_rad)
+        cos_sqr_ap = cos_ap * cos_ap
+        sin_sqr_ap = sin_ap * sin_ap
+        if azimuth_is_constant:
+            cos_sqr_ap = np.repeat(cos_sqr_ap.reshape(1, -1, 3), self.nk, axis = 0).reshape((-1, 3))
+            sin_sqr_ap = np.repeat(sin_sqr_ap.reshape(1, -1, 3), self.nk, axis = 0).reshape((-1, 3))
+        # local elliptical permeability projected in directions of azimuths
+        k = np.sqrt((primary_k * primary_k).reshape((-1, 1)) * cos_sqr_ap +
+                    (orthogonal_k * orthogonal_k).reshape((-1, 1)) * sin_sqr_ap)
 
-      return k
+        return k
 
-   def half_cell_transmissibility(self, use_property = True, realization = None, tolerance = 1.0e-6):
-      """Returns (and caches if realization is None) half cell transmissibilities for this vertical prism grid.
+    def half_cell_transmissibility(self, use_property = True, realization = None, tolerance = 1.0e-6):
+        """Returns (and caches if realization is None) half cell transmissibilities for this vertical prism grid.
 
       arguments:
          use_property (boolean, default True): if True, the grid's property collection is inspected for
@@ -2042,108 +2051,110 @@ class VerticalPrismGrid(PrismGrid):
          tolerance will only be used if the half cell transmissibilities are actually computed
       """
 
-      if realization is None and hasattr(self, 'array_half_cell_t'):
-         return self.array_half_cell_t
+        if realization is None and hasattr(self, 'array_half_cell_t'):
+            return self.array_half_cell_t
 
-      half_t = None
-      pc = self.property_collection
+        half_t = None
+        pc = self.property_collection
 
-      if use_property:
-         half_t = pc.single_array_ref(property_kind = 'transmissibility',
+        if use_property:
+            half_t = pc.single_array_ref(property_kind = 'transmissibility',
+                                         realization = realization,
+                                         continuous = True,
+                                         count = 1,
+                                         indexable = 'faces per cell')
+            if half_t:
+                assert half_t.size == 5 * self.cell_count
+                half_t = half_t.reshape(self.cell_count, 5)
+
+        if half_t is None:
+            # note: properties must be identifiable in property_collection
+            # TODO: gather property arrays, deriving tri-permeablities
+            # make sub-collection of permeability properties
+            ppc = rqp.selective_version_of_collection(pc,
+                                                      continuous = True,
+                                                      realization = realization,
+                                                      property_kind = 'permeability rock')
+            assert ppc.number_of_parts() > 0, 'no permeability properties available for vertical prism grid'
+
+            # look for a triple permeability; if present, assume to be per face horizontal permeabilities
+            triple_perm_horizontal = ppc.single_array_ref(count = 3, indexable = 'cells')
+
+            if triple_perm_horizontal is None:
+                # look for horizontal isotropic permeability
+                iso_h_part = None
+                if ppc.number_of_parts() == 1:
+                    iso_h_part = ppc.parts()[0]
+                    assert ppc.indexable_for_part(
+                        iso_h_part) == 'cells', 'single permeability property is not for cells'
+                else:
+                    iso_h_part = ppc.singleton(facet_type = 'direction',
+                                               facet = 'horizontal',
+                                               count = 1,
+                                               indexable = 'cells')
+                if iso_h_part is not None:
+                    triple_perm_horizontal = np.repeat(ppc.cached_part_array_ref(iso_h_part), 3).reshape((-1, 3))
+                else:
+                    # look for horizontal permeability field properties and derive triple perm array
+                    primary_k = ppc.single_array_ref(facet_type = 'direction',
+                                                     facet = 'primary',
+                                                     count = 1,
+                                                     indexable = 'cells')
+                    orthogonal_k = ppc.single_array_ref(facet_type = 'direction',
+                                                        facet = 'orthogonal',
+                                                        count = 1,
+                                                        indexable = 'cells')
+                    assert primary_k is not None and orthogonal_k is not None,  \
+                       'failed to identify horizontal permeability properties for vertical prism grid'
+                    # todo: add extra metadata or further faceting to be sure of finding correct property
+                    azimuth_part = pc.singleton(property_kind = 'plane angle',
+                                                facet_type = 'direction',
+                                                facet = 'primary',
+                                                realization = realization,
+                                                continuous = True,
+                                                count = 1,
+                                                indexable = 'cells')
+                    if azimuth_part is None:
+                        primary_azimuth = 0.0  # default to north
+                    else:
+                        primary_azimuth = pc.cached_part_array_ref(azimuth_part)
+                        azi_uom = pc.uom_for_part(azimuth_part)
+                        if azi_uom is not None and azi_uom != 'dega':
+                            primary_azimuth = wam.convert(primary_azimuth, azi_uom, 'dega', quantity = 'plane angle')
+                    triple_perm_horizontal = self.triple_horizontal_permeability(primary_k, orthogonal_k,
+                                                                                 primary_azimuth)
+
+            perm_k = ppc.single_array_ref(facet_type = 'direction', facet = 'K', count = 1, indexable = 'cells')
+
+            ntg = pc.single_array_ref(property_kind = 'net to gross ratio',
                                       realization = realization,
                                       continuous = True,
                                       count = 1,
-                                      indexable = 'faces per cell')
-         if half_t:
-            assert half_t.size == 5 * self.cell_count
-            half_t = half_t.reshape(self.cell_count, 5)
+                                      indexable = 'cells')
 
-      if half_t is None:
-         # note: properties must be identifiable in property_collection
-         # TODO: gather property arrays, deriving tri-permeablities
-         # make sub-collection of permeability properties
-         ppc = rqp.selective_version_of_collection(pc,
-                                                   continuous = True,
-                                                   realization = realization,
-                                                   property_kind = 'permeability rock')
-         assert ppc.number_of_parts() > 0, 'no permeability properties available for vertical prism grid'
+            half_t = rqtr.half_cell_t_vertical_prism(self,
+                                                     triple_perm_horizontal = triple_perm_horizontal,
+                                                     perm_k = perm_k,
+                                                     ntg = ntg)
 
-         # look for a triple permeability; if present, assume to be per face horizontal permeabilities
-         triple_perm_horizontal = ppc.single_array_ref(count = 3, indexable = 'cells')
+        if realization is None:
+            self.array_half_cell_t = half_t
 
-         if triple_perm_horizontal is None:
-            # look for horizontal isotropic permeability
-            iso_h_part = None
-            if ppc.number_of_parts() == 1:
-               iso_h_part = ppc.parts()[0]
-               assert ppc.indexable_for_part(iso_h_part) == 'cells', 'single permeability property is not for cells'
-            else:
-               iso_h_part = ppc.singleton(facet_type = 'direction',
-                                          facet = 'horizontal',
-                                          count = 1,
-                                          indexable = 'cells')
-            if iso_h_part is not None:
-               triple_perm_horizontal = np.repeat(ppc.cached_part_array_ref(iso_h_part), 3).reshape((-1, 3))
-            else:
-               # look for horizontal permeability field properties and derive triple perm array
-               primary_k = ppc.single_array_ref(facet_type = 'direction',
-                                                facet = 'primary',
-                                                count = 1,
-                                                indexable = 'cells')
-               orthogonal_k = ppc.single_array_ref(facet_type = 'direction',
-                                                   facet = 'orthogonal',
-                                                   count = 1,
-                                                   indexable = 'cells')
-               assert primary_k is not None and orthogonal_k is not None,  \
-                  'failed to identify horizontal permeability properties for vertical prism grid'
-               # todo: add extra metadata or further faceting to be sure of finding correct property
-               azimuth_part = pc.singleton(property_kind = 'plane angle',
-                                           facet_type = 'direction',
-                                           facet = 'primary',
-                                           realization = realization,
-                                           continuous = True,
-                                           count = 1,
-                                           indexable = 'cells')
-               if azimuth_part is None:
-                  primary_azimuth = 0.0  # default to north
-               else:
-                  primary_azimuth = pc.cached_part_array_ref(azimuth_part)
-                  azi_uom = pc.uom_for_part(azimuth_part)
-                  if azi_uom is not None and azi_uom != 'dega':
-                     primary_azimuth = wam.convert(primary_azimuth, azi_uom, 'dega', quantity = 'plane angle')
-               triple_perm_horizontal = self.triple_horizontal_permeability(primary_k, orthogonal_k, primary_azimuth)
-
-         perm_k = ppc.single_array_ref(facet_type = 'direction', facet = 'K', count = 1, indexable = 'cells')
-
-         ntg = pc.single_array_ref(property_kind = 'net to gross ratio',
-                                   realization = realization,
-                                   continuous = True,
-                                   count = 1,
-                                   indexable = 'cells')
-
-         half_t = rqtr.half_cell_t_vertical_prism(self,
-                                                  triple_perm_horizontal = triple_perm_horizontal,
-                                                  perm_k = perm_k,
-                                                  ntg = ntg)
-
-      if realization is None:
-         self.array_half_cell_t = half_t
-
-      return half_t
+        return half_t
 
 
 class HexaGrid(UnstructuredGrid):
-   """Class for unstructured grids where every cell is hexahedral (faces may be degenerate)."""
+    """Class for unstructured grids where every cell is hexahedral (faces may be degenerate)."""
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                find_properties = True,
-                cache_geometry = False,
-                title = None,
-                originator = None,
-                extra_metadata = {}):
-      """Creates a new resqpy HexaGrid object (RESQML UnstructuredGrid with cell shape hexahedral)
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 find_properties = True,
+                 cache_geometry = False,
+                 title = None,
+                 originator = None,
+                 extra_metadata = {}):
+        """Creates a new resqpy HexaGrid object (RESQML UnstructuredGrid with cell shape hexahedral)
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -2163,31 +2174,31 @@ class HexaGrid(UnstructuredGrid):
          a newly created HexaGrid object
       """
 
-      super().__init__(parent_model = parent_model,
-                       uuid = uuid,
-                       find_properties = find_properties,
-                       geometry_required = True,
-                       cache_geometry = cache_geometry,
-                       cell_shape = 'hexahedral',
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata)
+        super().__init__(parent_model = parent_model,
+                         uuid = uuid,
+                         find_properties = find_properties,
+                         geometry_required = True,
+                         cache_geometry = cache_geometry,
+                         cell_shape = 'hexahedral',
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata)
 
-      if self.root is not None:
-         assert grr.grid_flavour(self.root) == 'HexaGrid'
-         self.check_hexahedral()
+        if self.root is not None:
+            assert grr.grid_flavour(self.root) == 'HexaGrid'
+            self.check_hexahedral()
 
-      self.grid_representation = 'HexaGrid'  #: flavour of grid; not much used
+        self.grid_representation = 'HexaGrid'  #: flavour of grid; not much used
 
-   @classmethod
-   def from_unsplit_grid(cls,
-                         parent_model,
-                         grid_uuid,
-                         inherit_properties = True,
-                         title = None,
-                         extra_metadata = {},
-                         write_active = None):
-      """Creates a new (unstructured) HexaGrid from an existing resqpy unsplit (IJK) Grid without K gaps.
+    @classmethod
+    def from_unsplit_grid(cls,
+                          parent_model,
+                          grid_uuid,
+                          inherit_properties = True,
+                          title = None,
+                          extra_metadata = {},
+                          write_active = None):
+        """Creates a new (unstructured) HexaGrid from an existing resqpy unsplit (IJK) Grid without K gaps.
 
       arguments:
          parent_model (model.Model object): the model which this grid is part of
@@ -2205,164 +2216,167 @@ class HexaGrid(UnstructuredGrid):
          this method includes the writing of hdf5 data, creation of xml for the new grid and adding it as a part
       """
 
-      import resqpy.grid as grr
+        import resqpy.grid as grr
 
-      # establish existing IJK grid
-      ijk_grid = grr.Grid(parent_model, uuid = grid_uuid, find_properties = inherit_properties)
-      assert ijk_grid is not None
-      assert not ijk_grid.has_split_coordinate_lines, 'IJK grid has split coordinate lines (faults)'
-      assert not ijk_grid.k_gaps, 'IJK grid has K gaps'
-      ijk_grid.cache_all_geometry_arrays()
-      ijk_points = ijk_grid.points_ref(masked = False)
-      if title is None:
-         title = ijk_grid.title
+        # establish existing IJK grid
+        ijk_grid = grr.Grid(parent_model, uuid = grid_uuid, find_properties = inherit_properties)
+        assert ijk_grid is not None
+        assert not ijk_grid.has_split_coordinate_lines, 'IJK grid has split coordinate lines (faults)'
+        assert not ijk_grid.k_gaps, 'IJK grid has K gaps'
+        ijk_grid.cache_all_geometry_arrays()
+        ijk_points = ijk_grid.points_ref(masked = False)
+        if title is None:
+            title = ijk_grid.title
 
-      # make empty unstructured hexa grid
-      hexa_grid = cls(parent_model, title = title, extra_metadata = extra_metadata)
+        # make empty unstructured hexa grid
+        hexa_grid = cls(parent_model, title = title, extra_metadata = extra_metadata)
 
-      # derive hexa grid attributes from ijk grid
-      hexa_grid.crs_uuid = ijk_grid.crs_uuid
-      hexa_grid.set_cell_count(ijk_grid.cell_count())
-      if ijk_grid.inactive is not None:
-         hexa_grid.inactive = ijk_grid.inactive.reshape((hexa_grid.cell_count,))
-         hexa_grid.all_inactive = np.all(hexa_grid.inactive)
-         if hexa_grid.all_inactive:
-            log.warning(f'all cells marked as inactive for unstructured hexa grid {hexa_grid.title}')
-      else:
-         hexa_grid.all_inactive = False
+        # derive hexa grid attributes from ijk grid
+        hexa_grid.crs_uuid = ijk_grid.crs_uuid
+        hexa_grid.set_cell_count(ijk_grid.cell_count())
+        if ijk_grid.inactive is not None:
+            hexa_grid.inactive = ijk_grid.inactive.reshape((hexa_grid.cell_count,))
+            hexa_grid.all_inactive = np.all(hexa_grid.inactive)
+            if hexa_grid.all_inactive:
+                log.warning(f'all cells marked as inactive for unstructured hexa grid {hexa_grid.title}')
+        else:
+            hexa_grid.all_inactive = False
 
-      # inherit points (nodes) in IJK grid order, ie. K cycling fastest, then I, then J
-      hexa_grid.points_cached = ijk_points.reshape((-1, 3))
+        # inherit points (nodes) in IJK grid order, ie. K cycling fastest, then I, then J
+        hexa_grid.points_cached = ijk_points.reshape((-1, 3))
 
-      # setup faces per cell
-      # ordering of faces (in nodes per face): all K faces, then all J faces, then all I faces
-      # within J faces, ordering is all of J- faces for J = 0 first, then increasing planes in J
-      # similarly for I faces
-      nk_plus_1 = ijk_grid.nk + 1
-      nj_plus_1 = ijk_grid.nj + 1
-      ni_plus_1 = ijk_grid.ni + 1
-      k_face_count = nk_plus_1 * ijk_grid.nj * ijk_grid.ni
-      j_face_count = ijk_grid.nk * nj_plus_1 * ijk_grid.ni
-      i_face_count = ijk_grid.nk * ijk_grid.nj * ni_plus_1
-      kj_face_count = k_face_count + j_face_count
-      hexa_grid.face_count = k_face_count + j_face_count + i_face_count
-      hexa_grid.faces_per_cell_cl = 6 * (1 + np.arange(hexa_grid.cell_count, dtype = int))  # 6 faces per cell
-      hexa_grid.faces_per_cell = np.empty(6 * hexa_grid.cell_count, dtype = int)
-      arange = np.arange(hexa_grid.cell_count, dtype = int)
-      hexa_grid.faces_per_cell[0::6] = arange  # K- faces
-      hexa_grid.faces_per_cell[1::6] = ijk_grid.nj * ijk_grid.ni + arange  # K+ faces
-      nki = ijk_grid.nk * ijk_grid.ni
-      nkj = ijk_grid.nk * ijk_grid.nj
-      # todo: vectorise following for loop
-      for cell in range(hexa_grid.cell_count):
-         k, j, i = ijk_grid.denaturalized_cell_index(cell)
-         j_minus_face = k_face_count + nki * j + ijk_grid.ni * k + i
-         hexa_grid.faces_per_cell[6 * cell + 2] = j_minus_face  # J- face
-         hexa_grid.faces_per_cell[6 * cell + 3] = j_minus_face + nki  # J+ face
-         i_minus_face = kj_face_count + nkj * i + ijk_grid.nj * k + j
-         hexa_grid.faces_per_cell[6 * cell + 4] = i_minus_face  # I- face
-         hexa_grid.faces_per_cell[6 * cell + 5] = i_minus_face + nkj  # I+ face
+        # setup faces per cell
+        # ordering of faces (in nodes per face): all K faces, then all J faces, then all I faces
+        # within J faces, ordering is all of J- faces for J = 0 first, then increasing planes in J
+        # similarly for I faces
+        nk_plus_1 = ijk_grid.nk + 1
+        nj_plus_1 = ijk_grid.nj + 1
+        ni_plus_1 = ijk_grid.ni + 1
+        k_face_count = nk_plus_1 * ijk_grid.nj * ijk_grid.ni
+        j_face_count = ijk_grid.nk * nj_plus_1 * ijk_grid.ni
+        i_face_count = ijk_grid.nk * ijk_grid.nj * ni_plus_1
+        kj_face_count = k_face_count + j_face_count
+        hexa_grid.face_count = k_face_count + j_face_count + i_face_count
+        hexa_grid.faces_per_cell_cl = 6 * (1 + np.arange(hexa_grid.cell_count, dtype = int))  # 6 faces per cell
+        hexa_grid.faces_per_cell = np.empty(6 * hexa_grid.cell_count, dtype = int)
+        arange = np.arange(hexa_grid.cell_count, dtype = int)
+        hexa_grid.faces_per_cell[0::6] = arange  # K- faces
+        hexa_grid.faces_per_cell[1::6] = ijk_grid.nj * ijk_grid.ni + arange  # K+ faces
+        nki = ijk_grid.nk * ijk_grid.ni
+        nkj = ijk_grid.nk * ijk_grid.nj
+        # todo: vectorise following for loop
+        for cell in range(hexa_grid.cell_count):
+            k, j, i = ijk_grid.denaturalized_cell_index(cell)
+            j_minus_face = k_face_count + nki * j + ijk_grid.ni * k + i
+            hexa_grid.faces_per_cell[6 * cell + 2] = j_minus_face  # J- face
+            hexa_grid.faces_per_cell[6 * cell + 3] = j_minus_face + nki  # J+ face
+            i_minus_face = kj_face_count + nkj * i + ijk_grid.nj * k + j
+            hexa_grid.faces_per_cell[6 * cell + 4] = i_minus_face  # I- face
+            hexa_grid.faces_per_cell[6 * cell + 5] = i_minus_face + nkj  # I+ face
 
-      # setup nodes per face, clockwise when viewed from negative side of face if ijk handedness matches xyz handedness
-      # ordering of nodes in points array is as for the IJK grid
-      hexa_grid.node_count = hexa_grid.points_cached.shape[0]
-      assert hexa_grid.node_count == (ijk_grid.nk + 1) * (ijk_grid.nj + 1) * (ijk_grid.ni + 1)
-      hexa_grid.nodes_per_face_cl = 4 * (1 + np.arange(hexa_grid.face_count, dtype = int))  # 4 nodes per face
-      hexa_grid.nodes_per_face = np.empty(4 * hexa_grid.face_count, dtype = int)
-      # todo: vectorise for loops
-      # K faces
-      face_base = 0
-      for k in range(nk_plus_1):
-         for j in range(ijk_grid.nj):
-            for i in range(ijk_grid.ni):
-               hexa_grid.nodes_per_face[face_base] = (k * nj_plus_1 + j) * ni_plus_1 + i  # ip 0, jp 0
-               hexa_grid.nodes_per_face[face_base + 1] = (k * nj_plus_1 + j + 1) * ni_plus_1 + i  # ip 0, jp 1
-               hexa_grid.nodes_per_face[face_base + 2] = (k * nj_plus_1 + j + 1) * ni_plus_1 + i + 1  # ip 1, jp 1
-               hexa_grid.nodes_per_face[face_base + 3] = (k * nj_plus_1 + j) * ni_plus_1 + i + 1  # ip 1, jp 0
-               face_base += 4
-      # J faces
-      assert face_base == 4 * k_face_count
-      for j in range(nj_plus_1):
-         for k in range(ijk_grid.nk):
-            for i in range(ijk_grid.ni):
-               hexa_grid.nodes_per_face[face_base] = (k * nj_plus_1 + j) * ni_plus_1 + i  # ip 0, kp 0
-               hexa_grid.nodes_per_face[face_base + 1] = (k * nj_plus_1 + j) * ni_plus_1 + i + 1  # ip 1, kp 0
-               hexa_grid.nodes_per_face[face_base + 2] = ((k + 1) * nj_plus_1 + j) * ni_plus_1 + i + 1  # ip 1, kp 1
-               hexa_grid.nodes_per_face[face_base + 3] = ((k + 1) * nj_plus_1 + j) * ni_plus_1 + i  # ip 0, kp 1
-               face_base += 4
-      # I faces
-      assert face_base == 4 * kj_face_count
-      for i in range(ni_plus_1):
-         for k in range(ijk_grid.nk):
+        # setup nodes per face, clockwise when viewed from negative side of face if ijk handedness matches xyz handedness
+        # ordering of nodes in points array is as for the IJK grid
+        hexa_grid.node_count = hexa_grid.points_cached.shape[0]
+        assert hexa_grid.node_count == (ijk_grid.nk + 1) * (ijk_grid.nj + 1) * (ijk_grid.ni + 1)
+        hexa_grid.nodes_per_face_cl = 4 * (1 + np.arange(hexa_grid.face_count, dtype = int))  # 4 nodes per face
+        hexa_grid.nodes_per_face = np.empty(4 * hexa_grid.face_count, dtype = int)
+        # todo: vectorise for loops
+        # K faces
+        face_base = 0
+        for k in range(nk_plus_1):
             for j in range(ijk_grid.nj):
-               hexa_grid.nodes_per_face[face_base] = (k * nj_plus_1 + j) * ni_plus_1 + i  # jp 0, kp 0
-               hexa_grid.nodes_per_face[face_base + 1] = ((k + 1) * nj_plus_1 + j) * ni_plus_1 + i  # jp 0, kp 1
-               hexa_grid.nodes_per_face[face_base + 2] = ((k + 1) * nj_plus_1 + j + 1) * ni_plus_1 + i  # jp 1, kp 1
-               hexa_grid.nodes_per_face[face_base + 3] = (k * nj_plus_1 + j + 1) * ni_plus_1 + i  # jp 1, kp 0
-               face_base += 4
-      assert face_base == 4 * hexa_grid.face_count
+                for i in range(ijk_grid.ni):
+                    hexa_grid.nodes_per_face[face_base] = (k * nj_plus_1 + j) * ni_plus_1 + i  # ip 0, jp 0
+                    hexa_grid.nodes_per_face[face_base + 1] = (k * nj_plus_1 + j + 1) * ni_plus_1 + i  # ip 0, jp 1
+                    hexa_grid.nodes_per_face[face_base + 2] = (k * nj_plus_1 + j + 1) * ni_plus_1 + i + 1  # ip 1, jp 1
+                    hexa_grid.nodes_per_face[face_base + 3] = (k * nj_plus_1 + j) * ni_plus_1 + i + 1  # ip 1, jp 0
+                    face_base += 4
+        # J faces
+        assert face_base == 4 * k_face_count
+        for j in range(nj_plus_1):
+            for k in range(ijk_grid.nk):
+                for i in range(ijk_grid.ni):
+                    hexa_grid.nodes_per_face[face_base] = (k * nj_plus_1 + j) * ni_plus_1 + i  # ip 0, kp 0
+                    hexa_grid.nodes_per_face[face_base + 1] = (k * nj_plus_1 + j) * ni_plus_1 + i + 1  # ip 1, kp 0
+                    hexa_grid.nodes_per_face[face_base +
+                                             2] = ((k + 1) * nj_plus_1 + j) * ni_plus_1 + i + 1  # ip 1, kp 1
+                    hexa_grid.nodes_per_face[face_base + 3] = ((k + 1) * nj_plus_1 + j) * ni_plus_1 + i  # ip 0, kp 1
+                    face_base += 4
+        # I faces
+        assert face_base == 4 * kj_face_count
+        for i in range(ni_plus_1):
+            for k in range(ijk_grid.nk):
+                for j in range(ijk_grid.nj):
+                    hexa_grid.nodes_per_face[face_base] = (k * nj_plus_1 + j) * ni_plus_1 + i  # jp 0, kp 0
+                    hexa_grid.nodes_per_face[face_base + 1] = ((k + 1) * nj_plus_1 + j) * ni_plus_1 + i  # jp 0, kp 1
+                    hexa_grid.nodes_per_face[face_base +
+                                             2] = ((k + 1) * nj_plus_1 + j + 1) * ni_plus_1 + i  # jp 1, kp 1
+                    hexa_grid.nodes_per_face[face_base + 3] = (k * nj_plus_1 + j + 1) * ni_plus_1 + i  # jp 1, kp 0
+                    face_base += 4
+        assert face_base == 4 * hexa_grid.face_count
 
-      # set cell face is right handed
-      # todo: check Energistics documents for meaning of cell face is right handed
-      # here the assumption is clockwise ordering of nodes viewed from within cell means 'right handed'
-      hexa_grid.cell_face_is_right_handed = np.zeros(6 * hexa_grid.cell_count,
-                                                     dtype = bool)  # initially set to left handed
-      # if IJK grid's ijk handedness matches the xyz handedness, then set +ve faces to right handed; else -ve faces
-      if ijk_grid.off_handed():
-         hexa_grid.cell_face_is_right_handed[0::2] = True  # negative faces are right handed
-      else:
-         hexa_grid.cell_face_is_right_handed[1::2] = True  # positive faces are right handed
+        # set cell face is right handed
+        # todo: check Energistics documents for meaning of cell face is right handed
+        # here the assumption is clockwise ordering of nodes viewed from within cell means 'right handed'
+        hexa_grid.cell_face_is_right_handed = np.zeros(6 * hexa_grid.cell_count,
+                                                       dtype = bool)  # initially set to left handed
+        # if IJK grid's ijk handedness matches the xyz handedness, then set +ve faces to right handed; else -ve faces
+        if ijk_grid.off_handed():
+            hexa_grid.cell_face_is_right_handed[0::2] = True  # negative faces are right handed
+        else:
+            hexa_grid.cell_face_is_right_handed[1::2] = True  # positive faces are right handed
 
-      hexa_grid.write_hdf5(write_active = write_active)
-      hexa_grid.create_xml(write_active = write_active)
+        hexa_grid.write_hdf5(write_active = write_active)
+        hexa_grid.create_xml(write_active = write_active)
 
-      if inherit_properties:
-         ijk_pc = ijk_grid.extract_property_collection()
-         hexa_pc = rqp.PropertyCollection(support = hexa_grid)
-         for part in ijk_pc.parts():
-            count = ijk_pc.count_for_part(part)
-            hexa_part_shape = (hexa_grid.cell_count,) if count == 1 else (hexa_grid.cell_count, count)
-            hexa_pc.add_cached_array_to_imported_list(ijk_pc.cached_part_array_ref(part).reshape(hexa_part_shape),
-                                                      'inherited from grid ' + str(ijk_grid.title),
-                                                      ijk_pc.citation_title_for_part(part),
-                                                      discrete = not ijk_pc.continuous_for_part(part),
-                                                      uom = ijk_pc.uom_for_part(part),
-                                                      time_index = ijk_pc.time_index_for_part(part),
-                                                      null_value = ijk_pc.null_value_for_part(part),
-                                                      property_kind = ijk_pc.property_kind_for_part(part),
-                                                      local_property_kind_uuid = ijk_pc.local_property_kind_uuid(part),
-                                                      facet_type = ijk_pc.facet_type_for_part(part),
-                                                      facet = ijk_pc.facet_for_part(part),
-                                                      realization = ijk_pc.realization_for_part(part),
-                                                      indexable_element = ijk_pc.indexable_for_part(part),
-                                                      count = count,
-                                                      const_value = ijk_pc.constant_value_for_part(part))
-            # todo: patch min & max values if present in ijk part
-            hexa_pc.write_hdf5_for_imported_list()
-            hexa_pc.create_xml_for_imported_list_and_add_parts_to_model(
-               support_uuid = hexa_grid.uuid,
-               time_series_uuid = ijk_pc.time_series_uuid_for_part(part),
-               string_lookup_uuid = ijk_pc.string_lookup_uuid_for_part(part),
-               extra_metadata = ijk_pc.extra_metadata_for_part(part))
+        if inherit_properties:
+            ijk_pc = ijk_grid.extract_property_collection()
+            hexa_pc = rqp.PropertyCollection(support = hexa_grid)
+            for part in ijk_pc.parts():
+                count = ijk_pc.count_for_part(part)
+                hexa_part_shape = (hexa_grid.cell_count,) if count == 1 else (hexa_grid.cell_count, count)
+                hexa_pc.add_cached_array_to_imported_list(
+                    ijk_pc.cached_part_array_ref(part).reshape(hexa_part_shape),
+                    'inherited from grid ' + str(ijk_grid.title),
+                    ijk_pc.citation_title_for_part(part),
+                    discrete = not ijk_pc.continuous_for_part(part),
+                    uom = ijk_pc.uom_for_part(part),
+                    time_index = ijk_pc.time_index_for_part(part),
+                    null_value = ijk_pc.null_value_for_part(part),
+                    property_kind = ijk_pc.property_kind_for_part(part),
+                    local_property_kind_uuid = ijk_pc.local_property_kind_uuid(part),
+                    facet_type = ijk_pc.facet_type_for_part(part),
+                    facet = ijk_pc.facet_for_part(part),
+                    realization = ijk_pc.realization_for_part(part),
+                    indexable_element = ijk_pc.indexable_for_part(part),
+                    count = count,
+                    const_value = ijk_pc.constant_value_for_part(part))
+                # todo: patch min & max values if present in ijk part
+                hexa_pc.write_hdf5_for_imported_list()
+                hexa_pc.create_xml_for_imported_list_and_add_parts_to_model(
+                    support_uuid = hexa_grid.uuid,
+                    time_series_uuid = ijk_pc.time_series_uuid_for_part(part),
+                    string_lookup_uuid = ijk_pc.string_lookup_uuid_for_part(part),
+                    extra_metadata = ijk_pc.extra_metadata_for_part(part))
 
-      return hexa_grid
+        return hexa_grid
 
-   def check_hexahedral(self):
-      """Checks that each cell has 6 faces and each face has 4 nodes.
+    def check_hexahedral(self):
+        """Checks that each cell has 6 faces and each face has 4 nodes.
 
       notes:
          currently only performs a cursory check, without checking nodes are shared;
          assumes that degenerate faces still have four nodes identified
       """
 
-      assert self.cell_shape == 'hexahedral'
-      self.cache_all_geometry_arrays()
-      assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
-      assert self.faces_per_cell_cl[0] == 6 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 6)
-      assert self.nodes_per_face_cl[0] == 4 and np.all(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1] == 4)
+        assert self.cell_shape == 'hexahedral'
+        self.cache_all_geometry_arrays()
+        assert self.faces_per_cell_cl is not None and self.nodes_per_face_cl is not None
+        assert self.faces_per_cell_cl[0] == 6 and np.all(self.faces_per_cell_cl[1:] - self.faces_per_cell_cl[:-1] == 6)
+        assert self.nodes_per_face_cl[0] == 4 and np.all(self.nodes_per_face_cl[1:] - self.nodes_per_face_cl[:-1] == 4)
 
-   def corner_points(self, cell):
-      """Returns corner points (nodes) of a single cell.
+    def corner_points(self, cell):
+        """Returns corner points (nodes) of a single cell.
 
       arguments:
          cell (int): the index of the cell for which the corner points are required
@@ -2375,11 +2389,11 @@ class HexaGrid(UnstructuredGrid):
          reshaped to (2, 2, 2, 3) for corner points compatible with those used by the Grid class
       """
 
-      self.cache_all_geometry_arrays()
-      return self.points_cached[self.distinct_node_indices_for_cell(cell)]
+        self.cache_all_geometry_arrays()
+        return self.points_cached[self.distinct_node_indices_for_cell(cell)]
 
-   def volume(self, cell):
-      """Returns the volume of a single cell.
+    def volume(self, cell):
+        """Returns the volume of a single cell.
 
       arguments:
          cell (int): the index of the cell for which the volume is required
@@ -2388,21 +2402,21 @@ class HexaGrid(UnstructuredGrid):
          float being the volume of the hexahedral cell; units of measure is implied by crs units
       """
 
-      self._set_crs_handedness()
-      apex = self.cell_centre_point(cell)
-      v = 0.0
-      faces, handednesses = self.face_indices_and_handedness_for_cell(cell)
-      for face_index, handedness in zip(faces, handednesses):
-         nodes = self.node_indices_for_face(face_index)
-         abcd = self.points_cached[nodes]
-         assert abcd.shape == (4, 3)
-         v += vol.pyramid_volume(apex,
-                                 abcd[0],
-                                 abcd[1],
-                                 abcd[2],
-                                 abcd[3],
-                                 crs_is_right_handed = (self.crs_is_right_handed == handedness))
-      return v
+        self._set_crs_handedness()
+        apex = self.cell_centre_point(cell)
+        v = 0.0
+        faces, handednesses = self.face_indices_and_handedness_for_cell(cell)
+        for face_index, handedness in zip(faces, handednesses):
+            nodes = self.node_indices_for_face(face_index)
+            abcd = self.points_cached[nodes]
+            assert abcd.shape == (4, 3)
+            v += vol.pyramid_volume(apex,
+                                    abcd[0],
+                                    abcd[1],
+                                    abcd[2],
+                                    abcd[3],
+                                    crs_is_right_handed = (self.crs_is_right_handed == handedness))
+        return v
 
-   # todo: add hexahedral specific method for centre_point()?
-   # todo: also add other methods equivalent to those in Grid class
+    # todo: add hexahedral specific method for centre_point()?
+    # todo: also add other methods equivalent to those in Grid class

--- a/resqpy/weights_and_measures.py
+++ b/resqpy/weights_and_measures.py
@@ -24,58 +24,58 @@ s_to_d = 1.0 / d_to_s
 # Nb. No need to write out fractional combinations such as "bbl/day"
 # note: some of the aliases are ambiguous, e.g. 'gm' could mean gigametre or gramme
 UOM_ALIASES = {
-   # Mass
-   'g': {'gm', 'gram', 'gramme', 'grams', 'grammes'},
-   'lbm': {'lb', 'lbs'},  # assumes pounds mass rather than pounds force
+    # Mass
+    'g': {'gm', 'gram', 'gramme', 'grams', 'grammes'},
+    'lbm': {'lb', 'lbs'},  # assumes pounds mass rather than pounds force
 
-   # Length
-   'm': {'m', 'metre', 'metres', 'meter', 'meters'},
-   'ft': {'ft', 'foot', 'feet'},
-   'cm': {'centimetre', 'centimetres', 'centimeter', 'centimeters'},
+    # Length
+    'm': {'m', 'metre', 'metres', 'meter', 'meters'},
+    'ft': {'ft', 'foot', 'feet'},
+    'cm': {'centimetre', 'centimetres', 'centimeter', 'centimeters'},
 
-   # Time
-   'ms': {'ms', 'msec', 'millisecs', 'millisecond', 'milliseconds'},
-   's': {'s', 'sec', 'secs', 'second', 'seconds'},
-   'min': {'min', 'mins', 'minute', 'minutes'},
-   'h': {'h', 'hr', 'hour', 'hours'},
-   'd': {'day', 'days'},
-   'wk': {'wk', 'week', 'weeks'},
-   'a': {'a', 'yr', 'year', 'years'},
+    # Time
+    'ms': {'ms', 'msec', 'millisecs', 'millisecond', 'milliseconds'},
+    's': {'s', 'sec', 'secs', 'second', 'seconds'},
+    'min': {'min', 'mins', 'minute', 'minutes'},
+    'h': {'h', 'hr', 'hour', 'hours'},
+    'd': {'day', 'days'},
+    'wk': {'wk', 'week', 'weeks'},
+    'a': {'a', 'yr', 'year', 'years'},
 
-   # Ratio
-   '%': {'%', 'pu', 'p.u.', 'percent'},
-   'm3/m3': {'m3/m3', 'v/v'},
-   'g/cm3': {'g/cm3', 'g/cc'},
+    # Ratio
+    '%': {'%', 'pu', 'p.u.', 'percent'},
+    'm3/m3': {'m3/m3', 'v/v'},
+    'g/cm3': {'g/cm3', 'g/cc'},
 
-   # Volume
-   'bbl': {'bbl', 'stb', 'rb'},
-   '1000 bbl': {'1000 bbl', 'mstb', 'mbbl', 'mrb'},
-   '1E6 bbl': {'1E6 bbl', 'mmstb', 'mmbbl'},
-   '1E6 ft3': {'1E6 ft3', 'mmscf'},
-   '1000 ft3': {'1000 ft3', 'mscf'},
-   'm3': {'m3', 'sm3', 'stm3', 'rm3'},
-   '1000 m3': {'kstm3', 'krm3', 'msm3', 'mrm3'},
-   'ft3': {'ft3', 'scf', 'cf', 'rcf', 'cu.ft.'},
-   'cm3': {'cc', 'scc', 'stcc'},
-   'L': {'krcc', 'kstcc', 'kscc', 'litre', 'litres', 'liter', 'liters'},
+    # Volume
+    'bbl': {'bbl', 'stb', 'rb'},
+    '1000 bbl': {'1000 bbl', 'mstb', 'mbbl', 'mrb'},
+    '1E6 bbl': {'1E6 bbl', 'mmstb', 'mmbbl'},
+    '1E6 ft3': {'1E6 ft3', 'mmscf'},
+    '1000 ft3': {'1000 ft3', 'mscf'},
+    'm3': {'m3', 'sm3', 'stm3', 'rm3'},
+    '1000 m3': {'kstm3', 'krm3', 'msm3', 'mrm3'},
+    'ft3': {'ft3', 'scf', 'cf', 'rcf', 'cu.ft.'},
+    'cm3': {'cc', 'scc', 'stcc'},
+    'L': {'krcc', 'kstcc', 'kscc', 'litre', 'litres', 'liter', 'liters'},
 
-   # Pressure & Reciprocal Pressure
-   'psi': {'psi', 'psia'},
+    # Pressure & Reciprocal Pressure
+    'psi': {'psi', 'psia'},
 
-   # Thermodynamic Temperature
-   'degC': {'c', 'degrees c', 'degreesc'},
-   'degF': {'f', 'degrees f', 'degreesf'},
+    # Thermodynamic Temperature
+    'degC': {'c', 'degrees c', 'degreesc'},
+    'degF': {'f', 'degrees f', 'degreesf'},
 
-   # Energy
-   'Btu[IT]': {'btu'},  # assumes BTU to refer to ISO standard, rather than older Btu[UK]
-   'kJ': {'kj'},
+    # Energy
+    'Btu[IT]': {'btu'},  # assumes BTU to refer to ISO standard, rather than older Btu[UK]
+    'kJ': {'kj'},
 
-   # Other
-   'gAPI': {'gapi'},
-   'S': {'mho'},
-   'mS': {'mmho'},
-   'mol': {'mole', 'moles'},
-   'Euc': {'count', 'fraction', 'none'},
+    # Other
+    'gAPI': {'gapi'},
+    'S': {'mho'},
+    'mS': {'mmho'},
+    'mol': {'mole', 'moles'},
+    'Euc': {'count', 'fraction', 'none'},
 }
 # Mapping from alias to valid uom
 UOM_ALIAS_MAP = {alias.casefold(): uom for uom, aliases in UOM_ALIASES.items() for alias in aliases}
@@ -86,7 +86,7 @@ CASE_INSENSITIVE_UOMS = {'m', 'ft', 'm3', 'ft3', 'm3/m3', 'ft3/ft3', 'bbl', 'bar
 
 @lru_cache(None)
 def rq_uom(units, quantity = None):
-   """Returns RESQML uom string equivalent to units
+    """Returns RESQML uom string equivalent to units
    
    Args:
       units (str): unit to coerce
@@ -99,24 +99,24 @@ def rq_uom(units, quantity = None):
    Raises:
       InvalidUnitError: if units cannot be coerced into RESQML units for the given quantity
    """
-   if not units:
-      raise InvalidUnitError("Must provide non-empty unit")
+    if not units:
+        raise InvalidUnitError("Must provide non-empty unit")
 
-   uom = _try_parse_unit(units.strip())
+    uom = _try_parse_unit(units.strip())
 
-   if uom is None:
-      raise InvalidUnitError(f"Cannot coerce {units} into a valid RESQML unit of measure.")
+    if uom is None:
+        raise InvalidUnitError(f"Cannot coerce {units} into a valid RESQML unit of measure.")
 
-   if quantity is not None:
-      supported_uoms = valid_uoms(quantity = quantity)
-      if uom not in supported_uoms:
-         raise InvalidUnitError(f"Unit {uom} is not supported for quantity {quantity}.\n"
-                                f"Supported units:\n{supported_uoms}")
-   return uom
+    if quantity is not None:
+        supported_uoms = valid_uoms(quantity = quantity)
+        if uom not in supported_uoms:
+            raise InvalidUnitError(f"Unit {uom} is not supported for quantity {quantity}.\n"
+                                   f"Supported units:\n{supported_uoms}")
+    return uom
 
 
 def convert(x, unit_from, unit_to, quantity = None, inplace = False):
-   """Convert value between two compatible units
+    """Convert value between two compatible units
 
    Args:
       x (numeric or np.array): value(s) to convert
@@ -134,45 +134,45 @@ def convert(x, unit_from, unit_to, quantity = None, inplace = False):
       IncompatibleUnitsError: if units do not have compatible base units
    """
 
-   # conversion data assume the formula "y=(A + Bx)/(C + Dx)" where "y" represents a value in the base unit.
-   # Backwards formula: x=(A-Cy)/(Dy-B)
-   # All current units have D==0
+    # conversion data assume the formula "y=(A + Bx)/(C + Dx)" where "y" represents a value in the base unit.
+    # Backwards formula: x=(A-Cy)/(Dy-B)
+    # All current units have D==0
 
-   uom1 = rq_uom(unit_from, quantity = quantity)
-   uom2 = rq_uom(unit_to, quantity = quantity)
+    uom1 = rq_uom(unit_from, quantity = quantity)
+    uom2 = rq_uom(unit_to, quantity = quantity)
 
-   if uom1 == uom2:
-      return x
+    if uom1 == uom2:
+        return x
 
-   base1, dim1, (A1, B1, C1, D1) = get_conversion_factors(uom1)
-   base2, dim2, (A2, B2, C2, D2) = get_conversion_factors(uom2)
+    base1, dim1, (A1, B1, C1, D1) = get_conversion_factors(uom1)
+    base2, dim2, (A2, B2, C2, D2) = get_conversion_factors(uom2)
 
-   if base1 != base2:
-      if dim1 != dim2:
-         raise IncompatibleUnitsError(f"Cannot convert from '{unit_from}' to '{unit_to}':"
-                                      f"\n - '{uom1}' has base unit '{base1} and dimension '{dim1}'."
-                                      f"\n - '{uom2}' has base unit '{base2} and dimension '{dim2}'.")
-      else:
-         warnings.warn(f"Assuming base units {base1} and {base2} are equivalent as they have the same dimensions:"
-                       f"\n - '{uom1}' has base unit '{base1} and dimension '{dim1}'."
-                       f"\n - '{uom2}' has base unit '{base2} and dimension '{dim2}'.")
+    if base1 != base2:
+        if dim1 != dim2:
+            raise IncompatibleUnitsError(f"Cannot convert from '{unit_from}' to '{unit_to}':"
+                                         f"\n - '{uom1}' has base unit '{base1} and dimension '{dim1}'."
+                                         f"\n - '{uom2}' has base unit '{base2} and dimension '{dim2}'.")
+        else:
+            warnings.warn(f"Assuming base units {base1} and {base2} are equivalent as they have the same dimensions:"
+                          f"\n - '{uom1}' has base unit '{base1} and dimension '{dim1}'."
+                          f"\n - '{uom2}' has base unit '{base2} and dimension '{dim2}'.")
 
-   if not inplace:
-      y = (A1 + (B1 * x)) / (C1 + (D1 * x))
-      return (A2 - (C2 * y)) / ((D2 * y) - B2)
+    if not inplace:
+        y = (A1 + (B1 * x)) / (C1 + (D1 * x))
+        return (A2 - (C2 * y)) / ((D2 * y) - B2)
 
-   else:
-      if any(f != 0 for f in [A1, A2, D1, D2]):
-         raise NotImplementedError("In-place conversion not yet implemented for non-trivial conversions")
+    else:
+        if any(f != 0 for f in [A1, A2, D1, D2]):
+            raise NotImplementedError("In-place conversion not yet implemented for non-trivial conversions")
 
-      factor = (B1 * C2) / (C1 * B2)
-      x *= factor
-      return x
+        factor = (B1 * C2) / (C1 * B2)
+        x *= factor
+        return x
 
 
 @lru_cache(None)
 def valid_uoms(quantity = None, return_attributes = False):
-   """Return set of valid RESQML units of measure
+    """Return set of valid RESQML units of measure
    
    Args:
       quantity (str): If given, filter to uoms supported by this quanitity.
@@ -183,20 +183,20 @@ def valid_uoms(quantity = None, return_attributes = False):
    Returns
       set or dict
    """
-   uoms = _properties_data()['units']
-   if quantity:
-      all_quantities = _properties_data()['quantities']
-      supported_members = all_quantities[quantity]['members']
-      uoms = {k: v for k, v in uoms.items() if k in supported_members}
-   if return_attributes:
-      return uoms
-   else:
-      return set(uoms.keys())
+    uoms = _properties_data()['units']
+    if quantity:
+        all_quantities = _properties_data()['quantities']
+        supported_members = all_quantities[quantity]['members']
+        uoms = {k: v for k, v in uoms.items() if k in supported_members}
+    if return_attributes:
+        return uoms
+    else:
+        return set(uoms.keys())
 
 
 @lru_cache(None)
 def valid_quantities(return_attributes = False):
-   """Return set of valid RESQML quantities
+    """Return set of valid RESQML quantities
    
    Args:
       return_attributes (bool): If True, return a dict of all quantities and their
@@ -206,52 +206,52 @@ def valid_quantities(return_attributes = False):
    Returns
       set or dict
    """
-   quantities = _properties_data()['quantities']
-   if return_attributes:
-      return quantities
-   else:
-      return set(quantities.keys())
+    quantities = _properties_data()['quantities']
+    if return_attributes:
+        return quantities
+    else:
+        return set(quantities.keys())
 
 
 def valid_property_kinds():
-   """Return set of valid property kinds"""
+    """Return set of valid property kinds"""
 
-   return set(_properties_data()['property_kinds'].keys())
+    return set(_properties_data()['property_kinds'].keys())
 
 
 def rq_uom_list(units_list):
-   """Returns a list of RESQML uom equivalents for units in list."""
+    """Returns a list of RESQML uom equivalents for units in list."""
 
-   return [rq_uom(u) for u in units_list]
+    return [rq_uom(u) for u in units_list]
 
 
 def rq_length_unit(units):
-   """Returns length units string as expected by resqml."""
+    """Returns length units string as expected by resqml."""
 
-   return rq_uom(units, quantity = 'length')
+    return rq_uom(units, quantity = 'length')
 
 
 def rq_time_unit(units):
-   """Returns time units string as expected by resqml."""
+    """Returns time units string as expected by resqml."""
 
-   return rq_uom(units, quantity = 'time')
+    return rq_uom(units, quantity = 'time')
 
 
 def convert_times(a, from_units, to_units, invert = False):
-   """Converts values in numpy array (or a scalar) from one time unit to another, in situ if array.
+    """Converts values in numpy array (or a scalar) from one time unit to another, in situ if array.
    
    note:
       To see supported units, use: `valid_uoms(quantity='time')`
    """
 
-   if invert:
-      from_units, to_units = to_units, from_units
+    if invert:
+        from_units, to_units = to_units, from_units
 
-   return convert(a, from_units, to_units, quantity = 'time', inplace = True)
+    return convert(a, from_units, to_units, quantity = 'time', inplace = True)
 
 
 def convert_lengths(a, from_units, to_units):
-   """Converts values in numpy array (or a scalar) from one length unit to another, in situ if array.
+    """Converts values in numpy array (or a scalar) from one length unit to another, in situ if array.
 
    arguments:
       a (numpy float array, or float): array of length values to undergo unit conversion in situ, or a scalar
@@ -265,11 +265,11 @@ def convert_lengths(a, from_units, to_units):
       To see supported units, use: `valid_uoms(quantity='length')`
    """
 
-   return convert(a, from_units, to_units, quantity = 'length', inplace = True)
+    return convert(a, from_units, to_units, quantity = 'length', inplace = True)
 
 
 def convert_pressures(a, from_units, to_units):
-   """Converts values in numpy array (or a scalar) from one pressure unit to another, in situ if array.
+    """Converts values in numpy array (or a scalar) from one pressure unit to another, in situ if array.
 
    arguments:
       a (numpy float array, or float): array of pressure values to undergo unit conversion in situ, or a scalar
@@ -282,11 +282,11 @@ def convert_pressures(a, from_units, to_units):
    note:
       To see supported units, use: `valid_uoms(quantity='pressure')`
    """
-   return convert(a, from_units, to_units, quantity = 'pressure', inplace = True)
+    return convert(a, from_units, to_units, quantity = 'pressure', inplace = True)
 
 
 def convert_volumes(a, from_units, to_units):
-   """Converts values in numpy array (or a scalar) from one volume unit to another, in situ if array.
+    """Converts values in numpy array (or a scalar) from one volume unit to another, in situ if array.
 
    arguments:
       a (numpy float array, or float): array of volume values to undergo unit conversion in situ, or a scalar
@@ -300,11 +300,11 @@ def convert_volumes(a, from_units, to_units):
       To see supported units, use: `valid_uoms(quantity='volume')`
 
    """
-   return convert(a, from_units, to_units, quantity = 'volume', inplace = True)
+    return convert(a, from_units, to_units, quantity = 'volume', inplace = True)
 
 
 def convert_flow_rates(a, from_units, to_units):
-   """Converts values in numpy array (or a scalar) from one volume flow rate unit to another, in situ if array.
+    """Converts values in numpy array (or a scalar) from one volume flow rate unit to another, in situ if array.
 
    arguments:
       a (numpy float array, or float): array of volume flow rate values to undergo unit conversion in situ, or a scalar
@@ -317,12 +317,12 @@ def convert_flow_rates(a, from_units, to_units):
    note:
       To see supported units, use: `valid_uoms(quantity='volume per time')`
    """
-   return convert(a, from_units, to_units, quantity = 'volume per time', inplace = True)
+    return convert(a, from_units, to_units, quantity = 'volume per time', inplace = True)
 
 
 @lru_cache(None)
 def get_conversion_factors(uom):
-   """Return base unit and conversion factors (A, B, C, D) for a given uom.
+    """Return base unit and conversion factors (A, B, C, D) for a given uom.
    
    The formula "y=(A + Bx)/(C + Dx)" where "y" represents a value in the base unit.
 
@@ -332,18 +332,18 @@ def get_conversion_factors(uom):
    Raises:
       ValueError if either uom is not a valid resqml uom
    """
-   if uom not in valid_uoms():
-      raise ValueError(f"{uom} is not a valid uom")
-   uoms_data = _properties_data()["units"][uom]
+    if uom not in valid_uoms():
+        raise ValueError(f"{uom} is not a valid uom")
+    uoms_data = _properties_data()["units"][uom]
 
-   dimension = uoms_data["dimension"]
-   try:
-      a, b, c, d = uoms_data["A"], uoms_data["B"], uoms_data["C"], uoms_data["D"]
-      base_unit = uoms_data["baseUnit"]
-   except KeyError:  # Base units do not have factors defined
-      a, b, c, d = 0, 1, 1, 0
-      base_unit = uom
-   return base_unit, dimension, (a, b, c, d)
+    dimension = uoms_data["dimension"]
+    try:
+        a, b, c, d = uoms_data["A"], uoms_data["B"], uoms_data["C"], uoms_data["D"]
+        base_unit = uoms_data["baseUnit"]
+    except KeyError:  # Base units do not have factors defined
+        a, b, c, d = 0, 1, 1, 0
+        base_unit = uom
+    return base_unit, dimension, (a, b, c, d)
 
 
 # Private functions
@@ -351,7 +351,7 @@ def get_conversion_factors(uom):
 
 @lru_cache(None)
 def _properties_data():
-   """ Return a data structure that represents resqml unit system.
+    """ Return a data structure that represents resqml unit system.
 
    The dict is loaded directly from a JSON file which is bundled with resqpy.
    The unit system is represented as a dict with the following keys:
@@ -366,37 +366,37 @@ def _properties_data():
       dict: resqml unit system
       
    """
-   json_path = Path(__file__).parent / 'olio/data/properties.json'
-   with open(json_path) as f:
-      data = json.load(f)
-   return data
+    json_path = Path(__file__).parent / 'olio/data/properties.json'
+    with open(json_path) as f:
+        data = json.load(f)
+    return data
 
 
 def _try_parse_unit(units):
-   """Try to match unit against known uoms and aliases, else return None"""
+    """Try to match unit against known uoms and aliases, else return None"""
 
-   uom_list = valid_uoms()
-   ul = units.casefold()
+    uom_list = valid_uoms()
+    ul = units.casefold()
 
-   uom = None
+    uom = None
 
-   if units in uom_list:
-      uom = units
-   elif ul in CASE_INSENSITIVE_UOMS:
-      uom = ul
-   elif ul in UOM_ALIAS_MAP:
-      uom = UOM_ALIAS_MAP[ul]
-   elif ul in uom_list:
-      uom = ul  # dangerous! for example, 'D' means D'Arcy and 'd' means day
-   elif units.startswith('(') and units.endswith(')') and '(' not in units[1:]:  # simplistic
-      uom = _try_parse_unit(units[1:-1])
-   elif '/' in units:  # May be a fraction: match each part against known aliases
-      parts = units.split('/', 1)
-      newpart0 = _try_parse_unit(parts[0])
-      newpart1 = _try_parse_unit(parts[1])
-      if newpart0 and newpart1:
-         ratio = f"{newpart0}/{newpart1}"
-         if ratio in uom_list:
-            uom = ratio
+    if units in uom_list:
+        uom = units
+    elif ul in CASE_INSENSITIVE_UOMS:
+        uom = ul
+    elif ul in UOM_ALIAS_MAP:
+        uom = UOM_ALIAS_MAP[ul]
+    elif ul in uom_list:
+        uom = ul  # dangerous! for example, 'D' means D'Arcy and 'd' means day
+    elif units.startswith('(') and units.endswith(')') and '(' not in units[1:]:  # simplistic
+        uom = _try_parse_unit(units[1:-1])
+    elif '/' in units:  # May be a fraction: match each part against known aliases
+        parts = units.split('/', 1)
+        newpart0 = _try_parse_unit(parts[0])
+        newpart1 = _try_parse_unit(parts[1])
+        if newpart0 and newpart1:
+            ratio = f"{newpart0}/{newpart1}"
+            if ratio in uom_list:
+                uom = ratio
 
-   return uom
+    return uom

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -61,32 +61,32 @@ from resqpy.olio.xml_namespaces import curly_namespace as ns
 from resqpy.olio.base import BaseResqpy
 
 valid_md_reference_list = [
-   "ground level", "kelly bushing", "mean sea level", "derrick floor", "casing flange", "arbitrary point",
-   "crown valve", "rotary bushing", "rotary table", "sea floor", "lowest astronomical tide", "mean higher high water",
-   "mean high water", "mean lower low water", "mean low water", "mean tide level", "kickoff point"
+    "ground level", "kelly bushing", "mean sea level", "derrick floor", "casing flange", "arbitrary point",
+    "crown valve", "rotary bushing", "rotary table", "sea floor", "lowest astronomical tide", "mean higher high water",
+    "mean high water", "mean lower low water", "mean low water", "mean tide level", "kickoff point"
 ]
 
 # todo: could require/maintain DeviationSurvey mds in same units as md datum object's crs vertical units?
 
 
 class MdDatum(BaseResqpy):
-   """Class for RESQML measured depth datum."""
+    """Class for RESQML measured depth datum."""
 
-   resqml_type = 'MdDatum'
+    resqml_type = 'MdDatum'
 
-   def __init__(
-         self,
-         parent_model,
-         uuid = None,
-         md_datum_root = None,
-         crs_uuid = None,
-         crs_root = None,  # deprecated
-         location = None,
-         md_reference = 'mean sea level',
-         title = None,
-         originator = None,
-         extra_metadata = None):
-      """Initialises a new MdDatum object.
+    def __init__(
+            self,
+            parent_model,
+            uuid = None,
+            md_datum_root = None,
+            crs_uuid = None,
+            crs_root = None,  # deprecated
+            location = None,
+            md_reference = 'mean sea level',
+            title = None,
+            originator = None,
+            extra_metadata = None):
+        """Initialises a new MdDatum object.
 
       arguments:
          parent_model (model.Model object): the model which the new md datum belongs to
@@ -118,77 +118,77 @@ class MdDatum(BaseResqpy):
          if initialising from data other than an existing RESQML object
       """
 
-      if crs_root is not None:
-         warnings.warn("Attribute 'crs_root' is deprecated. Use 'crs_uuid'", DeprecationWarning)
-      # TODO: remove crs_root argument
+        if crs_root is not None:
+            warnings.warn("Attribute 'crs_root' is deprecated. Use 'crs_uuid'", DeprecationWarning)
+        # TODO: remove crs_root argument
 
-      self.location = location
-      self.md_reference = md_reference
-      self.crs_uuid = crs_uuid
+        self.location = location
+        self.md_reference = md_reference
+        self.crs_uuid = crs_uuid
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = md_datum_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = md_datum_root)
 
-      # temporary code to sort out crs reference, till crs_root arg is retired
-      if self.crs_uuid is None and crs_root is not None:
-         self.crs_uuid = rqet.uuid_for_part_root(crs_root)
+        # temporary code to sort out crs reference, till crs_root arg is retired
+        if self.crs_uuid is None and crs_root is not None:
+            self.crs_uuid = rqet.uuid_for_part_root(crs_root)
 
-      assert self.crs_uuid is not None
-      if self.root is None and (location is not None or md_reference):
-         assert location is not None and md_reference
-         assert md_reference in valid_md_reference_list
-         assert len(location) == 3
+        assert self.crs_uuid is not None
+        if self.root is None and (location is not None or md_reference):
+            assert location is not None and md_reference
+            assert md_reference in valid_md_reference_list
+            assert len(location) == 3
 
-   def _load_from_xml(self):
-      md_datum_root = self.root
-      assert md_datum_root is not None
-      location_node = rqet.find_tag(md_datum_root, 'Location')
-      self.location = (rqet.find_tag_float(location_node,
-                                           'Coordinate1'), rqet.find_tag_float(location_node, 'Coordinate2'),
-                       rqet.find_tag_float(location_node, 'Coordinate3'))
-      self.md_reference = rqet.node_text(rqet.find_tag(md_datum_root, 'MdReference')).strip().lower()
-      assert self.md_reference in valid_md_reference_list
-      self.crs_uuid = self.extract_crs_uuid()
+    def _load_from_xml(self):
+        md_datum_root = self.root
+        assert md_datum_root is not None
+        location_node = rqet.find_tag(md_datum_root, 'Location')
+        self.location = (rqet.find_tag_float(location_node,
+                                             'Coordinate1'), rqet.find_tag_float(location_node, 'Coordinate2'),
+                         rqet.find_tag_float(location_node, 'Coordinate3'))
+        self.md_reference = rqet.node_text(rqet.find_tag(md_datum_root, 'MdReference')).strip().lower()
+        assert self.md_reference in valid_md_reference_list
+        self.crs_uuid = self.extract_crs_uuid()
 
-   @property
-   def crs_root(self):
-      """XML node corresponding to self.crs_uuid"""
+    @property
+    def crs_root(self):
+        """XML node corresponding to self.crs_uuid"""
 
-      return self.model.root_for_uuid(self.crs_uuid)
+        return self.model.root_for_uuid(self.crs_uuid)
 
-   # todo: the following function is almost identical to one in the grid module: it should be made common and put in model.py
+    # todo: the following function is almost identical to one in the grid module: it should be made common and put in model.py
 
-   def extract_crs_uuid(self):
-      """Returns uuid for coordinate reference system, as stored in reference node of this md datum's xml tree."""
+    def extract_crs_uuid(self):
+        """Returns uuid for coordinate reference system, as stored in reference node of this md datum's xml tree."""
 
-      if self.crs_uuid is not None:
-         return self.crs_uuid
-      crs_root = rqet.find_tag(self.root, 'LocalCrs')
-      uuid_str = rqet.find_tag(crs_root, 'UUID').text
-      self.crs_uuid = bu.uuid_from_string(uuid_str)
-      return self.crs_uuid
+        if self.crs_uuid is not None:
+            return self.crs_uuid
+        crs_root = rqet.find_tag(self.root, 'LocalCrs')
+        uuid_str = rqet.find_tag(crs_root, 'UUID').text
+        self.crs_uuid = bu.uuid_from_string(uuid_str)
+        return self.crs_uuid
 
-   def extract_crs_root(self):
-      """Returns root in parent model xml parts forest of coordinate reference system used by this md datum."""
+    def extract_crs_root(self):
+        """Returns root in parent model xml parts forest of coordinate reference system used by this md datum."""
 
-      if self.crs_uuid is None:
-         self.extract_crs_uuid()
-      return self.crs_root
+        if self.crs_uuid is None:
+            self.extract_crs_uuid()
+        return self.crs_root
 
-   def create_part(self):
-      """Creates xml for this md datum object and adds to parent model as a part; returns root node for part."""
+    def create_part(self):
+        """Creates xml for this md datum object and adds to parent model as a part; returns root node for part."""
 
-      # note: deprecated, call create_xml() directly
-      assert self.root is None
-      assert self.location is not None
-      self.create_xml(add_as_part = True)
+        # note: deprecated, call create_xml() directly
+        assert self.root is None
+        assert self.location is not None
+        self.create_xml(add_as_part = True)
 
-   def create_xml(self, add_as_part = True, add_relationships = True, title = None, originator = None):
-      """Creates xml for a measured depth datum element; crs node must already exist; optionally adds as part.
+    def create_xml(self, add_as_part = True, add_relationships = True, title = None, originator = None):
+        """Creates xml for a measured depth datum element; crs node must already exist; optionally adds as part.
 
          arguments:
             add_as_part (boolean, default True): if True, the newly created xml node is added as a part
@@ -203,46 +203,46 @@ class MdDatum(BaseResqpy):
             the newly created measured depth datum xml node
       """
 
-      md_reference = self.md_reference.lower()
-      assert md_reference in valid_md_reference_list, 'invalid measured depth reference: ' + md_reference
+        md_reference = self.md_reference.lower()
+        assert md_reference in valid_md_reference_list, 'invalid measured depth reference: ' + md_reference
 
-      if title:
-         self.title = title
-      if not self.title:
-         self.title = 'measured depth datum'
+        if title:
+            self.title = title
+        if not self.title:
+            self.title = 'measured depth datum'
 
-      crs_uuid = self.crs_uuid
-      assert crs_uuid is not None
+        crs_uuid = self.crs_uuid
+        assert crs_uuid is not None
 
-      datum = super().create_xml(add_as_part = False, originator = originator)
+        datum = super().create_xml(add_as_part = False, originator = originator)
 
-      self.model.create_solitary_point3d('Location', datum, self.location)
+        self.model.create_solitary_point3d('Location', datum, self.location)
 
-      md_ref = rqet.SubElement(datum, ns['resqml2'] + 'MdReference')
-      md_ref.set(ns['xsi'] + 'type', ns['resqml2'] + 'MdReference')
-      md_ref.text = md_reference
+        md_ref = rqet.SubElement(datum, ns['resqml2'] + 'MdReference')
+        md_ref.set(ns['xsi'] + 'type', ns['resqml2'] + 'MdReference')
+        md_ref.text = md_reference
 
-      self.model.create_crs_reference(crs_uuid = crs_uuid, root = datum)
+        self.model.create_crs_reference(crs_uuid = crs_uuid, root = datum)
 
-      if add_as_part:
-         self.model.add_part('obj_MdDatum', self.uuid, datum)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(datum, 'destinationObject', self.crs_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_MdDatum', self.uuid, datum)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(datum, 'destinationObject', self.crs_root, 'sourceObject')
 
-      return datum
+        return datum
 
-   def is_equivalent(self, other):
-      """Implements equals operator, comparing metadata items deemed significant."""
+    def is_equivalent(self, other):
+        """Implements equals operator, comparing metadata items deemed significant."""
 
-      if not isinstance(other, self.__class__):
-         return False
-      if self.md_reference != other.md_reference or not np.allclose(self.location, other.location):
-         return False
-      return bu.matching_uuids(self.crs_uuid, other.crs_uuid)
+        if not isinstance(other, self.__class__):
+            return False
+        if self.md_reference != other.md_reference or not np.allclose(self.location, other.location):
+            return False
+        return bu.matching_uuids(self.crs_uuid, other.crs_uuid)
 
 
 class DeviationSurvey(BaseResqpy):
-   """Class for RESQML wellbore deviation survey.
+    """Class for RESQML wellbore deviation survey.
 
    RESQML documentation:
 
@@ -261,26 +261,26 @@ class DeviationSurvey(BaseResqpy):
       units of measure for wellbore trajectory representation.
    """
 
-   resqml_type = 'DeviationSurveyRepresentation'
+    resqml_type = 'DeviationSurveyRepresentation'
 
-   def __init__(self,
-                parent_model,
-                uuid = None,
-                title = None,
-                deviation_survey_root = None,
-                represented_interp = None,
-                md_datum = None,
-                md_uom = 'm',
-                angle_uom = 'dega',
-                measured_depths = None,
-                azimuths = None,
-                inclinations = None,
-                station_count = None,
-                first_station = None,
-                is_final = False,
-                originator = None,
-                extra_metadata = None):
-      """Load or create a DeviationSurvey object.
+    def __init__(self,
+                 parent_model,
+                 uuid = None,
+                 title = None,
+                 deviation_survey_root = None,
+                 represented_interp = None,
+                 md_datum = None,
+                 md_uom = 'm',
+                 angle_uom = 'dega',
+                 measured_depths = None,
+                 azimuths = None,
+                 inclinations = None,
+                 station_count = None,
+                 first_station = None,
+                 is_final = False,
+                 originator = None,
+                 extra_metadata = None):
+        """Load or create a DeviationSurvey object.
 
       If uuid is given, loads from XML. Else, create new. If loading from disk, other
       parameters will be overwritten.
@@ -312,49 +312,49 @@ class DeviationSurvey(BaseResqpy):
          this method does not create an xml node, nor write hdf5 arrays
       """
 
-      self.is_final = is_final
-      self.md_uom = bwam.rq_length_unit(md_uom)
+        self.is_final = is_final
+        self.md_uom = bwam.rq_length_unit(md_uom)
 
-      self.angles_in_degrees = angle_uom.strip().lower().startswith('deg')
-      """boolean: True for degrees, False for radians (nothing else supported). Should be 'dega' or 'rad'"""
+        self.angles_in_degrees = angle_uom.strip().lower().startswith('deg')
+        """boolean: True for degrees, False for radians (nothing else supported). Should be 'dega' or 'rad'"""
 
-      # Array data
-      self.measured_depths = _as_optional_array(measured_depths)
-      self.azimuths = _as_optional_array(azimuths)
-      self.inclinations = _as_optional_array(inclinations)
+        # Array data
+        self.measured_depths = _as_optional_array(measured_depths)
+        self.azimuths = _as_optional_array(azimuths)
+        self.inclinations = _as_optional_array(inclinations)
 
-      if station_count is None and measured_depths is not None:
-         station_count = len(measured_depths)
-      self.station_count = station_count
-      self.first_station = first_station
+        if station_count is None and measured_depths is not None:
+            station_count = len(measured_depths)
+        self.station_count = station_count
+        self.first_station = first_station
 
-      # Referenced objects
-      self.md_datum = md_datum  # md datum is an object in its own right, with a related crs!
-      self.wellbore_interpretation = represented_interp
+        # Referenced objects
+        self.md_datum = md_datum  # md datum is an object in its own right, with a related crs!
+        self.wellbore_interpretation = represented_interp
 
-      # TODO: remove deviation_survey_root, use just uuid
+        # TODO: remove deviation_survey_root, use just uuid
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = deviation_survey_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = deviation_survey_root)
 
-   @classmethod
-   def from_data_frame(cls,
-                       parent_model,
-                       data_frame,
-                       md_datum = None,
-                       md_col = 'MD',
-                       azimuth_col = 'AZIM_GN',
-                       inclination_col = 'INCL',
-                       x_col = 'X',
-                       y_col = 'Y',
-                       z_col = 'Z',
-                       md_uom = 'm',
-                       angle_uom = 'dega'):
-      """Load MD, aximuth & inclination data from a pandas data frame.
+    @classmethod
+    def from_data_frame(cls,
+                        parent_model,
+                        data_frame,
+                        md_datum = None,
+                        md_col = 'MD',
+                        azimuth_col = 'AZIM_GN',
+                        inclination_col = 'INCL',
+                        x_col = 'X',
+                        y_col = 'Y',
+                        z_col = 'Z',
+                        md_uom = 'm',
+                        angle_uom = 'dega'):
+        """Load MD, aximuth & inclination data from a pandas data frame.
 
       Args:
          parent_model (model.Model): the parent resqml model
@@ -379,41 +379,41 @@ class DeviationSurvey(BaseResqpy):
          The X, Y & Z columns are only used to set the first station location (from the first row)
       """
 
-      for col in [md_col, azimuth_col, inclination_col, x_col, y_col, z_col]:
-         assert col in data_frame.columns
-      station_count = len(data_frame)
-      assert station_count >= 2  # vertical well could be hamdled by allowing a single station in survey?
-      #         self.md_uom = bwam.p_length_unit(md_uom)
+        for col in [md_col, azimuth_col, inclination_col, x_col, y_col, z_col]:
+            assert col in data_frame.columns
+        station_count = len(data_frame)
+        assert station_count >= 2  # vertical well could be hamdled by allowing a single station in survey?
+        #         self.md_uom = bwam.p_length_unit(md_uom)
 
-      start = data_frame.iloc[0]
+        start = data_frame.iloc[0]
 
-      return cls(parent_model = parent_model,
-                 station_count = station_count,
-                 md_datum = md_datum,
-                 md_uom = md_uom,
-                 angle_uom = angle_uom,
-                 first_station = (start[x_col], start[y_col], start[z_col]),
-                 measured_depths = data_frame[md_col].values,
-                 azimuths = data_frame[azimuth_col].values,
-                 inclinations = data_frame[inclination_col].values,
-                 is_final = True)  # assume this is a finalised deviation survey
+        return cls(parent_model = parent_model,
+                   station_count = station_count,
+                   md_datum = md_datum,
+                   md_uom = md_uom,
+                   angle_uom = angle_uom,
+                   first_station = (start[x_col], start[y_col], start[z_col]),
+                   measured_depths = data_frame[md_col].values,
+                   azimuths = data_frame[azimuth_col].values,
+                   inclinations = data_frame[inclination_col].values,
+                   is_final = True)  # assume this is a finalised deviation survey
 
-   @classmethod
-   def from_ascii_file(cls,
-                       parent_model,
-                       deviation_survey_file,
-                       comment_character = '#',
-                       space_separated_instead_of_csv = False,
-                       md_col = 'MD',
-                       azimuth_col = 'AZIM_GN',
-                       inclination_col = 'INCL',
-                       x_col = 'X',
-                       y_col = 'Y',
-                       z_col = 'Z',
-                       md_uom = 'm',
-                       angle_uom = 'dega',
-                       md_datum = None):
-      """Load MD, aximuth & inclination data from an ascii deviation survey file.
+    @classmethod
+    def from_ascii_file(cls,
+                        parent_model,
+                        deviation_survey_file,
+                        comment_character = '#',
+                        space_separated_instead_of_csv = False,
+                        md_col = 'MD',
+                        azimuth_col = 'AZIM_GN',
+                        inclination_col = 'INCL',
+                        x_col = 'X',
+                        y_col = 'Y',
+                        z_col = 'Z',
+                        md_uom = 'm',
+                        angle_uom = 'dega',
+                        md_datum = None):
+        """Load MD, aximuth & inclination data from an ascii deviation survey file.
 
       Arguments:
          parent_model (model.Model): the parent resqml model
@@ -441,30 +441,30 @@ class DeviationSurvey(BaseResqpy):
          The X, Y & Z columns are only used to set the first station location (from the first row)
       """
 
-      try:
-         df = pd.read_csv(deviation_survey_file,
-                          comment = comment_character,
-                          delim_whitespace = space_separated_instead_of_csv)
-         if df is None:
-            raise Exception
-      except Exception:
-         log.error('failed to read ascii deviation survey file ' + deviation_survey_file)
-         raise
+        try:
+            df = pd.read_csv(deviation_survey_file,
+                             comment = comment_character,
+                             delim_whitespace = space_separated_instead_of_csv)
+            if df is None:
+                raise Exception
+        except Exception:
+            log.error('failed to read ascii deviation survey file ' + deviation_survey_file)
+            raise
 
-      return cls.from_data_frame(parent_model,
-                                 df,
-                                 md_col = md_col,
-                                 azimuth_col = azimuth_col,
-                                 inclination_col = inclination_col,
-                                 x_col = x_col,
-                                 y_col = y_col,
-                                 z_col = z_col,
-                                 md_uom = md_uom,
-                                 angle_uom = angle_uom,
-                                 md_datum = md_datum)
+        return cls.from_data_frame(parent_model,
+                                   df,
+                                   md_col = md_col,
+                                   azimuth_col = azimuth_col,
+                                   inclination_col = inclination_col,
+                                   x_col = x_col,
+                                   y_col = y_col,
+                                   z_col = z_col,
+                                   md_uom = md_uom,
+                                   angle_uom = angle_uom,
+                                   md_datum = md_datum)
 
-   def _load_from_xml(self):
-      """Load attributes from xml and associated hdf5 data.
+    def _load_from_xml(self):
+        """Load attributes from xml and associated hdf5 data.
 
       This is invoked as part of the init method when an existing uuid is given.
       
@@ -472,44 +472,44 @@ class DeviationSurvey(BaseResqpy):
          [bool]: True if sucessful
       """
 
-      # Get node from self.uuid
-      node = self.root
-      assert node is not None
+        # Get node from self.uuid
+        node = self.root
+        assert node is not None
 
-      # Load XML data
-      self.md_uom = rqet.length_units_from_node(rqet.find_tag(node, 'MdUom', must_exist = True))
-      self.angle_uom = rqet.find_tag_text(node, 'AngleUom', must_exist = True)
-      self.station_count = rqet.find_tag_int(node, 'StationCount', must_exist = True)
-      self.first_station = extract_xyz(rqet.find_tag(node, 'FirstStationLocation', must_exist = True))
-      self.is_final = rqet.find_tag_bool(node, 'IsFinal')
+        # Load XML data
+        self.md_uom = rqet.length_units_from_node(rqet.find_tag(node, 'MdUom', must_exist = True))
+        self.angle_uom = rqet.find_tag_text(node, 'AngleUom', must_exist = True)
+        self.station_count = rqet.find_tag_int(node, 'StationCount', must_exist = True)
+        self.first_station = extract_xyz(rqet.find_tag(node, 'FirstStationLocation', must_exist = True))
+        self.is_final = rqet.find_tag_bool(node, 'IsFinal')
 
-      # Load HDF5 data
-      mds_node = rqet.find_tag(node, 'Mds', must_exist = True)
-      load_hdf5_array(self, mds_node, 'measured_depths')
-      azimuths_node = rqet.find_tag(node, 'Azimuths', must_exist = True)
-      load_hdf5_array(self, azimuths_node, 'azimuths')
-      inclinations_node = rqet.find_tag(node, 'Inclinations', must_exist = True)
-      load_hdf5_array(self, inclinations_node, 'inclinations')
+        # Load HDF5 data
+        mds_node = rqet.find_tag(node, 'Mds', must_exist = True)
+        load_hdf5_array(self, mds_node, 'measured_depths')
+        azimuths_node = rqet.find_tag(node, 'Azimuths', must_exist = True)
+        load_hdf5_array(self, azimuths_node, 'azimuths')
+        inclinations_node = rqet.find_tag(node, 'Inclinations', must_exist = True)
+        load_hdf5_array(self, inclinations_node, 'inclinations')
 
-      # Set related objects
-      self.md_datum = self._load_related_datum()
-      self.represented_interp = self._load_related_wellbore_interp()
+        # Set related objects
+        self.md_datum = self._load_related_datum()
+        self.represented_interp = self._load_related_wellbore_interp()
 
-      # Validate
-      assert self.measured_depths is not None
-      assert len(self.measured_depths) > 0
+        # Validate
+        assert self.measured_depths is not None
+        assert len(self.measured_depths) > 0
 
-      return True
+        return True
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  md_datum_root = None,
-                  md_datum_xyz = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  title = None,
-                  originator = None):
-      """Creates a deviation survey representation xml element from this DeviationSurvey object.
+    def create_xml(self,
+                   ext_uuid = None,
+                   md_datum_root = None,
+                   md_datum_xyz = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   title = None,
+                   originator = None):
+        """Creates a deviation survey representation xml element from this DeviationSurvey object.
 
       arguments:
          ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the deviation survey arrays
@@ -529,167 +529,167 @@ class DeviationSurvey(BaseResqpy):
          the newly created deviation survey xml node
       """
 
-      assert self.station_count > 0
+        assert self.station_count > 0
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      if md_datum_root is None:
-         if self.md_datum is None:
-            if md_datum_xyz is None:
-               raise ValueError("Must provide a MD Datum for the DeviationSurvey")
-            self.md_datum = MdDatum(self.model, location = md_datum_xyz)
-         if self.md_datum.root is None:
-            md_datum_root = self.md_datum.create_xml()
-         else:
-            md_datum_root = self.md_datum.root
-      assert md_datum_root is not None
+        if md_datum_root is None:
+            if self.md_datum is None:
+                if md_datum_xyz is None:
+                    raise ValueError("Must provide a MD Datum for the DeviationSurvey")
+                self.md_datum = MdDatum(self.model, location = md_datum_xyz)
+            if self.md_datum.root is None:
+                md_datum_root = self.md_datum.create_xml()
+            else:
+                md_datum_root = self.md_datum.root
+        assert md_datum_root is not None
 
-      # Create root node, write citation block
-      ds_node = super().create_xml(title = title, originator = originator, add_as_part = False)
+        # Create root node, write citation block
+        ds_node = super().create_xml(title = title, originator = originator, add_as_part = False)
 
-      if_node = rqet.SubElement(ds_node, ns['resqml2'] + 'IsFinal')
-      if_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
-      if_node.text = str(self.is_final).lower()
+        if_node = rqet.SubElement(ds_node, ns['resqml2'] + 'IsFinal')
+        if_node.set(ns['xsi'] + 'type', ns['xsd'] + 'boolean')
+        if_node.text = str(self.is_final).lower()
 
-      sc_node = rqet.SubElement(ds_node, ns['resqml2'] + 'StationCount')
-      sc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      sc_node.text = str(self.station_count)
+        sc_node = rqet.SubElement(ds_node, ns['resqml2'] + 'StationCount')
+        sc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        sc_node.text = str(self.station_count)
 
-      md_uom = rqet.SubElement(ds_node, ns['resqml2'] + 'MdUom')
-      md_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
-      md_uom.text = bwam.rq_length_unit(self.md_uom)
+        md_uom = rqet.SubElement(ds_node, ns['resqml2'] + 'MdUom')
+        md_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
+        md_uom.text = bwam.rq_length_unit(self.md_uom)
 
-      self.model.create_md_datum_reference(md_datum_root, root = ds_node)
+        self.model.create_md_datum_reference(md_datum_root, root = ds_node)
 
-      self.model.create_solitary_point3d('FirstStationLocation', ds_node, self.first_station)
+        self.model.create_solitary_point3d('FirstStationLocation', ds_node, self.first_station)
 
-      angle_uom = rqet.SubElement(ds_node, ns['resqml2'] + 'AngleUom')
-      angle_uom.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleUom')
-      if self.angles_in_degrees:
-         angle_uom.text = 'dega'
-      else:
-         angle_uom.text = 'rad'
+        angle_uom = rqet.SubElement(ds_node, ns['resqml2'] + 'AngleUom')
+        angle_uom.set(ns['xsi'] + 'type', ns['eml'] + 'PlaneAngleUom')
+        if self.angles_in_degrees:
+            angle_uom.text = 'dega'
+        else:
+            angle_uom.text = 'rad'
 
-      mds = rqet.SubElement(ds_node, ns['resqml2'] + 'Mds')
-      mds.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-      mds.text = rqet.null_xml_text
+        mds = rqet.SubElement(ds_node, ns['resqml2'] + 'Mds')
+        mds.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+        mds.text = rqet.null_xml_text
 
-      mds_values_node = rqet.SubElement(mds, ns['resqml2'] + 'Values')
-      mds_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
-      mds_values_node.text = rqet.null_xml_text
+        mds_values_node = rqet.SubElement(mds, ns['resqml2'] + 'Values')
+        mds_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
+        mds_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Mds', root = mds_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Mds', root = mds_values_node)
 
-      azimuths = rqet.SubElement(ds_node, ns['resqml2'] + 'Azimuths')
-      azimuths.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-      azimuths.text = rqet.null_xml_text
+        azimuths = rqet.SubElement(ds_node, ns['resqml2'] + 'Azimuths')
+        azimuths.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+        azimuths.text = rqet.null_xml_text
 
-      azimuths_values_node = rqet.SubElement(azimuths, ns['resqml2'] + 'Values')
-      azimuths_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
-      azimuths_values_node.text = rqet.null_xml_text
+        azimuths_values_node = rqet.SubElement(azimuths, ns['resqml2'] + 'Values')
+        azimuths_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
+        azimuths_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Azimuths', root = azimuths_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Azimuths', root = azimuths_values_node)
 
-      inclinations = rqet.SubElement(ds_node, ns['resqml2'] + 'Inclinations')
-      inclinations.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-      inclinations.text = rqet.null_xml_text
+        inclinations = rqet.SubElement(ds_node, ns['resqml2'] + 'Inclinations')
+        inclinations.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+        inclinations.text = rqet.null_xml_text
 
-      inclinations_values_node = rqet.SubElement(inclinations, ns['resqml2'] + 'Values')
-      inclinations_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
-      inclinations_values_node.text = rqet.null_xml_text
+        inclinations_values_node = rqet.SubElement(inclinations, ns['resqml2'] + 'Values')
+        inclinations_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
+        inclinations_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Inclinations', root = inclinations_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'Inclinations', root = inclinations_values_node)
 
-      interp_root = None
-      if self.wellbore_interpretation is not None:
-         interp_root = self.wellbore_interpretation.root
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
-                                    bu.uuid_from_string(interp_root.attrib['uuid']),
-                                    content_type = 'obj_WellboreInterpretation',
-                                    root = ds_node)
+        interp_root = None
+        if self.wellbore_interpretation is not None:
+            interp_root = self.wellbore_interpretation.root
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
+                                       bu.uuid_from_string(interp_root.attrib['uuid']),
+                                       content_type = 'obj_WellboreInterpretation',
+                                       root = ds_node)
 
-      if add_as_part:
-         self.model.add_part('obj_DeviationSurveyRepresentation', self.uuid, ds_node)
-         if add_relationships:
-            # todo: check following relationship
-            self.model.create_reciprocal_relationship(ds_node, 'destinationObject', md_datum_root, 'sourceObject')
-            if interp_root is not None:
-               self.model.create_reciprocal_relationship(ds_node, 'destinationObject', interp_root, 'sourceObject')
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(ds_node, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+        if add_as_part:
+            self.model.add_part('obj_DeviationSurveyRepresentation', self.uuid, ds_node)
+            if add_relationships:
+                # todo: check following relationship
+                self.model.create_reciprocal_relationship(ds_node, 'destinationObject', md_datum_root, 'sourceObject')
+                if interp_root is not None:
+                    self.model.create_reciprocal_relationship(ds_node, 'destinationObject', interp_root, 'sourceObject')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(ds_node, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
 
-      return ds_node
+        return ds_node
 
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Create or append to an hdf5 file, writing datasets for the measured depths, azimuths, and inclinations."""
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Create or append to an hdf5 file, writing datasets for the measured depths, azimuths, and inclinations."""
 
-      # NB: array data must all have been set up prior to calling this function
-      h5_reg = rwh5.H5Register(self.model)
-      h5_reg.register_dataset(self.uuid, 'Mds', self.measured_depths, dtype = float)
-      h5_reg.register_dataset(self.uuid, 'Azimuths', self.azimuths, dtype = float)
-      h5_reg.register_dataset(self.uuid, 'Inclinations', self.inclinations, dtype = float)
-      h5_reg.write(file = file_name, mode = mode)
+        # NB: array data must all have been set up prior to calling this function
+        h5_reg = rwh5.H5Register(self.model)
+        h5_reg.register_dataset(self.uuid, 'Mds', self.measured_depths, dtype = float)
+        h5_reg.register_dataset(self.uuid, 'Azimuths', self.azimuths, dtype = float)
+        h5_reg.register_dataset(self.uuid, 'Inclinations', self.inclinations, dtype = float)
+        h5_reg.write(file = file_name, mode = mode)
 
-   def _load_related_datum(self):
-      """Return related MdDatum object from XML if present"""
+    def _load_related_datum(self):
+        """Return related MdDatum object from XML if present"""
 
-      md_datum_uuid = bu.uuid_from_string(rqet.find_tag(rqet.find_tag(self.root, 'MdDatum'), 'UUID'))
-      if md_datum_uuid is not None:
-         md_datum_part = 'obj_MdDatum_' + str(md_datum_uuid) + '.xml'
-         md_datum = MdDatum(self.model, md_datum_root = self.model.root_for_part(md_datum_part, is_rels = False))
-      else:
-         md_datum = None
-      return md_datum
+        md_datum_uuid = bu.uuid_from_string(rqet.find_tag(rqet.find_tag(self.root, 'MdDatum'), 'UUID'))
+        if md_datum_uuid is not None:
+            md_datum_part = 'obj_MdDatum_' + str(md_datum_uuid) + '.xml'
+            md_datum = MdDatum(self.model, md_datum_root = self.model.root_for_part(md_datum_part, is_rels = False))
+        else:
+            md_datum = None
+        return md_datum
 
-   def _load_related_wellbore_interp(self):
-      """Return related wellbore interp object from XML if present"""
+    def _load_related_wellbore_interp(self):
+        """Return related wellbore interp object from XML if present"""
 
-      interp_uuid = rqet.find_nested_tags_text(self.root, ['RepresentedInterpretation', 'UUID'])
-      if interp_uuid is None:
-         represented_interp = None
-      else:
-         represented_interp = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
-      return represented_interp
+        interp_uuid = rqet.find_nested_tags_text(self.root, ['RepresentedInterpretation', 'UUID'])
+        if interp_uuid is None:
+            represented_interp = None
+        else:
+            represented_interp = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
+        return represented_interp
 
 
 class Trajectory(BaseResqpy):
-   """Class for RESQML Wellbore Trajectory Representation (Geometry).
+    """Class for RESQML Wellbore Trajectory Representation (Geometry).
 
    note:
       resqml allows trajectory to have different crs to the measured depth datum crs;
       however, this code requires the trajectory to be in the same crs as the md datum
    """
 
-   resqml_type = 'WellboreTrajectoryRepresentation'
-   well_name = rqo._alias_for_attribute("title")
+    resqml_type = 'WellboreTrajectoryRepresentation'
+    well_name = rqo._alias_for_attribute("title")
 
-   def __init__(
-         self,
-         parent_model,
-         trajectory_root = None,  # deprecated
-         uuid = None,
-         md_datum = None,
-         deviation_survey = None,
-         data_frame = None,
-         grid = None,
-         cell_kji0_list = None,
-         wellspec_file = None,
-         spline_mode = 'cube',
-         deviation_survey_file = None,
-         survey_file_space_separated = False,
-         length_uom = None,
-         md_domain = None,
-         represented_interp = None,
-         well_name = None,
-         set_tangent_vectors = False,
-         hdf5_source_model = None,
-         originator = None,
-         extra_metadata = None):
-      """Creates a new trajectory object and optionally loads it from xml, deviation survey, pandas dataframe, or ascii file.
+    def __init__(
+            self,
+            parent_model,
+            trajectory_root = None,  # deprecated
+            uuid = None,
+            md_datum = None,
+            deviation_survey = None,
+            data_frame = None,
+            grid = None,
+            cell_kji0_list = None,
+            wellspec_file = None,
+            spline_mode = 'cube',
+            deviation_survey_file = None,
+            survey_file_space_separated = False,
+            length_uom = None,
+            md_domain = None,
+            represented_interp = None,
+            well_name = None,
+            set_tangent_vectors = False,
+            hdf5_source_model = None,
+            originator = None,
+            extra_metadata = None):
+        """Creates a new trajectory object and optionally loads it from xml, deviation survey, pandas dataframe, or ascii file.
 
       arguments:
          parent_model (model.Model object): the model which the new trajectory belongs to
@@ -744,341 +744,341 @@ class Trajectory(BaseResqpy):
       :meta common:
       """
 
-      self.crs_uuid = None
-      self.title = well_name
-      self.start_md = None
-      self.finish_md = None
-      self.md_uom = length_uom
-      self.md_domain = md_domain
-      self.md_datum = md_datum  # md datum is an object in its own right, with a related crs!
-      # parametric line geometry elements
-      self.knot_count = None
-      self.line_kind_index = None
-      # 0 for vertical
-      # 1 for linear spline
-      # 2 for natural cubic spline
-      # 3 for cubic spline
-      # 4 for z linear cubic spline
-      # 5 for minimum-curvature spline   # in practice this is the value actually used  in datasets
-      # (-1) for null: no line
-      self.measured_depths = None  # known as control point parameters in the parametric line geometry
-      self.control_points = None  # xyz array of shape (knot_count, 3)
-      self.tangent_vectors = None  # optional xyz tangent vector array, if present has same shape as control points)
-      self.deviation_survey = deviation_survey  # optional related deviation survey
-      self.wellbore_interpretation = represented_interp
-      self.wellbore_feature = None
-      self.feature_and_interpretation_to_be_written = False
-      # todo: parent intersection for multi-lateral wells
-      # todo: witsml trajectory reference (optional)
+        self.crs_uuid = None
+        self.title = well_name
+        self.start_md = None
+        self.finish_md = None
+        self.md_uom = length_uom
+        self.md_domain = md_domain
+        self.md_datum = md_datum  # md datum is an object in its own right, with a related crs!
+        # parametric line geometry elements
+        self.knot_count = None
+        self.line_kind_index = None
+        # 0 for vertical
+        # 1 for linear spline
+        # 2 for natural cubic spline
+        # 3 for cubic spline
+        # 4 for z linear cubic spline
+        # 5 for minimum-curvature spline   # in practice this is the value actually used  in datasets
+        # (-1) for null: no line
+        self.measured_depths = None  # known as control point parameters in the parametric line geometry
+        self.control_points = None  # xyz array of shape (knot_count, 3)
+        self.tangent_vectors = None  # optional xyz tangent vector array, if present has same shape as control points)
+        self.deviation_survey = deviation_survey  # optional related deviation survey
+        self.wellbore_interpretation = represented_interp
+        self.wellbore_feature = None
+        self.feature_and_interpretation_to_be_written = False
+        # todo: parent intersection for multi-lateral wells
+        # todo: witsml trajectory reference (optional)
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = well_name,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = trajectory_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = well_name,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = trajectory_root)
 
-      if self.root is not None:
-         return
+        if self.root is not None:
+            return
 
-      if set_tangent_vectors and self.knot_count > 1 and self.tangent_vectors is None:
-         self.set_tangents()
-      elif self.deviation_survey is not None:
-         self.compute_from_deviation_survey(method = 'minimum curvature', set_tangent_vectors = set_tangent_vectors)
-      elif data_frame is not None:
-         self.load_from_data_frame(data_frame,
-                                   md_uom = length_uom,
-                                   md_datum = md_datum,
-                                   set_tangent_vectors = set_tangent_vectors)
-      elif cell_kji0_list is not None:
-         self.load_from_cell_list(grid, cell_kji0_list, spline_mode, length_uom)
-      elif wellspec_file:
-         self.load_from_wellspec(grid, wellspec_file, well_name, spline_mode, length_uom)
-      elif deviation_survey_file:
-         self.load_from_ascii_file(deviation_survey_file,
-                                   space_separated_instead_of_csv = survey_file_space_separated,
-                                   md_uom = length_uom,
-                                   md_datum = md_datum,
-                                   title = well_name,
-                                   set_tangent_vectors = set_tangent_vectors)
-      # todo: create from already loaded deviation_survey node (ie. derive xyz points)
+        if set_tangent_vectors and self.knot_count > 1 and self.tangent_vectors is None:
+            self.set_tangents()
+        elif self.deviation_survey is not None:
+            self.compute_from_deviation_survey(method = 'minimum curvature', set_tangent_vectors = set_tangent_vectors)
+        elif data_frame is not None:
+            self.load_from_data_frame(data_frame,
+                                      md_uom = length_uom,
+                                      md_datum = md_datum,
+                                      set_tangent_vectors = set_tangent_vectors)
+        elif cell_kji0_list is not None:
+            self.load_from_cell_list(grid, cell_kji0_list, spline_mode, length_uom)
+        elif wellspec_file:
+            self.load_from_wellspec(grid, wellspec_file, well_name, spline_mode, length_uom)
+        elif deviation_survey_file:
+            self.load_from_ascii_file(deviation_survey_file,
+                                      space_separated_instead_of_csv = survey_file_space_separated,
+                                      md_uom = length_uom,
+                                      md_datum = md_datum,
+                                      title = well_name,
+                                      set_tangent_vectors = set_tangent_vectors)
+        # todo: create from already loaded deviation_survey node (ie. derive xyz points)
 
-      if self.crs_uuid is None:
-         if self.md_datum is not None:
-            self.crs_uuid = self.md_datum.crs_uuid
-         else:
-            self.crs_uuid = self.model.crs_uuid
+        if self.crs_uuid is None:
+            if self.md_datum is not None:
+                self.crs_uuid = self.md_datum.crs_uuid
+            else:
+                self.crs_uuid = self.model.crs_uuid
 
-      if not self.title:
-         self.title = 'well trajectory'
+        if not self.title:
+            self.title = 'well trajectory'
 
-      if self.md_datum is None and self.control_points is not None:
-         self.md_datum = MdDatum(self.model, crs_uuid = self.crs_uuid, location = self.control_points[0])
+        if self.md_datum is None and self.control_points is not None:
+            self.md_datum = MdDatum(self.model, crs_uuid = self.crs_uuid, location = self.control_points[0])
 
-   @property
-   def crs_root(self):
-      """XML node corresponding to self.crs_uuid"""
+    @property
+    def crs_root(self):
+        """XML node corresponding to self.crs_uuid"""
 
-      return self.model.root_for_uuid(self.crs_uuid)
+        return self.model.root_for_uuid(self.crs_uuid)
 
-   def iter_wellbore_frames(self):
-      """ Iterable of all WellboreFrames associated with a trajectory
+    def iter_wellbore_frames(self):
+        """ Iterable of all WellboreFrames associated with a trajectory
 
       Yields:
          frame: instance of :class:`resqpy.organize.WellboreFrame`
 
       :meta common:
       """
-      uuids = self.model.uuids(obj_type = "WellboreFrameRepresentation", related_uuid = self.uuid)
-      for uuid in uuids:
-         yield WellboreFrame(self.model, uuid = uuid)
+        uuids = self.model.uuids(obj_type = "WellboreFrameRepresentation", related_uuid = self.uuid)
+        for uuid in uuids:
+            yield WellboreFrame(self.model, uuid = uuid)
 
-   def _load_from_xml(self):
-      """Loads the trajectory object from an xml node (and associated hdf5 data)."""
+    def _load_from_xml(self):
+        """Loads the trajectory object from an xml node (and associated hdf5 data)."""
 
-      node = self.root
-      assert node is not None
-      self.start_md = float(rqet.node_text(rqet.find_tag(node, 'StartMd')).strip())
-      self.finish_md = float(rqet.node_text(rqet.find_tag(node, 'FinishMd')).strip())
-      self.md_uom = rqet.length_units_from_node(rqet.find_tag(node, 'MdUom'))
-      self.md_domain = rqet.node_text(rqet.find_tag(node, 'MdDomain'))
-      geometry_node = rqet.find_tag(node, 'Geometry')
-      self.crs_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(geometry_node, ['LocalCrs', 'UUID']))
-      self.knot_count = int(rqet.node_text(rqet.find_tag(geometry_node, 'KnotCount')).strip())
-      self.line_kind_index = int(rqet.node_text(rqet.find_tag(geometry_node, 'LineKindIndex')).strip())
-      mds_node = rqet.find_tag(geometry_node, 'ControlPointParameters')
-      if mds_node is not None:  # not required for vertical or z linear cubic spline
-         load_hdf5_array(self, mds_node, 'measured_depths')
-      control_points_node = rqet.find_tag(geometry_node, 'ControlPoints')
-      load_hdf5_array(self, control_points_node, 'control_points', tag = 'Coordinates')
-      tangents_node = rqet.find_tag(geometry_node, 'TangentVectors')
-      if tangents_node is not None:
-         load_hdf5_array(self, tangents_node, 'tangent_vectors', tag = 'Coordinates')
-      relatives_model = self.model  # if hdf5_source_model is None else hdf5_source_model
-      # md_datum - separate part, referred to in this tree
-      md_datum_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['MdDatum', 'UUID']))
-      assert md_datum_uuid is not None, 'failed to fetch uuid of md datum for trajectory'
-      md_datum_part = relatives_model.part_for_uuid(md_datum_uuid)
-      assert md_datum_part, 'md datum part not found in model'
-      self.md_datum = MdDatum(self.model, uuid = relatives_model.uuid_for_part(md_datum_part))
-      ds_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['DeviationSurvey', 'UUID']))
-      if ds_uuid is not None:  # this will probably not work when relatives model is different from self.model
-         ds_part = rqet.part_name_for_object('obj_DeviationSurveyRepresentation_', ds_uuid)
-         self.deviation_survey = DeviationSurvey(self.model,
-                                                 uuid = relatives_model.uuid_for_part(ds_part, is_rels = False),
-                                                 md_datum = self.md_datum)
-      interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
-      if interp_uuid is None:
-         self.wellbore_interpretation = None
-      else:
-         self.wellbore_interpretation = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
+        node = self.root
+        assert node is not None
+        self.start_md = float(rqet.node_text(rqet.find_tag(node, 'StartMd')).strip())
+        self.finish_md = float(rqet.node_text(rqet.find_tag(node, 'FinishMd')).strip())
+        self.md_uom = rqet.length_units_from_node(rqet.find_tag(node, 'MdUom'))
+        self.md_domain = rqet.node_text(rqet.find_tag(node, 'MdDomain'))
+        geometry_node = rqet.find_tag(node, 'Geometry')
+        self.crs_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(geometry_node, ['LocalCrs', 'UUID']))
+        self.knot_count = int(rqet.node_text(rqet.find_tag(geometry_node, 'KnotCount')).strip())
+        self.line_kind_index = int(rqet.node_text(rqet.find_tag(geometry_node, 'LineKindIndex')).strip())
+        mds_node = rqet.find_tag(geometry_node, 'ControlPointParameters')
+        if mds_node is not None:  # not required for vertical or z linear cubic spline
+            load_hdf5_array(self, mds_node, 'measured_depths')
+        control_points_node = rqet.find_tag(geometry_node, 'ControlPoints')
+        load_hdf5_array(self, control_points_node, 'control_points', tag = 'Coordinates')
+        tangents_node = rqet.find_tag(geometry_node, 'TangentVectors')
+        if tangents_node is not None:
+            load_hdf5_array(self, tangents_node, 'tangent_vectors', tag = 'Coordinates')
+        relatives_model = self.model  # if hdf5_source_model is None else hdf5_source_model
+        # md_datum - separate part, referred to in this tree
+        md_datum_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['MdDatum', 'UUID']))
+        assert md_datum_uuid is not None, 'failed to fetch uuid of md datum for trajectory'
+        md_datum_part = relatives_model.part_for_uuid(md_datum_uuid)
+        assert md_datum_part, 'md datum part not found in model'
+        self.md_datum = MdDatum(self.model, uuid = relatives_model.uuid_for_part(md_datum_part))
+        ds_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['DeviationSurvey', 'UUID']))
+        if ds_uuid is not None:  # this will probably not work when relatives model is different from self.model
+            ds_part = rqet.part_name_for_object('obj_DeviationSurveyRepresentation_', ds_uuid)
+            self.deviation_survey = DeviationSurvey(self.model,
+                                                    uuid = relatives_model.uuid_for_part(ds_part, is_rels = False),
+                                                    md_datum = self.md_datum)
+        interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
+        if interp_uuid is None:
+            self.wellbore_interpretation = None
+        else:
+            self.wellbore_interpretation = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
 
-   def compute_from_deviation_survey(self,
-                                     survey = None,
-                                     method = 'minimum curvature',
-                                     md_domain = None,
-                                     set_tangent_vectors = True):
-      """Derive wellbore trajectory from deviation survey azimuth and inclination data."""
+    def compute_from_deviation_survey(self,
+                                      survey = None,
+                                      method = 'minimum curvature',
+                                      md_domain = None,
+                                      set_tangent_vectors = True):
+        """Derive wellbore trajectory from deviation survey azimuth and inclination data."""
 
-      if survey is None:
-         assert self.deviation_survey is not None
-         survey = self.deviation_survey
-      else:
-         self.deviation_survey = survey
+        if survey is None:
+            assert self.deviation_survey is not None
+            survey = self.deviation_survey
+        else:
+            self.deviation_survey = survey
 
-      assert method in ['minimum curvature']  # if adding other methods, set line_kind_index appropriately
+        assert method in ['minimum curvature']  # if adding other methods, set line_kind_index appropriately
 
-      self.knot_count = survey.station_count
-      assert self.knot_count >= 2  # vertical well could be hamdled by allowing a single station in survey?
-      self.line_kind_index = 5  # minimum curvature spline
-      self.measured_depths = survey.measured_depths.copy()
-      self.md_uom = survey.md_uom
-      if not self.title:
-         self.title = rqet.find_nested_tags_text(survey.root_node, ['Citation', 'Title'])
-      self.start_md = self.measured_depths[0]
-      self.finish_md = self.measured_depths[-1]
-      if md_domain is not None:
-         self.md_domain = md_domain
-      self.control_points = np.empty((self.knot_count, 3))
-      self.control_points[0, :] = survey.first_station
-      for sp in range(1, self.knot_count):
-         i1 = survey.inclinations[sp - 1]
-         i2 = survey.inclinations[sp]
-         az1 = survey.azimuths[sp - 1]
-         az2 = survey.azimuths[sp]
-         delta_md = survey.measured_depths[sp] - survey.measured_depths[sp - 1]
-         assert delta_md > 0.0
-         if i1 == i2 and az1 == az2:
-            matrix = vec.rotation_3d_matrix((180.0 - i1, -az1, 0.0))  # TODO: check sign of az1
-            delta_v = vec.rotate_vector(matrix, np.array([0.0, delta_md, 0.0]))
-         else:
-            i1 = maths.radians(i1)
-            i2 = maths.radians(i2)
-            az1 = maths.radians(az1)
-            az2 = maths.radians(az2)
-            sin_i1 = maths.sin(i1)
-            sin_i2 = maths.sin(i2)
-            cos_theta = min(max(maths.cos(i2 - i1) - sin_i1 * sin_i2 * (1.0 - maths.cos(az2 - az1)), -1.0), 1.0)
-            theta = maths.acos(cos_theta)
-            #           theta = maths.acos(sin_i1 * sin_i2 * maths.cos(az2 - az1)  +  (maths.cos(i1) * maths.cos(i2)))
-            assert theta != 0.0  # shouldn't happen as covered by if clause above
-            half_rf = maths.tan(0.5 * theta) / theta
-            delta_y = delta_md * half_rf * ((sin_i1 * maths.cos(az1)) + (sin_i2 * maths.cos(az2)))
-            delta_x = delta_md * half_rf * ((sin_i1 * maths.sin(az1)) + (sin_i2 * maths.sin(az2)))
-            delta_z = delta_md * half_rf * (maths.cos(i1) + maths.cos(i2))
-            delta_v = np.array((delta_x, delta_y, delta_z))
-         self.control_points[sp] = self.control_points[sp - 1] + delta_v
-      self.tangent_vectors = None
-      if set_tangent_vectors:
-         self.set_tangents()
-      self.md_datum = survey.md_datum
-
-   def load_from_data_frame(
-         self,
-         data_frame,
-         md_col = 'MD',
-         x_col = 'X',
-         y_col = 'Y',
-         z_col = 'Z',
-         md_uom = 'm',
-         md_domain = None,
-         md_datum = None,  # MdDatum object
-         title = None,
-         set_tangent_vectors = True):
-      """Load MD and control points (xyz) data from a pandas data frame."""
-
-      try:
-         for col in [md_col, x_col, y_col, z_col]:
-            assert col in data_frame.columns
-         self.knot_count = len(data_frame)
-         assert self.knot_count >= 2  # vertical well could be hamdled by allowing a single station in survey?
-         self.line_kind_index = 5  # assume minimum curvature spline
-         #         self.md_uom = bwam.p_length_unit(md_uom)
-         self.md_uom = bwam.rq_length_unit(md_uom)
-         start = data_frame.iloc[0]
-         finish = data_frame.iloc[-1]
-         if title:
-            self.title = title
-         self.start_md = start[md_col]
-         self.finish_md = finish[md_col]
-         if md_domain is not None:
+        self.knot_count = survey.station_count
+        assert self.knot_count >= 2  # vertical well could be hamdled by allowing a single station in survey?
+        self.line_kind_index = 5  # minimum curvature spline
+        self.measured_depths = survey.measured_depths.copy()
+        self.md_uom = survey.md_uom
+        if not self.title:
+            self.title = rqet.find_nested_tags_text(survey.root_node, ['Citation', 'Title'])
+        self.start_md = self.measured_depths[0]
+        self.finish_md = self.measured_depths[-1]
+        if md_domain is not None:
             self.md_domain = md_domain
-         self.measured_depths = np.empty(self.knot_count)
-         self.measured_depths[:] = data_frame[md_col]
-         self.control_points = np.empty((self.knot_count, 3))
-         self.control_points[:, 0] = data_frame[x_col]
-         self.control_points[:, 1] = data_frame[y_col]
-         self.control_points[:, 2] = data_frame[z_col]
-         self.tangent_vectors = None
-         if set_tangent_vectors:
+        self.control_points = np.empty((self.knot_count, 3))
+        self.control_points[0, :] = survey.first_station
+        for sp in range(1, self.knot_count):
+            i1 = survey.inclinations[sp - 1]
+            i2 = survey.inclinations[sp]
+            az1 = survey.azimuths[sp - 1]
+            az2 = survey.azimuths[sp]
+            delta_md = survey.measured_depths[sp] - survey.measured_depths[sp - 1]
+            assert delta_md > 0.0
+            if i1 == i2 and az1 == az2:
+                matrix = vec.rotation_3d_matrix((180.0 - i1, -az1, 0.0))  # TODO: check sign of az1
+                delta_v = vec.rotate_vector(matrix, np.array([0.0, delta_md, 0.0]))
+            else:
+                i1 = maths.radians(i1)
+                i2 = maths.radians(i2)
+                az1 = maths.radians(az1)
+                az2 = maths.radians(az2)
+                sin_i1 = maths.sin(i1)
+                sin_i2 = maths.sin(i2)
+                cos_theta = min(max(maths.cos(i2 - i1) - sin_i1 * sin_i2 * (1.0 - maths.cos(az2 - az1)), -1.0), 1.0)
+                theta = maths.acos(cos_theta)
+                #           theta = maths.acos(sin_i1 * sin_i2 * maths.cos(az2 - az1)  +  (maths.cos(i1) * maths.cos(i2)))
+                assert theta != 0.0  # shouldn't happen as covered by if clause above
+                half_rf = maths.tan(0.5 * theta) / theta
+                delta_y = delta_md * half_rf * ((sin_i1 * maths.cos(az1)) + (sin_i2 * maths.cos(az2)))
+                delta_x = delta_md * half_rf * ((sin_i1 * maths.sin(az1)) + (sin_i2 * maths.sin(az2)))
+                delta_z = delta_md * half_rf * (maths.cos(i1) + maths.cos(i2))
+                delta_v = np.array((delta_x, delta_y, delta_z))
+            self.control_points[sp] = self.control_points[sp - 1] + delta_v
+        self.tangent_vectors = None
+        if set_tangent_vectors:
             self.set_tangents()
-         self.md_datum = md_datum
-      except Exception:
-         log.exception('failed to load trajectory object from data frame')
+        self.md_datum = survey.md_datum
 
-   def load_from_cell_list(self, grid, cell_kji0_list, spline_mode = 'cube', md_uom = 'm'):
-      """Loads the trajectory object based on the centre points of a list of cells."""
+    def load_from_data_frame(
+            self,
+            data_frame,
+            md_col = 'MD',
+            x_col = 'X',
+            y_col = 'Y',
+            z_col = 'Z',
+            md_uom = 'm',
+            md_domain = None,
+            md_datum = None,  # MdDatum object
+            title = None,
+            set_tangent_vectors = True):
+        """Load MD and control points (xyz) data from a pandas data frame."""
 
-      assert grid is not None, 'grid argument missing for trajectory initislisation from cell list'
-      cell_kji0_list = np.array(cell_kji0_list, dtype = int)
-      assert cell_kji0_list.ndim == 2 and cell_kji0_list.shape[1] == 3
-      assert spline_mode in ['none', 'linear', 'square', 'cube']
+        try:
+            for col in [md_col, x_col, y_col, z_col]:
+                assert col in data_frame.columns
+            self.knot_count = len(data_frame)
+            assert self.knot_count >= 2  # vertical well could be hamdled by allowing a single station in survey?
+            self.line_kind_index = 5  # assume minimum curvature spline
+            #         self.md_uom = bwam.p_length_unit(md_uom)
+            self.md_uom = bwam.rq_length_unit(md_uom)
+            start = data_frame.iloc[0]
+            finish = data_frame.iloc[-1]
+            if title:
+                self.title = title
+            self.start_md = start[md_col]
+            self.finish_md = finish[md_col]
+            if md_domain is not None:
+                self.md_domain = md_domain
+            self.measured_depths = np.empty(self.knot_count)
+            self.measured_depths[:] = data_frame[md_col]
+            self.control_points = np.empty((self.knot_count, 3))
+            self.control_points[:, 0] = data_frame[x_col]
+            self.control_points[:, 1] = data_frame[y_col]
+            self.control_points[:, 2] = data_frame[z_col]
+            self.tangent_vectors = None
+            if set_tangent_vectors:
+                self.set_tangents()
+            self.md_datum = md_datum
+        except Exception:
+            log.exception('failed to load trajectory object from data frame')
 
-      cell_centres = grid.centre_point_list(cell_kji0_list)
+    def load_from_cell_list(self, grid, cell_kji0_list, spline_mode = 'cube', md_uom = 'm'):
+        """Loads the trajectory object based on the centre points of a list of cells."""
 
-      knot_count = len(cell_kji0_list) + 2
-      self.line_kind_index = 5  # 5 means minimum curvature spline; todo: set to cubic spline value?
-      self.md_uom = bwam.rq_length_unit(md_uom)
-      self.start_md = 0.0
-      points = np.empty((knot_count, 3))
-      points[1:-1] = cell_centres
-      points[0] = points[1]
-      points[0, 2] = 0.0
-      points[-1] = points[-2]
-      points[-1, 2] *= 1.05
-      if spline_mode == 'none':
-         self.knot_count = knot_count
-         self.control_points = points
-      else:
-         self.control_points = rql.spline(points, tangent_weight = spline_mode, min_subdivisions = 3)
-         self.knot_count = len(self.control_points)
-      self.set_measured_depths()
+        assert grid is not None, 'grid argument missing for trajectory initislisation from cell list'
+        cell_kji0_list = np.array(cell_kji0_list, dtype = int)
+        assert cell_kji0_list.ndim == 2 and cell_kji0_list.shape[1] == 3
+        assert spline_mode in ['none', 'linear', 'square', 'cube']
 
-   def load_from_wellspec(self, grid, wellspec_file, well_name, spline_mode = 'cube', md_uom = 'm'):
+        cell_centres = grid.centre_point_list(cell_kji0_list)
 
-      col_list = ['IW', 'JW', 'L']
-      wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list)
+        knot_count = len(cell_kji0_list) + 2
+        self.line_kind_index = 5  # 5 means minimum curvature spline; todo: set to cubic spline value?
+        self.md_uom = bwam.rq_length_unit(md_uom)
+        self.start_md = 0.0
+        points = np.empty((knot_count, 3))
+        points[1:-1] = cell_centres
+        points[0] = points[1]
+        points[0, 2] = 0.0
+        points[-1] = points[-2]
+        points[-1, 2] *= 1.05
+        if spline_mode == 'none':
+            self.knot_count = knot_count
+            self.control_points = points
+        else:
+            self.control_points = rql.spline(points, tangent_weight = spline_mode, min_subdivisions = 3)
+            self.knot_count = len(self.control_points)
+        self.set_measured_depths()
 
-      assert len(wellspec_dict) == 1, 'no wellspec data found in file ' + wellspec_file + ' for well ' + well_name
+    def load_from_wellspec(self, grid, wellspec_file, well_name, spline_mode = 'cube', md_uom = 'm'):
 
-      df = wellspec_dict[well_name]
-      assert len(df) > 0, 'no rows of perforation data found in wellspec for well ' + well_name
+        col_list = ['IW', 'JW', 'L']
+        wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list)
 
-      cell_kji0_list = np.empty((len(df), 3), dtype = int)
-      cell_kji0_list[:, 0] = df['L']
-      cell_kji0_list[:, 1] = df['JW']
-      cell_kji0_list[:, 2] = df['IW']
+        assert len(wellspec_dict) == 1, 'no wellspec data found in file ' + wellspec_file + ' for well ' + well_name
 
-      self.load_from_cell_list(grid, cell_kji0_list, spline_mode, md_uom)
+        df = wellspec_dict[well_name]
+        assert len(df) > 0, 'no rows of perforation data found in wellspec for well ' + well_name
 
-   def load_from_ascii_file(self,
-                            trajectory_file,
-                            comment_character = '#',
-                            space_separated_instead_of_csv = False,
-                            md_col = 'MD',
-                            x_col = 'X',
-                            y_col = 'Y',
-                            z_col = 'Z',
-                            md_uom = 'm',
-                            md_domain = None,
-                            md_datum = None,
-                            well_col = None,
-                            title = None,
-                            set_tangent_vectors = True):
-      """Loads the trajectory object from an ascii file with columns for MD, X, Y & Z (and optionally WELL)."""
+        cell_kji0_list = np.empty((len(df), 3), dtype = int)
+        cell_kji0_list[:, 0] = df['L']
+        cell_kji0_list[:, 1] = df['JW']
+        cell_kji0_list[:, 2] = df['IW']
 
-      if not title and not self.title:
-         self.title = 'well trajectory'
+        self.load_from_cell_list(grid, cell_kji0_list, spline_mode, md_uom)
 
-      try:
-         df = pd.read_csv(trajectory_file,
-                          comment = comment_character,
-                          delim_whitespace = space_separated_instead_of_csv)
-         if df is None:
-            raise Exception
-      except Exception:
-         log.error('failed to read ascii deviation survey file ' + str(trajectory_file))
-         raise
-      if well_col and well_col not in df.columns:
-         log.warning('well column ' + str(well_col) + ' not found in ascii trajectory file ' + str(trajectory_file))
-         well_col = None
-      if well_col is None:
-         for col in df.columns:
-            if str(col).upper().startswith('WELL'):
-               well_col = col
-               break
-      if title:  # filter data frame by well name
-         if well_col:
-            df = df[df[well_col] == title]
-            if len(df) == 0:
-               log.error('no data found for well ' + str(title) + ' in file ' + str(trajectory_file))
-      elif well_col is not None:
-         if len(set(df[well_col])) > 1:
-            raise Exception(
-               'attempt to set trajectory for unidentified well from ascii file holding data for multiple wells')
-      self.load_from_data_frame(df,
-                                md_col = md_col,
-                                x_col = x_col,
-                                y_col = y_col,
-                                z_col = z_col,
-                                md_uom = md_uom,
-                                md_domain = md_domain,
-                                md_datum = md_datum,
-                                title = title,
-                                set_tangent_vectors = set_tangent_vectors)
+    def load_from_ascii_file(self,
+                             trajectory_file,
+                             comment_character = '#',
+                             space_separated_instead_of_csv = False,
+                             md_col = 'MD',
+                             x_col = 'X',
+                             y_col = 'Y',
+                             z_col = 'Z',
+                             md_uom = 'm',
+                             md_domain = None,
+                             md_datum = None,
+                             well_col = None,
+                             title = None,
+                             set_tangent_vectors = True):
+        """Loads the trajectory object from an ascii file with columns for MD, X, Y & Z (and optionally WELL)."""
 
-   def set_tangents(self, force = False, write_hdf5 = False, weight = 'cube'):
-      """Calculates tangent vectors based on control points.
+        if not title and not self.title:
+            self.title = 'well trajectory'
+
+        try:
+            df = pd.read_csv(trajectory_file,
+                             comment = comment_character,
+                             delim_whitespace = space_separated_instead_of_csv)
+            if df is None:
+                raise Exception
+        except Exception:
+            log.error('failed to read ascii deviation survey file ' + str(trajectory_file))
+            raise
+        if well_col and well_col not in df.columns:
+            log.warning('well column ' + str(well_col) + ' not found in ascii trajectory file ' + str(trajectory_file))
+            well_col = None
+        if well_col is None:
+            for col in df.columns:
+                if str(col).upper().startswith('WELL'):
+                    well_col = col
+                    break
+        if title:  # filter data frame by well name
+            if well_col:
+                df = df[df[well_col] == title]
+                if len(df) == 0:
+                    log.error('no data found for well ' + str(title) + ' in file ' + str(trajectory_file))
+        elif well_col is not None:
+            if len(set(df[well_col])) > 1:
+                raise Exception(
+                    'attempt to set trajectory for unidentified well from ascii file holding data for multiple wells')
+        self.load_from_data_frame(df,
+                                  md_col = md_col,
+                                  x_col = x_col,
+                                  y_col = y_col,
+                                  z_col = z_col,
+                                  md_uom = md_uom,
+                                  md_domain = md_domain,
+                                  md_datum = md_datum,
+                                  title = title,
+                                  set_tangent_vectors = set_tangent_vectors)
+
+    def set_tangents(self, force = False, write_hdf5 = False, weight = 'cube'):
+        """Calculates tangent vectors based on control points.
 
       arguments:
          force (boolean, default False): if False and tangent vectors already exist then the existing ones are used;
@@ -1098,22 +1098,22 @@ class Trajectory(BaseResqpy):
          the write_hdf5 argument to this method to True if the other arrays for the trajectory already exist in the hdf5 file
       """
 
-      if self.tangent_vectors is not None and not force:
-         return self.tangent_vectors
-      assert self.knot_count is not None and self.knot_count >= 2
-      assert self.control_points is not None and len(self.control_points) == self.knot_count
+        if self.tangent_vectors is not None and not force:
+            return self.tangent_vectors
+        assert self.knot_count is not None and self.knot_count >= 2
+        assert self.control_points is not None and len(self.control_points) == self.knot_count
 
-      self.tangent_vectors = rql.tangents(self.control_points, weight = weight)
+        self.tangent_vectors = rql.tangents(self.control_points, weight = weight)
 
-      if write_hdf5:
-         h5_reg = rwh5.H5Register(self.model)
-         h5_reg.register_dataset(self.uuid, 'tangentVectors', self.tangent_vectors)
-         h5_reg.write(file = self.model.h5_filename(), mode = 'a')
+        if write_hdf5:
+            h5_reg = rwh5.H5Register(self.model)
+            h5_reg.register_dataset(self.uuid, 'tangentVectors', self.tangent_vectors)
+            h5_reg.write(file = self.model.h5_filename(), mode = 'a')
 
-      return self.tangent_vectors
+        return self.tangent_vectors
 
-   def dataframe(self, md_col = 'MD', x_col = 'X', y_col = 'Y', z_col = 'Z'):
-      """Returns a pandas data frame containing MD and control points (xyz) data.
+    def dataframe(self, md_col = 'MD', x_col = 'X', y_col = 'Y', z_col = 'Z'):
+        """Returns a pandas data frame containing MD and control points (xyz) data.
 
       note:
          set md_col to None for a dataframe containing only X, Y & Z data
@@ -1121,39 +1121,39 @@ class Trajectory(BaseResqpy):
       :meta common:
       """
 
-      if md_col:
-         column_list = [md_col, x_col, y_col, z_col]
-      else:
-         column_list = [x_col, y_col, z_col]
+        if md_col:
+            column_list = [md_col, x_col, y_col, z_col]
+        else:
+            column_list = [x_col, y_col, z_col]
 
-      data_frame = pd.DataFrame(columns = column_list)
-      if md_col:
-         data_frame[md_col] = self.measured_depths
-      data_frame[x_col] = self.control_points[:, 0]
-      data_frame[y_col] = self.control_points[:, 1]
-      data_frame[z_col] = self.control_points[:, 2]
-      return data_frame
+        data_frame = pd.DataFrame(columns = column_list)
+        if md_col:
+            data_frame[md_col] = self.measured_depths
+        data_frame[x_col] = self.control_points[:, 0]
+        data_frame[y_col] = self.control_points[:, 1]
+        data_frame[z_col] = self.control_points[:, 2]
+        return data_frame
 
-   def write_to_ascii_file(self,
-                           trajectory_file,
-                           mode = 'w',
-                           space_separated_instead_of_csv = False,
-                           md_col = 'MD',
-                           x_col = 'X',
-                           y_col = 'Y',
-                           z_col = 'Z'):
-      """Writes trajectory to an ascii file.
+    def write_to_ascii_file(self,
+                            trajectory_file,
+                            mode = 'w',
+                            space_separated_instead_of_csv = False,
+                            md_col = 'MD',
+                            x_col = 'X',
+                            y_col = 'Y',
+                            z_col = 'Z'):
+        """Writes trajectory to an ascii file.
 
       note:
          set md_col to None for a dataframe containing only X, Y & Z data
       """
 
-      df = self.dataframe(md_col = md_col, x_col = x_col, y_col = y_col, z_col = z_col)
-      sep = ' ' if space_separated_instead_of_csv else ','
-      df.to_csv(trajectory_file, sep = sep, index = False, mode = mode)
+        df = self.dataframe(md_col = md_col, x_col = x_col, y_col = y_col, z_col = z_col)
+        sep = ' ' if space_separated_instead_of_csv else ','
+        df.to_csv(trajectory_file, sep = sep, index = False, mode = mode)
 
-   def xyz_for_md(self, md):
-      """Returns an xyz triplet corresponding to the given measured depth; uses simple linear interpolation between knots.
+    def xyz_for_md(self, md):
+        """Returns an xyz triplet corresponding to the given measured depth; uses simple linear interpolation between knots.
 
       args:
          md (float): measured depth for which xyz location is required; units must be those of self.md_uom
@@ -1169,36 +1169,37 @@ class Trajectory(BaseResqpy):
       :meta common:
       """
 
-      def interpolate(p1, p2, f):
-         return f * p2 + (1.0 - f) * p1
+        def interpolate(p1, p2, f):
+            return f * p2 + (1.0 - f) * p1
 
-      def search(md, i1, i2):
-         if i2 - i1 <= 1:
-            if md == self.measured_depths[i1]:
-               return self.control_points[i1]
-            return interpolate(self.control_points[i1], self.control_points[i1 + 1], (md - self.measured_depths[i1]) /
-                               (self.measured_depths[i1 + 1] - self.measured_depths[i1]))
-         im = i1 + (i2 - i1) // 2
-         if self.measured_depths[im] >= md:
-            return search(md, i1, im)
-         return search(md, im, i2)
+        def search(md, i1, i2):
+            if i2 - i1 <= 1:
+                if md == self.measured_depths[i1]:
+                    return self.control_points[i1]
+                return interpolate(self.control_points[i1], self.control_points[i1 + 1],
+                                   (md - self.measured_depths[i1]) /
+                                   (self.measured_depths[i1 + 1] - self.measured_depths[i1]))
+            im = i1 + (i2 - i1) // 2
+            if self.measured_depths[im] >= md:
+                return search(md, i1, im)
+            return search(md, im, i2)
 
-      if md < 0.0 or md > self.finish_md or md > self.measured_depths[-1]:
-         return None
-      if md <= self.start_md:
-         if self.start_md == 0.0:
-            return self.md_datum.location
-         return interpolate(np.array(self.md_datum.location), self.control_points[0], md / self.start_md)
-      return search(md, 0, self.knot_count - 1)
+        if md < 0.0 or md > self.finish_md or md > self.measured_depths[-1]:
+            return None
+        if md <= self.start_md:
+            if self.start_md == 0.0:
+                return self.md_datum.location
+            return interpolate(np.array(self.md_datum.location), self.control_points[0], md / self.start_md)
+        return search(md, 0, self.knot_count - 1)
 
-   def splined_trajectory(self,
-                          well_name,
-                          min_subdivisions = 1,
-                          max_segment_length = None,
-                          max_degrees_per_knot = 5.0,
-                          use_tangents_if_present = True,
-                          store_tangents_if_calculated = True):
-      """Creates and returns a new Trajectory derived as a cubic spline of this trajectory.
+    def splined_trajectory(self,
+                           well_name,
+                           min_subdivisions = 1,
+                           max_segment_length = None,
+                           max_degrees_per_knot = 5.0,
+                           use_tangents_if_present = True,
+                           store_tangents_if_calculated = True):
+        """Creates and returns a new Trajectory derived as a cubic spline of this trajectory.
 
       arguments:
          well_name (string): the name to use as the citation title for the new trajectory
@@ -1233,81 +1234,81 @@ class Trajectory(BaseResqpy):
          ensure locally calculated tangent vectors are used
       """
 
-      assert self.knot_count > 1 and self.control_points is not None
-      assert min_subdivisions >= 1
-      assert max_segment_length is None or max_segment_length > 0.0
-      assert max_degrees_per_knot is None or max_degrees_per_knot > 0.0
-      if not well_name:
-         well_name = self.title
+        assert self.knot_count > 1 and self.control_points is not None
+        assert min_subdivisions >= 1
+        assert max_segment_length is None or max_segment_length > 0.0
+        assert max_degrees_per_knot is None or max_degrees_per_knot > 0.0
+        if not well_name:
+            well_name = self.title
 
-      tangent_vectors = self.tangent_vectors
-      if tangent_vectors is None or not use_tangents_if_present:
-         tangent_vectors = rql.tangents(self.control_points, weight = 'square')
-         if store_tangents_if_calculated:
-            self.tangent_vectors = tangent_vectors
+        tangent_vectors = self.tangent_vectors
+        if tangent_vectors is None or not use_tangents_if_present:
+            tangent_vectors = rql.tangents(self.control_points, weight = 'square')
+            if store_tangents_if_calculated:
+                self.tangent_vectors = tangent_vectors
 
-      spline_traj = Trajectory(self.model,
-                               well_name = well_name,
-                               md_datum = self.md_datum,
-                               length_uom = self.md_uom,
-                               md_domain = self.md_domain)
-      spline_traj.line_kind_index = self.line_kind_index  # not sure how we should really be setting this
-      spline_traj.crs_uuid = self.crs_uuid
-      spline_traj.start_md = self.start_md
-      spline_traj.deviation_survey = self.deviation_survey
+        spline_traj = Trajectory(self.model,
+                                 well_name = well_name,
+                                 md_datum = self.md_datum,
+                                 length_uom = self.md_uom,
+                                 md_domain = self.md_domain)
+        spline_traj.line_kind_index = self.line_kind_index  # not sure how we should really be setting this
+        spline_traj.crs_uuid = self.crs_uuid
+        spline_traj.start_md = self.start_md
+        spline_traj.deviation_survey = self.deviation_survey
 
-      spline_traj.control_points = rql.spline(self.control_points,
-                                              tangent_vectors = tangent_vectors,
-                                              min_subdivisions = min_subdivisions,
-                                              max_segment_length = max_segment_length,
-                                              max_degrees_per_knot = max_degrees_per_knot)
-      spline_traj.knot_count = len(spline_traj.control_points)
+        spline_traj.control_points = rql.spline(self.control_points,
+                                                tangent_vectors = tangent_vectors,
+                                                min_subdivisions = min_subdivisions,
+                                                max_segment_length = max_segment_length,
+                                                max_degrees_per_knot = max_degrees_per_knot)
+        spline_traj.knot_count = len(spline_traj.control_points)
 
-      spline_traj.set_measured_depths()
+        spline_traj.set_measured_depths()
 
-      return spline_traj
+        return spline_traj
 
-   def set_measured_depths(self):
-      """Sets the measured depths from the start_md value and the control points."""
+    def set_measured_depths(self):
+        """Sets the measured depths from the start_md value and the control points."""
 
-      self.measured_depths = np.empty(self.knot_count)
-      self.measured_depths[0] = self.start_md
-      for sk in range(1, self.knot_count):
-         self.measured_depths[sk] = (self.measured_depths[sk - 1] +
-                                     vec.naive_length(self.control_points[sk] - self.control_points[sk - 1]))
-      self.finish_md = self.measured_depths[-1]
+        self.measured_depths = np.empty(self.knot_count)
+        self.measured_depths[0] = self.start_md
+        for sk in range(1, self.knot_count):
+            self.measured_depths[sk] = (self.measured_depths[sk - 1] +
+                                        vec.naive_length(self.control_points[sk] - self.control_points[sk - 1]))
+        self.finish_md = self.measured_depths[-1]
 
-      return self.measured_depths
+        return self.measured_depths
 
-   def create_feature_and_interpretation(self):
-      """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does not already exist.
+    def create_feature_and_interpretation(self):
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does not already exist.
       
       Uses the trajectory citation title as the well name
       """
 
-      log.debug("Creating a new WellboreInterpretation..")
-      log.debug(f"WellboreFeature exists: {self.wellbore_feature is not None}")
-      log.debug(f"WellboreInterpretation exists: {self.wellbore_interpretation is not None}")
+        log.debug("Creating a new WellboreInterpretation..")
+        log.debug(f"WellboreFeature exists: {self.wellbore_feature is not None}")
+        log.debug(f"WellboreInterpretation exists: {self.wellbore_interpretation is not None}")
 
-      if self.wellbore_interpretation is None:
-         log.info(f"Creating WellboreInterpretation and WellboreFeature with name {self.title}")
-         self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, feature_name = self.title)
-         self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
-                                                                   wellbore_feature = self.wellbore_feature)
-         self.feature_and_interpretation_to_be_written = True
-      else:
-         raise ValueError("Cannot add WellboreFeature, trajectory already has an associated WellboreInterpretation")
+        if self.wellbore_interpretation is None:
+            log.info(f"Creating WellboreInterpretation and WellboreFeature with name {self.title}")
+            self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, feature_name = self.title)
+            self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
+                                                                      wellbore_feature = self.wellbore_feature)
+            self.feature_and_interpretation_to_be_written = True
+        else:
+            raise ValueError("Cannot add WellboreFeature, trajectory already has an associated WellboreInterpretation")
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  wbt_uuid = None,
-                  md_datum_root = None,
-                  md_datum_xyz = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  title = None,
-                  originator = None):
-      """Create a wellbore trajectory representation node from a Trajectory object, optionally add as part.
+    def create_xml(self,
+                   ext_uuid = None,
+                   wbt_uuid = None,
+                   md_datum_root = None,
+                   md_datum_xyz = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   title = None,
+                   originator = None):
+        """Create a wellbore trajectory representation node from a Trajectory object, optionally add as part.
 
          notes:
             measured depth datum xml node must be in place before calling this function;
@@ -1318,170 +1319,172 @@ class Trajectory(BaseResqpy):
       :meta common:
       """
 
-      if title:
-         self.title = title
-      if not self.title:
-         self.title = 'wellbore trajectory'
+        if title:
+            self.title = title
+        if not self.title:
+            self.title = 'wellbore trajectory'
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      if self.feature_and_interpretation_to_be_written:
-         if self.wellbore_interpretation is None:
-            self.create_feature_and_interpretation()
-         if self.wellbore_feature is not None:
-            self.wellbore_feature.create_xml(add_as_part = add_as_part, originator = originator)
-         self.wellbore_interpretation.create_xml(add_as_part = add_as_part,
-                                                 add_relationships = add_relationships,
-                                                 originator = originator)
+        if self.feature_and_interpretation_to_be_written:
+            if self.wellbore_interpretation is None:
+                self.create_feature_and_interpretation()
+            if self.wellbore_feature is not None:
+                self.wellbore_feature.create_xml(add_as_part = add_as_part, originator = originator)
+            self.wellbore_interpretation.create_xml(add_as_part = add_as_part,
+                                                    add_relationships = add_relationships,
+                                                    originator = originator)
 
-      if md_datum_root is None:
-         if self.md_datum is None:
-            assert md_datum_xyz is not None
-            self.md_datum = MdDatum(self.model, location = md_datum_xyz)
-         if self.md_datum.root is None:
-            md_datum_root = self.md_datum.create_xml()
-         else:
-            md_datum_root = self.md_datum.root
+        if md_datum_root is None:
+            if self.md_datum is None:
+                assert md_datum_xyz is not None
+                self.md_datum = MdDatum(self.model, location = md_datum_xyz)
+            if self.md_datum.root is None:
+                md_datum_root = self.md_datum.create_xml()
+            else:
+                md_datum_root = self.md_datum.root
 
-      wbt_node = super().create_xml(originator = originator, add_as_part = False)
+        wbt_node = super().create_xml(originator = originator, add_as_part = False)
 
-      start_node = rqet.SubElement(wbt_node, ns['resqml2'] + 'StartMd')
-      start_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-      start_node.text = str(self.start_md)
+        start_node = rqet.SubElement(wbt_node, ns['resqml2'] + 'StartMd')
+        start_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+        start_node.text = str(self.start_md)
 
-      finish_node = rqet.SubElement(wbt_node, ns['resqml2'] + 'FinishMd')
-      finish_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
-      finish_node.text = str(self.finish_md)
+        finish_node = rqet.SubElement(wbt_node, ns['resqml2'] + 'FinishMd')
+        finish_node.set(ns['xsi'] + 'type', ns['xsd'] + 'double')
+        finish_node.text = str(self.finish_md)
 
-      md_uom = rqet.SubElement(wbt_node, ns['resqml2'] + 'MdUom')
-      md_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
-      md_uom.text = bwam.rq_length_unit(self.md_uom)
+        md_uom = rqet.SubElement(wbt_node, ns['resqml2'] + 'MdUom')
+        md_uom.set(ns['xsi'] + 'type', ns['eml'] + 'LengthUom')
+        md_uom.text = bwam.rq_length_unit(self.md_uom)
 
-      self.model.create_md_datum_reference(self.md_datum.root, root = wbt_node)
+        self.model.create_md_datum_reference(self.md_datum.root, root = wbt_node)
 
-      if self.line_kind_index != 0:  # 0 means vertical well, which doesn't need a geometry
+        if self.line_kind_index != 0:  # 0 means vertical well, which doesn't need a geometry
 
-         # todo: check geometry elements for parametric curve flavours other than minimum curvature
+            # todo: check geometry elements for parametric curve flavours other than minimum curvature
 
-         geom = rqet.SubElement(wbt_node, ns['resqml2'] + 'Geometry')
-         geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'ParametricLineGeometry')
-         geom.text = '\n'
+            geom = rqet.SubElement(wbt_node, ns['resqml2'] + 'Geometry')
+            geom.set(ns['xsi'] + 'type', ns['resqml2'] + 'ParametricLineGeometry')
+            geom.text = '\n'
 
-         # note: resqml standard allows trajectory to be in different crs to md datum
-         #       however, this module often uses the md datum crs, if the trajectory has been imported
-         if self.crs_uuid is None:
-            self.crs_uuid = self.md_datum.crs_uuid
-         assert self.crs_uuid is not None
-         self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
+            # note: resqml standard allows trajectory to be in different crs to md datum
+            #       however, this module often uses the md datum crs, if the trajectory has been imported
+            if self.crs_uuid is None:
+                self.crs_uuid = self.md_datum.crs_uuid
+            assert self.crs_uuid is not None
+            self.model.create_crs_reference(crs_uuid = self.crs_uuid, root = geom)
 
-         kc_node = rqet.SubElement(geom, ns['resqml2'] + 'KnotCount')
-         kc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-         kc_node.text = str(self.knot_count)
+            kc_node = rqet.SubElement(geom, ns['resqml2'] + 'KnotCount')
+            kc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+            kc_node.text = str(self.knot_count)
 
-         lki_node = rqet.SubElement(geom, ns['resqml2'] + 'LineKindIndex')
-         lki_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-         lki_node.text = str(self.line_kind_index)
+            lki_node = rqet.SubElement(geom, ns['resqml2'] + 'LineKindIndex')
+            lki_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+            lki_node.text = str(self.line_kind_index)
 
-         cpp_node = rqet.SubElement(geom, ns['resqml2'] + 'ControlPointParameters')
-         cpp_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-         cpp_node.text = rqet.null_xml_text
+            cpp_node = rqet.SubElement(geom, ns['resqml2'] + 'ControlPointParameters')
+            cpp_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+            cpp_node.text = rqet.null_xml_text
 
-         cpp_values_node = rqet.SubElement(cpp_node, ns['resqml2'] + 'Values')
-         cpp_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         cpp_values_node.text = rqet.null_xml_text
+            cpp_values_node = rqet.SubElement(cpp_node, ns['resqml2'] + 'Values')
+            cpp_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            cpp_values_node.text = rqet.null_xml_text
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'controlPointParameters', root = cpp_values_node)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'controlPointParameters', root = cpp_values_node)
 
-         cp_node = rqet.SubElement(geom, ns['resqml2'] + 'ControlPoints')
-         cp_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-         cp_node.text = rqet.null_xml_text
+            cp_node = rqet.SubElement(geom, ns['resqml2'] + 'ControlPoints')
+            cp_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+            cp_node.text = rqet.null_xml_text
 
-         cp_coords_node = rqet.SubElement(cp_node, ns['resqml2'] + 'Coordinates')
-         cp_coords_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-         cp_coords_node.text = rqet.null_xml_text
+            cp_coords_node = rqet.SubElement(cp_node, ns['resqml2'] + 'Coordinates')
+            cp_coords_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+            cp_coords_node.text = rqet.null_xml_text
 
-         self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'controlPoints', root = cp_coords_node)
+            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'controlPoints', root = cp_coords_node)
 
-         if self.tangent_vectors is not None:
+            if self.tangent_vectors is not None:
 
-            tv_node = rqet.SubElement(geom, ns['resqml2'] + 'TangentVectors')
-            tv_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
-            tv_node.text = rqet.null_xml_text
+                tv_node = rqet.SubElement(geom, ns['resqml2'] + 'TangentVectors')
+                tv_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Point3dHdf5Array')
+                tv_node.text = rqet.null_xml_text
 
-            tv_coords_node = rqet.SubElement(tv_node, ns['resqml2'] + 'Coordinates')
-            tv_coords_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-            tv_coords_node.text = rqet.null_xml_text
+                tv_coords_node = rqet.SubElement(tv_node, ns['resqml2'] + 'Coordinates')
+                tv_coords_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+                tv_coords_node.text = rqet.null_xml_text
 
-            self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'tangentVectors', root = tv_coords_node)
+                self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'tangentVectors', root = tv_coords_node)
 
-      if self.md_domain:
-         domain_node = rqet.SubElement(wbt_node, ns['resqml2'] + 'MdDomain')
-         domain_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'MdDomain')
-         domain_node.text = self.md_domain
+        if self.md_domain:
+            domain_node = rqet.SubElement(wbt_node, ns['resqml2'] + 'MdDomain')
+            domain_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'MdDomain')
+            domain_node.text = self.md_domain
 
-      if self.deviation_survey is not None:
-         ds_root = self.deviation_survey.root_node
-         self.model.create_ref_node('DeviationSurvey',
-                                    rqet.find_tag(rqet.find_tag(ds_root, 'Citation'), 'Title').text,
-                                    bu.uuid_from_string(ds_root.attrib['uuid']),
-                                    content_type = 'obj_DeviationSurveyRepresentation',
-                                    root = wbt_node)
+        if self.deviation_survey is not None:
+            ds_root = self.deviation_survey.root_node
+            self.model.create_ref_node('DeviationSurvey',
+                                       rqet.find_tag(rqet.find_tag(ds_root, 'Citation'), 'Title').text,
+                                       bu.uuid_from_string(ds_root.attrib['uuid']),
+                                       content_type = 'obj_DeviationSurveyRepresentation',
+                                       root = wbt_node)
 
-      interp_root = None
-      if self.wellbore_interpretation is not None:
-         interp_root = self.wellbore_interpretation.root
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
-                                    bu.uuid_from_string(interp_root.attrib['uuid']),
-                                    content_type = 'obj_WellboreInterpretation',
-                                    root = wbt_node)
+        interp_root = None
+        if self.wellbore_interpretation is not None:
+            interp_root = self.wellbore_interpretation.root
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
+                                       bu.uuid_from_string(interp_root.attrib['uuid']),
+                                       content_type = 'obj_WellboreInterpretation',
+                                       root = wbt_node)
 
-      if add_as_part:
-         self.model.add_part('obj_WellboreTrajectoryRepresentation', self.uuid, wbt_node)
-         if add_relationships:
-            crs_root = self.crs_root
-            self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', crs_root, 'sourceObject')
-            self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', self.md_datum.root, 'sourceObject')
-            if self.deviation_survey is not None:
-               self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', self.deviation_survey.root_node,
-                                                         'sourceObject')
-            if interp_root is not None:
-               self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', interp_root, 'sourceObject')
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(wbt_node, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+        if add_as_part:
+            self.model.add_part('obj_WellboreTrajectoryRepresentation', self.uuid, wbt_node)
+            if add_relationships:
+                crs_root = self.crs_root
+                self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', crs_root, 'sourceObject')
+                self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', self.md_datum.root,
+                                                          'sourceObject')
+                if self.deviation_survey is not None:
+                    self.model.create_reciprocal_relationship(wbt_node, 'destinationObject',
+                                                              self.deviation_survey.root_node, 'sourceObject')
+                if interp_root is not None:
+                    self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', interp_root,
+                                                              'sourceObject')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(wbt_node, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
 
-      return wbt_node
+        return wbt_node
 
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Create or append to an hdf5 file, writing datasets for the measured depths, control points and tangent vectors.
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Create or append to an hdf5 file, writing datasets for the measured depths, control points and tangent vectors.
 
       :meta common:
       """
 
-      # NB: array data must all have been set up prior to calling this function
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
+        # NB: array data must all have been set up prior to calling this function
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
 
-      h5_reg = rwh5.H5Register(self.model)
-      h5_reg.register_dataset(self.uuid, 'controlPointParameters', self.measured_depths)
-      h5_reg.register_dataset(self.uuid, 'controlPoints', self.control_points)
-      if self.tangent_vectors is not None:
-         h5_reg.register_dataset(self.uuid, 'tangentVectors', self.tangent_vectors)
-      h5_reg.write(file = file_name, mode = mode)
+        h5_reg = rwh5.H5Register(self.model)
+        h5_reg.register_dataset(self.uuid, 'controlPointParameters', self.measured_depths)
+        h5_reg.register_dataset(self.uuid, 'controlPoints', self.control_points)
+        if self.tangent_vectors is not None:
+            h5_reg.register_dataset(self.uuid, 'tangentVectors', self.tangent_vectors)
+        h5_reg.write(file = file_name, mode = mode)
 
-   def __eq__(self, other):
-      """Implements equals operator. Compares class type and uuid"""
+    def __eq__(self, other):
+        """Implements equals operator. Compares class type and uuid"""
 
-      # TODO: more detailed equality comparison
-      other_uuid = getattr(other, "uuid", None)
-      return isinstance(other, self.__class__) and bu.matching_uuids(self.uuid, other_uuid)
+        # TODO: more detailed equality comparison
+        other_uuid = getattr(other, "uuid", None)
+        return isinstance(other, self.__class__) and bu.matching_uuids(self.uuid, other_uuid)
 
 
 class WellboreFrame(BaseResqpy):
-   """Class for RESQML WellboreFrameRepresentation objects (supporting well log Properties)
+    """Class for RESQML WellboreFrameRepresentation objects (supporting well log Properties)
 
    RESQML documentation:
 
@@ -1495,19 +1498,19 @@ class WellboreFrame(BaseResqpy):
 
    """
 
-   resqml_type = 'WellboreFrameRepresentation'
+    resqml_type = 'WellboreFrameRepresentation'
 
-   def __init__(self,
-                parent_model,
-                frame_root = None,
-                uuid = None,
-                trajectory = None,
-                mds = None,
-                represented_interp = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Creates a new wellbore frame object and optionally loads it from xml or list of measured depths.
+    def __init__(self,
+                 parent_model,
+                 frame_root = None,
+                 uuid = None,
+                 trajectory = None,
+                 mds = None,
+                 represented_interp = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Creates a new wellbore frame object and optionally loads it from xml or list of measured depths.
 
       arguments:
          parent_model (model.Model object): the model which the new wellbore frame belongs to
@@ -1534,185 +1537,190 @@ class WellboreFrame(BaseResqpy):
          if initialising from a list of measured depths, the wellbore trajectory object must already exist
       """
 
-      #: Associated wellbore trajectory, an instance of :class:`resqpy.well.Trajectory`.
-      self.trajectory = trajectory
-      self.trajectory_uuid = None if trajectory is None else trajectory.uuid
+        #: Associated wellbore trajectory, an instance of :class:`resqpy.well.Trajectory`.
+        self.trajectory = trajectory
+        self.trajectory_uuid = None if trajectory is None else trajectory.uuid
 
-      #: Instance of :class:`resqpy.organize.WellboreInterpretation`
-      self.wellbore_interpretation = represented_interp
-      self.wellbore_feature = None
-      self.feature_and_interpretation_to_be_written = False
+        #: Instance of :class:`resqpy.organize.WellboreInterpretation`
+        self.wellbore_interpretation = represented_interp
+        self.wellbore_feature = None
+        self.feature_and_interpretation_to_be_written = False
 
-      #: number of measured depth nodes, each being an entry or exit point of trajectory with a cell
-      self.node_count = None
+        #: number of measured depth nodes, each being an entry or exit point of trajectory with a cell
+        self.node_count = None
 
-      #: node_count measured depths (in same units and datum as trajectory) of cell entry and/or exit points
-      self.node_mds = None
+        #: node_count measured depths (in same units and datum as trajectory) of cell entry and/or exit points
+        self.node_mds = None
 
-      #: All logs associated with the wellbore frame; an instance of :class:`resqpy.property.WellLogCollection`
-      self.logs = None
+        #: All logs associated with the wellbore frame; an instance of :class:`resqpy.property.WellLogCollection`
+        self.logs = None
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = frame_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = frame_root)
 
-      if self.root is None and trajectory is not None and mds is not None and len(mds) > 1:
-         self.node_count = len(mds)
-         self.node_mds = np.array(mds)
-         assert self.node_mds is not None and self.node_mds.ndim == 1
+        if self.root is None and trajectory is not None and mds is not None and len(mds) > 1:
+            self.node_count = len(mds)
+            self.node_mds = np.array(mds)
+            assert self.node_mds is not None and self.node_mds.ndim == 1
 
-      # UUID needs to have been created before LogCollection can be made
-      # TODO: Figure out when this should be created, and how it is kept in sync when new logs are created
-      self.logs = rqp.WellLogCollection(frame = self)
+        # UUID needs to have been created before LogCollection can be made
+        # TODO: Figure out when this should be created, and how it is kept in sync when new logs are created
+        self.logs = rqp.WellLogCollection(frame = self)
 
-   def _load_from_xml(self):
-      """Loads the wellbore frame object from an xml node (and associated hdf5 data)."""
+    def _load_from_xml(self):
+        """Loads the wellbore frame object from an xml node (and associated hdf5 data)."""
 
-      # NB: node is the root level xml node, not a node in the md list!
+        # NB: node is the root level xml node, not a node in the md list!
 
-      node = self.root
-      assert node is not None
+        node = self.root
+        assert node is not None
 
-      trajectory_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['Trajectory', 'UUID']))
-      assert trajectory_uuid is not None, 'wellbore frame trajectory reference not found in xml'
-      if self.trajectory is None:
-         self.trajectory = Trajectory(self.model, uuid = trajectory_uuid)
-      else:
-         assert bu.matching_uuids(self.trajectory.uuid, trajectory_uuid), 'wellbore frame trajectory uuid mismatch'
+        trajectory_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['Trajectory', 'UUID']))
+        assert trajectory_uuid is not None, 'wellbore frame trajectory reference not found in xml'
+        if self.trajectory is None:
+            self.trajectory = Trajectory(self.model, uuid = trajectory_uuid)
+        else:
+            assert bu.matching_uuids(self.trajectory.uuid, trajectory_uuid), 'wellbore frame trajectory uuid mismatch'
 
-      self.node_count = rqet.find_tag_int(node, 'NodeCount')
-      assert self.node_count is not None, 'node count not found in xml for wellbore frame'
-      assert self.node_count > 1, 'fewer than 2 nodes for wellbore frame'
+        self.node_count = rqet.find_tag_int(node, 'NodeCount')
+        assert self.node_count is not None, 'node count not found in xml for wellbore frame'
+        assert self.node_count > 1, 'fewer than 2 nodes for wellbore frame'
 
-      mds_node = rqet.find_tag(node, 'NodeMd')
-      assert mds_node is not None, 'wellbore frame measured depths hdf5 reference not found in xml'
-      load_hdf5_array(self, mds_node, 'node_mds')
+        mds_node = rqet.find_tag(node, 'NodeMd')
+        assert mds_node is not None, 'wellbore frame measured depths hdf5 reference not found in xml'
+        load_hdf5_array(self, mds_node, 'node_mds')
 
-      assert self.node_mds is not None and self.node_mds.ndim == 1 and self.node_mds.size == self.node_count
+        assert self.node_mds is not None and self.node_mds.ndim == 1 and self.node_mds.size == self.node_count
 
-      interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
-      if interp_uuid is None:
-         self.wellbore_interpretation = None
-      else:
-         self.wellbore_interpretation = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
+        interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
+        if interp_uuid is None:
+            self.wellbore_interpretation = None
+        else:
+            self.wellbore_interpretation = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
 
-      # Create well log collection of all log data
-      self.logs = rqp.WellLogCollection(frame = self)
+        # Create well log collection of all log data
+        self.logs = rqp.WellLogCollection(frame = self)
 
-   def extract_crs_root(self):
-      """Returns the xml root node of the coordinate reference system used by the related trajectory."""
+    def extract_crs_root(self):
+        """Returns the xml root node of the coordinate reference system used by the related trajectory."""
 
-      if self.trajectory is None:
-         return None
-      return self.trajectory.crs_root
+        if self.trajectory is None:
+            return None
+        return self.trajectory.crs_root
 
-   def create_feature_and_interpretation(self):
-      """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does not already exist.
+    def create_feature_and_interpretation(self):
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does not already exist.
       
       Uses the wellboreframe citation title as the well name
       """
-      if self.wellbore_interpretation is not None:
-         log.info(f"Creating WellboreInterpretation and WellboreFeature with name {self.title}")
-         self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, feature_name = self.title)
-         self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
-                                                                   wellbore_feature = self.wellbore_feature)
-         self.feature_and_interpretation_to_be_written = True
-      else:
-         log.info("WellboreInterpretation already exists")
+        if self.wellbore_interpretation is not None:
+            log.info(f"Creating WellboreInterpretation and WellboreFeature with name {self.title}")
+            self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, feature_name = self.title)
+            self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
+                                                                      wellbore_feature = self.wellbore_feature)
+            self.feature_and_interpretation_to_be_written = True
+        else:
+            log.info("WellboreInterpretation already exists")
 
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Create or append to an hdf5 file, writing datasets for the measured depths."""
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Create or append to an hdf5 file, writing datasets for the measured depths."""
 
-      # NB: array data must have been set up prior to calling this function
+        # NB: array data must have been set up prior to calling this function
 
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
 
-      h5_reg = rwh5.H5Register(self.model)
-      h5_reg.register_dataset(self.uuid, 'NodeMd', self.node_mds)
-      h5_reg.write(file = file_name, mode = mode)
+        h5_reg = rwh5.H5Register(self.model)
+        h5_reg.register_dataset(self.uuid, 'NodeMd', self.node_mds)
+        h5_reg.write(file = file_name, mode = mode)
 
-   def create_xml(self, ext_uuid = None, add_as_part = True, add_relationships = True, title = None, originator = None):
-      """Create a wellbore frame representation node from this WellboreFrame object, optionally add as part.
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   title = None,
+                   originator = None):
+        """Create a wellbore frame representation node from this WellboreFrame object, optionally add as part.
 
       note:
          trajectory xml node must be in place before calling this function
       """
 
-      assert self.trajectory is not None, 'trajectory object missing'
-      assert self.trajectory.root is not None, 'trajectory xml not established'
+        assert self.trajectory is not None, 'trajectory object missing'
+        assert self.trajectory.root is not None, 'trajectory xml not established'
 
-      if self.feature_and_interpretation_to_be_written:
-         if self.wellbore_interpretation is None:
-            self.create_feature_and_interpretation()
-         if self.wellbore_feature is not None:
-            self.wellbore_feature.create_xml(add_as_part = add_as_part, originator = originator)
-         self.wellbore_interpretation.create_xml(add_as_part = add_as_part,
-                                                 add_relationships = add_relationships,
-                                                 originator = originator)
+        if self.feature_and_interpretation_to_be_written:
+            if self.wellbore_interpretation is None:
+                self.create_feature_and_interpretation()
+            if self.wellbore_feature is not None:
+                self.wellbore_feature.create_xml(add_as_part = add_as_part, originator = originator)
+            self.wellbore_interpretation.create_xml(add_as_part = add_as_part,
+                                                    add_relationships = add_relationships,
+                                                    originator = originator)
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      if title:
-         self.title = title
-      if not self.title:
-         self.title = 'wellbore frame'
+        if title:
+            self.title = title
+        if not self.title:
+            self.title = 'wellbore frame'
 
-      wf_node = super().create_xml(originator = originator, add_as_part = False)
+        wf_node = super().create_xml(originator = originator, add_as_part = False)
 
-      # wellbore frame elements
+        # wellbore frame elements
 
-      nc_node = rqet.SubElement(wf_node, ns['resqml2'] + 'NodeCount')
-      nc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      nc_node.text = str(self.node_count)
+        nc_node = rqet.SubElement(wf_node, ns['resqml2'] + 'NodeCount')
+        nc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        nc_node.text = str(self.node_count)
 
-      mds_node = rqet.SubElement(wf_node, ns['resqml2'] + 'NodeMd')
-      mds_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-      mds_node.text = rqet.null_xml_text
+        mds_node = rqet.SubElement(wf_node, ns['resqml2'] + 'NodeMd')
+        mds_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+        mds_node.text = rqet.null_xml_text
 
-      mds_values_node = rqet.SubElement(mds_node, ns['resqml2'] + 'Values')
-      mds_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
-      mds_values_node.text = rqet.null_xml_text
+        mds_values_node = rqet.SubElement(mds_node, ns['resqml2'] + 'Values')
+        mds_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
+        mds_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'NodeMd', root = mds_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'NodeMd', root = mds_values_node)
 
-      traj_root = self.trajectory.root
-      self.model.create_ref_node('Trajectory',
-                                 rqet.find_nested_tags_text(traj_root, ['Citation', 'Title']),
-                                 bu.uuid_from_string(traj_root.attrib['uuid']),
-                                 content_type = 'obj_WellboreTrajectoryRepresentation',
-                                 root = wf_node)
+        traj_root = self.trajectory.root
+        self.model.create_ref_node('Trajectory',
+                                   rqet.find_nested_tags_text(traj_root, ['Citation', 'Title']),
+                                   bu.uuid_from_string(traj_root.attrib['uuid']),
+                                   content_type = 'obj_WellboreTrajectoryRepresentation',
+                                   root = wf_node)
 
-      if self.wellbore_interpretation is not None:
-         interp_root = self.wellbore_interpretation.root
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
-                                    bu.uuid_from_string(interp_root.attrib['uuid']),
-                                    content_type = 'obj_WellboreInterpretation',
-                                    root = wf_node)
+        if self.wellbore_interpretation is not None:
+            interp_root = self.wellbore_interpretation.root
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
+                                       bu.uuid_from_string(interp_root.attrib['uuid']),
+                                       content_type = 'obj_WellboreInterpretation',
+                                       root = wf_node)
 
-      if add_as_part:
-         self.model.add_part('obj_WellboreFrameRepresentation', self.uuid, wf_node)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(wf_node, 'destinationObject', self.trajectory.root,
-                                                      'sourceObject')
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(wf_node, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
-            if self.wellbore_interpretation is not None:
-               interp_root = self.wellbore_interpretation.root
-               self.model.create_reciprocal_relationship(wf_node, 'destinationObject', interp_root, 'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_WellboreFrameRepresentation', self.uuid, wf_node)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(wf_node, 'destinationObject', self.trajectory.root,
+                                                          'sourceObject')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(wf_node, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
+                if self.wellbore_interpretation is not None:
+                    interp_root = self.wellbore_interpretation.root
+                    self.model.create_reciprocal_relationship(wf_node, 'destinationObject', interp_root, 'sourceObject')
 
-      return wf_node
+        return wf_node
 
 
 class BlockedWell(BaseResqpy):
-   """Class for RESQML Blocked Wellbore Representation (Wells), ie cells visited by wellbore.
+    """Class for RESQML Blocked Wellbore Representation (Wells), ie cells visited by wellbore.
 
    RESQML documentation:
 
@@ -1724,26 +1732,26 @@ class BlockedWell(BaseResqpy):
       measured depth data must be in same crs as those for the related trajectory
    """
 
-   resqml_type = 'BlockedWellboreRepresentation'
-   well_name = rqo._alias_for_attribute("title")
+    resqml_type = 'BlockedWellboreRepresentation'
+    well_name = rqo._alias_for_attribute("title")
 
-   def __init__(self,
-                parent_model,
-                blocked_well_root = None,
-                uuid = None,
-                grid = None,
-                trajectory = None,
-                wellspec_file = None,
-                cellio_file = None,
-                column_ji0 = None,
-                well_name = None,
-                check_grid_name = False,
-                use_face_centres = False,
-                represented_interp = None,
-                originator = None,
-                extra_metadata = None,
-                add_wellspec_properties = False):
-      """Creates a new blocked well object and optionally loads it from xml, or trajectory, or Nexus wellspec file.
+    def __init__(self,
+                 parent_model,
+                 blocked_well_root = None,
+                 uuid = None,
+                 grid = None,
+                 trajectory = None,
+                 wellspec_file = None,
+                 cellio_file = None,
+                 column_ji0 = None,
+                 well_name = None,
+                 check_grid_name = False,
+                 use_face_centres = False,
+                 represented_interp = None,
+                 originator = None,
+                 extra_metadata = None,
+                 add_wellspec_properties = False):
+        """Creates a new blocked well object and optionally loads it from xml, or trajectory, or Nexus wellspec file.
 
       arguments:
          parent_model (model.Model object): the model which the new blocked well belongs to
@@ -1797,280 +1805,281 @@ class BlockedWell(BaseResqpy):
       :meta common:
       """
 
-      self.trajectory = trajectory  #: trajectory object associated with the wellbore
-      self.trajectory_to_be_written = False
-      self.feature_to_be_written = False
-      self.interpretation_to_be_written = False
-      self.node_count = None  #: number of measured depth nodes, each being an entry or exit point of trajectory with a cell
-      self.node_mds = None  #: node_count measured depths (in same units and datum as trajectory) of cell entry and/or exit points
-      self.cell_count = None  #: number of blocked intervals (<= node_count - 1)
-      self.cell_indices = None  #: cell_count natural cell indices, paired with non-null grid_indices
-      self.grid_indices = None  #: node_count-1 indices into grid list for each interval in node_mds; -1 for unblocked interval
-      self.face_pair_indices = None  #: entry, exit face per cell indices, -1 for Target Depth termination within a cell
-      self.grid_list = [
-      ]  #: list of grid objects indexed by grid_indices; for now only handles 1 grid unless loading from xml
-      self.wellbore_interpretation = None  #: associated wellbore interpretation object
-      self.wellbore_feature = None  #: associated wellbore feature object
+        self.trajectory = trajectory  #: trajectory object associated with the wellbore
+        self.trajectory_to_be_written = False
+        self.feature_to_be_written = False
+        self.interpretation_to_be_written = False
+        self.node_count = None  #: number of measured depth nodes, each being an entry or exit point of trajectory with a cell
+        self.node_mds = None  #: node_count measured depths (in same units and datum as trajectory) of cell entry and/or exit points
+        self.cell_count = None  #: number of blocked intervals (<= node_count - 1)
+        self.cell_indices = None  #: cell_count natural cell indices, paired with non-null grid_indices
+        self.grid_indices = None  #: node_count-1 indices into grid list for each interval in node_mds; -1 for unblocked interval
+        self.face_pair_indices = None  #: entry, exit face per cell indices, -1 for Target Depth termination within a cell
+        self.grid_list = [
+        ]  #: list of grid objects indexed by grid_indices; for now only handles 1 grid unless loading from xml
+        self.wellbore_interpretation = None  #: associated wellbore interpretation object
+        self.wellbore_feature = None  #: associated wellbore feature object
 
-      #: All logs associated with the blockedwellbore; an instance of :class:`resqpy.property.WellIntervalPropertyCollection`
-      self.logs = None
-      self.cellind_null = None
-      self.gridind_null = None
-      self.facepair_null = None
+        #: All logs associated with the blockedwellbore; an instance of :class:`resqpy.property.WellIntervalPropertyCollection`
+        self.logs = None
+        self.cellind_null = None
+        self.gridind_null = None
+        self.facepair_null = None
 
-      # face_index_map maps from (axis, p01) to face index value in range 0..5
-      # this is the default as indicated on page 139 (but not p. 180) of the RESQML Usage Gude v2.0.1
-      # also assumes K is generally increasing downwards
-      # see DevOps backlog item 269001 discussion for more information
-      #     self.face_index_map = np.array([[0, 1], [4, 2], [5, 3]], dtype = int)
-      self.face_index_map = np.array([[0, 1], [2, 4], [5, 3]], dtype = int)  # order: top, base, J-, I+, J+, I-
-      # and the inverse, maps from 0..5 to (axis, p01)
-      #     self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 1], [2, 1], [1, 0], [2, 0]], dtype = int)
-      self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 0], [2, 1], [1, 1], [2, 0]], dtype = int)
-      # note: the rework_face_pairs() method, below, overwrites the face indices based on I, J cell indices
+        # face_index_map maps from (axis, p01) to face index value in range 0..5
+        # this is the default as indicated on page 139 (but not p. 180) of the RESQML Usage Gude v2.0.1
+        # also assumes K is generally increasing downwards
+        # see DevOps backlog item 269001 discussion for more information
+        #     self.face_index_map = np.array([[0, 1], [4, 2], [5, 3]], dtype = int)
+        self.face_index_map = np.array([[0, 1], [2, 4], [5, 3]], dtype = int)  # order: top, base, J-, I+, J+, I-
+        # and the inverse, maps from 0..5 to (axis, p01)
+        #     self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 1], [2, 1], [1, 0], [2, 0]], dtype = int)
+        self.face_index_inverse_map = np.array([[0, 0], [0, 1], [1, 0], [2, 1], [1, 1], [2, 0]], dtype = int)
+        # note: the rework_face_pairs() method, below, overwrites the face indices based on I, J cell indices
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = well_name,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = blocked_well_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = well_name,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = blocked_well_root)
 
-      if self.root is None:
-         self.wellbore_interpretation = represented_interp
-         if grid is None and (self.trajectory is not None or wellspec_file is not None or cellio_file is not None or
-                              column_ji0 is not None):
-            grid = self.model.grid()
-         if self.trajectory is not None:
-            self.compute_from_trajectory(self.trajectory, grid)
-         elif wellspec_file is not None:
-            okay = self.derive_from_wellspec(wellspec_file,
-                                             well_name,
-                                             grid,
-                                             check_grid_name = check_grid_name,
-                                             use_face_centres = use_face_centres,
-                                             add_properties = add_wellspec_properties)
-         elif cellio_file is not None:
-            okay = self.import_from_rms_cellio(cellio_file, well_name, grid)
-            if not okay:
-               self.node_count = 0
-         elif column_ji0 is not None:
-            okay = self.set_for_column(well_name, grid, column_ji0)
-         self.gridind_null = -1
-         self.facepair_null = -1
-         self.cellind_null = -1
-      # else an empty object is returned
+        if self.root is None:
+            self.wellbore_interpretation = represented_interp
+            if grid is None and (self.trajectory is not None or wellspec_file is not None or cellio_file is not None or
+                                 column_ji0 is not None):
+                grid = self.model.grid()
+            if self.trajectory is not None:
+                self.compute_from_trajectory(self.trajectory, grid)
+            elif wellspec_file is not None:
+                okay = self.derive_from_wellspec(wellspec_file,
+                                                 well_name,
+                                                 grid,
+                                                 check_grid_name = check_grid_name,
+                                                 use_face_centres = use_face_centres,
+                                                 add_properties = add_wellspec_properties)
+            elif cellio_file is not None:
+                okay = self.import_from_rms_cellio(cellio_file, well_name, grid)
+                if not okay:
+                    self.node_count = 0
+            elif column_ji0 is not None:
+                okay = self.set_for_column(well_name, grid, column_ji0)
+            self.gridind_null = -1
+            self.facepair_null = -1
+            self.cellind_null = -1
+        # else an empty object is returned
 
-   def _load_from_xml(self):
-      """Loads the blocked wellbore object from an xml node (and associated hdf5 data)."""
+    def _load_from_xml(self):
+        """Loads the blocked wellbore object from an xml node (and associated hdf5 data)."""
 
-      node = self.root
-      assert node is not None
+        node = self.root
+        assert node is not None
 
-      trajectory_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['Trajectory', 'UUID']))
-      assert trajectory_uuid is not None, 'blocked well trajectory reference not found in xml'
-      if self.trajectory is None:
-         self.trajectory = Trajectory(self.model, uuid = trajectory_uuid)
-      else:
-         assert bu.matching_uuids(self.trajectory.uuid, trajectory_uuid), 'blocked well trajectory uuid mismatch'
+        trajectory_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['Trajectory', 'UUID']))
+        assert trajectory_uuid is not None, 'blocked well trajectory reference not found in xml'
+        if self.trajectory is None:
+            self.trajectory = Trajectory(self.model, uuid = trajectory_uuid)
+        else:
+            assert bu.matching_uuids(self.trajectory.uuid, trajectory_uuid), 'blocked well trajectory uuid mismatch'
 
-      self.node_count = rqet.find_tag_int(node, 'NodeCount')
-      assert self.node_count is not None and self.node_count >= 2, 'problem with blocked well node count'
+        self.node_count = rqet.find_tag_int(node, 'NodeCount')
+        assert self.node_count is not None and self.node_count >= 2, 'problem with blocked well node count'
 
-      mds_node = rqet.find_tag(node, 'NodeMd')
-      assert mds_node is not None, 'blocked well node measured depths hdf5 reference not found in xml'
-      load_hdf5_array(self, mds_node, 'node_mds')
+        mds_node = rqet.find_tag(node, 'NodeMd')
+        assert mds_node is not None, 'blocked well node measured depths hdf5 reference not found in xml'
+        load_hdf5_array(self, mds_node, 'node_mds')
 
-      # Statement below has no effect, is this a bug?
-      self.node_mds is not None and self.node_mds.ndim == 1 and self.node_mds.size == self.node_count
+        # Statement below has no effect, is this a bug?
+        self.node_mds is not None and self.node_mds.ndim == 1 and self.node_mds.size == self.node_count
 
-      self.cell_count = rqet.find_tag_int(node, 'CellCount')
-      assert self.cell_count is not None and self.cell_count > 0
+        self.cell_count = rqet.find_tag_int(node, 'CellCount')
+        assert self.cell_count is not None and self.cell_count > 0
 
-      # TODO: remove this if block once RMS export issue resolved
-      if self.cell_count == self.node_count:
-         extended_mds = np.empty((self.node_mds.size + 1,))
-         extended_mds[:-1] = self.node_mds
-         extended_mds[-1] = self.node_mds[-1] + 1.0
-         self.node_mds = extended_mds
-         self.node_count += 1
+        # TODO: remove this if block once RMS export issue resolved
+        if self.cell_count == self.node_count:
+            extended_mds = np.empty((self.node_mds.size + 1,))
+            extended_mds[:-1] = self.node_mds
+            extended_mds[-1] = self.node_mds[-1] + 1.0
+            self.node_mds = extended_mds
+            self.node_count += 1
 
-      assert self.cell_count < self.node_count
+        assert self.cell_count < self.node_count
 
-      ci_node = rqet.find_tag(node, 'CellIndices')
-      assert ci_node is not None, 'blocked well cell indices hdf5 reference not found in xml'
-      load_hdf5_array(self, ci_node, 'cell_indices', dtype = int)
-      assert (self.cell_indices is not None and self.cell_indices.ndim == 1 and
-              self.cell_indices.size == self.cell_count), 'mismatch in number of cell indices for blocked well'
-      self.cellind_null = rqet.find_tag_int(ci_node, 'NullValue')
-      if self.cellind_null is None:
-         self.cellind_null = -1  # if no Null found assume -1 default
+        ci_node = rqet.find_tag(node, 'CellIndices')
+        assert ci_node is not None, 'blocked well cell indices hdf5 reference not found in xml'
+        load_hdf5_array(self, ci_node, 'cell_indices', dtype = int)
+        assert (self.cell_indices is not None and self.cell_indices.ndim == 1 and
+                self.cell_indices.size == self.cell_count), 'mismatch in number of cell indices for blocked well'
+        self.cellind_null = rqet.find_tag_int(ci_node, 'NullValue')
+        if self.cellind_null is None:
+            self.cellind_null = -1  # if no Null found assume -1 default
 
-      fi_node = rqet.find_tag(node, 'LocalFacePairPerCellIndices')
-      assert fi_node is not None, 'blocked well face indices hdf5 reference not found in xml'
-      load_hdf5_array(self, fi_node, 'raw_face_indices', dtype = 'int')
-      assert self.raw_face_indices is not None, 'failed to load face indices for blocked well'
-      assert self.raw_face_indices.size == 2 * self.cell_count, 'mismatch in number of cell faces for blocked well'
-      if self.raw_face_indices.ndim > 1:
-         self.raw_face_indices = self.raw_face_indices.reshape((self.raw_face_indices.size,))
-      mask = np.where(self.raw_face_indices == -1)
-      self.raw_face_indices[mask] = 0
-      self.face_pair_indices = self.face_index_inverse_map[self.raw_face_indices]
-      self.face_pair_indices[mask] = (-1, -1)
-      self.face_pair_indices = self.face_pair_indices.reshape((-1, 2, 2))
-      del self.raw_face_indices
-      self.facepair_null = rqet.find_tag_int(fi_node, 'NullValue')
-      if self.facepair_null is None:
-         self.facepair_null = -1
+        fi_node = rqet.find_tag(node, 'LocalFacePairPerCellIndices')
+        assert fi_node is not None, 'blocked well face indices hdf5 reference not found in xml'
+        load_hdf5_array(self, fi_node, 'raw_face_indices', dtype = 'int')
+        assert self.raw_face_indices is not None, 'failed to load face indices for blocked well'
+        assert self.raw_face_indices.size == 2 * self.cell_count, 'mismatch in number of cell faces for blocked well'
+        if self.raw_face_indices.ndim > 1:
+            self.raw_face_indices = self.raw_face_indices.reshape((self.raw_face_indices.size,))
+        mask = np.where(self.raw_face_indices == -1)
+        self.raw_face_indices[mask] = 0
+        self.face_pair_indices = self.face_index_inverse_map[self.raw_face_indices]
+        self.face_pair_indices[mask] = (-1, -1)
+        self.face_pair_indices = self.face_pair_indices.reshape((-1, 2, 2))
+        del self.raw_face_indices
+        self.facepair_null = rqet.find_tag_int(fi_node, 'NullValue')
+        if self.facepair_null is None:
+            self.facepair_null = -1
 
-      gi_node = rqet.find_tag(node, 'GridIndices')
-      assert gi_node is not None, 'blocked well grid indices hdf5 reference not found in xml'
-      load_hdf5_array(self, gi_node, 'grid_indices', dtype = 'int')
-      assert self.grid_indices is not None and self.grid_indices.ndim == 1 and self.grid_indices.size == self.node_count - 1
-      unique_grid_indices = np.unique(self.grid_indices)  # sorted list of unique values
-      self.gridind_null = rqet.find_tag_int(gi_node, 'NullValue')
-      if self.gridind_null is None:
-         self.gridind_null = -1  # if no Null found assume -1 default
+        gi_node = rqet.find_tag(node, 'GridIndices')
+        assert gi_node is not None, 'blocked well grid indices hdf5 reference not found in xml'
+        load_hdf5_array(self, gi_node, 'grid_indices', dtype = 'int')
+        assert self.grid_indices is not None and self.grid_indices.ndim == 1 and self.grid_indices.size == self.node_count - 1
+        unique_grid_indices = np.unique(self.grid_indices)  # sorted list of unique values
+        self.gridind_null = rqet.find_tag_int(gi_node, 'NullValue')
+        if self.gridind_null is None:
+            self.gridind_null = -1  # if no Null found assume -1 default
 
-      grid_node_list = rqet.list_of_tag(node, 'Grid')
-      assert len(grid_node_list) > 0, 'blocked well grid reference(s) not found in xml'
-      assert unique_grid_indices[0] >= -1 and unique_grid_indices[-1] < len(
-         grid_node_list), 'blocked well grid index out of range'
-      assert np.count_nonzero(self.grid_indices >= 0) == self.cell_count, 'mismatch in number of blocked well intervals'
-      self.grid_list = []
-      for grid_ref_node in grid_node_list:
-         grid_node = self.model.referenced_node(grid_ref_node)
-         assert grid_node is not None, 'grid referenced in blocked well xml is not present in model'
-         grid_uuid = rqet.uuid_for_part_root(grid_node)
-         grid_obj = self.model.grid(uuid = grid_uuid, find_properties = False)
-         self.grid_list.append(grid_obj)
+        grid_node_list = rqet.list_of_tag(node, 'Grid')
+        assert len(grid_node_list) > 0, 'blocked well grid reference(s) not found in xml'
+        assert unique_grid_indices[0] >= -1 and unique_grid_indices[-1] < len(
+            grid_node_list), 'blocked well grid index out of range'
+        assert np.count_nonzero(
+            self.grid_indices >= 0) == self.cell_count, 'mismatch in number of blocked well intervals'
+        self.grid_list = []
+        for grid_ref_node in grid_node_list:
+            grid_node = self.model.referenced_node(grid_ref_node)
+            assert grid_node is not None, 'grid referenced in blocked well xml is not present in model'
+            grid_uuid = rqet.uuid_for_part_root(grid_node)
+            grid_obj = self.model.grid(uuid = grid_uuid, find_properties = False)
+            self.grid_list.append(grid_obj)
 
-      interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
-      if interp_uuid is None:
-         self.wellbore_interpretation = None
-      else:
-         self.wellbore_interpretation = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
+        interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
+        if interp_uuid is None:
+            self.wellbore_interpretation = None
+        else:
+            self.wellbore_interpretation = rqo.WellboreInterpretation(self.model, uuid = interp_uuid)
 
-      # Create blocked well log collection of all log data
-      self.logs = rqp.WellIntervalPropertyCollection(frame = self)
+        # Create blocked well log collection of all log data
+        self.logs = rqp.WellIntervalPropertyCollection(frame = self)
 
-      # Set up matches between cell_indices and grid_indices
-      self.cell_grid_link = self.map_cell_and_grid_indices()
+        # Set up matches between cell_indices and grid_indices
+        self.cell_grid_link = self.map_cell_and_grid_indices()
 
-   def map_cell_and_grid_indices(self):
-      """Returns a list of index values linking the grid_indices to cell_indices.
+    def map_cell_and_grid_indices(self):
+        """Returns a list of index values linking the grid_indices to cell_indices.
 
       note:
          length will match grid_indices, and will show -1 where cell is unblocked
       """
 
-      indexmap = []
-      j = 0
-      for i in self.grid_indices:
-         if i == -1:
-            indexmap.append(-1)
-         else:
-            indexmap.append(j)
-            j += 1
-      return indexmap
+        indexmap = []
+        j = 0
+        for i in self.grid_indices:
+            if i == -1:
+                indexmap.append(-1)
+            else:
+                indexmap.append(j)
+                j += 1
+        return indexmap
 
-   def compressed_grid_indices(self):
-      """Returns a list of grid indices excluding the -1 elements (unblocked intervals).
+    def compressed_grid_indices(self):
+        """Returns a list of grid indices excluding the -1 elements (unblocked intervals).
 
       note:
          length will match that of cell_indices
       """
 
-      compressed = []
-      for i in self.grid_indices:
-         if i >= 0:
-            compressed.append(i)
-      assert len(compressed) == self.cell_count
-      return compressed
+        compressed = []
+        for i in self.grid_indices:
+            if i >= 0:
+                compressed.append(i)
+        assert len(compressed) == self.cell_count
+        return compressed
 
-   def number_of_grids(self):
-      """Returns the number of grids referenced by the blocked well object."""
+    def number_of_grids(self):
+        """Returns the number of grids referenced by the blocked well object."""
 
-      if self.grid_list is None:
-         return 0
-      return len(self.grid_list)
+        if self.grid_list is None:
+            return 0
+        return len(self.grid_list)
 
-   def single_grid(self):
-      """Asserts that exactly one grid is being referenced and returns a grid object for that grid."""
+    def single_grid(self):
+        """Asserts that exactly one grid is being referenced and returns a grid object for that grid."""
 
-      assert len(self.grid_list) == 1, 'blocked well is not referring to exactly one grid'
-      return self.grid_list[0]
+        assert len(self.grid_list) == 1, 'blocked well is not referring to exactly one grid'
+        return self.grid_list[0]
 
-   def grid_uuid_list(self):
-      """Returns a list of the uuids of the grids referenced by the blocked well object.
-
-      :meta common:
-      """
-
-      uuid_list = []
-      if self.grid_list is None:
-         return uuid_list
-      for g in self.grid_list:
-         uuid_list.append(g.uuid)
-      return uuid_list
-
-   def cell_indices_kji0(self):
-      """Returns a numpy int array of shape (N, 3) of cells visited by well, for a single grid situation.
+    def grid_uuid_list(self):
+        """Returns a list of the uuids of the grids referenced by the blocked well object.
 
       :meta common:
       """
 
-      grid = self.single_grid()
-      return grid.denaturalized_cell_indices(self.cell_indices)
+        uuid_list = []
+        if self.grid_list is None:
+            return uuid_list
+        for g in self.grid_list:
+            uuid_list.append(g.uuid)
+        return uuid_list
 
-   def cell_indices_and_grid_list(self):
-      """Returns a numpy int array of shape (N, 3) of cells visited by well, and a list of grid objects of length N.
-
-      :meta common:
-      """
-
-      grid_for_cell_list = []
-      grid_indices = self.compressed_grid_indices()
-      assert len(grid_indices) == self.cell_count
-      cell_indices = np.empty((self.cell_count, 3), dtype = int)
-      for cell_number in range(self.cell_count):
-         grid = self.grid_list[grid_indices[cell_number]]
-         grid_for_cell_list.append(grid)
-         cell_indices[cell_number] = grid.denaturalized_cell_index(self.cell_indices[cell_number])
-      return cell_indices, grid_for_cell_list
-
-   def cell_indices_for_grid_uuid(self, grid_uuid):
-      """Returns a numpy int array of shape (N, 3) of cells visited by well in specified grid.
+    def cell_indices_kji0(self):
+        """Returns a numpy int array of shape (N, 3) of cells visited by well, for a single grid situation.
 
       :meta common:
       """
 
-      if isinstance(grid_uuid, str):
-         grid_uuid = bu.uuid_from_string(grid_uuid)
-      ci_list, grid_list = self.cell_indices_and_grid_list()
-      mask = np.zeros((len(ci_list),), dtype = bool)
-      for cell_number in range(len(ci_list)):
-         mask[cell_number] = bu.matching_uuids(grid_list[cell_number].uuid, grid_uuid)
-      ci_selected = ci_list[mask]
-      return ci_selected
+        grid = self.single_grid()
+        return grid.denaturalized_cell_indices(self.cell_indices)
 
-   def box(self, grid_uuid = None):
-      """Returns the KJI box containing the cells visited by the well, for single grid if grid_uuid is None."""
+    def cell_indices_and_grid_list(self):
+        """Returns a numpy int array of shape (N, 3) of cells visited by well, and a list of grid objects of length N.
 
-      if grid_uuid is None:
-         cells_kji0 = self.cell_indices_kji0()
-      else:
-         cells_kji0 = self.cell_indices_for_grid_uuid(grid_uuid)
+      :meta common:
+      """
 
-      if cells_kji0 is None or len(cells_kji0) == 0:
-         return None
-      well_box = np.empty((2, 3), dtype = int)
-      well_box[0] = np.min(cells_kji0, axis = 0)
-      well_box[1] = np.max(cells_kji0, axis = 0)
-      return well_box
+        grid_for_cell_list = []
+        grid_indices = self.compressed_grid_indices()
+        assert len(grid_indices) == self.cell_count
+        cell_indices = np.empty((self.cell_count, 3), dtype = int)
+        for cell_number in range(self.cell_count):
+            grid = self.grid_list[grid_indices[cell_number]]
+            grid_for_cell_list.append(grid)
+            cell_indices[cell_number] = grid.denaturalized_cell_index(self.cell_indices[cell_number])
+        return cell_indices, grid_for_cell_list
 
-   def face_pair_array(self):
-      """Returns numpy int array of shape (N, 2, 2) being pairs of face (axis, polarity) pairs, to go with cell_kji0_array().
+    def cell_indices_for_grid_uuid(self, grid_uuid):
+        """Returns a numpy int array of shape (N, 3) of cells visited by well in specified grid.
+
+      :meta common:
+      """
+
+        if isinstance(grid_uuid, str):
+            grid_uuid = bu.uuid_from_string(grid_uuid)
+        ci_list, grid_list = self.cell_indices_and_grid_list()
+        mask = np.zeros((len(ci_list),), dtype = bool)
+        for cell_number in range(len(ci_list)):
+            mask[cell_number] = bu.matching_uuids(grid_list[cell_number].uuid, grid_uuid)
+        ci_selected = ci_list[mask]
+        return ci_selected
+
+    def box(self, grid_uuid = None):
+        """Returns the KJI box containing the cells visited by the well, for single grid if grid_uuid is None."""
+
+        if grid_uuid is None:
+            cells_kji0 = self.cell_indices_kji0()
+        else:
+            cells_kji0 = self.cell_indices_for_grid_uuid(grid_uuid)
+
+        if cells_kji0 is None or len(cells_kji0) == 0:
+            return None
+        well_box = np.empty((2, 3), dtype = int)
+        well_box[0] = np.min(cells_kji0, axis = 0)
+        well_box[1] = np.max(cells_kji0, axis = 0)
+        return well_box
+
+    def face_pair_array(self):
+        """Returns numpy int array of shape (N, 2, 2) being pairs of face (axis, polarity) pairs, to go with cell_kji0_array().
 
       note:
 
@@ -2082,15 +2091,15 @@ class BlockedWell(BaseResqpy):
          the polarity values are zero for the 'negative' face and 1 for the 'positive' face;
          exit values may be -1 to indicate TD within the cell (ie. no exit point)
       """
-      return self.face_pair_indices
+        return self.face_pair_indices
 
-   def compute_from_trajectory(self,
-                               trajectory,
-                               grid,
-                               active_only = False,
-                               quad_triangles = True,
-                               use_single_layer_tactics = True):
-      """Populate this blocked wellbore object based on intersection of trajectory with cells of grid.
+    def compute_from_trajectory(self,
+                                trajectory,
+                                grid,
+                                active_only = False,
+                                quad_triangles = True,
+                                use_single_layer_tactics = True):
+        """Populate this blocked wellbore object based on intersection of trajectory with cells of grid.
 
       arguments:
          trajectory (Trajectory object): the trajectory to intersect with the grid; control_points and crs_root attributes must
@@ -2110,65 +2119,65 @@ class BlockedWell(BaseResqpy):
          grids with k gaps, or setting use_single_layer_tactics False will typically result in significantly longer processing time
       """
 
-      import resqpy.grid_surface as rgs  # was causing circular import issue when at global level
+        import resqpy.grid_surface as rgs  # was causing circular import issue when at global level
 
-      # note: see also extract_box_for_well code
-      assert trajectory is not None and grid is not None
-      if np.any(np.isnan(grid.points_ref(masked = False))):
-         log.warning('grid does not have geometry defined everywhere: attempting fill')
-         import resqpy.derived_model as rqdm
-         fill_grid = rqdm.copy_grid(grid)
-         fill_grid.set_geometry_is_defined(nullify_partial_pillars = True, complete_all = True)
-         # note: may need to write hdf5 and create xml for fill_grid, depending on use in populate_blocked_well_from_trajectory()
-         # fill_grid.write_hdf_from_caches()
-         # fill_grid.create_xml
-         grid = fill_grid
-      assert trajectory.control_points is not None and trajectory.crs_root is not None and grid.crs_root is not None
-      assert len(trajectory.control_points)
+        # note: see also extract_box_for_well code
+        assert trajectory is not None and grid is not None
+        if np.any(np.isnan(grid.points_ref(masked = False))):
+            log.warning('grid does not have geometry defined everywhere: attempting fill')
+            import resqpy.derived_model as rqdm
+            fill_grid = rqdm.copy_grid(grid)
+            fill_grid.set_geometry_is_defined(nullify_partial_pillars = True, complete_all = True)
+            # note: may need to write hdf5 and create xml for fill_grid, depending on use in populate_blocked_well_from_trajectory()
+            # fill_grid.write_hdf_from_caches()
+            # fill_grid.create_xml
+            grid = fill_grid
+        assert trajectory.control_points is not None and trajectory.crs_root is not None and grid.crs_root is not None
+        assert len(trajectory.control_points)
 
-      self.trajectory = trajectory
-      if not self.well_name:
-         self.well_name = trajectory.title
-      bw = rgs.populate_blocked_well_from_trajectory(self,
-                                                     grid,
-                                                     active_only = active_only,
-                                                     quad_triangles = quad_triangles,
-                                                     lazy = False,
-                                                     use_single_layer_tactics = use_single_layer_tactics)
-      if bw is None:
-         raise Exception('failed to generate blocked well from trajectory with uuid: ' + str(trajectory.uuid))
+        self.trajectory = trajectory
+        if not self.well_name:
+            self.well_name = trajectory.title
+        bw = rgs.populate_blocked_well_from_trajectory(self,
+                                                       grid,
+                                                       active_only = active_only,
+                                                       quad_triangles = quad_triangles,
+                                                       lazy = False,
+                                                       use_single_layer_tactics = use_single_layer_tactics)
+        if bw is None:
+            raise Exception('failed to generate blocked well from trajectory with uuid: ' + str(trajectory.uuid))
 
-      assert bw is self
+        assert bw is self
 
-   def set_for_column(self, well_name, grid, col_ji0, skip_inactive = True):
-      """Populates empty blocked well for a 'vertical' well in given column; creates simulation trajectory and md datum."""
+    def set_for_column(self, well_name, grid, col_ji0, skip_inactive = True):
+        """Populates empty blocked well for a 'vertical' well in given column; creates simulation trajectory and md datum."""
 
-      if well_name:
-         self.well_name = well_name
-      col_list = ['IW', 'JW', 'L', 'ANGLA', 'ANGLV']  # NB: L is Layer, ie. k
-      df = pd.DataFrame(columns = col_list)
-      pinch_col = grid.pinched_out(cache_cp_array = True, cache_pinchout_array = True)[:, col_ji0[0], col_ji0[1]]
-      if skip_inactive and grid.inactive is not None:
-         inactive_col = grid.inactive[:, col_ji0[0], col_ji0[1]]
-      else:
-         inactive_col = np.zeros(grid.nk, dtype = bool)
-      for k0 in range(grid.nk):
-         if pinch_col[k0] or inactive_col[k0]:
-            continue
-         # note: leaving ANGLA & ANGLV columns as NA will cause K face centres to be used when deriving from dataframe
-         row_dict = {'IW': col_ji0[1] + 1, 'JW': col_ji0[0] + 1, 'L': k0 + 1}
-         df = df.append(row_dict, ignore_index = True)
+        if well_name:
+            self.well_name = well_name
+        col_list = ['IW', 'JW', 'L', 'ANGLA', 'ANGLV']  # NB: L is Layer, ie. k
+        df = pd.DataFrame(columns = col_list)
+        pinch_col = grid.pinched_out(cache_cp_array = True, cache_pinchout_array = True)[:, col_ji0[0], col_ji0[1]]
+        if skip_inactive and grid.inactive is not None:
+            inactive_col = grid.inactive[:, col_ji0[0], col_ji0[1]]
+        else:
+            inactive_col = np.zeros(grid.nk, dtype = bool)
+        for k0 in range(grid.nk):
+            if pinch_col[k0] or inactive_col[k0]:
+                continue
+            # note: leaving ANGLA & ANGLV columns as NA will cause K face centres to be used when deriving from dataframe
+            row_dict = {'IW': col_ji0[1] + 1, 'JW': col_ji0[0] + 1, 'L': k0 + 1}
+            df = df.append(row_dict, ignore_index = True)
 
-      return self.derive_from_dataframe(df, self.well_name, grid, use_face_centres = True)
+        return self.derive_from_dataframe(df, self.well_name, grid, use_face_centres = True)
 
-   def derive_from_wellspec(self,
-                            wellspec_file,
-                            well_name,
-                            grid,
-                            check_grid_name = False,
-                            use_face_centres = False,
-                            add_properties = True):
-      """Populates empty blocked well from Nexus WELLSPEC data; creates simulation trajectory and md datum.
+    def derive_from_wellspec(self,
+                             wellspec_file,
+                             well_name,
+                             grid,
+                             check_grid_name = False,
+                             use_face_centres = False,
+                             add_properties = True):
+        """Populates empty blocked well from Nexus WELLSPEC data; creates simulation trajectory and md datum.
 
       args:
          wellspec_file (string): path of Nexus ascii file holding WELLSPEC keyword
@@ -2193,258 +2202,259 @@ class BlockedWell(BaseResqpy):
          parts to the model for this blocked well and the properties
       """
 
-      if well_name:
-         self.well_name = well_name
-      else:
-         well_name = self.well_name
+        if well_name:
+            self.well_name = well_name
+        else:
+            well_name = self.well_name
 
-      if add_properties:
-         if isinstance(add_properties, list):
-            col_list = ['IW', 'JW', 'L'] + [col.upper() for col in add_properties if col not in ['IW', 'JW', 'L']]
-         else:
-            col_list = []
-      else:
-         col_list = ['IW', 'JW', 'L', 'ANGLA', 'ANGLV']
-      if check_grid_name:
-         grid_name = rqet.citation_title_for_node(grid.root).upper()
-         if not grid_name:
-            check_grid_name = False
-         else:
-            col_list.append('GRID')
+        if add_properties:
+            if isinstance(add_properties, list):
+                col_list = ['IW', 'JW', 'L'] + [col.upper() for col in add_properties if col not in ['IW', 'JW', 'L']]
+            else:
+                col_list = []
+        else:
+            col_list = ['IW', 'JW', 'L', 'ANGLA', 'ANGLV']
+        if check_grid_name:
+            grid_name = rqet.citation_title_for_node(grid.root).upper()
+            if not grid_name:
+                check_grid_name = False
+            else:
+                col_list.append('GRID')
 
-      wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list)
+        wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list)
 
-      assert len(wellspec_dict) == 1, 'no wellspec data found in file ' + wellspec_file + ' for well ' + well_name
+        assert len(wellspec_dict) == 1, 'no wellspec data found in file ' + wellspec_file + ' for well ' + well_name
 
-      df = wellspec_dict[well_name]
-      assert len(df) > 0, 'no rows of perforation data found in wellspec for well ' + well_name
+        df = wellspec_dict[well_name]
+        assert len(df) > 0, 'no rows of perforation data found in wellspec for well ' + well_name
 
-      name_for_check = grid_name if check_grid_name else None
-      return self.derive_from_dataframe(df,
-                                        well_name,
-                                        grid,
-                                        grid_name_to_check = name_for_check,
-                                        use_face_centres = use_face_centres,
-                                        add_as_properties = add_properties)
+        name_for_check = grid_name if check_grid_name else None
+        return self.derive_from_dataframe(df,
+                                          well_name,
+                                          grid,
+                                          grid_name_to_check = name_for_check,
+                                          use_face_centres = use_face_centres,
+                                          add_as_properties = add_properties)
 
-   def derive_from_cell_list(self, cell_kji0_list, well_name, grid):
-      """Populate empty blocked well from numpy int array of shape (N, 3) being list of cells."""
+    def derive_from_cell_list(self, cell_kji0_list, well_name, grid):
+        """Populate empty blocked well from numpy int array of shape (N, 3) being list of cells."""
 
-      df = pd.DataFrame(columns = ['IW', 'JW', 'L'])
-      df['IW'] = cell_kji0_list[:, 2] + 1
-      df['JW'] = cell_kji0_list[:, 1] + 1
-      df['L'] = cell_kji0_list[:, 0] + 1
+        df = pd.DataFrame(columns = ['IW', 'JW', 'L'])
+        df['IW'] = cell_kji0_list[:, 2] + 1
+        df['JW'] = cell_kji0_list[:, 1] + 1
+        df['L'] = cell_kji0_list[:, 0] + 1
 
-      return self.derive_from_dataframe(df, well_name, grid, use_face_centres = True)
+        return self.derive_from_dataframe(df, well_name, grid, use_face_centres = True)
 
-   def derive_from_dataframe(self,
-                             df,
-                             well_name,
-                             grid,
-                             grid_name_to_check = None,
-                             use_face_centres = True,
-                             add_as_properties = False):
-      """Populate empty blocked well from WELLSPEC-like dataframe; first columns must be IW, JW, L (i, j, k).
+    def derive_from_dataframe(self,
+                              df,
+                              well_name,
+                              grid,
+                              grid_name_to_check = None,
+                              use_face_centres = True,
+                              add_as_properties = False):
+        """Populate empty blocked well from WELLSPEC-like dataframe; first columns must be IW, JW, L (i, j, k).
 
       note:
          if add_as_properties is True or present as a list of wellspec column names, both the blocked well and
          the properties will have their hdf5 data written, xml created and be added as parts to the model
       """
 
-      def cell_kji0_from_df(df, df_row):
-         row = df.iloc[df_row]
-         if pd.isna(row[0]) or pd.isna(row[1]) or pd.isna(row[2]):
-            return None
-         cell_kji0 = np.empty((3,), dtype = int)
-         cell_kji0[:] = row[2], row[1], row[0]
-         cell_kji0[:] -= 1
-         return cell_kji0
+        def cell_kji0_from_df(df, df_row):
+            row = df.iloc[df_row]
+            if pd.isna(row[0]) or pd.isna(row[1]) or pd.isna(row[2]):
+                return None
+            cell_kji0 = np.empty((3,), dtype = int)
+            cell_kji0[:] = row[2], row[1], row[0]
+            cell_kji0[:] -= 1
+            return cell_kji0
 
-      if well_name:
-         self.well_name = well_name
-      else:
-         well_name = self.well_name
+        if well_name:
+            self.well_name = well_name
+        else:
+            well_name = self.well_name
 
-      assert len(df) > 0, 'empty dataframe for blocked well ' + str(well_name)
+        assert len(df) > 0, 'empty dataframe for blocked well ' + str(well_name)
 
-      length_uom = grid.z_units()
-      assert grid.xy_units() == length_uom, 'mixed length units in grid crs'
+        length_uom = grid.z_units()
+        assert grid.xy_units() == length_uom, 'mixed length units in grid crs'
 
-      previous_xyz = None
-      trajectory_mds = []
-      trajectory_points = []  # entries paired with trajectory_mds
-      blocked_intervals = [
-      ]  # will have one fewer entries than trajectory nodes; 0 = blocked, -1 = not blocked (for grid indices)
-      blocked_cells_kji0 = []  # will have length equal to number of 0's in blocked intervals
-      blocked_face_pairs = [
-      ]  # same length as blocked_cells_kji0; each is ((entry axis, entry polarity), (exit axis, exit polarity))
+        previous_xyz = None
+        trajectory_mds = []
+        trajectory_points = []  # entries paired with trajectory_mds
+        blocked_intervals = [
+        ]  # will have one fewer entries than trajectory nodes; 0 = blocked, -1 = not blocked (for grid indices)
+        blocked_cells_kji0 = []  # will have length equal to number of 0's in blocked intervals
+        blocked_face_pairs = [
+        ]  # same length as blocked_cells_kji0; each is ((entry axis, entry polarity), (exit axis, exit polarity))
 
-      log.debug('wellspec dataframe for well ' + str(well_name) + ' has ' + str(len(df)) + ' row' + _pl(len(df)))
+        log.debug('wellspec dataframe for well ' + str(well_name) + ' has ' + str(len(df)) + ' row' + _pl(len(df)))
 
-      skipped_warning_grid = None
+        skipped_warning_grid = None
 
-      angles_present = ('ANGLV' in df.columns and 'ANGLA' in df.columns and not pd.isnull(df.iloc[0]['ANGLV']) and
-                        not pd.isnull(df.iloc[0]['ANGLA']))
+        angles_present = ('ANGLV' in df.columns and 'ANGLA' in df.columns and not pd.isnull(df.iloc[0]['ANGLV']) and
+                          not pd.isnull(df.iloc[0]['ANGLA']))
 
-      # TODO: remove these temporary overrides
-      angles_present = False
-      use_face_centres = True
+        # TODO: remove these temporary overrides
+        angles_present = False
+        use_face_centres = True
 
-      if not angles_present and not use_face_centres:
-         log.warning(f'ANGLV and/or ANGLA data unavailable for well {well_name}: using face centres')
-         use_face_centres = True
+        if not angles_present and not use_face_centres:
+            log.warning(f'ANGLV and/or ANGLA data unavailable for well {well_name}: using face centres')
+            use_face_centres = True
 
-      for i in range(len(df)):  # for each row in the dataframe for this well
+        for i in range(len(df)):  # for each row in the dataframe for this well
 
-         cell_kji0 = cell_kji0_from_df(df, i)
-         if cell_kji0 is None:
-            log.error('missing cell index in wellspec data for well ' + str(well_name) + ' row ' + str(i + 1))
-            continue
+            cell_kji0 = cell_kji0_from_df(df, i)
+            if cell_kji0 is None:
+                log.error('missing cell index in wellspec data for well ' + str(well_name) + ' row ' + str(i + 1))
+                continue
 
-         row = df.iloc[i]
+            row = df.iloc[i]
 
-         if grid_name_to_check and pd.notna(row['GRID']) and grid_name_to_check != str(row['GRID']).upper():
-            other_grid = str(row['GRID'])
-            if skipped_warning_grid != other_grid:
-               log.warning('skipping perforation(s) in grid ' + other_grid + ' for well ' + str(well_name))
-               skipped_warning_grid = other_grid
-            continue
-         cp = grid.corner_points(cell_kji0 = cell_kji0, cache_resqml_array = False)
-         assert not np.any(np.isnan(cp)), 'missing geometry for perforation cell for well ' + str(well_name)
+            if grid_name_to_check and pd.notna(row['GRID']) and grid_name_to_check != str(row['GRID']).upper():
+                other_grid = str(row['GRID'])
+                if skipped_warning_grid != other_grid:
+                    log.warning('skipping perforation(s) in grid ' + other_grid + ' for well ' + str(well_name))
+                    skipped_warning_grid = other_grid
+                continue
+            cp = grid.corner_points(cell_kji0 = cell_kji0, cache_resqml_array = False)
+            assert not np.any(np.isnan(cp)), 'missing geometry for perforation cell for well ' + str(well_name)
 
-         if angles_present:
-            log.debug('row ' + str(i) + ': using angles')
-            angla = row['ANGLA']
-            inclination = row['ANGLV']
-            if inclination < 0.1:
-               azimuth = 0.0
+            if angles_present:
+                log.debug('row ' + str(i) + ': using angles')
+                angla = row['ANGLA']
+                inclination = row['ANGLV']
+                if inclination < 0.1:
+                    azimuth = 0.0
+                else:
+                    i_vector = np.sum(cp[:, :, 1] - cp[:, :, 0], axis = (0, 1))
+                    azimuth = vec.azimuth(i_vector) - angla  # see Nexus keyword reference doc
+                well_vector = vec.unit_vector_from_azimuth_and_inclination(azimuth, inclination) * 10000.0
+                # todo: the following might be producing NaN's when vector passes precisely through an edge
+                (entry_axis, entry_polarity, entry_xyz, exit_axis, exit_polarity,
+                 exit_xyz) = find_entry_and_exit(cp, -well_vector, well_vector, well_name)
             else:
-               i_vector = np.sum(cp[:, :, 1] - cp[:, :, 0], axis = (0, 1))
-               azimuth = vec.azimuth(i_vector) - angla  # see Nexus keyword reference doc
-            well_vector = vec.unit_vector_from_azimuth_and_inclination(azimuth, inclination) * 10000.0
-            # todo: the following might be producing NaN's when vector passes precisely through an edge
-            (entry_axis, entry_polarity, entry_xyz, exit_axis, exit_polarity,
-             exit_xyz) = find_entry_and_exit(cp, -well_vector, well_vector, well_name)
-         else:
-            # fabricate entry and exit axes and polarities based on indices alone
-            # note: could use geometry but here a cheap rough-and-ready approach is used
-            log.debug('row ' + str(i) + ': using cell moves')
-            if i == 0:
-               entry_axis, entry_polarity = 0, 0  # K-
-            else:
-               entry_move = cell_kji0 - blocked_cells_kji0[-1]
-               log.debug(f'entry move: {entry_move}')
-               if entry_move[1] == 0 and entry_move[2] == 0:  # K move
-                  entry_axis = 0
-                  entry_polarity = 0 if entry_move[0] >= 0 else 1
-               elif abs(entry_move[1]) > abs(entry_move[2]):  # J dominant move
-                  entry_axis = 1
-                  entry_polarity = 0 if entry_move[1] >= 0 else 1
-               else:  # I dominant move
-                  entry_axis = 2
-                  entry_polarity = 0 if entry_move[2] >= 0 else 1
-            if i == len(df) - 1:
-               exit_axis, exit_polarity = entry_axis, 1 - entry_polarity
-            else:
-               next_cell_kji0 = cell_kji0_from_df(df, i + 1)
-               if next_cell_kji0 is None:
-                  exit_axis, exit_polarity = entry_axis, 1 - entry_polarity
-               else:
-                  exit_move = next_cell_kji0 - cell_kji0
-                  log.debug(f'exit move: {exit_move}')
-                  if exit_move[1] == 0 and exit_move[2] == 0:  # K move
-                     exit_axis = 0
-                     exit_polarity = 1 if exit_move[0] >= 0 else 0
-                  elif abs(exit_move[1]) > abs(exit_move[2]):  # J dominant move
-                     exit_axis = 1
-                     exit_polarity = 1 if exit_move[1] >= 0 else 0
-                  else:  # I dominant move
-                     exit_axis = 2
-                     exit_polarity = 1 if exit_move[2] >= 0 else 0
+                # fabricate entry and exit axes and polarities based on indices alone
+                # note: could use geometry but here a cheap rough-and-ready approach is used
+                log.debug('row ' + str(i) + ': using cell moves')
+                if i == 0:
+                    entry_axis, entry_polarity = 0, 0  # K-
+                else:
+                    entry_move = cell_kji0 - blocked_cells_kji0[-1]
+                    log.debug(f'entry move: {entry_move}')
+                    if entry_move[1] == 0 and entry_move[2] == 0:  # K move
+                        entry_axis = 0
+                        entry_polarity = 0 if entry_move[0] >= 0 else 1
+                    elif abs(entry_move[1]) > abs(entry_move[2]):  # J dominant move
+                        entry_axis = 1
+                        entry_polarity = 0 if entry_move[1] >= 0 else 1
+                    else:  # I dominant move
+                        entry_axis = 2
+                        entry_polarity = 0 if entry_move[2] >= 0 else 1
+                if i == len(df) - 1:
+                    exit_axis, exit_polarity = entry_axis, 1 - entry_polarity
+                else:
+                    next_cell_kji0 = cell_kji0_from_df(df, i + 1)
+                    if next_cell_kji0 is None:
+                        exit_axis, exit_polarity = entry_axis, 1 - entry_polarity
+                    else:
+                        exit_move = next_cell_kji0 - cell_kji0
+                        log.debug(f'exit move: {exit_move}')
+                        if exit_move[1] == 0 and exit_move[2] == 0:  # K move
+                            exit_axis = 0
+                            exit_polarity = 1 if exit_move[0] >= 0 else 0
+                        elif abs(exit_move[1]) > abs(exit_move[2]):  # J dominant move
+                            exit_axis = 1
+                            exit_polarity = 1 if exit_move[1] >= 0 else 0
+                        else:  # I dominant move
+                            exit_axis = 2
+                            exit_polarity = 1 if exit_move[2] >= 0 else 0
 
-         if use_face_centres:  # override the vector based xyz entry and exit points with face centres
-            if entry_axis == 0:
-               entry_xyz = np.mean(cp[entry_polarity, :, :], axis = (0, 1))
-            elif entry_axis == 1:
-               entry_xyz = np.mean(cp[:, entry_polarity, :], axis = (0, 1))
-            else:
-               entry_xyz = np.mean(cp[:, :, entry_polarity], axis = (0, 1))  # entry_axis == 2, ie. I
-            if exit_axis == 0:
-               exit_xyz = np.mean(cp[exit_polarity, :, :], axis = (0, 1))
-            elif exit_axis == 1:
-               exit_xyz = np.mean(cp[:, exit_polarity, :], axis = (0, 1))
-            else:
-               exit_xyz = np.mean(cp[:, :, exit_polarity], axis = (0, 1))  # exit_axis == 2, ie. I
+            if use_face_centres:  # override the vector based xyz entry and exit points with face centres
+                if entry_axis == 0:
+                    entry_xyz = np.mean(cp[entry_polarity, :, :], axis = (0, 1))
+                elif entry_axis == 1:
+                    entry_xyz = np.mean(cp[:, entry_polarity, :], axis = (0, 1))
+                else:
+                    entry_xyz = np.mean(cp[:, :, entry_polarity], axis = (0, 1))  # entry_axis == 2, ie. I
+                if exit_axis == 0:
+                    exit_xyz = np.mean(cp[exit_polarity, :, :], axis = (0, 1))
+                elif exit_axis == 1:
+                    exit_xyz = np.mean(cp[:, exit_polarity, :], axis = (0, 1))
+                else:
+                    exit_xyz = np.mean(cp[:, :, exit_polarity], axis = (0, 1))  # exit_axis == 2, ie. I
 
-         log.debug(
-            f'cell: {cell_kji0}; entry axis: {entry_axis}; polarity {entry_polarity}; exit axis: {exit_axis}; polarity {exit_polarity}'
-         )
+            log.debug(
+                f'cell: {cell_kji0}; entry axis: {entry_axis}; polarity {entry_polarity}; exit axis: {exit_axis}; polarity {exit_polarity}'
+            )
 
-         if previous_xyz is None:  # first entry
-            log.debug('adding mean sea level trajectory start')
-            previous_xyz = entry_xyz.copy()
-            previous_xyz[2] = 0.0  # use depth zero as md datum
-            trajectory_mds.append(0.0)
-            trajectory_points.append(previous_xyz)
-         if not vec.isclose(previous_xyz, entry_xyz, tolerance = 0.05):  # add an unblocked interval
-            log.debug('adding unblocked interval')
-            trajectory_points.append(entry_xyz)
-            new_md = trajectory_mds[-1] + vec.naive_length(entry_xyz - previous_xyz)  # assumes x, y & z units are same
+            if previous_xyz is None:  # first entry
+                log.debug('adding mean sea level trajectory start')
+                previous_xyz = entry_xyz.copy()
+                previous_xyz[2] = 0.0  # use depth zero as md datum
+                trajectory_mds.append(0.0)
+                trajectory_points.append(previous_xyz)
+            if not vec.isclose(previous_xyz, entry_xyz, tolerance = 0.05):  # add an unblocked interval
+                log.debug('adding unblocked interval')
+                trajectory_points.append(entry_xyz)
+                new_md = trajectory_mds[-1] + vec.naive_length(
+                    entry_xyz - previous_xyz)  # assumes x, y & z units are same
+                trajectory_mds.append(new_md)
+                blocked_intervals.append(-1)  # unblocked interval
+                previous_xyz = entry_xyz
+            log.debug('adding blocked interval for cell kji0: ' + str(cell_kji0))
+            trajectory_points.append(exit_xyz)
+            new_md = trajectory_mds[-1] + vec.naive_length(exit_xyz - previous_xyz)  # assumes x, y & z units are same
             trajectory_mds.append(new_md)
-            blocked_intervals.append(-1)  # unblocked interval
-            previous_xyz = entry_xyz
-         log.debug('adding blocked interval for cell kji0: ' + str(cell_kji0))
-         trajectory_points.append(exit_xyz)
-         new_md = trajectory_mds[-1] + vec.naive_length(exit_xyz - previous_xyz)  # assumes x, y & z units are same
-         trajectory_mds.append(new_md)
-         blocked_intervals.append(0)  # blocked interval
-         previous_xyz = exit_xyz
-         blocked_cells_kji0.append(cell_kji0)
-         blocked_face_pairs.append(((entry_axis, entry_polarity), (exit_axis, exit_polarity)))
+            blocked_intervals.append(0)  # blocked interval
+            previous_xyz = exit_xyz
+            blocked_cells_kji0.append(cell_kji0)
+            blocked_face_pairs.append(((entry_axis, entry_polarity), (exit_axis, exit_polarity)))
 
-      blocked_count = len(blocked_cells_kji0)
-      if blocked_count == 0:
-         log.warning('no intervals blocked for well ' + str(well_name))
-         return None
-      else:
-         log.info(str(blocked_count) + ' interval' + _pl(blocked_count) + ' blocked for well ' + str(well_name))
+        blocked_count = len(blocked_cells_kji0)
+        if blocked_count == 0:
+            log.warning('no intervals blocked for well ' + str(well_name))
+            return None
+        else:
+            log.info(str(blocked_count) + ' interval' + _pl(blocked_count) + ' blocked for well ' + str(well_name))
 
-      self.node_count = len(trajectory_mds)
-      self.node_mds = np.array(trajectory_mds)
-      self.cell_count = len(blocked_cells_kji0)
-      self.grid_indices = np.array(blocked_intervals, dtype = int)  # NB. only supporting one grid at the moment
-      self.cell_indices = grid.natural_cell_indices(np.array(blocked_cells_kji0))
-      self.face_pair_indices = np.array(blocked_face_pairs, dtype = int)
-      self.grid_list = [grid]
+        self.node_count = len(trajectory_mds)
+        self.node_mds = np.array(trajectory_mds)
+        self.cell_count = len(blocked_cells_kji0)
+        self.grid_indices = np.array(blocked_intervals, dtype = int)  # NB. only supporting one grid at the moment
+        self.cell_indices = grid.natural_cell_indices(np.array(blocked_cells_kji0))
+        self.face_pair_indices = np.array(blocked_face_pairs, dtype = int)
+        self.grid_list = [grid]
 
-      # if last segment terminates at bottom face in bottom layer, add a tail to trajectory
-      if blocked_count > 0 and exit_axis == 0 and exit_polarity == 1 and cell_kji0[
-            0] == grid.nk - 1 and grid.k_direction_is_down:
-         tail_length = 10.0  # metres or feet
-         tail_xyz = trajectory_points[-1].copy()
-         tail_xyz[2] += tail_length * (1.0 if grid.z_inc_down() else -1.0)
-         trajectory_points.append(tail_xyz)
-         new_md = trajectory_mds[-1] + tail_length
-         trajectory_mds.append(new_md)
+        # if last segment terminates at bottom face in bottom layer, add a tail to trajectory
+        if blocked_count > 0 and exit_axis == 0 and exit_polarity == 1 and cell_kji0[
+                0] == grid.nk - 1 and grid.k_direction_is_down:
+            tail_length = 10.0  # metres or feet
+            tail_xyz = trajectory_points[-1].copy()
+            tail_xyz[2] += tail_length * (1.0 if grid.z_inc_down() else -1.0)
+            trajectory_points.append(tail_xyz)
+            new_md = trajectory_mds[-1] + tail_length
+            trajectory_mds.append(new_md)
 
-      self.create_md_datum_and_trajectory(grid, trajectory_mds, trajectory_points, length_uom, well_name)
+        self.create_md_datum_and_trajectory(grid, trajectory_mds, trajectory_points, length_uom, well_name)
 
-      if add_as_properties and len(df.columns) > 3:
-         # NB: atypical writing of hdf5 data and xml creation in order to support related properties
-         self.write_hdf5()
-         self.create_xml()
-         if isinstance(add_as_properties, list):
-            for col in add_as_properties:
-               assert col in df.columns[3:]  # could just skip missing columns
-            property_columns = add_as_properties
-         else:
-            property_columns = df.columns[3:]
-         self._add_df_properties(df, property_columns, length_uom = length_uom)
+        if add_as_properties and len(df.columns) > 3:
+            # NB: atypical writing of hdf5 data and xml creation in order to support related properties
+            self.write_hdf5()
+            self.create_xml()
+            if isinstance(add_as_properties, list):
+                for col in add_as_properties:
+                    assert col in df.columns[3:]  # could just skip missing columns
+                property_columns = add_as_properties
+            else:
+                property_columns = df.columns[3:]
+            self._add_df_properties(df, property_columns, length_uom = length_uom)
 
-      return self
+        return self
 
-   def import_from_rms_cellio(self, cellio_file, well_name, grid, include_overburden_unblocked_interval = False):
-      """Populates empty blocked well from RMS cell I/O data; creates simulation trajectory and md datum.
+    def import_from_rms_cellio(self, cellio_file, well_name, grid, include_overburden_unblocked_interval = False):
+        """Populates empty blocked well from RMS cell I/O data; creates simulation trajectory and md datum.
 
       args:
          cellio_file (string): path of RMS ascii export file holding blocked well cell I/O data; cell entry and
@@ -2456,170 +2466,171 @@ class BlockedWell(BaseResqpy):
          self if successful; None otherwise
       """
 
-      if well_name:
-         self.well_name = well_name
-      else:
-         well_name = self.well_name
+        if well_name:
+            self.well_name = well_name
+        else:
+            well_name = self.well_name
 
-      grid_name = rqet.citation_title_for_node(grid.root)
-      length_uom = grid.z_units()
-      grid_z_inc_down = crs.Crs(grid.model, uuid = grid.crs_uuid).z_inc_down
-      log.debug('grid z increasing downwards: ' + str(grid_z_inc_down) + '(type: ' + str(type(grid_z_inc_down)) + ')')
-      cellio_z_inc_down = None
+        grid_name = rqet.citation_title_for_node(grid.root)
+        length_uom = grid.z_units()
+        grid_z_inc_down = crs.Crs(grid.model, uuid = grid.crs_uuid).z_inc_down
+        log.debug('grid z increasing downwards: ' + str(grid_z_inc_down) + '(type: ' + str(type(grid_z_inc_down)) + ')')
+        cellio_z_inc_down = None
 
-      try:
-         assert ' ' not in well_name, 'cannot import for well name containing spaces'
-         with open(cellio_file, 'r') as fp:
-            while True:
-               kf.skip_blank_lines_and_comments(fp)
-               line = fp.readline()  # file format version number?
-               assert line, 'well ' + str(well_name) + ' not found in file ' + str(cellio_file)
-               fp.readline()  # 'Undefined'
-               words = fp.readline().split()
-               assert len(words), 'missing header info in cell I/O file'
-               if words[0].upper() == well_name.upper():
-                  break
-               while not kf.blank_line(fp):
-                  fp.readline()  # skip to block of data for next well
-            header_lines = int(fp.readline().strip())
-            for _ in range(header_lines):
-               fp.readline()
-            previous_xyz = None
-            trajectory_mds = []
-            trajectory_points = []  # entries paired with trajectory_mds
-            blocked_intervals = [
-            ]  # will have one fewer entries than trajectory nodes; 0 = blocked, -1 = not blocked (for grid indices)
-            blocked_cells_kji0 = []  # will have length equal to number of 0's in blocked intervals
-            blocked_face_pairs = [
-            ]  # same length as blocked_cells_kji0; each is ((entry axis, entry polarity), (exit axis, exit polarity))
+        try:
+            assert ' ' not in well_name, 'cannot import for well name containing spaces'
+            with open(cellio_file, 'r') as fp:
+                while True:
+                    kf.skip_blank_lines_and_comments(fp)
+                    line = fp.readline()  # file format version number?
+                    assert line, 'well ' + str(well_name) + ' not found in file ' + str(cellio_file)
+                    fp.readline()  # 'Undefined'
+                    words = fp.readline().split()
+                    assert len(words), 'missing header info in cell I/O file'
+                    if words[0].upper() == well_name.upper():
+                        break
+                    while not kf.blank_line(fp):
+                        fp.readline()  # skip to block of data for next well
+                header_lines = int(fp.readline().strip())
+                for _ in range(header_lines):
+                    fp.readline()
+                previous_xyz = None
+                trajectory_mds = []
+                trajectory_points = []  # entries paired with trajectory_mds
+                blocked_intervals = [
+                ]  # will have one fewer entries than trajectory nodes; 0 = blocked, -1 = not blocked (for grid indices)
+                blocked_cells_kji0 = []  # will have length equal to number of 0's in blocked intervals
+                blocked_face_pairs = [
+                ]  # same length as blocked_cells_kji0; each is ((entry axis, entry polarity), (exit axis, exit polarity))
 
-            while not kf.blank_line(fp):
+                while not kf.blank_line(fp):
 
-               line = fp.readline()
-               words = line.split()
-               assert len(words) >= 9, 'not enough items on data line in cell I/O file, minimum 9 expected'
-               i1, j1, k1 = int(words[0]), int(words[1]), int(words[2])
-               cell_kji0 = np.array((k1 - 1, j1 - 1, i1 - 1), dtype = int)
-               assert np.all(0 <= cell_kji0) and np.all(
-                  cell_kji0 < grid.extent_kji), 'cell I/O cell index not within grid extent'
-               entry_xyz = np.array((float(words[3]), float(words[4]), float(words[5])))
-               exit_xyz = np.array((float(words[6]), float(words[7]), float(words[8])))
-               if cellio_z_inc_down is None:
-                  cellio_z_inc_down = bool(entry_xyz[2] + exit_xyz[2] > 0.0)
-               if cellio_z_inc_down != grid_z_inc_down:
-                  entry_xyz[2] = -entry_xyz[2]
-                  exit_xyz[2] = -exit_xyz[2]
+                    line = fp.readline()
+                    words = line.split()
+                    assert len(words) >= 9, 'not enough items on data line in cell I/O file, minimum 9 expected'
+                    i1, j1, k1 = int(words[0]), int(words[1]), int(words[2])
+                    cell_kji0 = np.array((k1 - 1, j1 - 1, i1 - 1), dtype = int)
+                    assert np.all(0 <= cell_kji0) and np.all(
+                        cell_kji0 < grid.extent_kji), 'cell I/O cell index not within grid extent'
+                    entry_xyz = np.array((float(words[3]), float(words[4]), float(words[5])))
+                    exit_xyz = np.array((float(words[6]), float(words[7]), float(words[8])))
+                    if cellio_z_inc_down is None:
+                        cellio_z_inc_down = bool(entry_xyz[2] + exit_xyz[2] > 0.0)
+                    if cellio_z_inc_down != grid_z_inc_down:
+                        entry_xyz[2] = -entry_xyz[2]
+                        exit_xyz[2] = -exit_xyz[2]
 
-               cp = grid.corner_points(cell_kji0 = cell_kji0, cache_resqml_array = False)
-               assert not np.any(np.isnan(
-                  cp)), 'missing geometry for perforation cell(kji0) ' + str(cell_kji0) + ' for well ' + str(well_name)
-               cell_centre = np.mean(cp, axis = (0, 1, 2))
+                    cp = grid.corner_points(cell_kji0 = cell_kji0, cache_resqml_array = False)
+                    assert not np.any(np.isnan(cp)), 'missing geometry for perforation cell(kji0) ' + str(
+                        cell_kji0) + ' for well ' + str(well_name)
+                    cell_centre = np.mean(cp, axis = (0, 1, 2))
 
-               # let's hope everything is in the same coordinate reference system!
-               entry_vector = 100.0 * (entry_xyz - cell_centre)
-               exit_vector = 100.0 * (exit_xyz - cell_centre)
-               (entry_axis, entry_polarity, facial_entry_xyz, exit_axis, exit_polarity,
-                facial_exit_xyz) = find_entry_and_exit(cp, entry_vector, exit_vector, well_name)
+                    # let's hope everything is in the same coordinate reference system!
+                    entry_vector = 100.0 * (entry_xyz - cell_centre)
+                    exit_vector = 100.0 * (exit_xyz - cell_centre)
+                    (entry_axis, entry_polarity, facial_entry_xyz, exit_axis, exit_polarity,
+                     facial_exit_xyz) = find_entry_and_exit(cp, entry_vector, exit_vector, well_name)
 
-               if previous_xyz is None:  # first entry
-                  previous_xyz = entry_xyz.copy()
-                  if include_overburden_unblocked_interval:
-                     log.debug('adding mean sea level trajectory start')
-                     previous_xyz[2] = 0.0  # use depth zero as md datum
-                  trajectory_mds.append(previous_xyz[2])
-                  trajectory_points.append(previous_xyz)
+                    if previous_xyz is None:  # first entry
+                        previous_xyz = entry_xyz.copy()
+                        if include_overburden_unblocked_interval:
+                            log.debug('adding mean sea level trajectory start')
+                            previous_xyz[2] = 0.0  # use depth zero as md datum
+                        trajectory_mds.append(previous_xyz[2])
+                        trajectory_points.append(previous_xyz)
 
-               if not vec.isclose(previous_xyz, entry_xyz, tolerance = 0.05):  # add an unblocked interval
-                  log.debug('adding unblocked interval')
-                  trajectory_points.append(entry_xyz)
-                  new_md = trajectory_mds[-1] + vec.naive_length(
-                     entry_xyz - previous_xyz)  # assumes x, y & z units are same
-                  trajectory_mds.append(new_md)
-                  blocked_intervals.append(-1)  # unblocked interval
-                  previous_xyz = entry_xyz
+                    if not vec.isclose(previous_xyz, entry_xyz, tolerance = 0.05):  # add an unblocked interval
+                        log.debug('adding unblocked interval')
+                        trajectory_points.append(entry_xyz)
+                        new_md = trajectory_mds[-1] + vec.naive_length(
+                            entry_xyz - previous_xyz)  # assumes x, y & z units are same
+                        trajectory_mds.append(new_md)
+                        blocked_intervals.append(-1)  # unblocked interval
+                        previous_xyz = entry_xyz
 
-               log.debug('adding blocked interval for cell kji0: ' + str(cell_kji0))
-               trajectory_points.append(exit_xyz)
-               new_md = trajectory_mds[-1] + vec.naive_length(
-                  exit_xyz - previous_xyz)  # assumes x, y & z units are same
-               trajectory_mds.append(new_md)
-               blocked_intervals.append(0)  # blocked interval
-               previous_xyz = exit_xyz
-               blocked_cells_kji0.append(cell_kji0)
-               blocked_face_pairs.append(((entry_axis, entry_polarity), (exit_axis, exit_polarity)))
+                    log.debug('adding blocked interval for cell kji0: ' + str(cell_kji0))
+                    trajectory_points.append(exit_xyz)
+                    new_md = trajectory_mds[-1] + vec.naive_length(
+                        exit_xyz - previous_xyz)  # assumes x, y & z units are same
+                    trajectory_mds.append(new_md)
+                    blocked_intervals.append(0)  # blocked interval
+                    previous_xyz = exit_xyz
+                    blocked_cells_kji0.append(cell_kji0)
+                    blocked_face_pairs.append(((entry_axis, entry_polarity), (exit_axis, exit_polarity)))
 
-            blocked_count = len(blocked_cells_kji0)
-            if blocked_count == 0:
-               log.warning('no intervals blocked for well ' + well_name + ' in grid ' + str(grid_name))
-               return None
-            else:
-               log.info(
-                  str(blocked_count) + ' interval' + _pl(blocked_count) + ' blocked for well ' + well_name +
-                  ' in grid ' + str(grid_name))
+                blocked_count = len(blocked_cells_kji0)
+                if blocked_count == 0:
+                    log.warning('no intervals blocked for well ' + well_name + ' in grid ' + str(grid_name))
+                    return None
+                else:
+                    log.info(
+                        str(blocked_count) + ' interval' + _pl(blocked_count) + ' blocked for well ' + well_name +
+                        ' in grid ' + str(grid_name))
 
-            self.create_md_datum_and_trajectory(grid,
-                                                trajectory_mds,
-                                                trajectory_points,
-                                                length_uom,
-                                                well_name,
-                                                set_depth_zero = True,
-                                                set_tangent_vectors = True)
+                self.create_md_datum_and_trajectory(grid,
+                                                    trajectory_mds,
+                                                    trajectory_points,
+                                                    length_uom,
+                                                    well_name,
+                                                    set_depth_zero = True,
+                                                    set_tangent_vectors = True)
 
-            self.node_count = len(trajectory_mds)
-            self.node_mds = np.array(trajectory_mds)
-            self.cell_count = len(blocked_cells_kji0)
-            self.grid_indices = np.array(blocked_intervals, dtype = int)  # NB. only supporting one grid at the moment
-            self.cell_indices = grid.natural_cell_indices(np.array(blocked_cells_kji0))
-            self.face_pair_indices = np.array(blocked_face_pairs)
-            self.grid_list = [grid]
+                self.node_count = len(trajectory_mds)
+                self.node_mds = np.array(trajectory_mds)
+                self.cell_count = len(blocked_cells_kji0)
+                self.grid_indices = np.array(blocked_intervals,
+                                             dtype = int)  # NB. only supporting one grid at the moment
+                self.cell_indices = grid.natural_cell_indices(np.array(blocked_cells_kji0))
+                self.face_pair_indices = np.array(blocked_face_pairs)
+                self.grid_list = [grid]
 
-      except Exception:
-         log.exception('failed to import info for blocked well ' + str(well_name) + ' from cell I/O file ' +
-                       str(cellio_file))
-         return None
+        except Exception:
+            log.exception('failed to import info for blocked well ' + str(well_name) + ' from cell I/O file ' +
+                          str(cellio_file))
+            return None
 
-      return self
+        return self
 
-   def dataframe(self,
-                 i_col = 'IW',
-                 j_col = 'JW',
-                 k_col = 'L',
-                 one_based = True,
-                 extra_columns_list = [],
-                 ntg_uuid = None,
-                 perm_i_uuid = None,
-                 perm_j_uuid = None,
-                 perm_k_uuid = None,
-                 satw_uuid = None,
-                 sato_uuid = None,
-                 satg_uuid = None,
-                 region_uuid = None,
-                 radw = None,
-                 skin = None,
-                 stat = None,
-                 active_only = False,
-                 min_k0 = None,
-                 max_k0 = None,
-                 k0_list = None,
-                 min_length = None,
-                 min_kh = None,
-                 max_depth = None,
-                 max_satw = None,
-                 min_sato = None,
-                 max_satg = None,
-                 perforation_list = None,
-                 region_list = None,
-                 depth_inc_down = None,
-                 set_k_face_intervals_vertical = False,
-                 anglv_ref = 'normal ij down',
-                 angla_plane_ref = None,
-                 length_mode = 'MD',
-                 length_uom = None,
-                 use_face_centres = False,
-                 preferential_perforation = True,
-                 add_as_properties = False,
-                 use_properties = False):
-      """Returns a pandas data frame containing WELLSPEC style data.
+    def dataframe(self,
+                  i_col = 'IW',
+                  j_col = 'JW',
+                  k_col = 'L',
+                  one_based = True,
+                  extra_columns_list = [],
+                  ntg_uuid = None,
+                  perm_i_uuid = None,
+                  perm_j_uuid = None,
+                  perm_k_uuid = None,
+                  satw_uuid = None,
+                  sato_uuid = None,
+                  satg_uuid = None,
+                  region_uuid = None,
+                  radw = None,
+                  skin = None,
+                  stat = None,
+                  active_only = False,
+                  min_k0 = None,
+                  max_k0 = None,
+                  k0_list = None,
+                  min_length = None,
+                  min_kh = None,
+                  max_depth = None,
+                  max_satw = None,
+                  min_sato = None,
+                  max_satg = None,
+                  perforation_list = None,
+                  region_list = None,
+                  depth_inc_down = None,
+                  set_k_face_intervals_vertical = False,
+                  anglv_ref = 'normal ij down',
+                  angla_plane_ref = None,
+                  length_mode = 'MD',
+                  length_uom = None,
+                  use_face_centres = False,
+                  preferential_perforation = True,
+                  add_as_properties = False,
+                  use_properties = False):
+        """Returns a pandas data frame containing WELLSPEC style data.
 
       arguments:
          i_col (string, default 'IW'): the column name to use for cell I index values
@@ -2730,689 +2741,692 @@ class BlockedWell(BaseResqpy):
       :meta common:
       """
 
-      def prop_array(uuid_or_dict, grid):
-         assert uuid_or_dict is not None and grid is not None
-         if isinstance(uuid_or_dict, dict):
-            prop_uuid = uuid_or_dict[grid.uuid]
-         else:
-            prop_uuid = uuid_or_dict  # uuid either in form of string or uuid.UUID
-         return grid.property_collection.single_array_ref(uuid = prop_uuid)
-
-      def get_ref_vector(grid, grid_crs, cell_kji0, mode):
-         # gravity = np.array((0.0, 0.0, 1.0))
-         if mode == 'normal well i+':
-            return None  # ANGLA only: option for no projection onto a plane
-         ref_vector = None
-         # options for anglv or angla reference: 'z down', 'z+', 'k down', 'k+', 'normal ij', 'normal ij down'
-         cell_axial_vectors = None
-         if not mode.startswith('z'):
-            cell_axial_vectors = grid.interface_vectors_kji(cell_kji0)
-         if mode == 'z+':
-            ref_vector = np.array((0.0, 0.0, 1.0))
-         elif mode == 'z down':
-            if grid_crs.z_inc_down:
-               ref_vector = np.array((0.0, 0.0, 1.0))
+        def prop_array(uuid_or_dict, grid):
+            assert uuid_or_dict is not None and grid is not None
+            if isinstance(uuid_or_dict, dict):
+                prop_uuid = uuid_or_dict[grid.uuid]
             else:
-               ref_vector = np.array((0.0, 0.0, -1.0))
-         elif mode in ['k+', 'k down']:
-            ref_vector = vec.unit_vector(cell_axial_vectors[0])
-            if mode == 'k down' and not grid.k_direction_is_down:
-               ref_vector = -ref_vector
-         else:  # normal to plane of ij axes
-            ref_vector = vec.unit_vector(vec.cross_product(cell_axial_vectors[1], cell_axial_vectors[2]))
-            if mode == 'normal ij down':
-               if grid_crs.z_inc_down:
-                  if ref_vector[2] < 0.0:
-                     ref_vector = -ref_vector
-               else:
-                  if ref_vector[2] > 0.0:
-                     ref_vector = -ref_vector
-         if ref_vector is None or ref_vector[2] == 0.0:
-            if grid_crs.z_inc_down:
-               ref_vector = np.array((0.0, 0.0, 1.0))
+                prop_uuid = uuid_or_dict  # uuid either in form of string or uuid.UUID
+            return grid.property_collection.single_array_ref(uuid = prop_uuid)
+
+        def get_ref_vector(grid, grid_crs, cell_kji0, mode):
+            # gravity = np.array((0.0, 0.0, 1.0))
+            if mode == 'normal well i+':
+                return None  # ANGLA only: option for no projection onto a plane
+            ref_vector = None
+            # options for anglv or angla reference: 'z down', 'z+', 'k down', 'k+', 'normal ij', 'normal ij down'
+            cell_axial_vectors = None
+            if not mode.startswith('z'):
+                cell_axial_vectors = grid.interface_vectors_kji(cell_kji0)
+            if mode == 'z+':
+                ref_vector = np.array((0.0, 0.0, 1.0))
+            elif mode == 'z down':
+                if grid_crs.z_inc_down:
+                    ref_vector = np.array((0.0, 0.0, 1.0))
+                else:
+                    ref_vector = np.array((0.0, 0.0, -1.0))
+            elif mode in ['k+', 'k down']:
+                ref_vector = vec.unit_vector(cell_axial_vectors[0])
+                if mode == 'k down' and not grid.k_direction_is_down:
+                    ref_vector = -ref_vector
+            else:  # normal to plane of ij axes
+                ref_vector = vec.unit_vector(vec.cross_product(cell_axial_vectors[1], cell_axial_vectors[2]))
+                if mode == 'normal ij down':
+                    if grid_crs.z_inc_down:
+                        if ref_vector[2] < 0.0:
+                            ref_vector = -ref_vector
+                    else:
+                        if ref_vector[2] > 0.0:
+                            ref_vector = -ref_vector
+            if ref_vector is None or ref_vector[2] == 0.0:
+                if grid_crs.z_inc_down:
+                    ref_vector = np.array((0.0, 0.0, 1.0))
+                else:
+                    ref_vector = np.array((0.0, 0.0, -1.0))
+            return ref_vector
+
+        assert length_mode in ['MD', 'straight']
+        assert length_uom is None or length_uom in ['m', 'ft']
+        assert anglv_ref in ['gravity', 'z down', 'z+', 'k down', 'k+', 'normal ij', 'normal ij down']
+        if anglv_ref == 'gravity':
+            anglv_ref = 'z down'
+        if angla_plane_ref is None:
+            angla_plane_ref = anglv_ref
+        assert angla_plane_ref in [
+            'gravity', 'z down', 'z+', 'k down', 'k+', 'normal ij', 'normal ij down', 'normal well i+'
+        ]
+        if angla_plane_ref == 'gravity':
+            angla_plane_ref = 'z down'
+        column_list = [i_col, j_col, k_col]
+        if extra_columns_list:
+            for extra in extra_columns_list:
+                assert extra.upper() in [
+                    'GRID', 'ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'SKIN', 'RADW', 'PPERF', 'RADB',
+                    'WI', 'WBC'
+                ]
+                column_list.append(extra.upper())
+        else:
+            add_as_properties = use_properties = False
+        assert not (add_as_properties and use_properties)
+        pc = rqp.PropertyCollection(support = self) if use_properties else None
+        pc_titles = [] if pc is None else pc.titles()
+        isotropic_perm = None
+        if min_length is not None and min_length <= 0.0:
+            min_length = None
+        if min_kh is not None and min_kh <= 0.0:
+            min_kh = None
+        if max_satw is not None and max_satw >= 1.0:
+            max_satw = None
+        if min_sato is not None and min_sato <= 0.0:
+            min_sato = None
+        if max_satg is not None and max_satg >= 1.0:
+            max_satg = None
+        doing_kh = False
+        if ('KH' in column_list or min_kh is not None) and 'KH' not in pc_titles:
+            assert perm_i_uuid is not None, 'KH requested (or minimum specified) without I direction permeabilty being specified'
+            doing_kh = True
+        if 'WBC' in column_list and 'WBC' not in pc_titles:
+            assert perm_i_uuid is not None, 'WBC requested without I direction permeabilty being specified'
+            doing_kh = True
+        do_well_inflow = (('WI' in column_list and 'WI' not in pc_titles) or
+                          ('WBC' in column_list and 'WBC' not in pc_titles) or
+                          ('RADB' in column_list and 'RADB' not in pc_titles))
+        if do_well_inflow:
+            assert perm_i_uuid is not None, 'WI, RADB or WBC requested without I direction permeabilty being specified'
+        if doing_kh or do_well_inflow:
+            if perm_j_uuid is None and perm_k_uuid is None:
+                isotropic_perm = True
             else:
-               ref_vector = np.array((0.0, 0.0, -1.0))
-         return ref_vector
+                if perm_j_uuid is None:
+                    perm_j_uuid = perm_i_uuid
+                if perm_k_uuid is None:
+                    perm_k_uuid = perm_i_uuid
+                # following line assumes arguments are passed in same form; if not, some unnecessary maths might be done
+                isotropic_perm = (bu.matching_uuids(perm_i_uuid, perm_j_uuid) and
+                                  bu.matching_uuids(perm_i_uuid, perm_k_uuid))
+        if max_satw is not None:
+            assert satw_uuid is not None, 'water saturation limit specified without saturation property array'
+        if min_sato is not None:
+            assert sato_uuid is not None, 'oil saturation limit specified without saturation property array'
+        if max_satg is not None:
+            assert satg_uuid is not None, 'gas saturation limit specified without saturation property array'
+        if region_list is not None:
+            assert region_uuid is not None, 'region list specified without region property array'
+        if radw is not None and 'RADW' not in column_list:
+            column_list.append('RADW')
+        if radw is None:
+            radw = 0.25
+        if skin is not None and 'SKIN' not in column_list:
+            column_list.append('SKIN')
+        if skin is None:
+            skin = 0.0
+        if stat is not None:
+            assert str(stat).upper() in ['ON', 'OFF']
+            stat = str(stat).upper()
+            if 'STAT' not in column_list:
+                column_list.append('STAT')
+        else:
+            stat = 'ON'
+        if 'GRID' not in column_list and self.number_of_grids() > 1:
+            log.error('creating blocked well dataframe without GRID column for well that intersects more than one grid')
+        if 'LENGTH' in column_list and 'PPERF' in column_list and 'KH' not in column_list and perforation_list is not None:
+            log.warning(
+                'both LENGTH and PPERF will include effects of partial perforation; only one should be used in WELLSPEC'
+            )
+        elif (perforation_list is not None and 'LENGTH' not in column_list and 'PPERF' not in column_list and
+              'KH' not in column_list and 'WBC' not in column_list):
+            log.warning('perforation list supplied but no use of LENGTH, KH, PPERF nor WBC')
+        if min_k0 is None:
+            min_k0 = 0
+        else:
+            assert min_k0 >= 0
+        if max_k0 is not None:
+            assert min_k0 <= max_k0
+        if k0_list is not None and len(k0_list) == 0:
+            log.warning('no layers included for blocked well dataframe: no rows will be included')
+        if perforation_list is not None and len(perforation_list) == 0:
+            log.warning('empty perforation list specified for blocked well dataframe: no rows will be included')
+        doing_angles = (('ANGLA' in column_list and 'ANGLA' not in pc_titles) or
+                        ('ANGLV' in column_list and 'ANGLV' not in pc_titles) or doing_kh or do_well_inflow)
+        doing_xyz = (('X' in column_list and 'X' not in pc_titles) or ('Y' in column_list and 'Y' not in pc_titles) or
+                     ('DEPTH' in column_list and 'DEPTH' not in pc_titles))
+        doing_entry_exit = doing_angles or ('LENGTH' in column_list and 'LENGTH' not in pc_titles and
+                                            length_mode == 'straight')
+        grid_crs_list = []
+        for grid in self.grid_list:
+            grid_crs = crs.Crs(self.model, uuid = grid.crs_uuid)
+            grid_crs_list.append(grid_crs)
+            if grid_crs.z_units != grid_crs.xy_units and (len(column_list) > 1 or
+                                                          (len(column_list) == 1 and
+                                                           column_list[0] != 'GRID')) is not None:
+                log.error('grid ' + str(rqet.citation_title_for_node(grid.root_node)) +
+                          ' has z units different to xy units: some WELLSPEC data likely to be wrong')
+        k_face_check = np.zeros((2, 2), dtype = int)
+        k_face_check[1, 1] = 1  # now represents entry, exit of K-, K+
+        k_face_check_end = k_face_check.copy()
+        k_face_check_end[1] = -1  # entry through K-, terminating (TD) within cell
+        if self.trajectory is None or self.trajectory.crs_root is None:
+            traj_crs = None
+            traj_z_inc_down = None
+        else:
+            traj_crs = crs.Crs(self.trajectory.model, uuid = self.trajectory.crs_uuid)
+            assert traj_crs.xy_units == traj_crs.z_units
+            traj_z_inc_down = traj_crs.z_inc_down
 
-      assert length_mode in ['MD', 'straight']
-      assert length_uom is None or length_uom in ['m', 'ft']
-      assert anglv_ref in ['gravity', 'z down', 'z+', 'k down', 'k+', 'normal ij', 'normal ij down']
-      if anglv_ref == 'gravity':
-         anglv_ref = 'z down'
-      if angla_plane_ref is None:
-         angla_plane_ref = anglv_ref
-      assert angla_plane_ref in [
-         'gravity', 'z down', 'z+', 'k down', 'k+', 'normal ij', 'normal ij down', 'normal well i+'
-      ]
-      if angla_plane_ref == 'gravity':
-         angla_plane_ref = 'z down'
-      column_list = [i_col, j_col, k_col]
-      if extra_columns_list:
-         for extra in extra_columns_list:
-            assert extra.upper() in [
-               'GRID', 'ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'SKIN', 'RADW', 'PPERF', 'RADB', 'WI',
-               'WBC'
-            ]
-            column_list.append(extra.upper())
-      else:
-         add_as_properties = use_properties = False
-      assert not (add_as_properties and use_properties)
-      pc = rqp.PropertyCollection(support = self) if use_properties else None
-      pc_titles = [] if pc is None else pc.titles()
-      isotropic_perm = None
-      if min_length is not None and min_length <= 0.0:
-         min_length = None
-      if min_kh is not None and min_kh <= 0.0:
-         min_kh = None
-      if max_satw is not None and max_satw >= 1.0:
-         max_satw = None
-      if min_sato is not None and min_sato <= 0.0:
-         min_sato = None
-      if max_satg is not None and max_satg >= 1.0:
-         max_satg = None
-      doing_kh = False
-      if ('KH' in column_list or min_kh is not None) and 'KH' not in pc_titles:
-         assert perm_i_uuid is not None, 'KH requested (or minimum specified) without I direction permeabilty being specified'
-         doing_kh = True
-      if 'WBC' in column_list and 'WBC' not in pc_titles:
-         assert perm_i_uuid is not None, 'WBC requested without I direction permeabilty being specified'
-         doing_kh = True
-      do_well_inflow = (('WI' in column_list and 'WI' not in pc_titles) or
-                        ('WBC' in column_list and 'WBC' not in pc_titles) or
-                        ('RADB' in column_list and 'RADB' not in pc_titles))
-      if do_well_inflow:
-         assert perm_i_uuid is not None, 'WI, RADB or WBC requested without I direction permeabilty being specified'
-      if doing_kh or do_well_inflow:
-         if perm_j_uuid is None and perm_k_uuid is None:
-            isotropic_perm = True
-         else:
-            if perm_j_uuid is None:
-               perm_j_uuid = perm_i_uuid
-            if perm_k_uuid is None:
-               perm_k_uuid = perm_i_uuid
-            # following line assumes arguments are passed in same form; if not, some unnecessary maths might be done
-            isotropic_perm = (bu.matching_uuids(perm_i_uuid, perm_j_uuid) and
-                              bu.matching_uuids(perm_i_uuid, perm_k_uuid))
-      if max_satw is not None:
-         assert satw_uuid is not None, 'water saturation limit specified without saturation property array'
-      if min_sato is not None:
-         assert sato_uuid is not None, 'oil saturation limit specified without saturation property array'
-      if max_satg is not None:
-         assert satg_uuid is not None, 'gas saturation limit specified without saturation property array'
-      if region_list is not None:
-         assert region_uuid is not None, 'region list specified without region property array'
-      if radw is not None and 'RADW' not in column_list:
-         column_list.append('RADW')
-      if radw is None:
-         radw = 0.25
-      if skin is not None and 'SKIN' not in column_list:
-         column_list.append('SKIN')
-      if skin is None:
-         skin = 0.0
-      if stat is not None:
-         assert str(stat).upper() in ['ON', 'OFF']
-         stat = str(stat).upper()
-         if 'STAT' not in column_list:
-            column_list.append('STAT')
-      else:
-         stat = 'ON'
-      if 'GRID' not in column_list and self.number_of_grids() > 1:
-         log.error('creating blocked well dataframe without GRID column for well that intersects more than one grid')
-      if 'LENGTH' in column_list and 'PPERF' in column_list and 'KH' not in column_list and perforation_list is not None:
-         log.warning(
-            'both LENGTH and PPERF will include effects of partial perforation; only one should be used in WELLSPEC')
-      elif (perforation_list is not None and 'LENGTH' not in column_list and 'PPERF' not in column_list and
-            'KH' not in column_list and 'WBC' not in column_list):
-         log.warning('perforation list supplied but no use of LENGTH, KH, PPERF nor WBC')
-      if min_k0 is None:
-         min_k0 = 0
-      else:
-         assert min_k0 >= 0
-      if max_k0 is not None:
-         assert min_k0 <= max_k0
-      if k0_list is not None and len(k0_list) == 0:
-         log.warning('no layers included for blocked well dataframe: no rows will be included')
-      if perforation_list is not None and len(perforation_list) == 0:
-         log.warning('empty perforation list specified for blocked well dataframe: no rows will be included')
-      doing_angles = (('ANGLA' in column_list and 'ANGLA' not in pc_titles) or
-                      ('ANGLV' in column_list and 'ANGLV' not in pc_titles) or doing_kh or do_well_inflow)
-      doing_xyz = (('X' in column_list and 'X' not in pc_titles) or ('Y' in column_list and 'Y' not in pc_titles) or
-                   ('DEPTH' in column_list and 'DEPTH' not in pc_titles))
-      doing_entry_exit = doing_angles or ('LENGTH' in column_list and 'LENGTH' not in pc_titles and
-                                          length_mode == 'straight')
-      grid_crs_list = []
-      for grid in self.grid_list:
-         grid_crs = crs.Crs(self.model, uuid = grid.crs_uuid)
-         grid_crs_list.append(grid_crs)
-         if grid_crs.z_units != grid_crs.xy_units and (len(column_list) > 1 or (len(column_list) == 1 and
-                                                                                column_list[0] != 'GRID')) is not None:
-            log.error('grid ' + str(rqet.citation_title_for_node(grid.root_node)) +
-                      ' has z units different to xy units: some WELLSPEC data likely to be wrong')
-      k_face_check = np.zeros((2, 2), dtype = int)
-      k_face_check[1, 1] = 1  # now represents entry, exit of K-, K+
-      k_face_check_end = k_face_check.copy()
-      k_face_check_end[1] = -1  # entry through K-, terminating (TD) within cell
-      if self.trajectory is None or self.trajectory.crs_root is None:
-         traj_crs = None
-         traj_z_inc_down = None
-      else:
-         traj_crs = crs.Crs(self.trajectory.model, uuid = self.trajectory.crs_uuid)
-         assert traj_crs.xy_units == traj_crs.z_units
-         traj_z_inc_down = traj_crs.z_inc_down
+        df = pd.DataFrame(columns = column_list)
+        df = df.astype({i_col: int, j_col: int, k_col: int})
 
-      df = pd.DataFrame(columns = column_list)
-      df = df.astype({i_col: int, j_col: int, k_col: int})
-
-      ci = -1
-      row_ci_list = []
-      if self.node_count is None or self.node_count < 2:
-         interval_count = 0
-      else:
-         interval_count = self.node_count - 1
-      for interval in range(interval_count):
-         if self.grid_indices[interval] < 0:
-            continue  # unblocked interval
-         ci += 1
-         row_dict = {}
-         grid = self.grid_list[self.grid_indices[interval]]
-         grid_crs = grid_crs_list[self.grid_indices[interval]]
-         grid_name = rqet.citation_title_for_node(grid.root).replace(' ', '_')
-         natural_cell = self.cell_indices[ci]
-         cell_kji0 = grid.denaturalized_cell_index(natural_cell)
-         tuple_kji0 = tuple(cell_kji0)
-         if max_depth is not None:
-            cell_depth = grid.centre_point(cell_kji0)[2]
-            if not grid_crs.z_inc_down:
-               cell_depth = -cell_depth
-            if cell_depth > max_depth:
-               continue
-         if active_only and grid.inactive is not None and grid.inactive[tuple_kji0]:
-            continue
-         if (min_k0 is not None and cell_kji0[0] < min_k0) or (max_k0 is not None and cell_kji0[0] > max_k0):
-            continue
-         if k0_list is not None and cell_kji0[0] not in k0_list:
-            continue
-         if region_list is not None and prop_array(region_uuid, grid)[tuple_kji0] not in region_list:
-            continue
-         if max_satw is not None and prop_array(satw_uuid, grid)[tuple_kji0] > max_satw:
-            continue
-         if min_sato is not None and prop_array(sato_uuid, grid)[tuple_kji0] < min_sato:
-            continue
-         if max_satg is not None and prop_array(satg_uuid, grid)[tuple_kji0] > max_satg:
-            continue
-         if 'PPERF' in pc_titles:
-            part_perf_fraction = pc.single_array_ref(citation_title = 'PPERF')[ci]
-         else:
-            part_perf_fraction = 1.0
-            if perforation_list is not None:
-               perf_length = 0.0
-               for perf_start, perf_end in perforation_list:
-                  if perf_end <= self.node_mds[interval] or perf_start >= self.node_mds[interval + 1]:
-                     continue
-                  if perf_start <= self.node_mds[interval]:
-                     if perf_end >= self.node_mds[interval + 1]:
-                        perf_length += self.node_mds[interval + 1] - self.node_mds[interval]
-                        break
-                     else:
-                        perf_length += perf_end - self.node_mds[interval]
-                  else:
-                     if perf_end >= self.node_mds[interval + 1]:
-                        perf_length += self.node_mds[interval + 1] - perf_start
-                     else:
-                        perf_length += perf_end - perf_start
-               if perf_length == 0.0:
-                  continue
-               part_perf_fraction = min(1.0, perf_length / (self.node_mds[interval + 1] - self.node_mds[interval]))
+        ci = -1
+        row_ci_list = []
+        if self.node_count is None or self.node_count < 2:
+            interval_count = 0
+        else:
+            interval_count = self.node_count - 1
+        for interval in range(interval_count):
+            if self.grid_indices[interval] < 0:
+                continue  # unblocked interval
+            ci += 1
+            row_dict = {}
+            grid = self.grid_list[self.grid_indices[interval]]
+            grid_crs = grid_crs_list[self.grid_indices[interval]]
+            grid_name = rqet.citation_title_for_node(grid.root).replace(' ', '_')
+            natural_cell = self.cell_indices[ci]
+            cell_kji0 = grid.denaturalized_cell_index(natural_cell)
+            tuple_kji0 = tuple(cell_kji0)
+            if max_depth is not None:
+                cell_depth = grid.centre_point(cell_kji0)[2]
+                if not grid_crs.z_inc_down:
+                    cell_depth = -cell_depth
+                if cell_depth > max_depth:
+                    continue
+            if active_only and grid.inactive is not None and grid.inactive[tuple_kji0]:
+                continue
+            if (min_k0 is not None and cell_kji0[0] < min_k0) or (max_k0 is not None and cell_kji0[0] > max_k0):
+                continue
+            if k0_list is not None and cell_kji0[0] not in k0_list:
+                continue
+            if region_list is not None and prop_array(region_uuid, grid)[tuple_kji0] not in region_list:
+                continue
+            if max_satw is not None and prop_array(satw_uuid, grid)[tuple_kji0] > max_satw:
+                continue
+            if min_sato is not None and prop_array(sato_uuid, grid)[tuple_kji0] < min_sato:
+                continue
+            if max_satg is not None and prop_array(satg_uuid, grid)[tuple_kji0] > max_satg:
+                continue
+            if 'PPERF' in pc_titles:
+                part_perf_fraction = pc.single_array_ref(citation_title = 'PPERF')[ci]
+            else:
+                part_perf_fraction = 1.0
+                if perforation_list is not None:
+                    perf_length = 0.0
+                    for perf_start, perf_end in perforation_list:
+                        if perf_end <= self.node_mds[interval] or perf_start >= self.node_mds[interval + 1]:
+                            continue
+                        if perf_start <= self.node_mds[interval]:
+                            if perf_end >= self.node_mds[interval + 1]:
+                                perf_length += self.node_mds[interval + 1] - self.node_mds[interval]
+                                break
+                            else:
+                                perf_length += perf_end - self.node_mds[interval]
+                        else:
+                            if perf_end >= self.node_mds[interval + 1]:
+                                perf_length += self.node_mds[interval + 1] - perf_start
+                            else:
+                                perf_length += perf_end - perf_start
+                    if perf_length == 0.0:
+                        continue
+                    part_perf_fraction = min(1.0, perf_length / (self.node_mds[interval + 1] - self.node_mds[interval]))
 #        log.debug('kji0: ' + str(cell_kji0))
-         entry_xyz = None
-         exit_xyz = None
-         if doing_entry_exit:
-            assert self.trajectory is not None
-            if use_face_centres:
-               entry_xyz = grid.face_centre(cell_kji0, self.face_pair_indices[interval, 0, 0],
-                                            self.face_pair_indices[interval, 0, 1])
-               if self.face_pair_indices[interval, 1, 0] >= 0:
-                  exit_xyz = grid.face_centre(cell_kji0, self.face_pair_indices[interval, 1, 0],
-                                              self.face_pair_indices[interval, 1, 1])
-               else:
-                  exit_xyz = grid.face_centre(cell_kji0, self.face_pair_indices[interval, 0, 0],
-                                              1 - self.face_pair_indices[interval, 0, 1])
-               ee_crs = grid_crs
-            else:
-               entry_xyz = self.trajectory.xyz_for_md(self.node_mds[interval])
-               exit_xyz = self.trajectory.xyz_for_md(self.node_mds[interval + 1])
-               ee_crs = traj_crs
-         if length_mode == 'MD':
-            length = self.node_mds[interval + 1] - self.node_mds[interval]
-            if length_uom is not None and self.trajectory is not None and length_uom != self.trajectory.md_uom:
-               length = bwam.convert_lengths(length, self.trajectory.md_uom, length_uom)
-         else:  # use straight line length between entry and exit
-            length = vec.naive_length(np.array(exit_xyz) -
-                                      np.array(entry_xyz))  # trajectory crs, unless use_face_centres!
-            if length_uom is not None:
-               length = bwam.convert_lengths(length, ee_crs.z_units, length_uom)
-            elif self.trajectory is not None:
-               length = bwam.convert_lengths(length, ee_crs.z_units, self.trajectory.md_uom)
-         if perforation_list is not None:
-            length *= part_perf_fraction
-         if min_length is not None and length < min_length:
-            continue
-         sine_anglv = sine_angla = 0.0
-         cosine_anglv = cosine_angla = 1.0
-         xyz = (np.NaN, np.NaN, np.NaN)
-         md = 0.5 * (self.node_mds[interval + 1] + self.node_mds[interval])
-         anglv = pc.single_array_ref(citation_title = 'ANGLV')[ci] if 'ANGLV' in pc_titles else None
-         angla = pc.single_array_ref(citation_title = 'ANGLA')[ci] if 'ANGLA' in pc_titles else None
-         if doing_angles and not (set_k_face_intervals_vertical and
-                                  (np.all(self.face_pair_indices[ci] == k_face_check) or
-                                   np.all(self.face_pair_indices[ci] == k_face_check_end))):
-            vector = vec.unit_vector(np.array(exit_xyz) - np.array(entry_xyz))  # nominal wellbore vector for interval
-            if traj_z_inc_down is not None and traj_z_inc_down != grid_crs.z_inc_down:
-               vector[2] = -vector[2]
-            v_ref_vector = get_ref_vector(grid, grid_crs, cell_kji0, anglv_ref)
-            #           log.debug('v ref vector: ' + str(v_ref_vector))
-            if angla_plane_ref == anglv_ref:
-               a_ref_vector = v_ref_vector
-            else:
-               a_ref_vector = get_ref_vector(grid, grid_crs, cell_kji0, angla_plane_ref)
-            #           log.debug('a ref vector: ' + str(a_ref_vector))
-            if anglv is not None:
-               anglv_rad = vec.radians_from_degrees(anglv)
-               cosine_anglv = maths.cos(anglv_rad)
-               sine_anglv = maths.sin(anglv_rad)
-            else:
-               cosine_anglv = min(max(vec.dot_product(vector, v_ref_vector), -1.0), 1.0)
-               anglv_rad = maths.acos(cosine_anglv)
-               sine_anglv = maths.sin(anglv_rad)
-               anglv = vec.degrees_from_radians(anglv_rad)
+            entry_xyz = None
+            exit_xyz = None
+            if doing_entry_exit:
+                assert self.trajectory is not None
+                if use_face_centres:
+                    entry_xyz = grid.face_centre(cell_kji0, self.face_pair_indices[interval, 0, 0],
+                                                 self.face_pair_indices[interval, 0, 1])
+                    if self.face_pair_indices[interval, 1, 0] >= 0:
+                        exit_xyz = grid.face_centre(cell_kji0, self.face_pair_indices[interval, 1, 0],
+                                                    self.face_pair_indices[interval, 1, 1])
+                    else:
+                        exit_xyz = grid.face_centre(cell_kji0, self.face_pair_indices[interval, 0, 0],
+                                                    1 - self.face_pair_indices[interval, 0, 1])
+                    ee_crs = grid_crs
+                else:
+                    entry_xyz = self.trajectory.xyz_for_md(self.node_mds[interval])
+                    exit_xyz = self.trajectory.xyz_for_md(self.node_mds[interval + 1])
+                    ee_crs = traj_crs
+            if length_mode == 'MD':
+                length = self.node_mds[interval + 1] - self.node_mds[interval]
+                if length_uom is not None and self.trajectory is not None and length_uom != self.trajectory.md_uom:
+                    length = bwam.convert_lengths(length, self.trajectory.md_uom, length_uom)
+            else:  # use straight line length between entry and exit
+                length = vec.naive_length(np.array(exit_xyz) -
+                                          np.array(entry_xyz))  # trajectory crs, unless use_face_centres!
+                if length_uom is not None:
+                    length = bwam.convert_lengths(length, ee_crs.z_units, length_uom)
+                elif self.trajectory is not None:
+                    length = bwam.convert_lengths(length, ee_crs.z_units, self.trajectory.md_uom)
+            if perforation_list is not None:
+                length *= part_perf_fraction
+            if min_length is not None and length < min_length:
+                continue
+            sine_anglv = sine_angla = 0.0
+            cosine_anglv = cosine_angla = 1.0
+            xyz = (np.NaN, np.NaN, np.NaN)
+            md = 0.5 * (self.node_mds[interval + 1] + self.node_mds[interval])
+            anglv = pc.single_array_ref(citation_title = 'ANGLV')[ci] if 'ANGLV' in pc_titles else None
+            angla = pc.single_array_ref(citation_title = 'ANGLA')[ci] if 'ANGLA' in pc_titles else None
+            if doing_angles and not (set_k_face_intervals_vertical and
+                                     (np.all(self.face_pair_indices[ci] == k_face_check) or
+                                      np.all(self.face_pair_indices[ci] == k_face_check_end))):
+                vector = vec.unit_vector(np.array(exit_xyz) -
+                                         np.array(entry_xyz))  # nominal wellbore vector for interval
+                if traj_z_inc_down is not None and traj_z_inc_down != grid_crs.z_inc_down:
+                    vector[2] = -vector[2]
+                v_ref_vector = get_ref_vector(grid, grid_crs, cell_kji0, anglv_ref)
+                #           log.debug('v ref vector: ' + str(v_ref_vector))
+                if angla_plane_ref == anglv_ref:
+                    a_ref_vector = v_ref_vector
+                else:
+                    a_ref_vector = get_ref_vector(grid, grid_crs, cell_kji0, angla_plane_ref)
+                #           log.debug('a ref vector: ' + str(a_ref_vector))
+                if anglv is not None:
+                    anglv_rad = vec.radians_from_degrees(anglv)
+                    cosine_anglv = maths.cos(anglv_rad)
+                    sine_anglv = maths.sin(anglv_rad)
+                else:
+                    cosine_anglv = min(max(vec.dot_product(vector, v_ref_vector), -1.0), 1.0)
+                    anglv_rad = maths.acos(cosine_anglv)
+                    sine_anglv = maths.sin(anglv_rad)
+                    anglv = vec.degrees_from_radians(anglv_rad)
 #           log.debug('anglv: ' + str(anglv))
-            if anglv != 0.0:
-               # project well vector and i-axis vector onto plane defined by normal vector a_ref_vector
-               i_axis = grid.interface_vector(cell_kji0, 2)
-               i_axis = vec.unit_vector(i_axis)
-               if a_ref_vector is not None:  # project vector and i axis onto a plane
-                  vector -= vec.dot_product(vector, a_ref_vector) * a_ref_vector
-                  vector = vec.unit_vector(vector)
-                  #                 log.debug('i axis unit vector: ' + str(i_axis))
-                  i_axis -= vec.dot_product(i_axis, a_ref_vector) * a_ref_vector
-                  i_axis = vec.unit_vector(i_axis)
+                if anglv != 0.0:
+                    # project well vector and i-axis vector onto plane defined by normal vector a_ref_vector
+                    i_axis = grid.interface_vector(cell_kji0, 2)
+                    i_axis = vec.unit_vector(i_axis)
+                    if a_ref_vector is not None:  # project vector and i axis onto a plane
+                        vector -= vec.dot_product(vector, a_ref_vector) * a_ref_vector
+                        vector = vec.unit_vector(vector)
+                        #                 log.debug('i axis unit vector: ' + str(i_axis))
+                        i_axis -= vec.dot_product(i_axis, a_ref_vector) * a_ref_vector
+                        i_axis = vec.unit_vector(i_axis)
 #                 log.debug('i axis unit vector in reference plane: ' + str(i_axis))
-               if angla is not None:
-                  angla_rad = vec.radians_from_degrees(angla)
-                  cosine_angla = maths.cos(angla_rad)
-                  sine_angla = maths.sin(angla_rad)
-               else:
-                  cosine_angla = min(max(vec.dot_product(vector, i_axis), -1.0), 1.0)
-                  angla_rad = maths.acos(cosine_angla)
-                  # negate angla if vector is 'clockwise from' i_axis when viewed from above, projected in the xy plane
-                  # todo: have discussion around angla sign under different ijk handedness (and z inc direction?)
-                  sine_angla = maths.sin(angla_rad)
-                  angla = vec.degrees_from_radians(angla_rad)
-                  if vec.clockwise((0.0, 0.0), i_axis, vector) > 0.0:
-                     angla = -angla
-                     angle_rad = -angla_rad
-                     sine_angla = -sine_angla
+                    if angla is not None:
+                        angla_rad = vec.radians_from_degrees(angla)
+                        cosine_angla = maths.cos(angla_rad)
+                        sine_angla = maths.sin(angla_rad)
+                    else:
+                        cosine_angla = min(max(vec.dot_product(vector, i_axis), -1.0), 1.0)
+                        angla_rad = maths.acos(cosine_angla)
+                        # negate angla if vector is 'clockwise from' i_axis when viewed from above, projected in the xy plane
+                        # todo: have discussion around angla sign under different ijk handedness (and z inc direction?)
+                        sine_angla = maths.sin(angla_rad)
+                        angla = vec.degrees_from_radians(angla_rad)
+                        if vec.clockwise((0.0, 0.0), i_axis, vector) > 0.0:
+                            angla = -angla
+                            angle_rad = -angla_rad
+                            sine_angla = -sine_angla
 
 
 #              log.debug('angla: ' + str(angla))
-         else:
-            if angla is None:
-               angla = 0.0
-            if anglv is None:
-               anglv = 0.0
-         if doing_kh or do_well_inflow:
-            if ntg_uuid is None:
-               ntg = 1.0
-               ntg_is_one = True
             else:
-               ntg = prop_array(ntg_uuid, grid)[tuple_kji0]
-               ntg_is_one = maths.isclose(ntg, 1.0, rel_tol = 0.001)
-            if isotropic_perm and ntg_is_one:
-               k_i = k_j = k_k = prop_array(perm_i_uuid, grid)[tuple_kji0]
+                if angla is None:
+                    angla = 0.0
+                if anglv is None:
+                    anglv = 0.0
+            if doing_kh or do_well_inflow:
+                if ntg_uuid is None:
+                    ntg = 1.0
+                    ntg_is_one = True
+                else:
+                    ntg = prop_array(ntg_uuid, grid)[tuple_kji0]
+                    ntg_is_one = maths.isclose(ntg, 1.0, rel_tol = 0.001)
+                if isotropic_perm and ntg_is_one:
+                    k_i = k_j = k_k = prop_array(perm_i_uuid, grid)[tuple_kji0]
+                else:
+                    if preferential_perforation and not ntg_is_one:
+                        if part_perf_fraction <= ntg:
+                            ntg = 1.0  # effective ntg when perforated intervals are in pay
+                        else:
+                            ntg /= part_perf_fraction  # adjusted ntg when some perforations in non-pay
+                    # todo: check netgross facet type in property perm i & j parts: if set to gross then don't multiply by ntg below
+                    k_i = prop_array(perm_i_uuid, grid)[tuple_kji0] * ntg
+                    k_j = prop_array(perm_j_uuid, grid)[tuple_kji0] * ntg
+                    k_k = prop_array(perm_k_uuid, grid)[tuple_kji0]
+            if doing_kh:
+                if isotropic_perm and ntg_is_one:
+                    kh = length * prop_array(perm_i_uuid, grid)[tuple_kji0]
+                else:
+                    if np.isnan(k_i) or np.isnan(k_j):
+                        kh = 0.0
+                    elif anglv == 0.0:
+                        kh = length * maths.sqrt(k_i * k_j)
+                    elif np.isnan(k_k):
+                        kh = 0.0
+                    else:
+                        k_e = maths.pow(k_i * k_j * k_k, 1.0 / 3.0)
+                        if k_e == 0.0:
+                            kh = 0.0
+                        else:
+                            l_i = length * maths.sqrt(k_e / k_i) * sine_anglv * cosine_angla
+                            l_j = length * maths.sqrt(k_e / k_j) * sine_anglv * sine_angla
+                            l_k = length * maths.sqrt(k_e / k_k) * cosine_anglv
+                            l_p = maths.sqrt(l_i * l_i + l_j * l_j + l_k * l_k)
+                            kh = k_e * l_p
+                if min_kh is not None and kh < min_kh:
+                    continue
+            elif 'KH' in pc_titles:
+                kh = pc.single_array_ref(citation_title = 'KH')[ci]
             else:
-               if preferential_perforation and not ntg_is_one:
-                  if part_perf_fraction <= ntg:
-                     ntg = 1.0  # effective ntg when perforated intervals are in pay
-                  else:
-                     ntg /= part_perf_fraction  # adjusted ntg when some perforations in non-pay
-               # todo: check netgross facet type in property perm i & j parts: if set to gross then don't multiply by ntg below
-               k_i = prop_array(perm_i_uuid, grid)[tuple_kji0] * ntg
-               k_j = prop_array(perm_j_uuid, grid)[tuple_kji0] * ntg
-               k_k = prop_array(perm_k_uuid, grid)[tuple_kji0]
-         if doing_kh:
-            if isotropic_perm and ntg_is_one:
-               kh = length * prop_array(perm_i_uuid, grid)[tuple_kji0]
-            else:
-               if np.isnan(k_i) or np.isnan(k_j):
-                  kh = 0.0
-               elif anglv == 0.0:
-                  kh = length * maths.sqrt(k_i * k_j)
-               elif np.isnan(k_k):
-                  kh = 0.0
-               else:
-                  k_e = maths.pow(k_i * k_j * k_k, 1.0 / 3.0)
-                  if k_e == 0.0:
-                     kh = 0.0
-                  else:
-                     l_i = length * maths.sqrt(k_e / k_i) * sine_anglv * cosine_angla
-                     l_j = length * maths.sqrt(k_e / k_j) * sine_anglv * sine_angla
-                     l_k = length * maths.sqrt(k_e / k_k) * cosine_anglv
-                     l_p = maths.sqrt(l_i * l_i + l_j * l_j + l_k * l_k)
-                     kh = k_e * l_p
-            if min_kh is not None and kh < min_kh:
-               continue
-         elif 'KH' in pc_titles:
-            kh = pc.single_array_ref(citation_title = 'KH')[ci]
-         else:
-            kh = None
-         if 'LENGTH' in pc_titles:
-            length = pc.single_array_ref(citation_title = 'LENGTH')[ci]
-         if 'RADW' in pc_titles:
-            radw = pc.single_array_ref(citation_title = 'RADW')[ci]
-         assert radw > 0.0
-         if 'SKIN' in pc_titles:
-            skin = pc.single_array_ref(citation_title = 'SKIN')[ci]
-         radb = wi = wbc = None
-         if 'RADB' in pc_titles:
-            radb = pc.single_array_ref(citation_title = 'RADB')[ci]
-         if 'WI' in pc_titles:
-            wi = pc.single_array_ref(citation_title = 'WI')[ci]
-         if 'WBC' in pc_titles:
-            wbc = pc.single_array_ref(citation_title = 'WBC')[ci]
-         if do_well_inflow:
-            if isotropic_perm and ntg_is_one:
-               k_ei = k_ej = k_ek = k_i
-               radw_e = radw
-            else:
-               k_ei = maths.sqrt(k_j * k_k)
-               k_ej = maths.sqrt(k_i * k_k)
-               k_ek = maths.sqrt(k_i * k_j)
-               r_wi = 0.0 if k_ei == 0.0 else 0.5 * radw * (maths.sqrt(k_ei / k_j) + maths.sqrt(k_ei / k_k))
-               r_wj = 0.0 if k_ej == 0.0 else 0.5 * radw * (maths.sqrt(k_ej / k_i) + maths.sqrt(k_ej / k_k))
-               r_wk = 0.0 if k_ek == 0.0 else 0.5 * radw * (maths.sqrt(k_ek / k_i) + maths.sqrt(k_ek / k_j))
-               rwi = r_wi * sine_anglv * cosine_angla
-               rwj = r_wj * sine_anglv * sine_angla
-               rwk = r_wk * cosine_anglv
-               radw_e = maths.sqrt(rwi * rwi + rwj * rwj + rwk * rwk)
-               if radw_e == 0.0:
-                  radw_e = radw  # no permeability in this situation anyway
-            cell_axial_vectors = grid.interface_vectors_kji(cell_kji0)
-            d2 = np.empty(3)
-            for axis in range(3):
-               d2[axis] = np.sum(cell_axial_vectors[axis] * cell_axial_vectors[axis])
-            r_bi = 0.0 if k_ei == 0.0 else 0.14 * maths.sqrt(k_ei * (d2[1] / k_j + d2[0] / k_k))
-            r_bj = 0.0 if k_ej == 0.0 else 0.14 * maths.sqrt(k_ej * (d2[2] / k_i + d2[0] / k_k))
-            r_bk = 0.0 if k_ek == 0.0 else 0.14 * maths.sqrt(k_ek * (d2[2] / k_i + d2[1] / k_j))
-            rbi = r_bi * sine_anglv * cosine_angla
-            rbj = r_bj * sine_anglv * sine_angla
-            rbk = r_bk * cosine_anglv
-            radb_e = maths.sqrt(rbi * rbi + rbj * rbj + rbk * rbk)
-            if radb is None:
-               radb = radw * radb_e / radw_e
-            if wi is None:
-               wi = 0.0 if radb <= 0.0 else 2.0 * maths.pi / (maths.log(radb / radw) + skin)
-            if 'WBC' in column_list and wbc is None:
-               conversion_constant = 8.5270171e-5 if length_uom == 'm' else 0.006328286
-               wbc = conversion_constant * kh * wi  # note: pperf aleady accounted for in kh
-         if doing_xyz:
-            if length_mode == 'MD' and self.trajectory is not None:
-               xyz = self.trajectory.xyz_for_md(md)
-               if length_uom is not None and length_uom != self.trajectory.md_uom:
-                  bwam.convert_lengths(xyz, traj_crs.z_units, length_uom)
-               if depth_inc_down and traj_z_inc_down is False:
-                  xyz[2] = -xyz[2]
-            else:
-               xyz = 0.5 * (np.array(exit_xyz) + np.array(entry_xyz))
-               if length_uom is not None and length_uom != ee_crs.z_units:
-                  bwam.convert_lengths(xyz, ee_crs.z_units, length_uom)
-               if depth_inc_down and ee_crs.z_inc_down is False:
-                  xyz[2] = -xyz[2]
-         xyz = np.array(xyz)
-         if 'X' in pc_titles:
-            xyz[0] = pc.single_array_ref(citation_title = 'X')[ci]
-         if 'Y' in pc_titles:
-            xyz[1] = pc.single_array_ref(citation_title = 'Y')[ci]
-         if 'DEPTH' in pc_titles:
-            xyz[2] = pc.single_array_ref(citation_title = 'DEPTH')[ci]
-         if length_uom is not None and self.trajectory is not None and length_uom != self.trajectory.md_uom:
-            md = bwam.convert_lengths(md, self.trajectory.md_uom, length_uom)
-         if 'MD' in pc_titles:
-            md = pc.single_array_ref(citation_title = 'MD')[ci]
-         for col_index in range(len(column_list)):
-            column = column_list[col_index]
-            if col_index < 3:
-               if one_based:
-                  row_dict[column] = cell_kji0[2 - col_index] + 1
-               else:
-                  row_dict[column] = cell_kji0[2 - col_index]
-            elif column == 'GRID':
-               row_dict['GRID'] = grid_name  # todo: worry about spaces and quotes
-            elif column == 'RADW':
-               row_dict['RADW'] = radw
-            elif column == 'SKIN':
-               row_dict['SKIN'] = skin
-            elif column == 'ANGLA':
-               row_dict['ANGLA'] = angla
-            elif column == 'ANGLV':
-               row_dict['ANGLV'] = anglv
-            elif column == 'LENGTH':
-               # note: length units are those of trajectory length uom if length mode is MD and length_uom is None
-               row_dict['LENGTH'] = length
-            elif column == 'KH':
-               row_dict['KH'] = kh
-            elif column == 'DEPTH':
-               row_dict['DEPTH'] = xyz[2]
-            elif column == 'MD':
-               row_dict['MD'] = md
-            elif column == 'X':
-               row_dict['X'] = xyz[0]
-            elif column == 'Y':
-               row_dict['Y'] = xyz[1]
-            elif column == 'STAT':
-               row_dict['STAT'] = stat
-            elif column == 'PPERF':
-               row_dict['PPERF'] = part_perf_fraction
-            elif column == 'RADB':
-               row_dict['RADB'] = radb
-            elif column == 'WI':
-               row_dict['WI'] = wi
-            elif column == 'WBC':  # note: not a valid WELLSPEC column name
-               row_dict['WBC'] = wbc
-         df = df.append(row_dict, ignore_index = True)
-         row_ci_list.append(ci)
+                kh = None
+            if 'LENGTH' in pc_titles:
+                length = pc.single_array_ref(citation_title = 'LENGTH')[ci]
+            if 'RADW' in pc_titles:
+                radw = pc.single_array_ref(citation_title = 'RADW')[ci]
+            assert radw > 0.0
+            if 'SKIN' in pc_titles:
+                skin = pc.single_array_ref(citation_title = 'SKIN')[ci]
+            radb = wi = wbc = None
+            if 'RADB' in pc_titles:
+                radb = pc.single_array_ref(citation_title = 'RADB')[ci]
+            if 'WI' in pc_titles:
+                wi = pc.single_array_ref(citation_title = 'WI')[ci]
+            if 'WBC' in pc_titles:
+                wbc = pc.single_array_ref(citation_title = 'WBC')[ci]
+            if do_well_inflow:
+                if isotropic_perm and ntg_is_one:
+                    k_ei = k_ej = k_ek = k_i
+                    radw_e = radw
+                else:
+                    k_ei = maths.sqrt(k_j * k_k)
+                    k_ej = maths.sqrt(k_i * k_k)
+                    k_ek = maths.sqrt(k_i * k_j)
+                    r_wi = 0.0 if k_ei == 0.0 else 0.5 * radw * (maths.sqrt(k_ei / k_j) + maths.sqrt(k_ei / k_k))
+                    r_wj = 0.0 if k_ej == 0.0 else 0.5 * radw * (maths.sqrt(k_ej / k_i) + maths.sqrt(k_ej / k_k))
+                    r_wk = 0.0 if k_ek == 0.0 else 0.5 * radw * (maths.sqrt(k_ek / k_i) + maths.sqrt(k_ek / k_j))
+                    rwi = r_wi * sine_anglv * cosine_angla
+                    rwj = r_wj * sine_anglv * sine_angla
+                    rwk = r_wk * cosine_anglv
+                    radw_e = maths.sqrt(rwi * rwi + rwj * rwj + rwk * rwk)
+                    if radw_e == 0.0:
+                        radw_e = radw  # no permeability in this situation anyway
+                cell_axial_vectors = grid.interface_vectors_kji(cell_kji0)
+                d2 = np.empty(3)
+                for axis in range(3):
+                    d2[axis] = np.sum(cell_axial_vectors[axis] * cell_axial_vectors[axis])
+                r_bi = 0.0 if k_ei == 0.0 else 0.14 * maths.sqrt(k_ei * (d2[1] / k_j + d2[0] / k_k))
+                r_bj = 0.0 if k_ej == 0.0 else 0.14 * maths.sqrt(k_ej * (d2[2] / k_i + d2[0] / k_k))
+                r_bk = 0.0 if k_ek == 0.0 else 0.14 * maths.sqrt(k_ek * (d2[2] / k_i + d2[1] / k_j))
+                rbi = r_bi * sine_anglv * cosine_angla
+                rbj = r_bj * sine_anglv * sine_angla
+                rbk = r_bk * cosine_anglv
+                radb_e = maths.sqrt(rbi * rbi + rbj * rbj + rbk * rbk)
+                if radb is None:
+                    radb = radw * radb_e / radw_e
+                if wi is None:
+                    wi = 0.0 if radb <= 0.0 else 2.0 * maths.pi / (maths.log(radb / radw) + skin)
+                if 'WBC' in column_list and wbc is None:
+                    conversion_constant = 8.5270171e-5 if length_uom == 'm' else 0.006328286
+                    wbc = conversion_constant * kh * wi  # note: pperf aleady accounted for in kh
+            if doing_xyz:
+                if length_mode == 'MD' and self.trajectory is not None:
+                    xyz = self.trajectory.xyz_for_md(md)
+                    if length_uom is not None and length_uom != self.trajectory.md_uom:
+                        bwam.convert_lengths(xyz, traj_crs.z_units, length_uom)
+                    if depth_inc_down and traj_z_inc_down is False:
+                        xyz[2] = -xyz[2]
+                else:
+                    xyz = 0.5 * (np.array(exit_xyz) + np.array(entry_xyz))
+                    if length_uom is not None and length_uom != ee_crs.z_units:
+                        bwam.convert_lengths(xyz, ee_crs.z_units, length_uom)
+                    if depth_inc_down and ee_crs.z_inc_down is False:
+                        xyz[2] = -xyz[2]
+            xyz = np.array(xyz)
+            if 'X' in pc_titles:
+                xyz[0] = pc.single_array_ref(citation_title = 'X')[ci]
+            if 'Y' in pc_titles:
+                xyz[1] = pc.single_array_ref(citation_title = 'Y')[ci]
+            if 'DEPTH' in pc_titles:
+                xyz[2] = pc.single_array_ref(citation_title = 'DEPTH')[ci]
+            if length_uom is not None and self.trajectory is not None and length_uom != self.trajectory.md_uom:
+                md = bwam.convert_lengths(md, self.trajectory.md_uom, length_uom)
+            if 'MD' in pc_titles:
+                md = pc.single_array_ref(citation_title = 'MD')[ci]
+            for col_index in range(len(column_list)):
+                column = column_list[col_index]
+                if col_index < 3:
+                    if one_based:
+                        row_dict[column] = cell_kji0[2 - col_index] + 1
+                    else:
+                        row_dict[column] = cell_kji0[2 - col_index]
+                elif column == 'GRID':
+                    row_dict['GRID'] = grid_name  # todo: worry about spaces and quotes
+                elif column == 'RADW':
+                    row_dict['RADW'] = radw
+                elif column == 'SKIN':
+                    row_dict['SKIN'] = skin
+                elif column == 'ANGLA':
+                    row_dict['ANGLA'] = angla
+                elif column == 'ANGLV':
+                    row_dict['ANGLV'] = anglv
+                elif column == 'LENGTH':
+                    # note: length units are those of trajectory length uom if length mode is MD and length_uom is None
+                    row_dict['LENGTH'] = length
+                elif column == 'KH':
+                    row_dict['KH'] = kh
+                elif column == 'DEPTH':
+                    row_dict['DEPTH'] = xyz[2]
+                elif column == 'MD':
+                    row_dict['MD'] = md
+                elif column == 'X':
+                    row_dict['X'] = xyz[0]
+                elif column == 'Y':
+                    row_dict['Y'] = xyz[1]
+                elif column == 'STAT':
+                    row_dict['STAT'] = stat
+                elif column == 'PPERF':
+                    row_dict['PPERF'] = part_perf_fraction
+                elif column == 'RADB':
+                    row_dict['RADB'] = radb
+                elif column == 'WI':
+                    row_dict['WI'] = wi
+                elif column == 'WBC':  # note: not a valid WELLSPEC column name
+                    row_dict['WBC'] = wbc
+            df = df.append(row_dict, ignore_index = True)
+            row_ci_list.append(ci)
 
-      if add_as_properties:
-         if isinstance(add_as_properties, list):
-            for col in add_as_properties:
-               assert col in extra_columns_list
-            property_columns = add_as_properties
-         else:
-            property_columns = extra_columns_list
-         self._add_df_properties(df, property_columns, row_ci_list = row_ci_list, length_uom = length_uom)
-
-      return df
-
-   def _add_df_properties(self, df, columns, row_ci_list = None, length_uom = None):
-      # creates a property part for each named column, based on the dataframe values
-      # column name used as the citation title
-      # self must already exist as a part in the model
-      # currently only handles single grid situations
-      # todo: rewrite to add separate property objects for each grid references by the blocked well
-      log.debug('_add_df_props: df:')
-      log.debug(f'\n{df}')
-      log.debug(f'columns: {columns}')
-      assert len(self.grid_list) == 1
-      if columns is None or len(columns) == 0 or len(df) == 0:
-         return
-      if row_ci_list is None:
-         row_ci_list = np.arange(self.cell_count)
-      assert len(row_ci_list) == len(df)
-      if length_uom is None:
-         length_uom = self.trajectory.md_uom
-      extra_pc = rqp.PropertyCollection()
-      extra_pc.set_support(support = self)
-      ci_map = np.array(row_ci_list, dtype = int)
-      for e in columns:
-         extra = e.upper()
-         if extra in ['GRID', 'STAT']:
-            continue  # todo: other non-numeric columns may need to be added to this list
-         pk = 'continuous'
-         uom = 'Euc'
-         if extra in ['ANGLA', 'ANGLV']:
-            uom = 'dega'
-            # neither azimuth nor dip are correct property kinds; todo: create local property kinds
-            pk = 'azimuth' if extra == 'ANGLA' else 'inclination'
-         elif extra in ['LENGTH', 'MD', 'X', 'Y', 'DEPTH', 'RADW']:
-            if length_uom is None or length_uom == 'Euc':
-               if extra in ['LENGTH', 'MD']:
-                  uom = self.trajectory.md_uom
-               elif extra in ['X', 'Y', 'RADW']:
-                  uom = self.grid_list[0].xy_units()
-               else:
-                  uom = self.grid_list[0].z_units()
+        if add_as_properties:
+            if isinstance(add_as_properties, list):
+                for col in add_as_properties:
+                    assert col in extra_columns_list
+                property_columns = add_as_properties
             else:
-               uom = length_uom
-            if extra == 'DEPTH':
-               pk = 'depth'
-            else:
-               pk = 'length'
-         elif extra == 'KH':
-            uom = 'mD.' + length_uom
-            pk = 'permeability length'
-         elif extra == 'PPERF':
-            uom = length_uom + '/' + length_uom
-         else:
+                property_columns = extra_columns_list
+            self._add_df_properties(df, property_columns, row_ci_list = row_ci_list, length_uom = length_uom)
+
+        return df
+
+    def _add_df_properties(self, df, columns, row_ci_list = None, length_uom = None):
+        # creates a property part for each named column, based on the dataframe values
+        # column name used as the citation title
+        # self must already exist as a part in the model
+        # currently only handles single grid situations
+        # todo: rewrite to add separate property objects for each grid references by the blocked well
+        log.debug('_add_df_props: df:')
+        log.debug(f'\n{df}')
+        log.debug(f'columns: {columns}')
+        assert len(self.grid_list) == 1
+        if columns is None or len(columns) == 0 or len(df) == 0:
+            return
+        if row_ci_list is None:
+            row_ci_list = np.arange(self.cell_count)
+        assert len(row_ci_list) == len(df)
+        if length_uom is None:
+            length_uom = self.trajectory.md_uom
+        extra_pc = rqp.PropertyCollection()
+        extra_pc.set_support(support = self)
+        ci_map = np.array(row_ci_list, dtype = int)
+        for e in columns:
+            extra = e.upper()
+            if extra in ['GRID', 'STAT']:
+                continue  # todo: other non-numeric columns may need to be added to this list
+            pk = 'continuous'
             uom = 'Euc'
-         # 'SKIN': use defaults for now; todo: create local property kind for skin
-         expanded = np.full(self.cell_count, np.NaN)
-         expanded[ci_map] = df[extra]
-         extra_pc.add_cached_array_to_imported_list(expanded,
-                                                    'blocked well dataframe',
-                                                    extra,
-                                                    discrete = False,
-                                                    uom = uom,
-                                                    property_kind = pk,
-                                                    local_property_kind_uuid = None,
-                                                    facet_type = None,
-                                                    facet = None,
-                                                    realization = None,
-                                                    indexable_element = 'cells',
-                                                    count = 1)
-      extra_pc.write_hdf5_for_imported_list()
-      extra_pc.create_xml_for_imported_list_and_add_parts_to_model()
+            if extra in ['ANGLA', 'ANGLV']:
+                uom = 'dega'
+                # neither azimuth nor dip are correct property kinds; todo: create local property kinds
+                pk = 'azimuth' if extra == 'ANGLA' else 'inclination'
+            elif extra in ['LENGTH', 'MD', 'X', 'Y', 'DEPTH', 'RADW']:
+                if length_uom is None or length_uom == 'Euc':
+                    if extra in ['LENGTH', 'MD']:
+                        uom = self.trajectory.md_uom
+                    elif extra in ['X', 'Y', 'RADW']:
+                        uom = self.grid_list[0].xy_units()
+                    else:
+                        uom = self.grid_list[0].z_units()
+                else:
+                    uom = length_uom
+                if extra == 'DEPTH':
+                    pk = 'depth'
+                else:
+                    pk = 'length'
+            elif extra == 'KH':
+                uom = 'mD.' + length_uom
+                pk = 'permeability length'
+            elif extra == 'PPERF':
+                uom = length_uom + '/' + length_uom
+            else:
+                uom = 'Euc'
+            # 'SKIN': use defaults for now; todo: create local property kind for skin
+            expanded = np.full(self.cell_count, np.NaN)
+            expanded[ci_map] = df[extra]
+            extra_pc.add_cached_array_to_imported_list(expanded,
+                                                       'blocked well dataframe',
+                                                       extra,
+                                                       discrete = False,
+                                                       uom = uom,
+                                                       property_kind = pk,
+                                                       local_property_kind_uuid = None,
+                                                       facet_type = None,
+                                                       facet = None,
+                                                       realization = None,
+                                                       indexable_element = 'cells',
+                                                       count = 1)
+        extra_pc.write_hdf5_for_imported_list()
+        extra_pc.create_xml_for_imported_list_and_add_parts_to_model()
 
-   def static_kh(self,
-                 ntg_uuid = None,
-                 perm_i_uuid = None,
-                 perm_j_uuid = None,
-                 perm_k_uuid = None,
-                 satw_uuid = None,
-                 sato_uuid = None,
-                 satg_uuid = None,
-                 region_uuid = None,
-                 active_only = False,
-                 min_k0 = None,
-                 max_k0 = None,
-                 k0_list = None,
-                 min_length = None,
-                 min_kh = None,
-                 max_depth = None,
-                 max_satw = None,
-                 min_sato = None,
-                 max_satg = None,
-                 perforation_list = None,
-                 region_list = None,
-                 set_k_face_intervals_vertical = False,
-                 anglv_ref = 'gravity',
-                 angla_plane_ref = None,
-                 length_mode = 'MD',
-                 length_uom = None,
-                 use_face_centres = False,
-                 preferential_perforation = True):
-      """Returns the total static K.H (permeability x height); length units are those of trajectory md_uom unless length_upm is set.
+    def static_kh(self,
+                  ntg_uuid = None,
+                  perm_i_uuid = None,
+                  perm_j_uuid = None,
+                  perm_k_uuid = None,
+                  satw_uuid = None,
+                  sato_uuid = None,
+                  satg_uuid = None,
+                  region_uuid = None,
+                  active_only = False,
+                  min_k0 = None,
+                  max_k0 = None,
+                  k0_list = None,
+                  min_length = None,
+                  min_kh = None,
+                  max_depth = None,
+                  max_satw = None,
+                  min_sato = None,
+                  max_satg = None,
+                  perforation_list = None,
+                  region_list = None,
+                  set_k_face_intervals_vertical = False,
+                  anglv_ref = 'gravity',
+                  angla_plane_ref = None,
+                  length_mode = 'MD',
+                  length_uom = None,
+                  use_face_centres = False,
+                  preferential_perforation = True):
+        """Returns the total static K.H (permeability x height); length units are those of trajectory md_uom unless length_upm is set.
 
       note:
          see doc string for dataframe() method for argument descriptions; perm_i_uuid required
       """
 
-      df = self.dataframe(i_col = 'I',
-                          j_col = 'J',
-                          k_col = 'K',
-                          one_based = False,
-                          extra_columns_list = ['KH'],
-                          ntg_uuid = ntg_uuid,
-                          perm_i_uuid = perm_i_uuid,
-                          perm_j_uuid = perm_j_uuid,
-                          perm_k_uuid = perm_k_uuid,
-                          satw_uuid = satw_uuid,
-                          sato_uuid = sato_uuid,
-                          satg_uuid = satg_uuid,
-                          region_uuid = region_uuid,
-                          active_only = active_only,
-                          min_k0 = min_k0,
-                          max_k0 = max_k0,
-                          k0_list = k0_list,
-                          min_length = min_length,
-                          min_kh = min_kh,
-                          max_depth = max_depth,
-                          max_satw = max_satw,
-                          min_sato = min_sato,
-                          max_satg = max_satg,
-                          perforation_list = perforation_list,
-                          region_list = region_list,
-                          set_k_face_intervals_vertical = set_k_face_intervals_vertical,
-                          anglv_ref = anglv_ref,
-                          angla_plane_ref = angla_plane_ref,
-                          length_mode = length_mode,
-                          length_uom = length_uom,
-                          use_face_centres = use_face_centres,
-                          preferential_perforation = preferential_perforation)
+        df = self.dataframe(i_col = 'I',
+                            j_col = 'J',
+                            k_col = 'K',
+                            one_based = False,
+                            extra_columns_list = ['KH'],
+                            ntg_uuid = ntg_uuid,
+                            perm_i_uuid = perm_i_uuid,
+                            perm_j_uuid = perm_j_uuid,
+                            perm_k_uuid = perm_k_uuid,
+                            satw_uuid = satw_uuid,
+                            sato_uuid = sato_uuid,
+                            satg_uuid = satg_uuid,
+                            region_uuid = region_uuid,
+                            active_only = active_only,
+                            min_k0 = min_k0,
+                            max_k0 = max_k0,
+                            k0_list = k0_list,
+                            min_length = min_length,
+                            min_kh = min_kh,
+                            max_depth = max_depth,
+                            max_satw = max_satw,
+                            min_sato = min_sato,
+                            max_satg = max_satg,
+                            perforation_list = perforation_list,
+                            region_list = region_list,
+                            set_k_face_intervals_vertical = set_k_face_intervals_vertical,
+                            anglv_ref = anglv_ref,
+                            angla_plane_ref = angla_plane_ref,
+                            length_mode = length_mode,
+                            length_uom = length_uom,
+                            use_face_centres = use_face_centres,
+                            preferential_perforation = preferential_perforation)
 
-      return sum(df['KH'])
+        return sum(df['KH'])
 
-   def write_wellspec(self,
-                      wellspec_file,
-                      well_name = None,
-                      mode = 'a',
-                      extra_columns_list = [],
-                      ntg_uuid = None,
-                      perm_i_uuid = None,
-                      perm_j_uuid = None,
-                      perm_k_uuid = None,
-                      satw_uuid = None,
-                      sato_uuid = None,
-                      satg_uuid = None,
-                      region_uuid = None,
-                      radw = None,
-                      skin = None,
-                      stat = None,
-                      active_only = False,
-                      min_k0 = None,
-                      max_k0 = None,
-                      k0_list = None,
-                      min_length = None,
-                      min_kh = None,
-                      max_depth = None,
-                      max_satw = None,
-                      min_sato = None,
-                      max_satg = None,
-                      perforation_list = None,
-                      region_list = None,
-                      set_k_face_intervals_vertical = False,
-                      depth_inc_down = True,
-                      anglv_ref = 'gravity',
-                      angla_plane_ref = None,
-                      length_mode = 'MD',
-                      length_uom = None,
-                      preferential_perforation = True,
-                      space_instead_of_tab_separator = True,
-                      align_columns = True,
-                      preceeding_blank_lines = 0,
-                      trailing_blank_lines = 0,
-                      length_uom_comment = False,
-                      write_nexus_units = True,
-                      float_format = '5.3'):
-      """Writes Nexus WELLSPEC keyword to an ascii file.
+    def write_wellspec(self,
+                       wellspec_file,
+                       well_name = None,
+                       mode = 'a',
+                       extra_columns_list = [],
+                       ntg_uuid = None,
+                       perm_i_uuid = None,
+                       perm_j_uuid = None,
+                       perm_k_uuid = None,
+                       satw_uuid = None,
+                       sato_uuid = None,
+                       satg_uuid = None,
+                       region_uuid = None,
+                       radw = None,
+                       skin = None,
+                       stat = None,
+                       active_only = False,
+                       min_k0 = None,
+                       max_k0 = None,
+                       k0_list = None,
+                       min_length = None,
+                       min_kh = None,
+                       max_depth = None,
+                       max_satw = None,
+                       min_sato = None,
+                       max_satg = None,
+                       perforation_list = None,
+                       region_list = None,
+                       set_k_face_intervals_vertical = False,
+                       depth_inc_down = True,
+                       anglv_ref = 'gravity',
+                       angla_plane_ref = None,
+                       length_mode = 'MD',
+                       length_uom = None,
+                       preferential_perforation = True,
+                       space_instead_of_tab_separator = True,
+                       align_columns = True,
+                       preceeding_blank_lines = 0,
+                       trailing_blank_lines = 0,
+                       length_uom_comment = False,
+                       write_nexus_units = True,
+                       float_format = '5.3'):
+        """Writes Nexus WELLSPEC keyword to an ascii file.
 
       returns:
          pandas DataFrame containing data that has been written to the wellspec file
@@ -3422,244 +3436,248 @@ class BlockedWell(BaseResqpy):
          align_columns and float_format arguments are deprecated and no longer used
       """
 
-      def tidy_well_name(well_name):
-         nexus_friendly = ''
-         previous_underscore = False
-         for ch in well_name:
-            if not 32 <= ord(ch) < 128 or ch in ' ,!*#':
-               ch = '_'
-            if not (previous_underscore and ch == '_'):
-               nexus_friendly += ch
-            previous_underscore = (ch == '_')
-         if not nexus_friendly:
-            well_name = 'WELL_X'
-         return nexus_friendly
+        def tidy_well_name(well_name):
+            nexus_friendly = ''
+            previous_underscore = False
+            for ch in well_name:
+                if not 32 <= ord(ch) < 128 or ch in ' ,!*#':
+                    ch = '_'
+                if not (previous_underscore and ch == '_'):
+                    nexus_friendly += ch
+                previous_underscore = (ch == '_')
+            if not nexus_friendly:
+                well_name = 'WELL_X'
+            return nexus_friendly
 
-      def is_float_column(col_name):
-         if col_name.upper() in ['ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'SKIN', 'RADW', 'PPERF']:
-            return True
-         return False
+        def is_float_column(col_name):
+            if col_name.upper() in ['ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'SKIN', 'RADW', 'PPERF']:
+                return True
+            return False
 
-      def is_int_column(col_name):
-         if col_name.upper() in ['IW', 'JW', 'L']:
-            return True
-         return False
+        def is_int_column(col_name):
+            if col_name.upper() in ['IW', 'JW', 'L']:
+                return True
+            return False
 
-      assert wellspec_file, 'no output file specified to write WELLSPEC to'
+        assert wellspec_file, 'no output file specified to write WELLSPEC to'
 
-      col_width_dict = {
-         'IW': 4,
-         'JW': 4,
-         'L': 4,
-         'ANGLA': 8,
-         'ANGLV': 8,
-         'LENGTH': 8,
-         'KH': 10,
-         'DEPTH': 10,
-         'MD': 10,
-         'X': 8,
-         'Y': 12,
-         'SKIN': 7,
-         'RADW': 5,
-         'PPERF': 5
-      }
+        col_width_dict = {
+            'IW': 4,
+            'JW': 4,
+            'L': 4,
+            'ANGLA': 8,
+            'ANGLV': 8,
+            'LENGTH': 8,
+            'KH': 10,
+            'DEPTH': 10,
+            'MD': 10,
+            'X': 8,
+            'Y': 12,
+            'SKIN': 7,
+            'RADW': 5,
+            'PPERF': 5
+        }
 
-      if not well_name:
-         if self.well_name:
-            well_name = self.well_name
-         elif self.root is not None:
-            well_name = rqet.citation_title_for_node(self.root)
-         elif self.wellbore_interpretation is not None:
-            well_name = self.wellbore_interpretation.title
-         elif self.trajectory is not None:
-            well_name = self.trajectory.title
-         else:
-            log.warning('no well name identified for use in WELLSPEC')
-            well_name = 'WELLNAME'
-      well_name = tidy_well_name(well_name)
-
-      df = self.dataframe(one_based = True,
-                          extra_columns_list = extra_columns_list,
-                          ntg_uuid = ntg_uuid,
-                          perm_i_uuid = perm_i_uuid,
-                          perm_j_uuid = perm_j_uuid,
-                          perm_k_uuid = perm_k_uuid,
-                          satw_uuid = satw_uuid,
-                          sato_uuid = sato_uuid,
-                          satg_uuid = satg_uuid,
-                          region_uuid = region_uuid,
-                          radw = radw,
-                          skin = skin,
-                          stat = stat,
-                          active_only = active_only,
-                          min_k0 = min_k0,
-                          max_k0 = max_k0,
-                          k0_list = k0_list,
-                          min_length = min_length,
-                          min_kh = min_kh,
-                          max_depth = max_depth,
-                          max_satw = max_satw,
-                          min_sato = min_sato,
-                          max_satg = max_satg,
-                          perforation_list = perforation_list,
-                          region_list = region_list,
-                          depth_inc_down = depth_inc_down,
-                          set_k_face_intervals_vertical = set_k_face_intervals_vertical,
-                          anglv_ref = anglv_ref,
-                          angla_plane_ref = angla_plane_ref,
-                          length_mode = length_mode,
-                          length_uom = length_uom,
-                          preferential_perforation = preferential_perforation)
-
-      sep = ' ' if space_instead_of_tab_separator else '\t'
-
-      with open(wellspec_file, mode = mode) as fp:
-         for _ in range(preceeding_blank_lines):
-            fp.write('\n')
-         if write_nexus_units:
-            if length_uom == 'm':
-               fp.write('METRIC\n\n')
-            elif length_uom == 'ft':
-               fp.write('ENGLISH\n\n')
-         if length_uom_comment and self.trajectory is not None and ('LENGTH' in extra_columns_list or
-                                                                    'MD' in extra_columns_list or
-                                                                    'KH' in extra_columns_list):
-            fp.write(f'! Length units along wellbore: {self.trajectory.md_uom if length_uom is None else length_uom}\n')
-         fp.write('WELLSPEC ' + str(well_name) + '\n')
-         for col_name in df.columns:
-            if col_name in col_width_dict:
-               width = col_width_dict[col_name]
+        if not well_name:
+            if self.well_name:
+                well_name = self.well_name
+            elif self.root is not None:
+                well_name = rqet.citation_title_for_node(self.root)
+            elif self.wellbore_interpretation is not None:
+                well_name = self.wellbore_interpretation.title
+            elif self.trajectory is not None:
+                well_name = self.trajectory.title
             else:
-               width = 10
-            form = '{0:>' + str(width) + '}'
-            fp.write(sep + form.format(col_name))
-         fp.write('\n')
-         for row_info in df.iterrows():
-            row = row_info[1]
+                log.warning('no well name identified for use in WELLSPEC')
+                well_name = 'WELLNAME'
+        well_name = tidy_well_name(well_name)
+
+        df = self.dataframe(one_based = True,
+                            extra_columns_list = extra_columns_list,
+                            ntg_uuid = ntg_uuid,
+                            perm_i_uuid = perm_i_uuid,
+                            perm_j_uuid = perm_j_uuid,
+                            perm_k_uuid = perm_k_uuid,
+                            satw_uuid = satw_uuid,
+                            sato_uuid = sato_uuid,
+                            satg_uuid = satg_uuid,
+                            region_uuid = region_uuid,
+                            radw = radw,
+                            skin = skin,
+                            stat = stat,
+                            active_only = active_only,
+                            min_k0 = min_k0,
+                            max_k0 = max_k0,
+                            k0_list = k0_list,
+                            min_length = min_length,
+                            min_kh = min_kh,
+                            max_depth = max_depth,
+                            max_satw = max_satw,
+                            min_sato = min_sato,
+                            max_satg = max_satg,
+                            perforation_list = perforation_list,
+                            region_list = region_list,
+                            depth_inc_down = depth_inc_down,
+                            set_k_face_intervals_vertical = set_k_face_intervals_vertical,
+                            anglv_ref = anglv_ref,
+                            angla_plane_ref = angla_plane_ref,
+                            length_mode = length_mode,
+                            length_uom = length_uom,
+                            preferential_perforation = preferential_perforation)
+
+        sep = ' ' if space_instead_of_tab_separator else '\t'
+
+        with open(wellspec_file, mode = mode) as fp:
+            for _ in range(preceeding_blank_lines):
+                fp.write('\n')
+            if write_nexus_units:
+                if length_uom == 'm':
+                    fp.write('METRIC\n\n')
+                elif length_uom == 'ft':
+                    fp.write('ENGLISH\n\n')
+            if length_uom_comment and self.trajectory is not None and ('LENGTH' in extra_columns_list or
+                                                                       'MD' in extra_columns_list or
+                                                                       'KH' in extra_columns_list):
+                fp.write(
+                    f'! Length units along wellbore: {self.trajectory.md_uom if length_uom is None else length_uom}\n')
+            fp.write('WELLSPEC ' + str(well_name) + '\n')
             for col_name in df.columns:
-               try:
-                  if col_name in col_width_dict:
-                     width = col_width_dict[col_name]
-                  else:
-                     width = 10
-                  if is_float_column(col_name):
-                     form = '{0:>' + str(width) + '.3f}'
-                     fp.write(sep + form.format(float(row[col_name])))
-                  else:
-                     form = '{0:>' + str(width) + '}'
-                     if is_int_column(col_name):
-                        fp.write(sep + form.format(int(row[col_name])))
-                     else:
-                        fp.write(sep + form.format(str(row[col_name])))
-               except Exception:
-                  fp.write(sep + str(row[col_name]))
+                if col_name in col_width_dict:
+                    width = col_width_dict[col_name]
+                else:
+                    width = 10
+                form = '{0:>' + str(width) + '}'
+                fp.write(sep + form.format(col_name))
             fp.write('\n')
-         for _ in range(trailing_blank_lines):
-            fp.write('\n')
+            for row_info in df.iterrows():
+                row = row_info[1]
+                for col_name in df.columns:
+                    try:
+                        if col_name in col_width_dict:
+                            width = col_width_dict[col_name]
+                        else:
+                            width = 10
+                        if is_float_column(col_name):
+                            form = '{0:>' + str(width) + '.3f}'
+                            fp.write(sep + form.format(float(row[col_name])))
+                        else:
+                            form = '{0:>' + str(width) + '}'
+                            if is_int_column(col_name):
+                                fp.write(sep + form.format(int(row[col_name])))
+                            else:
+                                fp.write(sep + form.format(str(row[col_name])))
+                    except Exception:
+                        fp.write(sep + str(row[col_name]))
+                fp.write('\n')
+            for _ in range(trailing_blank_lines):
+                fp.write('\n')
 
-      return df
+        return df
 
-   def kji0_marker(self, active_only = True):
-      """Convenience method returning (k0, j0, i0), grid_uuid of first blocked interval."""
+    def kji0_marker(self, active_only = True):
+        """Convenience method returning (k0, j0, i0), grid_uuid of first blocked interval."""
 
-      cells, grids = self.cell_indices_and_grid_list()
-      if cells is None or grids is None or len(grids) == 0:
-         return None, None, None, None
-      return cells[0], grids[0].uuid
+        cells, grids = self.cell_indices_and_grid_list()
+        if cells is None or grids is None or len(grids) == 0:
+            return None, None, None, None
+        return cells[0], grids[0].uuid
 
-   def xyz_marker(self, active_only = True):
-      """Convenience method returning (x, y, z), crs_uuid of perforation in first blocked interval.
+    def xyz_marker(self, active_only = True):
+        """Convenience method returning (x, y, z), crs_uuid of perforation in first blocked interval.
 
       notes:
          active_only argument not yet in use;
          returns None, None if no blocked interval found
       """
 
-      cells, grids = self.cell_indices_and_grid_list()
-      if cells is None or grids is None or len(grids) == 0:
-         return None, None
-      node_index = 0
-      while node_index < self.node_count - 1 and self.grid_indices[node_index] == -1:
-         node_index += 1
-      if node_index >= self.node_count - 1:
-         return None, None
-      md = 0.5 * (self.node_mds[node_index] + self.node_mds[node_index + 1])
-      xyz = self.trajectory.xyz_for_md(md)
-      return xyz, rqet.uuid_for_part_root(self.trajectory.crs_root)
+        cells, grids = self.cell_indices_and_grid_list()
+        if cells is None or grids is None or len(grids) == 0:
+            return None, None
+        node_index = 0
+        while node_index < self.node_count - 1 and self.grid_indices[node_index] == -1:
+            node_index += 1
+        if node_index >= self.node_count - 1:
+            return None, None
+        md = 0.5 * (self.node_mds[node_index] + self.node_mds[node_index + 1])
+        xyz = self.trajectory.xyz_for_md(md)
+        return xyz, rqet.uuid_for_part_root(self.trajectory.crs_root)
 
-   def create_feature_and_interpretation(self, shared_interpretation = True):
-      """Instantiate new empty WellboreFeature and WellboreInterpretation objects
+    def create_feature_and_interpretation(self, shared_interpretation = True):
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects
       
       Uses the Blocked well citation title as the well name
       """
-      if self.trajectory is not None:
-         traj_interp_uuid = self.model.uuid(obj_type = 'WellboreInterpretation', related_uuid = self.trajectory.uuid)
-         if traj_interp_uuid is not None:
-            if shared_interpretation:
-               self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
-                                                                         uuid = traj_interp_uuid)
-            traj_feature_uuid = self.model.uuid(obj_type = 'WellboreFeature', related_uuid = traj_interp_uuid)
-            if traj_feature_uuid is not None:
-               self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, uuid = traj_feature_uuid)
-      if self.wellbore_feature is None:
-         self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, feature_name = self.trajectory.title)
-         self.feature_to_be_written = True
-      if self.wellbore_interpretation is None:
-         self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
-                                                                   wellbore_feature = self.wellbore_feature)
-         if self.trajectory.wellbore_interpretation is None and shared_interpretation:
-            self.trajectory.wellbore_interpretation = self.wellbore_interpretation
-         self.interpretation_to_be_written = True
+        if self.trajectory is not None:
+            traj_interp_uuid = self.model.uuid(obj_type = 'WellboreInterpretation', related_uuid = self.trajectory.uuid)
+            if traj_interp_uuid is not None:
+                if shared_interpretation:
+                    self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
+                                                                              uuid = traj_interp_uuid)
+                traj_feature_uuid = self.model.uuid(obj_type = 'WellboreFeature', related_uuid = traj_interp_uuid)
+                if traj_feature_uuid is not None:
+                    self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, uuid = traj_feature_uuid)
+        if self.wellbore_feature is None:
+            self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, feature_name = self.trajectory.title)
+            self.feature_to_be_written = True
+        if self.wellbore_interpretation is None:
+            self.wellbore_interpretation = rqo.WellboreInterpretation(parent_model = self.model,
+                                                                      wellbore_feature = self.wellbore_feature)
+            if self.trajectory.wellbore_interpretation is None and shared_interpretation:
+                self.trajectory.wellbore_interpretation = self.wellbore_interpretation
+            self.interpretation_to_be_written = True
 
-   def create_md_datum_and_trajectory(self,
-                                      grid,
-                                      trajectory_mds,
-                                      trajectory_points,
-                                      length_uom,
-                                      well_name,
-                                      set_depth_zero = False,
-                                      set_tangent_vectors = False,
-                                      create_feature_and_interp = True):
-      """Creates an Md Datum object and a (simulation) Trajectory object for this blocked well.
+    def create_md_datum_and_trajectory(self,
+                                       grid,
+                                       trajectory_mds,
+                                       trajectory_points,
+                                       length_uom,
+                                       well_name,
+                                       set_depth_zero = False,
+                                       set_tangent_vectors = False,
+                                       create_feature_and_interp = True):
+        """Creates an Md Datum object and a (simulation) Trajectory object for this blocked well.
 
       note:
          not usually called directly; used by import methods
       """
 
-      # create md datum node for synthetic trajectory, using crs for grid
-      datum_location = trajectory_points[0].copy()
-      if set_depth_zero:
-         datum_location[2] = 0.0
-      datum = MdDatum(self.model, crs_uuid = grid.crs_uuid, location = datum_location, md_reference = 'mean sea level')
+        # create md datum node for synthetic trajectory, using crs for grid
+        datum_location = trajectory_points[0].copy()
+        if set_depth_zero:
+            datum_location[2] = 0.0
+        datum = MdDatum(self.model,
+                        crs_uuid = grid.crs_uuid,
+                        location = datum_location,
+                        md_reference = 'mean sea level')
 
-      # create synthetic trajectory object, using crs for grid
-      trajectory_mds_array = np.array(trajectory_mds)
-      trajectory_xyz_array = np.array(trajectory_points)
-      trajectory_df = pd.DataFrame({
-         'MD': trajectory_mds_array,
-         'X': trajectory_xyz_array[..., 0],
-         'Y': trajectory_xyz_array[..., 1],
-         'Z': trajectory_xyz_array[..., 2]
-      })
-      self.trajectory = Trajectory(self.model,
-                                   md_datum = datum,
-                                   data_frame = trajectory_df,
-                                   length_uom = length_uom,
-                                   well_name = well_name,
-                                   set_tangent_vectors = set_tangent_vectors)
-      self.trajectory_to_be_written = True
+        # create synthetic trajectory object, using crs for grid
+        trajectory_mds_array = np.array(trajectory_mds)
+        trajectory_xyz_array = np.array(trajectory_points)
+        trajectory_df = pd.DataFrame({
+            'MD': trajectory_mds_array,
+            'X': trajectory_xyz_array[..., 0],
+            'Y': trajectory_xyz_array[..., 1],
+            'Z': trajectory_xyz_array[..., 2]
+        })
+        self.trajectory = Trajectory(self.model,
+                                     md_datum = datum,
+                                     data_frame = trajectory_df,
+                                     length_uom = length_uom,
+                                     well_name = well_name,
+                                     set_tangent_vectors = set_tangent_vectors)
+        self.trajectory_to_be_written = True
 
-      if create_feature_and_interp:
-         self.create_feature_and_interpretation()
+        if create_feature_and_interp:
+            self.create_feature_and_interpretation()
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  create_for_trajectory_if_needed = True,
-                  add_as_part = True,
-                  add_relationships = True,
-                  title = None,
-                  originator = None):
-      """Create a blocked wellbore representation node from this BlockedWell object, optionally add as part.
+    def create_xml(self,
+                   ext_uuid = None,
+                   create_for_trajectory_if_needed = True,
+                   add_as_part = True,
+                   add_relationships = True,
+                   title = None,
+                   originator = None):
+        """Create a blocked wellbore representation node from this BlockedWell object, optionally add as part.
 
       note:
          trajectory xml node must be in place before calling this function;
@@ -3668,201 +3686,202 @@ class BlockedWell(BaseResqpy):
       :meta common:
       """
 
-      assert self.trajectory is not None, 'trajectory object missing'
+        assert self.trajectory is not None, 'trajectory object missing'
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      if title:
-         self.title = title
-      if not self.title:
-         self.title = 'blocked well'
+        if title:
+            self.title = title
+        if not self.title:
+            self.title = 'blocked well'
 
-      if self.feature_to_be_written:
-         if self.wellbore_feature is None:
-            self.create_feature_and_interpretation()
-         self.wellbore_feature.create_xml(add_as_part = add_as_part, originator = originator)
-      if self.interpretation_to_be_written:
-         if self.wellbore_interpretation is None:
-            self.create_feature_and_interpretation()
-         self.wellbore_interpretation.create_xml(add_as_part = add_as_part,
-                                                 title_suffix = None,
-                                                 add_relationships = add_relationships,
-                                                 originator = originator)
+        if self.feature_to_be_written:
+            if self.wellbore_feature is None:
+                self.create_feature_and_interpretation()
+            self.wellbore_feature.create_xml(add_as_part = add_as_part, originator = originator)
+        if self.interpretation_to_be_written:
+            if self.wellbore_interpretation is None:
+                self.create_feature_and_interpretation()
+            self.wellbore_interpretation.create_xml(add_as_part = add_as_part,
+                                                    title_suffix = None,
+                                                    add_relationships = add_relationships,
+                                                    originator = originator)
 
-      if create_for_trajectory_if_needed and self.trajectory_to_be_written and self.trajectory.root is None:
-         md_datum_root = self.trajectory.md_datum.create_xml(add_as_part = add_as_part,
-                                                             add_relationships = add_relationships,
-                                                             title = str(self.title),
-                                                             originator = originator)
-         self.trajectory.create_xml(ext_uuid,
-                                    md_datum_root = md_datum_root,
-                                    add_as_part = add_as_part,
-                                    add_relationships = add_relationships,
-                                    title = title,
-                                    originator = originator)
+        if create_for_trajectory_if_needed and self.trajectory_to_be_written and self.trajectory.root is None:
+            md_datum_root = self.trajectory.md_datum.create_xml(add_as_part = add_as_part,
+                                                                add_relationships = add_relationships,
+                                                                title = str(self.title),
+                                                                originator = originator)
+            self.trajectory.create_xml(ext_uuid,
+                                       md_datum_root = md_datum_root,
+                                       add_as_part = add_as_part,
+                                       add_relationships = add_relationships,
+                                       title = title,
+                                       originator = originator)
 
-      assert self.trajectory.root is not None, 'trajectory xml not established'
+        assert self.trajectory.root is not None, 'trajectory xml not established'
 
-      bw_node = super().create_xml(title = title, originator = originator, add_as_part = False)
+        bw_node = super().create_xml(title = title, originator = originator, add_as_part = False)
 
-      # wellbore frame elements
+        # wellbore frame elements
 
-      nc_node = rqet.SubElement(bw_node, ns['resqml2'] + 'NodeCount')
-      nc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      nc_node.text = str(self.node_count)
+        nc_node = rqet.SubElement(bw_node, ns['resqml2'] + 'NodeCount')
+        nc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        nc_node.text = str(self.node_count)
 
-      mds_node = rqet.SubElement(bw_node, ns['resqml2'] + 'NodeMd')
-      mds_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-      mds_node.text = rqet.null_xml_text
+        mds_node = rqet.SubElement(bw_node, ns['resqml2'] + 'NodeMd')
+        mds_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+        mds_node.text = rqet.null_xml_text
 
-      mds_values_node = rqet.SubElement(mds_node, ns['resqml2'] + 'Values')
-      mds_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      mds_values_node.text = rqet.null_xml_text
+        mds_values_node = rqet.SubElement(mds_node, ns['resqml2'] + 'Values')
+        mds_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        mds_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'NodeMd', root = mds_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'NodeMd', root = mds_values_node)
 
-      traj_root = self.trajectory.root
-      self.model.create_ref_node('Trajectory',
-                                 rqet.find_nested_tags_text(traj_root, ['Citation', 'Title']),
-                                 bu.uuid_from_string(traj_root.attrib['uuid']),
-                                 content_type = 'obj_WellboreTrajectoryRepresentation',
-                                 root = bw_node)
+        traj_root = self.trajectory.root
+        self.model.create_ref_node('Trajectory',
+                                   rqet.find_nested_tags_text(traj_root, ['Citation', 'Title']),
+                                   bu.uuid_from_string(traj_root.attrib['uuid']),
+                                   content_type = 'obj_WellboreTrajectoryRepresentation',
+                                   root = bw_node)
 
-      # remaining blocked wellbore elements
+        # remaining blocked wellbore elements
 
-      cc_node = rqet.SubElement(bw_node, ns['resqml2'] + 'CellCount')
-      cc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
-      cc_node.text = str(self.cell_count)
+        cc_node = rqet.SubElement(bw_node, ns['resqml2'] + 'CellCount')
+        cc_node.set(ns['xsi'] + 'type', ns['xsd'] + 'nonNegativeInteger')
+        cc_node.text = str(self.cell_count)
 
-      cis_node = rqet.SubElement(bw_node, ns['resqml2'] + 'CellIndices')
-      cis_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      cis_node.text = rqet.null_xml_text
+        cis_node = rqet.SubElement(bw_node, ns['resqml2'] + 'CellIndices')
+        cis_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        cis_node.text = rqet.null_xml_text
 
-      cnull_node = rqet.SubElement(cis_node, ns['resqml2'] + 'NullValue')
-      cnull_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      cnull_node.text = str(self.cellind_null)
+        cnull_node = rqet.SubElement(cis_node, ns['resqml2'] + 'NullValue')
+        cnull_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        cnull_node.text = str(self.cellind_null)
 
-      cis_values_node = rqet.SubElement(cis_node, ns['resqml2'] + 'Values')
-      cis_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      cis_values_node.text = rqet.null_xml_text
+        cis_values_node = rqet.SubElement(cis_node, ns['resqml2'] + 'Values')
+        cis_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        cis_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellIndices', root = cis_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'CellIndices', root = cis_values_node)
 
-      gis_node = rqet.SubElement(bw_node, ns['resqml2'] + 'GridIndices')
-      gis_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      gis_node.text = rqet.null_xml_text
+        gis_node = rqet.SubElement(bw_node, ns['resqml2'] + 'GridIndices')
+        gis_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        gis_node.text = rqet.null_xml_text
 
-      gnull_node = rqet.SubElement(gis_node, ns['resqml2'] + 'NullValue')
-      gnull_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      gnull_node.text = str(self.gridind_null)
+        gnull_node = rqet.SubElement(gis_node, ns['resqml2'] + 'NullValue')
+        gnull_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        gnull_node.text = str(self.gridind_null)
 
-      gis_values_node = rqet.SubElement(gis_node, ns['resqml2'] + 'Values')
-      gis_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      gis_values_node.text = rqet.null_xml_text
+        gis_values_node = rqet.SubElement(gis_node, ns['resqml2'] + 'Values')
+        gis_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        gis_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'GridIndices', root = gis_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'GridIndices', root = gis_values_node)
 
-      fis_node = rqet.SubElement(bw_node, ns['resqml2'] + 'LocalFacePairPerCellIndices')
-      fis_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
-      fis_node.text = rqet.null_xml_text
+        fis_node = rqet.SubElement(bw_node, ns['resqml2'] + 'LocalFacePairPerCellIndices')
+        fis_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerHdf5Array')
+        fis_node.text = rqet.null_xml_text
 
-      fnull_node = rqet.SubElement(fis_node, ns['resqml2'] + 'NullValue')
-      fnull_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-      fnull_node.text = str(self.facepair_null)
+        fnull_node = rqet.SubElement(fis_node, ns['resqml2'] + 'NullValue')
+        fnull_node.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+        fnull_node.text = str(self.facepair_null)
 
-      fis_values_node = rqet.SubElement(fis_node, ns['resqml2'] + 'Values')
-      fis_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
-      fis_values_node.text = rqet.null_xml_text
+        fis_values_node = rqet.SubElement(fis_node, ns['resqml2'] + 'Values')
+        fis_values_node.set(ns['xsi'] + 'type', ns['eml'] + 'Hdf5Dataset')
+        fis_values_node.text = rqet.null_xml_text
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'LocalFacePairPerCellIndices', root = fis_values_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'LocalFacePairPerCellIndices', root = fis_values_node)
 
-      for grid in self.grid_list:
+        for grid in self.grid_list:
 
-         grid_root = grid.root
-         self.model.create_ref_node('Grid',
-                                    rqet.find_nested_tags_text(grid_root, ['Citation', 'Title']),
-                                    bu.uuid_from_string(grid_root.attrib['uuid']),
-                                    content_type = 'obj_IjkGridRepresentation',
-                                    root = bw_node)
+            grid_root = grid.root
+            self.model.create_ref_node('Grid',
+                                       rqet.find_nested_tags_text(grid_root, ['Citation', 'Title']),
+                                       bu.uuid_from_string(grid_root.attrib['uuid']),
+                                       content_type = 'obj_IjkGridRepresentation',
+                                       root = bw_node)
 
-      interp_root = None
-      if self.wellbore_interpretation is not None:
-         interp_root = self.wellbore_interpretation.root
-         self.model.create_ref_node('RepresentedInterpretation',
-                                    rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
-                                    bu.uuid_from_string(interp_root.attrib['uuid']),
-                                    content_type = 'obj_WellboreInterpretation',
-                                    root = bw_node)
+        interp_root = None
+        if self.wellbore_interpretation is not None:
+            interp_root = self.wellbore_interpretation.root
+            self.model.create_ref_node('RepresentedInterpretation',
+                                       rqet.find_nested_tags_text(interp_root, ['Citation', 'Title']),
+                                       bu.uuid_from_string(interp_root.attrib['uuid']),
+                                       content_type = 'obj_WellboreInterpretation',
+                                       root = bw_node)
 
-      if add_as_part:
-         self.model.add_part('obj_BlockedWellboreRepresentation', self.uuid, bw_node)
-         if add_relationships:
-            self.model.create_reciprocal_relationship(bw_node, 'destinationObject', self.trajectory.root,
-                                                      'sourceObject')
+        if add_as_part:
+            self.model.add_part('obj_BlockedWellboreRepresentation', self.uuid, bw_node)
+            if add_relationships:
+                self.model.create_reciprocal_relationship(bw_node, 'destinationObject', self.trajectory.root,
+                                                          'sourceObject')
 
-            for grid in self.grid_list:
-               self.model.create_reciprocal_relationship(bw_node, 'destinationObject', grid.root, 'sourceObject')
-            if interp_root is not None:
-               self.model.create_reciprocal_relationship(bw_node, 'destinationObject', interp_root, 'sourceObject')
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(bw_node, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+                for grid in self.grid_list:
+                    self.model.create_reciprocal_relationship(bw_node, 'destinationObject', grid.root, 'sourceObject')
+                if interp_root is not None:
+                    self.model.create_reciprocal_relationship(bw_node, 'destinationObject', interp_root, 'sourceObject')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(bw_node, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
 
-      return bw_node
+        return bw_node
 
-   def write_hdf5(self, file_name = None, mode = 'a', create_for_trajectory_if_needed = True):
-      """Create or append to an hdf5 file, writing datasets for the measured depths, grid, cell & face indices.
+    def write_hdf5(self, file_name = None, mode = 'a', create_for_trajectory_if_needed = True):
+        """Create or append to an hdf5 file, writing datasets for the measured depths, grid, cell & face indices.
 
       :meta common:
       """
 
-      # NB: array data must all have been set up prior to calling this function
+        # NB: array data must all have been set up prior to calling this function
 
-      if self.uuid is None:
-         self.uuid = bu.new_uuid()
+        if self.uuid is None:
+            self.uuid = bu.new_uuid()
 
-      h5_reg = rwh5.H5Register(self.model)
+        h5_reg = rwh5.H5Register(self.model)
 
-      if create_for_trajectory_if_needed and self.trajectory_to_be_written:
-         self.trajectory.write_hdf5(file_name, mode = mode)
-         mode = 'a'
+        if create_for_trajectory_if_needed and self.trajectory_to_be_written:
+            self.trajectory.write_hdf5(file_name, mode = mode)
+            mode = 'a'
 
-      h5_reg.register_dataset(self.uuid, 'NodeMd', self.node_mds)
-      h5_reg.register_dataset(self.uuid, 'CellIndices', self.cell_indices)  # could use int32?
-      h5_reg.register_dataset(self.uuid, 'GridIndices', self.grid_indices)  # could use int32?
-      # convert face index pairs from [axis, polarity] back to strange local face numbering
-      mask = (self.face_pair_indices.flatten() == -1).reshape((-1, 2))  # 2nd axis is (axis, polarity)
-      masked_face_indices = np.where(mask, 0, self.face_pair_indices.reshape((-1, 2)))  # 2nd axis is (axis, polarity)
-      # using flat array for raw_face_indices array
-      # other resqml writing code might use an array with one int per entry point and one per exit point, with 2nd axis as (entry, exit)
-      raw_face_indices = np.where(mask[:, 0], -1, self.face_index_map[masked_face_indices[:, 0],
-                                                                      masked_face_indices[:, 1]].flatten()).reshape(-1)
+        h5_reg.register_dataset(self.uuid, 'NodeMd', self.node_mds)
+        h5_reg.register_dataset(self.uuid, 'CellIndices', self.cell_indices)  # could use int32?
+        h5_reg.register_dataset(self.uuid, 'GridIndices', self.grid_indices)  # could use int32?
+        # convert face index pairs from [axis, polarity] back to strange local face numbering
+        mask = (self.face_pair_indices.flatten() == -1).reshape((-1, 2))  # 2nd axis is (axis, polarity)
+        masked_face_indices = np.where(mask, 0, self.face_pair_indices.reshape((-1, 2)))  # 2nd axis is (axis, polarity)
+        # using flat array for raw_face_indices array
+        # other resqml writing code might use an array with one int per entry point and one per exit point, with 2nd axis as (entry, exit)
+        raw_face_indices = np.where(mask[:, 0], -1, self.face_index_map[masked_face_indices[:, 0],
+                                                                        masked_face_indices[:,
+                                                                                            1]].flatten()).reshape(-1)
 
-      h5_reg.register_dataset(self.uuid, 'LocalFacePairPerCellIndices', raw_face_indices)  # could use uint8?
+        h5_reg.register_dataset(self.uuid, 'LocalFacePairPerCellIndices', raw_face_indices)  # could use uint8?
 
-      h5_reg.write(file = file_name, mode = mode)
+        h5_reg.write(file = file_name, mode = mode)
 
 
 class WellboreMarkerFrame(BaseResqpy):
-   """Class to handle RESQML WellBoreMarkerFrameRepresentation objects.
+    """Class to handle RESQML WellBoreMarkerFrameRepresentation objects.
 
    note:
       measured depth data must be in same crs as those for the related trajectory
    """
 
-   resqml_type = 'WellboreMarkerFrameRepresentation'
+    resqml_type = 'WellboreMarkerFrameRepresentation'
 
-   def __init__(self,
-                parent_model,
-                wellbore_marker_frame_root = None,
-                uuid = None,
-                trajectory = None,
-                title = None,
-                originator = None,
-                extra_metadata = None):
-      """Creates a new wellbore marker object and optionally loads it from xml, or trajectory, or Nexus wellspec file.
+    def __init__(self,
+                 parent_model,
+                 wellbore_marker_frame_root = None,
+                 uuid = None,
+                 trajectory = None,
+                 title = None,
+                 originator = None,
+                 extra_metadata = None):
+        """Creates a new wellbore marker object and optionally loads it from xml, or trajectory, or Nexus wellspec file.
 
       arguments:
          parent_model (model.Model object): the model which the new blocked well belongs to
@@ -3880,23 +3899,23 @@ class WellboreMarkerFrame(BaseResqpy):
          the newly created wellbore framework marker object
       """
 
-      self.trajectory = None
-      self.node_count = None  # number of measured depth nodes, each being for a marker
-      self.node_mds = None  # node_count measured depths (in same units and datum as trajectory) of markers
-      self.wellbore_marker_list = [
-      ]  # list of markers, each: (marker UUID, geologic boundary, marker citation title, interp. object)
-      if self.trajectory is not None:
-         self.trajectory = trajectory
+        self.trajectory = None
+        self.node_count = None  # number of measured depth nodes, each being for a marker
+        self.node_mds = None  # node_count measured depths (in same units and datum as trajectory) of markers
+        self.wellbore_marker_list = [
+        ]  # list of markers, each: (marker UUID, geologic boundary, marker citation title, interp. object)
+        if self.trajectory is not None:
+            self.trajectory = trajectory
 
-      super().__init__(model = parent_model,
-                       uuid = uuid,
-                       title = title,
-                       originator = originator,
-                       extra_metadata = extra_metadata,
-                       root_node = wellbore_marker_frame_root)
+        super().__init__(model = parent_model,
+                         uuid = uuid,
+                         title = title,
+                         originator = originator,
+                         extra_metadata = extra_metadata,
+                         root_node = wellbore_marker_frame_root)
 
-   def get_trajectory_obj(self, trajectory_uuid):
-      """Returns a trajectory object.
+    def get_trajectory_obj(self, trajectory_uuid):
+        """Returns a trajectory object.
 
       arguments:
          trajectory_uuid (string or uuid.UUID): the uuid of the trajectory for which a Trajectory object is required
@@ -3908,17 +3927,17 @@ class WellboreMarkerFrame(BaseResqpy):
          this method is not usually called directly
       """
 
-      if trajectory_uuid is None:
-         log.error('no trajectory was found')
-         return None
-      else:
-         # create new trajectory object
-         trajectory_root_node = self.model.root_for_uuid(trajectory_uuid)
-         assert trajectory_root_node is not None, 'referenced wellbore trajectory missing from model'
-         return Trajectory(self.model, trajectory_root = trajectory_root_node)
+        if trajectory_uuid is None:
+            log.error('no trajectory was found')
+            return None
+        else:
+            # create new trajectory object
+            trajectory_root_node = self.model.root_for_uuid(trajectory_uuid)
+            assert trajectory_root_node is not None, 'referenced wellbore trajectory missing from model'
+            return Trajectory(self.model, trajectory_root = trajectory_root_node)
 
-   def get_interpretation_obj(self, interpretation_uuid, interp_type = None):
-      """Creates an interpretation object; returns a horizon or fault interpretation object.
+    def get_interpretation_obj(self, interpretation_uuid, interp_type = None):
+        """Creates an interpretation object; returns a horizon or fault interpretation object.
 
       arguments:
          interpretation_uiud (string or uuid.UUID): the uuid of the required interpretation object
@@ -3932,209 +3951,210 @@ class WellboreMarkerFrame(BaseResqpy):
          this method is not usually called directly
       """
 
-      assert interpretation_uuid is not None, 'interpretation uuid argument missing'
+        assert interpretation_uuid is not None, 'interpretation uuid argument missing'
 
-      interpretation_root_node = self.model.root_for_uuid(interpretation_uuid)
+        interpretation_root_node = self.model.root_for_uuid(interpretation_uuid)
 
-      if not interp_type:
-         interp_type = rqet.node_type(interpretation_root_node)
+        if not interp_type:
+            interp_type = rqet.node_type(interpretation_root_node)
 
-      if not interp_type.startswith('obj_'):
-         interp_type = 'obj_' + interp_type
+        if not interp_type.startswith('obj_'):
+            interp_type = 'obj_' + interp_type
 
-      if interp_type == 'obj_HorizonInterpretation':
-         # create new horizon interpretation object
-         return rqo.HorizonInterpretation(self.model, root_node = interpretation_root_node)
+        if interp_type == 'obj_HorizonInterpretation':
+            # create new horizon interpretation object
+            return rqo.HorizonInterpretation(self.model, root_node = interpretation_root_node)
 
-      elif interp_type == 'obj_FaultInterpretation':
-         # create new fault interpretation object
-         return rqo.FaultInterpretation(self.model, root_node = interpretation_root_node)
+        elif interp_type == 'obj_FaultInterpretation':
+            # create new fault interpretation object
+            return rqo.FaultInterpretation(self.model, root_node = interpretation_root_node)
 
-      elif interp_type == 'obj_GeobodyInterpretation':
-         # create new geobody interpretation object
-         return rqo.GeobodyInterpretation(self.model, root_node = interpretation_root_node)
-      else:
-         # No interpretation for the marker
-         return None
-         # log.error('interpretation type not recognized: ' + str(interp_type))
+        elif interp_type == 'obj_GeobodyInterpretation':
+            # create new geobody interpretation object
+            return rqo.GeobodyInterpretation(self.model, root_node = interpretation_root_node)
+        else:
+            # No interpretation for the marker
+            return None
+            # log.error('interpretation type not recognized: ' + str(interp_type))
 
-   def _load_from_xml(self):
-      """Loads the wellbore marker frame object from an xml node (and associated hdf5 data).
+    def _load_from_xml(self):
+        """Loads the wellbore marker frame object from an xml node (and associated hdf5 data).
 
       note:
          this method is not usually called directly
       """
 
-      wellbore_marker_frame_root = self.root
-      assert wellbore_marker_frame_root is not None
+        wellbore_marker_frame_root = self.root
+        assert wellbore_marker_frame_root is not None
 
-      if self.trajectory is None:
-         self.trajectory = self.get_trajectory_obj(
-            rqet.find_nested_tags_text(wellbore_marker_frame_root, ['Trajectory', 'UUID']))
+        if self.trajectory is None:
+            self.trajectory = self.get_trajectory_obj(
+                rqet.find_nested_tags_text(wellbore_marker_frame_root, ['Trajectory', 'UUID']))
 
-      # list of Wellbore markers, each: (marker UUID, geologic boundary, marker citation title, interp. object)
-      self.wellbore_marker_list = []
-      for tag in rqet.list_of_tag(wellbore_marker_frame_root, 'WellboreMarker'):
-         interp_tag = rqet.content_type(rqet.find_nested_tags_text(tag, ['Interpretation', 'ContentType']))
-         if interp_tag is not None:
-            interp_obj = self.get_interpretation_obj(rqet.find_nested_tags_text(tag, ['Interpretation', 'UUID']),
-                                                     interp_tag)
-         else:
-            interp_obj = None
-         self.wellbore_marker_list.append(
-            (str(rqet.uuid_for_part_root(tag)), rqet.find_tag_text(tag, 'GeologicBoundaryKind'),
-             rqet.find_nested_tags_text(tag, ['Citation', 'Title']), interp_obj))
-
-      self.node_count = rqet.find_tag_int(wellbore_marker_frame_root, 'NodeCount')
-      load_hdf5_array(self, rqet.find_tag(wellbore_marker_frame_root, 'NodeMd'), "node_mds", tag = 'Values')
-      if self.node_count != len(self.node_mds):
-         log.error('node count does not match hdf5 array')
-
-      if len(self.wellbore_marker_list) != self.node_count:
-         log.error('wellbore marker list does not contain correct node count')
-
-   def dataframe(self):
-      """Returns a pandas dataframe with columns X, Y, Z, MD, Type, Surface, Well."""
-
-      # todo: handle fractures and geobody boundaries as well as horizons and faults
-
-      xyz = np.empty((self.node_count, 3))
-      type_list = []
-      surface_list = []
-      well_list = []
-
-      for i in range(self.node_count):
-         _, boundary_kind, title, interp = self.wellbore_marker_list[i]
-         if interp:
-            if boundary_kind == 'horizon':
-               feature_name = rqo.GeneticBoundaryFeature(self.model, root_node = interp.feature_root).feature_name
-            elif boundary_kind == 'fault':
-               feature_name = rqo.TectonicBoundaryFeature(self.model, root_node = interp.feature_root).feature_name
-            elif boundary_kind == 'geobody':
-               feature_name = rqo.GeneticBoundaryFeature(self.model, root_node = interp.feature_root).feature_name
+        # list of Wellbore markers, each: (marker UUID, geologic boundary, marker citation title, interp. object)
+        self.wellbore_marker_list = []
+        for tag in rqet.list_of_tag(wellbore_marker_frame_root, 'WellboreMarker'):
+            interp_tag = rqet.content_type(rqet.find_nested_tags_text(tag, ['Interpretation', 'ContentType']))
+            if interp_tag is not None:
+                interp_obj = self.get_interpretation_obj(rqet.find_nested_tags_text(tag, ['Interpretation', 'UUID']),
+                                                         interp_tag)
             else:
-               assert False, 'unexpected boundary kind'
-         else:
-            feature_name = title
-         boundary_kind = boundary_kind[0].upper() + boundary_kind[1:]
-         feature_name = '"' + feature_name + '"'
-         xyz[i] = self.trajectory.xyz_for_md(self.node_mds[i])
-         type_list.append(boundary_kind)
-         surface_list.append(feature_name)
-         if self.trajectory.wellbore_interpretation is None:
-            well_name = '"' + self.trajectory.title + '"'  # todo: trace through wellbore interp to wellbore feature name
-         else:
-            well_name = '"' + self.trajectory.wellbore_interpretation.title + '"'  # use wellbore_interpretation title instead, RMS exports have feature_name as "Wellbore feature"
-            # well_name = '"' + self.trajectory.wellbore_interpretation.wellbore_feature.feature_name + '"'
-         well_list.append(well_name)
+                interp_obj = None
+            self.wellbore_marker_list.append(
+                (str(rqet.uuid_for_part_root(tag)), rqet.find_tag_text(tag, 'GeologicBoundaryKind'),
+                 rqet.find_nested_tags_text(tag, ['Citation', 'Title']), interp_obj))
 
-      return pd.DataFrame({
-         'X': xyz[:, 0],
-         'Y': xyz[:, 1],
-         'Z': xyz[:, 2],
-         'MD': self.node_mds,
-         'Type': type_list,
-         'Surface': surface_list,
-         'Well': well_list
-      })
+        self.node_count = rqet.find_tag_int(wellbore_marker_frame_root, 'NodeCount')
+        load_hdf5_array(self, rqet.find_tag(wellbore_marker_frame_root, 'NodeMd'), "node_mds", tag = 'Values')
+        if self.node_count != len(self.node_mds):
+            log.error('node count does not match hdf5 array')
 
-   def create_xml(self,
-                  ext_uuid = None,
-                  add_as_part = True,
-                  add_relationships = True,
-                  wellbore_marker_list = None,
-                  title = 'wellbore marker framework',
-                  originator = None):
+        if len(self.wellbore_marker_list) != self.node_count:
+            log.error('wellbore marker list does not contain correct node count')
 
-      assert type(add_as_part) is bool
+    def dataframe(self):
+        """Returns a pandas dataframe with columns X, Y, Z, MD, Type, Surface, Well."""
 
-      if ext_uuid is None:
-         ext_uuid = self.model.h5_uuid()
+        # todo: handle fractures and geobody boundaries as well as horizons and faults
 
-      wbm_node = super().create_xml(originator = originator, add_as_part = False)
+        xyz = np.empty((self.node_count, 3))
+        type_list = []
+        surface_list = []
+        well_list = []
 
-      nodeCount = rqet.SubElement(wbm_node, ns['resqml2'] + 'NodeCount')
-      nodeCount.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-      nodeCount.text = str(self.node_count)
+        for i in range(self.node_count):
+            _, boundary_kind, title, interp = self.wellbore_marker_list[i]
+            if interp:
+                if boundary_kind == 'horizon':
+                    feature_name = rqo.GeneticBoundaryFeature(self.model, root_node = interp.feature_root).feature_name
+                elif boundary_kind == 'fault':
+                    feature_name = rqo.TectonicBoundaryFeature(self.model, root_node = interp.feature_root).feature_name
+                elif boundary_kind == 'geobody':
+                    feature_name = rqo.GeneticBoundaryFeature(self.model, root_node = interp.feature_root).feature_name
+                else:
+                    assert False, 'unexpected boundary kind'
+            else:
+                feature_name = title
+            boundary_kind = boundary_kind[0].upper() + boundary_kind[1:]
+            feature_name = '"' + feature_name + '"'
+            xyz[i] = self.trajectory.xyz_for_md(self.node_mds[i])
+            type_list.append(boundary_kind)
+            surface_list.append(feature_name)
+            if self.trajectory.wellbore_interpretation is None:
+                well_name = '"' + self.trajectory.title + '"'  # todo: trace through wellbore interp to wellbore feature name
+            else:
+                well_name = '"' + self.trajectory.wellbore_interpretation.title + '"'  # use wellbore_interpretation title instead, RMS exports have feature_name as "Wellbore feature"
+                # well_name = '"' + self.trajectory.wellbore_interpretation.wellbore_feature.feature_name + '"'
+            well_list.append(well_name)
 
-      nodeMd = rqet.SubElement(wbm_node, ns['resqml2'] + 'NodeMd')
-      nodeMd.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
-      nodeMd.text = rqet.null_xml_text
+        return pd.DataFrame({
+            'X': xyz[:, 0],
+            'Y': xyz[:, 1],
+            'Z': xyz[:, 2],
+            'MD': self.node_mds,
+            'Type': type_list,
+            'Surface': surface_list,
+            'Well': well_list
+        })
 
-      md_values_node = rqet.SubElement(nodeMd, ns['resqml2'] + 'Values')
-      md_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
-      md_values_node.text = rqet.null_xml_text
+    def create_xml(self,
+                   ext_uuid = None,
+                   add_as_part = True,
+                   add_relationships = True,
+                   wellbore_marker_list = None,
+                   title = 'wellbore marker framework',
+                   originator = None):
 
-      self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'mds', root = md_values_node)
+        assert type(add_as_part) is bool
 
-      if self.trajectory is not None:
-         traj_root = self.trajectory.root
-         self.model.create_ref_node('Trajectory',
-                                    rqet.find_tag(rqet.find_tag(traj_root, 'Citation'), 'Title').text,
-                                    bu.uuid_from_string(traj_root.attrib['uuid']),
-                                    content_type = 'obj_WellboreTrajectoryRepresentation',
-                                    root = wbm_node)
-      else:
-         log.error('trajectory object is missing and must be included')
+        if ext_uuid is None:
+            ext_uuid = self.model.h5_uuid()
 
-      # fill wellbore marker
-      for marker in self.wellbore_marker_list:
+        wbm_node = super().create_xml(originator = originator, add_as_part = False)
 
-         wbm_node_obj = self.model.new_obj_node('WellboreMarker', is_top_lvl_obj = False)
-         wbm_node_obj.set('uuid', marker[0])
-         wbm_node.append(wbm_node_obj)
-         wbm_gb_node = rqet.SubElement(wbm_node_obj, ns['resqml2'] + 'GeologicBoundaryKind')
-         wbm_gb_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
-         wbm_gb_node.text = str(marker[1])
+        nodeCount = rqet.SubElement(wbm_node, ns['resqml2'] + 'NodeCount')
+        nodeCount.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+        nodeCount.text = str(self.node_count)
 
-         interp = marker[3]
-         if interp is not None:
-            interp_root = marker[3].root
-            if 'HorizonInterpretation' in str(type(marker[3])):
-               self.model.create_ref_node('Interpretation',
-                                          rqet.find_tag(rqet.find_tag(interp_root, 'Citation'), 'Title').text,
-                                          bu.uuid_from_string(interp_root.attrib['uuid']),
-                                          content_type = 'obj_HorizonInterpretation',
-                                          root = wbm_node_obj)
+        nodeMd = rqet.SubElement(wbm_node, ns['resqml2'] + 'NodeMd')
+        nodeMd.set(ns['xsi'] + 'type', ns['resqml2'] + 'DoubleHdf5Array')
+        nodeMd.text = rqet.null_xml_text
 
-            elif 'FaultInterpretation' in str(type(marker[3])):
-               self.model.create_ref_node('Interpretation',
-                                          rqet.find_tag(rqet.find_tag(interp_root, 'Citation'), 'Title').text,
-                                          bu.uuid_from_string(interp_root.attrib['uuid']),
-                                          content_type = 'obj_FaultInterpretation',
-                                          root = wbm_node_obj)
+        md_values_node = rqet.SubElement(nodeMd, ns['resqml2'] + 'Values')
+        md_values_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'Hdf5Dataset')
+        md_values_node.text = rqet.null_xml_text
 
-      # add as part
-      if add_as_part:
-         self.model.add_part('obj_WellboreMarkerFrameRepresentation', self.uuid, wbm_node)
+        self.model.create_hdf5_dataset_ref(ext_uuid, self.uuid, 'mds', root = md_values_node)
 
-         if add_relationships:
-            self.model.create_reciprocal_relationship(wbm_node, 'destinationObject', self.trajectory.root,
-                                                      'sourceObject')
-            ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
-            ext_node = self.model.root_for_part(ext_part)
-            self.model.create_reciprocal_relationship(wbm_node, 'mlToExternalPartProxy', ext_node,
-                                                      'externalPartProxyToMl')
+        if self.trajectory is not None:
+            traj_root = self.trajectory.root
+            self.model.create_ref_node('Trajectory',
+                                       rqet.find_tag(rqet.find_tag(traj_root, 'Citation'), 'Title').text,
+                                       bu.uuid_from_string(traj_root.attrib['uuid']),
+                                       content_type = 'obj_WellboreTrajectoryRepresentation',
+                                       root = wbm_node)
+        else:
+            log.error('trajectory object is missing and must be included')
 
-            for marker in self.wellbore_marker_list:
-               self.model.create_reciprocal_relationship(wbm_node, 'destinationObject', marker[3].root, 'sourceObject')
+        # fill wellbore marker
+        for marker in self.wellbore_marker_list:
 
-      return wbm_node
+            wbm_node_obj = self.model.new_obj_node('WellboreMarker', is_top_lvl_obj = False)
+            wbm_node_obj.set('uuid', marker[0])
+            wbm_node.append(wbm_node_obj)
+            wbm_gb_node = rqet.SubElement(wbm_node_obj, ns['resqml2'] + 'GeologicBoundaryKind')
+            wbm_gb_node.set(ns['xsi'] + 'type', ns['xsd'] + 'string')
+            wbm_gb_node.text = str(marker[1])
 
-   def write_hdf5(self, file_name = None, mode = 'a'):
-      """Writes the hdf5 array associated with this object (the measured depth data).
+            interp = marker[3]
+            if interp is not None:
+                interp_root = marker[3].root
+                if 'HorizonInterpretation' in str(type(marker[3])):
+                    self.model.create_ref_node('Interpretation',
+                                               rqet.find_tag(rqet.find_tag(interp_root, 'Citation'), 'Title').text,
+                                               bu.uuid_from_string(interp_root.attrib['uuid']),
+                                               content_type = 'obj_HorizonInterpretation',
+                                               root = wbm_node_obj)
+
+                elif 'FaultInterpretation' in str(type(marker[3])):
+                    self.model.create_ref_node('Interpretation',
+                                               rqet.find_tag(rqet.find_tag(interp_root, 'Citation'), 'Title').text,
+                                               bu.uuid_from_string(interp_root.attrib['uuid']),
+                                               content_type = 'obj_FaultInterpretation',
+                                               root = wbm_node_obj)
+
+        # add as part
+        if add_as_part:
+            self.model.add_part('obj_WellboreMarkerFrameRepresentation', self.uuid, wbm_node)
+
+            if add_relationships:
+                self.model.create_reciprocal_relationship(wbm_node, 'destinationObject', self.trajectory.root,
+                                                          'sourceObject')
+                ext_part = rqet.part_name_for_object('obj_EpcExternalPartReference', ext_uuid, prefixed = False)
+                ext_node = self.model.root_for_part(ext_part)
+                self.model.create_reciprocal_relationship(wbm_node, 'mlToExternalPartProxy', ext_node,
+                                                          'externalPartProxyToMl')
+
+                for marker in self.wellbore_marker_list:
+                    self.model.create_reciprocal_relationship(wbm_node, 'destinationObject', marker[3].root,
+                                                              'sourceObject')
+
+        return wbm_node
+
+    def write_hdf5(self, file_name = None, mode = 'a'):
+        """Writes the hdf5 array associated with this object (the measured depth data).
 
       arguments:
          file_name (string): the name of the hdf5 file, or None, in which case the model's default will be used
          mode (string, default 'a'): the write mode for the hdf5, either 'w' or 'a'
       """
 
-      h5_reg = rwh5.H5Register(self.model)
-      h5_reg.register_dataset(self.uuid, 'Mds', self.node_mds)
-      h5_reg.write(file = file_name, mode = mode)
+        h5_reg = rwh5.H5Register(self.model)
+        h5_reg.register_dataset(self.uuid, 'Mds', self.node_mds)
+        h5_reg.write(file = file_name, mode = mode)
 
-   def find_marker_from_interp(self, interpetation_obj = None, uuid = None):
-      """Find wellbore marker by interpretation; can pass object or uuid.
+    def find_marker_from_interp(self, interpetation_obj = None, uuid = None):
+        """Find wellbore marker by interpretation; can pass object or uuid.
 
       arguments:
          interpretation_obj (organize.HorizonInterpretation or organize.FaultInterpretation object, optional):
@@ -4150,31 +4170,31 @@ class WellboreMarkerFrame(BaseResqpy):
          if no marker is found for the interpretation object, None is returned
       """
 
-      if interpetation_obj is None and uuid is None:
-         return self.wellbore_marker_list
+        if interpetation_obj is None and uuid is None:
+            return self.wellbore_marker_list
 
-      if interpetation_obj is not None:
-         uuid = interpetation_obj.uuid
+        if interpetation_obj is not None:
+            uuid = interpetation_obj.uuid
 
-      for marker in self.wellbore_marker_list:
-         if bu.matching_uuids(marker[3].uuid, uuid):
-            return marker
+        for marker in self.wellbore_marker_list:
+            if bu.matching_uuids(marker[3].uuid, uuid):
+                return marker
 
-      return None
+        return None
 
-   def get_marker_count(self):
-      '''Retruns number of wellbore markers'''
+    def get_marker_count(self):
+        '''Retruns number of wellbore markers'''
 
-      return len(self.wellbore_marker_list)
+        return len(self.wellbore_marker_list)
 
-   def find_marker_from_index(self, idx):
-      '''Returns wellbore marker by index'''
+    def find_marker_from_index(self, idx):
+        '''Returns wellbore marker by index'''
 
-      return self.wellbore_marker_list[idx - 1]
+        return self.wellbore_marker_list[idx - 1]
 
 
 def add_las_to_trajectory(las: lasio.LASFile, trajectory, realization = None, check_well_name = False):
-   """Creates a WellLogCollection and WellboreFrame from a LAS file.
+    """Creates a WellLogCollection and WellboreFrame from a LAS file.
 
    Note:
       In this current implementation, the first curve in the las object must be
@@ -4194,183 +4214,183 @@ def add_las_to_trajectory(las: lasio.LASFile, trajectory, realization = None, ch
 
    """
 
-   # Lookup relevant related resqml parts
-   model = trajectory.model
-   well_interp = trajectory.wellbore_interpretation
-   well_title = well_interp.title
+    # Lookup relevant related resqml parts
+    model = trajectory.model
+    well_interp = trajectory.wellbore_interpretation
+    well_title = well_interp.title
 
-   if check_well_name and well_title != las.well.WELL.value:
-      warnings.warn(f'LAS well title {las.well.WELL.value} does not match resqml tite {well_title}')
+    if check_well_name and well_title != las.well.WELL.value:
+        warnings.warn(f'LAS well title {las.well.WELL.value} does not match resqml tite {well_title}')
 
-   # Create a new wellbore frame, using depth data from first curve in las file
-   depth_values = np.array(las.index).copy()
-   assert isinstance(depth_values, np.ndarray)
-   las_depth_uom = bwam.rq_length_unit(las.curves[0].unit)
+    # Create a new wellbore frame, using depth data from first curve in las file
+    depth_values = np.array(las.index).copy()
+    assert isinstance(depth_values, np.ndarray)
+    las_depth_uom = bwam.rq_length_unit(las.curves[0].unit)
 
-   # Ensure depth units are correct
-   bwam.convert_lengths(depth_values, from_units = las_depth_uom, to_units = trajectory.md_uom)
-   assert len(depth_values) > 0
+    # Ensure depth units are correct
+    bwam.convert_lengths(depth_values, from_units = las_depth_uom, to_units = trajectory.md_uom)
+    assert len(depth_values) > 0
 
-   well_frame = WellboreFrame(
-      parent_model = model,
-      trajectory = trajectory,
-      mds = depth_values,
-      represented_interp = well_interp,
-   )
-   well_frame.write_hdf5()
-   well_frame.create_xml()
+    well_frame = WellboreFrame(
+        parent_model = model,
+        trajectory = trajectory,
+        mds = depth_values,
+        represented_interp = well_interp,
+    )
+    well_frame.write_hdf5()
+    well_frame.create_xml()
 
-   # Create a WellLogCollection in which to put logs
-   collection = rqp.WellLogCollection(frame = well_frame, realization = realization)
+    # Create a WellLogCollection in which to put logs
+    collection = rqp.WellLogCollection(frame = well_frame, realization = realization)
 
-   # Read in data from each curve in turn (skipping first curve which has depths)
-   for curve in las.curves[1:]:
+    # Read in data from each curve in turn (skipping first curve which has depths)
+    for curve in las.curves[1:]:
 
-      collection.add_log(
-         title = curve.mnemonic,
-         data = curve.data,
-         unit = curve.unit,
-         realization = realization,
-         write = False,
-      )
-      collection.write_hdf5_for_imported_list()
-      collection.create_xml_for_imported_list_and_add_parts_to_model()
+        collection.add_log(
+            title = curve.mnemonic,
+            data = curve.data,
+            unit = curve.unit,
+            realization = realization,
+            write = False,
+        )
+        collection.write_hdf5_for_imported_list()
+        collection.create_xml_for_imported_list_and_add_parts_to_model()
 
-   return collection, well_frame
+    return collection, well_frame
 
 
 def add_logs_from_cellio(blockedwell, cellio):
-   """Creates a WellIntervalPropertyCollection for a given BlockedWell, using a given cell I/O file.
+    """Creates a WellIntervalPropertyCollection for a given BlockedWell, using a given cell I/O file.
 
    Arguments:
       blockedwell: a resqml blockedwell object
       cellio: an ascii file exported from RMS containing blocked well geometry and logs. Must contain columns i_index, j_index and k_index, plus additional columns for logs to be imported.
    """
-   # Get the initial variables from the blocked well
-   assert isinstance(blockedwell, BlockedWell), 'Not a blocked wellbore object'
-   collection = rqp.WellIntervalPropertyCollection(frame = blockedwell)
-   well_name = blockedwell.trajectory.title.split(" ")[0]
-   grid = blockedwell.model.grid()
+    # Get the initial variables from the blocked well
+    assert isinstance(blockedwell, BlockedWell), 'Not a blocked wellbore object'
+    collection = rqp.WellIntervalPropertyCollection(frame = blockedwell)
+    well_name = blockedwell.trajectory.title.split(" ")[0]
+    grid = blockedwell.model.grid()
 
-   # Read the cell I/O file to get the available columns (cols) and the data (data), and write into a dataframe
-   with open(cellio, 'r') as fp:
-      wellfound = False
-      cols, data = [], []
-      for line in fp.readlines():
-         if line == "\n":
-            wellfound = False  # Blankline signifies end of well data
-         words = line.split()
-         if wellfound:
-            if len(words) > 2 and not words[0].isdigit():
-               cols.append(line)
+    # Read the cell I/O file to get the available columns (cols) and the data (data), and write into a dataframe
+    with open(cellio, 'r') as fp:
+        wellfound = False
+        cols, data = [], []
+        for line in fp.readlines():
+            if line == "\n":
+                wellfound = False  # Blankline signifies end of well data
+            words = line.split()
+            if wellfound:
+                if len(words) > 2 and not words[0].isdigit():
+                    cols.append(line)
+                else:
+                    if len(words) > 9:
+                        assert len(cols) == len(words), 'Number of columns found should match header of file'
+                        data.append(words)
+            if len(words) == 3:
+                if words[0].upper() == well_name.upper():
+                    wellfound = True
+        assert len(data) > 0 and len(cols) > 3, f"No data for well {well_name} found in file"
+        df = pd.DataFrame(data = data, columns = [x.split()[0] for x in cols])
+        df = df.apply(pd.to_numeric)
+        # Get the cell_indices from the grid for the given i/j/k
+        df['cell_indices'] = grid.natural_cell_indices(
+            np.array((df['k_index'] - 1, df['j_index'] - 1, df['i_index'] - 1), dtype = int).T)
+        df = df.drop(['i_index', 'j_index', 'k_index', 'x_in', 'y_in', 'z_in', 'x_out', 'y_out', 'z_out'], axis = 1)
+    assert (df['cell_indices'] == blockedwell.cell_indices
+           ).all(), 'Cell indices do not match between blocked well and log inputs'
+
+    # Work out if the data columns are continuous, categorical or discrete
+    type_dict = {}
+    lookup_dict = {}
+    for col in cols:
+        words = col.split()
+        if words[0] not in ['i_index', 'j_index', 'k_index', 'x_in', 'y_in', 'z_in', 'x_out', 'y_out', 'z_out']:
+            if words[1] == 'unit1':
+                type_dict[words[0]] = 'continuous'
+            elif words[1] == 'DISC' and not words[0] == 'ZONES':
+                type_dict[words[0]] = 'categorical'
+                lookup_dict[words[0]] = lookup_from_cellio(col, blockedwell.model)
+            elif words[1] == 'param' or words[0] == 'ZONES':
+                type_dict[words[0]] = 'discrete'
             else:
-               if len(words) > 9:
-                  assert len(cols) == len(words), 'Number of columns found should match header of file'
-                  data.append(words)
-         if len(words) == 3:
-            if words[0].upper() == well_name.upper():
-               wellfound = True
-      assert len(data) > 0 and len(cols) > 3, f"No data for well {well_name} found in file"
-      df = pd.DataFrame(data = data, columns = [x.split()[0] for x in cols])
-      df = df.apply(pd.to_numeric)
-      # Get the cell_indices from the grid for the given i/j/k
-      df['cell_indices'] = grid.natural_cell_indices(
-         np.array((df['k_index'] - 1, df['j_index'] - 1, df['i_index'] - 1), dtype = int).T)
-      df = df.drop(['i_index', 'j_index', 'k_index', 'x_in', 'y_in', 'z_in', 'x_out', 'y_out', 'z_out'], axis = 1)
-   assert (df['cell_indices'] == blockedwell.cell_indices
-          ).all(), 'Cell indices do not match between blocked well and log inputs'
+                raise TypeError(f'unrecognised data type for {col}')
 
-   # Work out if the data columns are continuous, categorical or discrete
-   type_dict = {}
-   lookup_dict = {}
-   for col in cols:
-      words = col.split()
-      if words[0] not in ['i_index', 'j_index', 'k_index', 'x_in', 'y_in', 'z_in', 'x_out', 'y_out', 'z_out']:
-         if words[1] == 'unit1':
-            type_dict[words[0]] = 'continuous'
-         elif words[1] == 'DISC' and not words[0] == 'ZONES':
-            type_dict[words[0]] = 'categorical'
-            lookup_dict[words[0]] = lookup_from_cellio(col, blockedwell.model)
-         elif words[1] == 'param' or words[0] == 'ZONES':
-            type_dict[words[0]] = 'discrete'
-         else:
-            raise TypeError(f'unrecognised data type for {col}')
-
-   # Loop over the columns, adding them to the blockedwell property collection
-   for log in df.columns:
-      if log not in ['cell_indices']:
-         data_type = type_dict[log]
-         if log == 'ZONES':
-            data_type, dtype, null, discrete = 'discrete', int, -1, True
-         elif data_type == 'continuous':
-            dtype, null, discrete = float, np.nan, False
-         else:
-            dtype, null, discrete = int, -1, True
-         if data_type == 'categorical':
-            lookup_uuid = lookup_dict[log]  # For categorical data, find or generate a StringLookupTable
-         else:
-            lookup_uuid = None
-         array_list = np.zeros((np.shape(blockedwell.grid_indices)), dtype = dtype)
-         vals = list(df[log])
-         for i, index in enumerate(blockedwell.cell_grid_link):
-            if index == -1:
-               assert blockedwell.grid_indices[i] == -1
-               array_list[i] = null
+    # Loop over the columns, adding them to the blockedwell property collection
+    for log in df.columns:
+        if log not in ['cell_indices']:
+            data_type = type_dict[log]
+            if log == 'ZONES':
+                data_type, dtype, null, discrete = 'discrete', int, -1, True
+            elif data_type == 'continuous':
+                dtype, null, discrete = float, np.nan, False
             else:
-               if blockedwell.cell_indices[index] == list(df['cell_indices'])[index]:
-                  array_list[i] = vals[index]
-         collection.add_cached_array_to_imported_list(
-            cached_array = array_list,
-            source_info = '',
-            keyword = f"{os.path.basename(cellio).split('.')[0]}.{blockedwell.trajectory.title}.{log}",
-            discrete = discrete,
-            uom = None,
-            property_kind = None,
-            facet = None,
-            null_value = null,
-            facet_type = None,
-            realization = None)
-         collection.write_hdf5_for_imported_list()
-         collection.create_xml_for_imported_list_and_add_parts_to_model(string_lookup_uuid = lookup_uuid)
+                dtype, null, discrete = int, -1, True
+            if data_type == 'categorical':
+                lookup_uuid = lookup_dict[log]  # For categorical data, find or generate a StringLookupTable
+            else:
+                lookup_uuid = None
+            array_list = np.zeros((np.shape(blockedwell.grid_indices)), dtype = dtype)
+            vals = list(df[log])
+            for i, index in enumerate(blockedwell.cell_grid_link):
+                if index == -1:
+                    assert blockedwell.grid_indices[i] == -1
+                    array_list[i] = null
+                else:
+                    if blockedwell.cell_indices[index] == list(df['cell_indices'])[index]:
+                        array_list[i] = vals[index]
+            collection.add_cached_array_to_imported_list(
+                cached_array = array_list,
+                source_info = '',
+                keyword = f"{os.path.basename(cellio).split('.')[0]}.{blockedwell.trajectory.title}.{log}",
+                discrete = discrete,
+                uom = None,
+                property_kind = None,
+                facet = None,
+                null_value = null,
+                facet_type = None,
+                realization = None)
+            collection.write_hdf5_for_imported_list()
+            collection.create_xml_for_imported_list_and_add_parts_to_model(string_lookup_uuid = lookup_uuid)
 
 
 def lookup_from_cellio(line, model):
-   """Create a StringLookup Object from a cell I/O row containing a categorical column name and details.
+    """Create a StringLookup Object from a cell I/O row containing a categorical column name and details.
    Arguments:
       line: a string from a cell I/O file, containing the column (log) name, type and categorical information
       model: the model to add the StringTableLookup to
    Returns:
       uuid: the uuid of a StringTableLookup, either for a newly created table, or for an existing table if an identical one exists
    """
-   lookup_dict = {}
-   value, string = None, None
-   # Generate a dictionary of values and strings
-   for i, word in enumerate(line.split()):
-      if i == 0:
-         title = word
-      elif not i < 2:
-         if value is not None and string is not None:
-            lookup_dict[value] = string
-            value, string = None, None
-         if value is None:
-            value = int(word)
-         else:
-            if i == len(line.split()) - 1:
-               lookup_dict[value] = word
+    lookup_dict = {}
+    value, string = None, None
+    # Generate a dictionary of values and strings
+    for i, word in enumerate(line.split()):
+        if i == 0:
+            title = word
+        elif not i < 2:
+            if value is not None and string is not None:
+                lookup_dict[value] = string
+                value, string = None, None
+            if value is None:
+                value = int(word)
             else:
-               string = word
+                if i == len(line.split()) - 1:
+                    lookup_dict[value] = word
+                else:
+                    string = word
 
-   # Check if a StringLookupTable already exists in the model, with the same name and values
-   for existing in model.parts_list_of_type('obj_StringTableLookup'):
-      table = rqp.StringLookup(parent_model = model, root_node = model.root_for_part(existing))
-      if table.title == title:
-         if table.str_dict == lookup_dict:
-            return table.uuid  # If the exact table exists, reuse it by returning the uuid
+    # Check if a StringLookupTable already exists in the model, with the same name and values
+    for existing in model.parts_list_of_type('obj_StringTableLookup'):
+        table = rqp.StringLookup(parent_model = model, root_node = model.root_for_part(existing))
+        if table.title == title:
+            if table.str_dict == lookup_dict:
+                return table.uuid  # If the exact table exists, reuse it by returning the uuid
 
-   # If no matching StringLookupTable exists, make a new one and return the uuid
-   lookup = rqp.StringLookup(parent_model = model, int_to_str_dict = lookup_dict, title = title)
-   lookup.create_xml(add_as_part = True)
-   return lookup.uuid
+    # If no matching StringLookupTable exists, make a new one and return the uuid
+    lookup = rqp.StringLookup(parent_model = model, int_to_str_dict = lookup_dict, title = title)
+    lookup.create_xml(add_as_part = True)
+    return lookup.uuid
 
 
 def add_wells_from_ascii_file(model,
@@ -4386,7 +4406,7 @@ def add_wells_from_ascii_file(model,
                               length_uom = 'm',
                               md_domain = None,
                               drilled = False):
-   """Creates new md datum, trajectory, interpretation and feature objects for each well in an ascii file.
+    """Creates new md datum, trajectory, interpretation and feature objects for each well in an ascii file.
 
    arguments:
       crs_uuid (uuid.UUID): the unique identifier of the coordinate reference system applicable to the x,y,z data;
@@ -4418,87 +4438,89 @@ def add_wells_from_ascii_file(model,
       generally affect computations
    """
 
-   assert md_col and x_col and y_col and z_col
-   md_col = str(md_col)
-   x_col = str(x_col)
-   y_col = str(y_col)
-   z_col = str(z_col)
-   if crs_uuid is None:
-      crs_uuid = model.crs_uuid
-   assert crs_uuid is not None, 'coordinate reference system not found when trying to add wells'
+    assert md_col and x_col and y_col and z_col
+    md_col = str(md_col)
+    x_col = str(x_col)
+    y_col = str(y_col)
+    z_col = str(z_col)
+    if crs_uuid is None:
+        crs_uuid = model.crs_uuid
+    assert crs_uuid is not None, 'coordinate reference system not found when trying to add wells'
 
-   try:
-      df = pd.read_csv(trajectory_file, comment = comment_character, delim_whitespace = space_separated_instead_of_csv)
-      if df is None:
-         raise Exception
-   except Exception:
-      log.error('failed to read ascii deviation survey file: ' + str(trajectory_file))
-      raise
-   if well_col and well_col not in df.columns:
-      log.warning('well column ' + str(well_col) + ' not found in ascii trajectory file: ' + str(trajectory_file))
-      well_col = None
-   if well_col is None:
-      for col in df.columns:
-         if str(col).upper().startswith('WELL'):
-            well_col = str(col)
-            break
-   else:
-      well_col = str(well_col)
-   assert well_col
-   unique_wells = set(df[well_col])
-   if len(unique_wells) == 0:
-      log.warning('no well data found in ascii trajectory file: ' + str(trajectory_file))
-      # note: empty lists will be returned, below
+    try:
+        df = pd.read_csv(trajectory_file,
+                         comment = comment_character,
+                         delim_whitespace = space_separated_instead_of_csv)
+        if df is None:
+            raise Exception
+    except Exception:
+        log.error('failed to read ascii deviation survey file: ' + str(trajectory_file))
+        raise
+    if well_col and well_col not in df.columns:
+        log.warning('well column ' + str(well_col) + ' not found in ascii trajectory file: ' + str(trajectory_file))
+        well_col = None
+    if well_col is None:
+        for col in df.columns:
+            if str(col).upper().startswith('WELL'):
+                well_col = str(col)
+                break
+    else:
+        well_col = str(well_col)
+    assert well_col
+    unique_wells = set(df[well_col])
+    if len(unique_wells) == 0:
+        log.warning('no well data found in ascii trajectory file: ' + str(trajectory_file))
+        # note: empty lists will be returned, below
 
-   feature_list = []
-   interpretation_list = []
-   trajectory_list = []
-   md_datum_list = []
+    feature_list = []
+    interpretation_list = []
+    trajectory_list = []
+    md_datum_list = []
 
-   for well_name in unique_wells:
+    for well_name in unique_wells:
 
-      log.debug('importing well: ' + str(well_name))
-      # create single well data frame (assumes measured depths increasing)
-      well_df = df[df[well_col] == well_name]
-      # create a measured depth datum for the well and add as part
-      first_row = well_df.iloc[0]
-      if first_row[md_col] == 0.0:
-         md_datum = MdDatum(model,
-                            crs_uuid = crs_uuid,
-                            location = (first_row[x_col], first_row[y_col], first_row[z_col]))
-      else:
-         md_datum = MdDatum(model, crs_uuid = crs_uuid,
-                            location = (first_row[x_col], first_row[y_col], 0.0))  # sea level datum
-      md_datum.create_xml(title = str(well_name))
-      md_datum_list.append(md_datum)
+        log.debug('importing well: ' + str(well_name))
+        # create single well data frame (assumes measured depths increasing)
+        well_df = df[df[well_col] == well_name]
+        # create a measured depth datum for the well and add as part
+        first_row = well_df.iloc[0]
+        if first_row[md_col] == 0.0:
+            md_datum = MdDatum(model,
+                               crs_uuid = crs_uuid,
+                               location = (first_row[x_col], first_row[y_col], first_row[z_col]))
+        else:
+            md_datum = MdDatum(model, crs_uuid = crs_uuid,
+                               location = (first_row[x_col], first_row[y_col], 0.0))  # sea level datum
+        md_datum.create_xml(title = str(well_name))
+        md_datum_list.append(md_datum)
 
-      # create a well feature and add as part
-      feature = rqo.WellboreFeature(model, feature_name = well_name)
-      feature.create_xml()
-      feature_list.append(feature)
+        # create a well feature and add as part
+        feature = rqo.WellboreFeature(model, feature_name = well_name)
+        feature.create_xml()
+        feature_list.append(feature)
 
-      # create interpretation and add as part
-      interpretation = rqo.WellboreInterpretation(model, is_drilled = drilled, wellbore_feature = feature)
-      interpretation.create_xml(title_suffix = None)
-      interpretation_list.append(interpretation)
+        # create interpretation and add as part
+        interpretation = rqo.WellboreInterpretation(model, is_drilled = drilled, wellbore_feature = feature)
+        interpretation.create_xml(title_suffix = None)
+        interpretation_list.append(interpretation)
 
-      # create trajectory, write arrays to hdf5 and add as part
-      trajectory = Trajectory(model,
-                              md_datum = md_datum,
-                              data_frame = well_df,
-                              length_uom = length_uom,
-                              md_domain = md_domain,
-                              represented_interp = interpretation,
-                              well_name = well_name)
-      trajectory.write_hdf5()
-      trajectory.create_xml(title = well_name)
-      trajectory_list.append(trajectory)
+        # create trajectory, write arrays to hdf5 and add as part
+        trajectory = Trajectory(model,
+                                md_datum = md_datum,
+                                data_frame = well_df,
+                                length_uom = length_uom,
+                                md_domain = md_domain,
+                                represented_interp = interpretation,
+                                well_name = well_name)
+        trajectory.write_hdf5()
+        trajectory.create_xml(title = well_name)
+        trajectory_list.append(trajectory)
 
-   return (feature_list, interpretation_list, trajectory_list, md_datum_list)
+    return (feature_list, interpretation_list, trajectory_list, md_datum_list)
 
 
 def well_name(well_object, model = None):
-   """Returns the 'best' citation title from the object or related well objects.
+    """Returns the 'best' citation title from the object or related well objects.
 
    arguments:
       well_object (object, uuid or root): Object for which a well name is required. Can be a
@@ -4513,142 +4535,142 @@ def well_name(well_object, model = None):
       xml and relationships must be established for this function to work
    """
 
-   def better_root(model, root_a, root_b):
-      a = rqet.citation_title_for_node(root_a)
-      b = rqet.citation_title_for_node(root_b)
-      if a is None or len(a) == 0:
-         return root_b
-      if b is None or len(b) == 0:
-         return root_a
-      parts_like_a = model.parts(title = a)
-      parts_like_b = model.parts(title = b)
-      if len(parts_like_a) > 1 and len(parts_like_b) == 1:
-         return root_b
-      elif len(parts_like_b) > 1 and len(parts_like_a) == 1:
-         return root_a
-      a_digits = 0
-      for c in a:
-         if c.isdigit():
-            a_digits += 1
-      b_digits = 0
-      for c in b:
-         if c.isdigit():
-            b_digits += 1
-      if a_digits < b_digits:
-         return root_b
-      return root_a
+    def better_root(model, root_a, root_b):
+        a = rqet.citation_title_for_node(root_a)
+        b = rqet.citation_title_for_node(root_b)
+        if a is None or len(a) == 0:
+            return root_b
+        if b is None or len(b) == 0:
+            return root_a
+        parts_like_a = model.parts(title = a)
+        parts_like_b = model.parts(title = b)
+        if len(parts_like_a) > 1 and len(parts_like_b) == 1:
+            return root_b
+        elif len(parts_like_b) > 1 and len(parts_like_a) == 1:
+            return root_a
+        a_digits = 0
+        for c in a:
+            if c.isdigit():
+                a_digits += 1
+        b_digits = 0
+        for c in b:
+            if c.isdigit():
+                b_digits += 1
+        if a_digits < b_digits:
+            return root_b
+        return root_a
 
-   def best_root(model, roots_list):
-      if len(roots_list) == 0:
-         return None
-      if len(roots_list) == 1:
-         return roots_list[0]
-      if len(roots_list) == 2:
-         return better_root(model, roots_list[0], roots_list[1])
-      return better_root(model, roots_list[0], best_root(model, roots_list[1:]))
+    def best_root(model, roots_list):
+        if len(roots_list) == 0:
+            return None
+        if len(roots_list) == 1:
+            return roots_list[0]
+        if len(roots_list) == 2:
+            return better_root(model, roots_list[0], roots_list[1])
+        return better_root(model, roots_list[0], best_root(model, roots_list[1:]))
 
-   def best_root_for_object(well_object, model = None):
+    def best_root_for_object(well_object, model = None):
 
-      if well_object is None:
-         return None
-      if model is None:
-         model = well_object.model
-      root_list = []
-      obj_root = None
-      obj_uuid = None
-      obj_type = None
-      traj_root = None
+        if well_object is None:
+            return None
+        if model is None:
+            model = well_object.model
+        root_list = []
+        obj_root = None
+        obj_uuid = None
+        obj_type = None
+        traj_root = None
 
-      if isinstance(well_object, str):
-         obj_uuid = bu.uuid_from_string(well_object)
-         assert obj_uuid is not None, 'well_name string argument could not be interpreted as uuid'
-         well_object = obj_uuid
-      if isinstance(well_object, bu.uuid.UUID):
-         obj_uuid = well_object
-         obj_root = model.root_for_uuid(obj_uuid)
-         assert obj_root is not None, 'uuid not found in model when looking for well name'
-         obj_type = rqet.node_type(obj_root)
-      elif rqet.is_node(well_object):
-         obj_root = well_object
-         obj_type = rqet.node_type(obj_root)
-         obj_uuid = rqet.uuid_for_part_root(obj_root)
-      elif isinstance(well_object, Trajectory):
-         obj_type = 'WellboreTrajectoryRepresentation'
-         traj_root = well_object.root
-      elif isinstance(well_object, rqo.WellboreFeature):
-         obj_type = 'WellboreFeature'
-      elif isinstance(well_object, rqo.WellboreInterpretation):
-         obj_type = 'WellboreInterpretation'
-      elif isinstance(well_object, BlockedWell):
-         obj_type = 'BlockedWellboreRepresentation'
-         if well_object.trajectory is not None:
-            traj_root = well_object.trajectory.root
-      elif isinstance(well_object, WellboreMarkerFrame):  # note: trajectory might be None
-         obj_type = 'WellboreMarkerFrameRepresentation'
-         if well_object.trajectory is not None:
-            traj_root = well_object.trajectory.root
-      elif isinstance(well_object, WellboreFrame):  # note: trajectory might be None
-         obj_type = 'WellboreFrameRepresentation'
-         if well_object.trajectory is not None:
-            traj_root = well_object.trajectory.root
-      elif isinstance(well_object, DeviationSurvey):
-         obj_type = 'DeviationSurveyRepresentation'
-      elif isinstance(well_object, MdDatum):
-         obj_type = 'MdDatum'
+        if isinstance(well_object, str):
+            obj_uuid = bu.uuid_from_string(well_object)
+            assert obj_uuid is not None, 'well_name string argument could not be interpreted as uuid'
+            well_object = obj_uuid
+        if isinstance(well_object, bu.uuid.UUID):
+            obj_uuid = well_object
+            obj_root = model.root_for_uuid(obj_uuid)
+            assert obj_root is not None, 'uuid not found in model when looking for well name'
+            obj_type = rqet.node_type(obj_root)
+        elif rqet.is_node(well_object):
+            obj_root = well_object
+            obj_type = rqet.node_type(obj_root)
+            obj_uuid = rqet.uuid_for_part_root(obj_root)
+        elif isinstance(well_object, Trajectory):
+            obj_type = 'WellboreTrajectoryRepresentation'
+            traj_root = well_object.root
+        elif isinstance(well_object, rqo.WellboreFeature):
+            obj_type = 'WellboreFeature'
+        elif isinstance(well_object, rqo.WellboreInterpretation):
+            obj_type = 'WellboreInterpretation'
+        elif isinstance(well_object, BlockedWell):
+            obj_type = 'BlockedWellboreRepresentation'
+            if well_object.trajectory is not None:
+                traj_root = well_object.trajectory.root
+        elif isinstance(well_object, WellboreMarkerFrame):  # note: trajectory might be None
+            obj_type = 'WellboreMarkerFrameRepresentation'
+            if well_object.trajectory is not None:
+                traj_root = well_object.trajectory.root
+        elif isinstance(well_object, WellboreFrame):  # note: trajectory might be None
+            obj_type = 'WellboreFrameRepresentation'
+            if well_object.trajectory is not None:
+                traj_root = well_object.trajectory.root
+        elif isinstance(well_object, DeviationSurvey):
+            obj_type = 'DeviationSurveyRepresentation'
+        elif isinstance(well_object, MdDatum):
+            obj_type = 'MdDatum'
 
-      assert obj_type is not None, 'argument type not recognized for well_name'
-      if obj_type.startswith('obj_'):
-         obj_type = obj_type[4:]
-      if obj_uuid is None:
-         obj_uuid = well_object.uuid
-         obj_root = model.root_for_uuid(obj_uuid)
+        assert obj_type is not None, 'argument type not recognized for well_name'
+        if obj_type.startswith('obj_'):
+            obj_type = obj_type[4:]
+        if obj_uuid is None:
+            obj_uuid = well_object.uuid
+            obj_root = model.root_for_uuid(obj_uuid)
 
-      if obj_type == 'WellboreFeature':
-         interp_parts = model.parts(obj_type = 'WellboreInterpretation')
-         interp_parts = model.parts_list_filtered_by_related_uuid(interp_parts, obj_uuid)
-         all_parts = interp_parts
-         all_traj_parts = model.parts(obj_type = 'WellboreTrajectoryRepresentation')
-         if interp_parts is not None:
-            for part in interp_parts:
-               traj_parts = model.parts_list_filtered_by_related_uuid(all_traj_parts, model.uuid_for_part(part))
-               all_parts += traj_parts
-         if all_parts is not None:
-            root_list = [model.root_for_part(part) for part in all_parts]
-      elif obj_type == 'WellboreInterpretation':
-         feat_roots = model.roots(obj_type = 'WellboreFeature', related_uuid = obj_uuid)  # should return one root
-         traj_roots = model.roots(obj_type = 'WellboreTrajectoryRepresentation', related_uuid = obj_uuid)
-         root_list = feat_roots + traj_roots
-      elif obj_type == 'WellboreTrajectoryRepresentation':
-         interp_parts = model.parts(obj_type = 'WellboreInterpretation')
-         interp_parts = model.parts_list_filtered_by_related_uuid(interp_parts, obj_uuid)
-         all_parts = interp_parts
-         all_feat_parts = model.parts(obj_type = 'WellboreFeature')
-         if interp_parts is not None:
-            for part in interp_parts:
-               feat_parts = model.parts_list_filtered_by_related_uuid(all_feat_parts, model.uuid_for_part(part))
-               all_parts += feat_parts
-         if all_parts is not None:
-            root_list = [model.root_for_part(part) for part in all_parts]
-      elif obj_type in [
-            'BlockedWellboreRepresentation', 'WellboreMarkerFrameRepresentation', 'WellboreFrameRepresentation'
-      ]:
-         if traj_root is None:
-            traj_root = model.root(obj_type = 'WellboreTrajectoryRepresentation', related_uuid = obj_uuid)
-         root_list = [best_root_for_object(traj_root, model = model)]
-      elif obj_type == 'DeviationSurveyRepresentation':
-         root_list = [best_root_for_object(model.root(obj_type = 'MdDatum', related_uuid = obj_uuid), model = model)]
-      elif obj_type == 'MdDatum':
-         pass
+        if obj_type == 'WellboreFeature':
+            interp_parts = model.parts(obj_type = 'WellboreInterpretation')
+            interp_parts = model.parts_list_filtered_by_related_uuid(interp_parts, obj_uuid)
+            all_parts = interp_parts
+            all_traj_parts = model.parts(obj_type = 'WellboreTrajectoryRepresentation')
+            if interp_parts is not None:
+                for part in interp_parts:
+                    traj_parts = model.parts_list_filtered_by_related_uuid(all_traj_parts, model.uuid_for_part(part))
+                    all_parts += traj_parts
+            if all_parts is not None:
+                root_list = [model.root_for_part(part) for part in all_parts]
+        elif obj_type == 'WellboreInterpretation':
+            feat_roots = model.roots(obj_type = 'WellboreFeature', related_uuid = obj_uuid)  # should return one root
+            traj_roots = model.roots(obj_type = 'WellboreTrajectoryRepresentation', related_uuid = obj_uuid)
+            root_list = feat_roots + traj_roots
+        elif obj_type == 'WellboreTrajectoryRepresentation':
+            interp_parts = model.parts(obj_type = 'WellboreInterpretation')
+            interp_parts = model.parts_list_filtered_by_related_uuid(interp_parts, obj_uuid)
+            all_parts = interp_parts
+            all_feat_parts = model.parts(obj_type = 'WellboreFeature')
+            if interp_parts is not None:
+                for part in interp_parts:
+                    feat_parts = model.parts_list_filtered_by_related_uuid(all_feat_parts, model.uuid_for_part(part))
+                    all_parts += feat_parts
+            if all_parts is not None:
+                root_list = [model.root_for_part(part) for part in all_parts]
+        elif obj_type in [
+                'BlockedWellboreRepresentation', 'WellboreMarkerFrameRepresentation', 'WellboreFrameRepresentation'
+        ]:
+            if traj_root is None:
+                traj_root = model.root(obj_type = 'WellboreTrajectoryRepresentation', related_uuid = obj_uuid)
+            root_list = [best_root_for_object(traj_root, model = model)]
+        elif obj_type == 'DeviationSurveyRepresentation':
+            root_list = [best_root_for_object(model.root(obj_type = 'MdDatum', related_uuid = obj_uuid), model = model)]
+        elif obj_type == 'MdDatum':
+            pass
 
-      root_list.append(obj_root)
+        root_list.append(obj_root)
 
-      return best_root(model, root_list)
+        return best_root(model, root_list)
 
-   return rqet.citation_title_for_node(best_root_for_object(well_object, model = model))
+    return rqet.citation_title_for_node(best_root_for_object(well_object, model = model))
 
 
 def add_blocked_wells_from_wellspec(model, grid, wellspec_file):
-   """Add a blocked well for each well in a Nexus WELLSPEC file.
+    """Add a blocked well for each well in a Nexus WELLSPEC file.
 
    arguments:
       model (model.Model object): model to which blocked wells are added
@@ -4663,29 +4685,29 @@ def add_blocked_wells_from_wellspec(model, grid, wellspec_file):
       'simulation' trajectory and measured depth datum objects will also be created
    """
 
-   well_list_dict = wsk.load_wellspecs(wellspec_file, column_list = None)
+    well_list_dict = wsk.load_wellspecs(wellspec_file, column_list = None)
 
-   count = 0
-   for well in well_list_dict:
-      log.info('processing well: ' + str(well))
-      bw = BlockedWell(model,
-                       grid = grid,
-                       wellspec_file = wellspec_file,
-                       well_name = well,
-                       check_grid_name = True,
-                       use_face_centres = True)
-      if not bw.node_count:  # failed to load from wellspec, eg. because of no perforations in grid
-         log.warning('no wellspec data loaded for well: ' + str(well))
-         continue
-      bw.write_hdf5(model.h5_file_name(), mode = 'a', create_for_trajectory_if_needed = True)
-      bw.create_xml(model.h5_uuid(), title = well)
-      count += 1
+    count = 0
+    for well in well_list_dict:
+        log.info('processing well: ' + str(well))
+        bw = BlockedWell(model,
+                         grid = grid,
+                         wellspec_file = wellspec_file,
+                         well_name = well,
+                         check_grid_name = True,
+                         use_face_centres = True)
+        if not bw.node_count:  # failed to load from wellspec, eg. because of no perforations in grid
+            log.warning('no wellspec data loaded for well: ' + str(well))
+            continue
+        bw.write_hdf5(model.h5_file_name(), mode = 'a', create_for_trajectory_if_needed = True)
+        bw.create_xml(model.h5_uuid(), title = well)
+        count += 1
 
-   log.info(f'{count} blocked wells created based on wellspec file: {wellspec_file}')
+    log.info(f'{count} blocked wells created based on wellspec file: {wellspec_file}')
 
 
 def extract_xyz(xyz_node):
-   """Extracts an x,y,z coordinate from a solitary point xml node.
+    """Extracts an x,y,z coordinate from a solitary point xml node.
 
       argument:
          xyz_node: the xml node representing the solitary point (in 3D space)
@@ -4694,97 +4716,97 @@ def extract_xyz(xyz_node):
          triple float: (x, y, z) coordinates as a tuple
    """
 
-   if xyz_node is None:
-      return None
-   xyz = np.zeros(3)
-   for axis in range(3):
-      xyz[axis] = rqet.find_tag_float(xyz_node, 'Coordinate' + str(axis + 1), must_exist = True)
-   return tuple(xyz)
+    if xyz_node is None:
+        return None
+    xyz = np.zeros(3)
+    for axis in range(3):
+        xyz[axis] = rqet.find_tag_float(xyz_node, 'Coordinate' + str(axis + 1), must_exist = True)
+    return tuple(xyz)
 
 
 def well_names_in_cellio_file(cellio_file):
-   """Returns a list of well names as found in the RMS blocked well export cell I/O file."""
+    """Returns a list of well names as found in the RMS blocked well export cell I/O file."""
 
-   well_list = []
-   with open(cellio_file, 'r') as fp:
-      while True:
-         kf.skip_blank_lines_and_comments(fp)
-         line = fp.readline()  # file format version number?
-         if line == '':
-            break  # end of file
-         fp.readline()  # 'Undefined'
-         words = fp.readline().split()
-         assert len(words), 'missing header info (well name) in cell I/O file'
-         well_list.append(words[0])
-         while not kf.blank_line(fp):
-            fp.readline()  # skip to block of data for next well
-   return well_list
+    well_list = []
+    with open(cellio_file, 'r') as fp:
+        while True:
+            kf.skip_blank_lines_and_comments(fp)
+            line = fp.readline()  # file format version number?
+            if line == '':
+                break  # end of file
+            fp.readline()  # 'Undefined'
+            words = fp.readline().split()
+            assert len(words), 'missing header info (well name) in cell I/O file'
+            well_list.append(words[0])
+            while not kf.blank_line(fp):
+                fp.readline()  # skip to block of data for next well
+    return well_list
 
 
 # 'private' functions
 
 
 def load_hdf5_array(object, node, array_attribute, tag = 'Values', dtype = 'float', model = None):
-   """Loads the property array data as an attribute of object, from the hdf5 referenced in xml node.
+    """Loads the property array data as an attribute of object, from the hdf5 referenced in xml node.
 
       :meta private:
    """
 
-   assert (rqet.node_type(node) in ['DoubleHdf5Array', 'IntegerHdf5Array', 'Point3dHdf5Array'])
-   if model is None:
-      model = object.model
-   h5_key_pair = model.h5_uuid_and_path_for_node(node, tag = tag)
-   if h5_key_pair is None:
-      return None
-   return model.h5_array_element(h5_key_pair,
-                                 index = None,
-                                 cache_array = True,
-                                 dtype = dtype,
-                                 object = object,
-                                 array_attribute = array_attribute)
+    assert (rqet.node_type(node) in ['DoubleHdf5Array', 'IntegerHdf5Array', 'Point3dHdf5Array'])
+    if model is None:
+        model = object.model
+    h5_key_pair = model.h5_uuid_and_path_for_node(node, tag = tag)
+    if h5_key_pair is None:
+        return None
+    return model.h5_array_element(h5_key_pair,
+                                  index = None,
+                                  cache_array = True,
+                                  dtype = dtype,
+                                  object = object,
+                                  array_attribute = array_attribute)
 
 
 def find_entry_and_exit(cp, entry_vector, exit_vector, well_name):
-   """Returns (entry_axis, entry_polarity, entry_xyz, exit_axis, exit_polarity, exit_xyz).
+    """Returns (entry_axis, entry_polarity, entry_xyz, exit_axis, exit_polarity, exit_xyz).
 
       :meta private:
    """
 
-   cell_centre = np.mean(cp, axis = (0, 1, 2))
-   face_triangles = gf.triangles_for_cell_faces(cp).reshape(-1, 3, 3)  # flattened first index 4 values per face
-   entry_points = intersect.line_triangles_intersects(cell_centre, entry_vector, face_triangles, line_segment = True)
-   entry_axis = entry_polarity = entry_xyz = exit_xyz = None
-   for t in range(24):
-      if not np.any(np.isnan(entry_points[t])):
-         entry_xyz = entry_points[t]
-         entry_axis = t // 8
-         entry_polarity = (t - 8 * entry_axis) // 4
-         break
-   assert entry_axis is not None, 'failed to find entry face for a perforation in well ' + str(well_name)
-   exit_points = intersect.line_triangles_intersects(cell_centre, exit_vector, face_triangles, line_segment = True)
-   exit_axis = exit_polarity = None
-   for t in range(24):
-      if not np.any(np.isnan(exit_points[t])):
-         exit_xyz = entry_points[t]
-         exit_axis = t // 8
-         exit_polarity = (t - 8 * exit_axis) // 4
-         break
-   assert exit_axis is not None, 'failed to find exit face for a perforation in well ' + str(well_name)
+    cell_centre = np.mean(cp, axis = (0, 1, 2))
+    face_triangles = gf.triangles_for_cell_faces(cp).reshape(-1, 3, 3)  # flattened first index 4 values per face
+    entry_points = intersect.line_triangles_intersects(cell_centre, entry_vector, face_triangles, line_segment = True)
+    entry_axis = entry_polarity = entry_xyz = exit_xyz = None
+    for t in range(24):
+        if not np.any(np.isnan(entry_points[t])):
+            entry_xyz = entry_points[t]
+            entry_axis = t // 8
+            entry_polarity = (t - 8 * entry_axis) // 4
+            break
+    assert entry_axis is not None, 'failed to find entry face for a perforation in well ' + str(well_name)
+    exit_points = intersect.line_triangles_intersects(cell_centre, exit_vector, face_triangles, line_segment = True)
+    exit_axis = exit_polarity = None
+    for t in range(24):
+        if not np.any(np.isnan(exit_points[t])):
+            exit_xyz = entry_points[t]
+            exit_axis = t // 8
+            exit_polarity = (t - 8 * exit_axis) // 4
+            break
+    assert exit_axis is not None, 'failed to find exit face for a perforation in well ' + str(well_name)
 
-   return (entry_axis, entry_polarity, entry_xyz, exit_axis, exit_polarity, exit_xyz)
+    return (entry_axis, entry_polarity, entry_xyz, exit_axis, exit_polarity, exit_xyz)
 
 
 def _as_optional_array(arr):
-   """If not None, cast as numpy array.
+    """If not None, cast as numpy array.
 
    Casting directly to an array can be problematic:
    np.array(None) creates an unsized array, which is potentially confusing.
    """
-   if arr is None:
-      return None
-   else:
-      return np.array(arr)
+    if arr is None:
+        return None
+    else:
+        return np.array(arr)
 
 
 def _pl(i, e = False):
-   return '' if i == 1 else 'es' if e else 's'
+    return '' if i == 1 else 'es' if e else 's'

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,7 @@ ignore_missing_imports = True
 
 [yapf]
 based_on_style = google
-indent_width = 3
-continuation_indent_width = 3
+indent_width = 4
+continuation_indent_width = 4
 spaces_around_default_or_named_assign = True
 column_limit = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,108 +20,108 @@ import resqpy.property as rqp
 
 @pytest.fixture(autouse = True)
 def capture_logs(caplog):
-   """Always capture log messages from respy"""
+    """Always capture log messages from respy"""
 
-   caplog.set_level(logging.DEBUG, logger = "resqpy")
+    caplog.set_level(logging.DEBUG, logger = "resqpy")
 
 
 @pytest.fixture
 def tmp_model(tmp_path):
-   """Example resqpy model in a temporary directory unique to each test"""
+    """Example resqpy model in a temporary directory unique to each test"""
 
-   return new_model(str(tmp_path / 'tmp_model.epc'))
+    return new_model(str(tmp_path / 'tmp_model.epc'))
 
 
 @pytest.fixture
 def example_model_and_crs(tmp_model):
-   """ Returns a fresh RESQML Model and Crs, in a temporary directory """
+    """ Returns a fresh RESQML Model and Crs, in a temporary directory """
 
-   # TODO: parameterise with m or feet
-   xyz_uom = 'm'
+    # TODO: parameterise with m or feet
+    xyz_uom = 'm'
 
-   # Create a model with a coordinate reference system
-   crs = Crs(parent_model = tmp_model, z_inc_down = True, xy_units = xyz_uom, z_units = xyz_uom)
-   crs.create_xml()
+    # Create a model with a coordinate reference system
+    crs = Crs(parent_model = tmp_model, z_inc_down = True, xy_units = xyz_uom, z_units = xyz_uom)
+    crs.create_xml()
 
-   return tmp_model, crs
+    return tmp_model, crs
 
 
 @pytest.fixture
 def example_model_with_well(example_model_and_crs):
-   """ Model with a single well with a vertical trajectory """
+    """ Model with a single well with a vertical trajectory """
 
-   wellname = 'well A'
-   elevation = 100
-   md_uom = 'm'
+    wellname = 'well A'
+    elevation = 100
+    md_uom = 'm'
 
-   model, crs = example_model_and_crs
+    model, crs = example_model_and_crs
 
-   # Create a single well feature and interpretation
-   well_feature = WellboreFeature(parent_model = model, feature_name = wellname)
-   well_feature.create_xml()
-   well_interp = WellboreInterpretation(parent_model = model, wellbore_feature = well_feature, is_drilled = True)
-   well_interp.create_xml()
+    # Create a single well feature and interpretation
+    well_feature = WellboreFeature(parent_model = model, feature_name = wellname)
+    well_feature.create_xml()
+    well_interp = WellboreInterpretation(parent_model = model, wellbore_feature = well_feature, is_drilled = True)
+    well_interp.create_xml()
 
-   # Create a measured depth datum
-   datum = MdDatum(parent_model = model,
-                   crs_uuid = crs.uuid,
-                   location = (0, 0, -elevation),
-                   md_reference = 'kelly bushing')
-   datum.create_xml()
+    # Create a measured depth datum
+    datum = MdDatum(parent_model = model,
+                    crs_uuid = crs.uuid,
+                    location = (0, 0, -elevation),
+                    md_reference = 'kelly bushing')
+    datum.create_xml()
 
-   # Create trajectory of a vertical well
-   mds = np.array([0, 1000, 2000])
-   zs = mds - elevation
-   traj = Trajectory(parent_model = model,
-                     md_datum = datum,
-                     data_frame = pd.DataFrame(dict(MD = mds, X = 0, Y = 0, Z = zs)),
-                     length_uom = md_uom,
-                     represented_interp = well_interp)
-   traj.write_hdf5(mode = 'w')
-   traj.create_xml()
+    # Create trajectory of a vertical well
+    mds = np.array([0, 1000, 2000])
+    zs = mds - elevation
+    traj = Trajectory(parent_model = model,
+                      md_datum = datum,
+                      data_frame = pd.DataFrame(dict(MD = mds, X = 0, Y = 0, Z = zs)),
+                      length_uom = md_uom,
+                      represented_interp = well_interp)
+    traj.write_hdf5(mode = 'w')
+    traj.create_xml()
 
-   return model, well_interp, datum, traj
+    return model, well_interp, datum, traj
 
 
 @pytest.fixture
 def example_model_with_logs(example_model_with_well):
 
-   model, well_interp, datum, traj = example_model_with_well
+    model, well_interp, datum, traj = example_model_with_well
 
-   frame = WellboreFrame(
-      model,
-      trajectory = traj,
-      represented_interp = well_interp,
-      mds = [1, 2, 3, 4],
-   )
-   frame.write_hdf5()
-   frame.create_xml(title = 'Log run A')
+    frame = WellboreFrame(
+        model,
+        trajectory = traj,
+        represented_interp = well_interp,
+        mds = [1, 2, 3, 4],
+    )
+    frame.write_hdf5()
+    frame.create_xml(title = 'Log run A')
 
-   log_collection = frame.logs
-   log_collection.add_log("GR", [1, 2, 1, 2], 'gAPI')
-   log_collection.add_log("NPHI", [0.1, 0.1, np.NaN, np.NaN], 'v/v')
+    log_collection = frame.logs
+    log_collection.add_log("GR", [1, 2, 1, 2], 'gAPI')
+    log_collection.add_log("NPHI", [0.1, 0.1, np.NaN, np.NaN], 'v/v')
 
-   return model, well_interp, datum, traj, frame, log_collection
+    return model, well_interp, datum, traj, frame, log_collection
 
 
 @pytest.fixture
 def test_data_path(tmp_path):
-   """ Return pathlib.Path pointing to temporary copy of tests/example_data
+    """ Return pathlib.Path pointing to temporary copy of tests/example_data
 
    Use a fresh temporary directory for each test.
    """
-   master_path = (Path(__file__) / '../test_data').resolve()
-   data_path = Path(tmp_path) / 'test_data'
+    master_path = (Path(__file__) / '../test_data').resolve()
+    data_path = Path(tmp_path) / 'test_data'
 
-   assert master_path.exists()
-   assert not data_path.exists()
-   copytree(str(master_path), str(data_path))
-   return data_path
+    assert master_path.exists()
+    assert not data_path.exists()
+    copytree(str(master_path), str(data_path))
+    return data_path
 
 
 @pytest.fixture
 def example_model_with_properties(tmp_path):
-   """Model with a grid (5x5x3) and properties.
+    """Model with a grid (5x5x3) and properties.
    Properties:
    - Zone (discrete)
    - VPC (discrete)
@@ -131,68 +131,68 @@ def example_model_with_properties(tmp_path):
    - POR (continuous)
    - SW (continuous)
    """
-   model_path = str(tmp_path / 'test_no_rels.epc')
-   model = Model(create_basics = True, create_hdf5_ext = True, epc_file = model_path, new_epc = True)
-   model.store_epc(model.epc_file)
+    model_path = str(tmp_path / 'test_no_rels.epc')
+    model = Model(create_basics = True, create_hdf5_ext = True, epc_file = model_path, new_epc = True)
+    model.store_epc(model.epc_file)
 
-   grid = grr.RegularGrid(parent_model = model,
-                          origin = (0, 0, 0),
-                          extent_kji = (3, 5, 5),
-                          crs_uuid = rqet.uuid_for_part_root(model.crs_root),
-                          set_points_cached = True)
-   grid.cache_all_geometry_arrays()
-   grid.write_hdf5_from_caches(file = model.h5_file_name(file_must_exist = False), mode = 'w')
+    grid = grr.RegularGrid(parent_model = model,
+                           origin = (0, 0, 0),
+                           extent_kji = (3, 5, 5),
+                           crs_uuid = rqet.uuid_for_part_root(model.crs_root),
+                           set_points_cached = True)
+    grid.cache_all_geometry_arrays()
+    grid.write_hdf5_from_caches(file = model.h5_file_name(file_must_exist = False), mode = 'w')
 
-   grid.create_xml(ext_uuid = model.h5_uuid(),
-                   title = 'grid',
-                   write_geometry = True,
-                   add_cell_length_properties = False)
-   model.store_epc()
+    grid.create_xml(ext_uuid = model.h5_uuid(),
+                    title = 'grid',
+                    write_geometry = True,
+                    add_cell_length_properties = False)
+    model.store_epc()
 
-   zone = np.ones(shape = (5, 5))
-   zone_array = np.array([zone, zone + 1, zone + 2])
+    zone = np.ones(shape = (5, 5))
+    zone_array = np.array([zone, zone + 1, zone + 2])
 
-   vpc = np.array([[1, 1, 1, 2, 2], [1, 1, 1, 2, 2], [1, 1, 1, 2, 2], [1, 1, 1, 2, 2], [1, 1, 1, 2, 2]])
-   vpc_array = np.array([vpc, vpc, vpc])
+    vpc = np.array([[1, 1, 1, 2, 2], [1, 1, 1, 2, 2], [1, 1, 1, 2, 2], [1, 1, 1, 2, 2], [1, 1, 1, 2, 2]])
+    vpc_array = np.array([vpc, vpc, vpc])
 
-   facies = np.array([[1, 1, 1, 2, 2], [1, 1, 2, 2, 2], [1, 2, 2, 2, 3], [2, 2, 2, 3, 3], [2, 2, 3, 3, 3]])
-   facies_array = np.array([facies, facies, facies])
+    facies = np.array([[1, 1, 1, 2, 2], [1, 1, 2, 2, 2], [1, 2, 2, 2, 3], [2, 2, 2, 3, 3], [2, 2, 3, 3, 3]])
+    facies_array = np.array([facies, facies, facies])
 
-   fb = np.array([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2]])
-   fb_array = np.array([fb, fb, fb])
+    fb = np.array([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2]])
+    fb_array = np.array([fb, fb, fb])
 
-   ntg = np.array([[0, 0.5, 0, 0.5, 0], [0.5, 0, 0.5, 0, 0.5], [0, 0.5, 0, 0.5, 0], [0.5, 0, 0.5, 0, 0.5],
-                   [0, 0.5, 0, 0.5, 0]])
-   ntg_array = np.array([ntg, ntg, ntg])
+    ntg = np.array([[0, 0.5, 0, 0.5, 0], [0.5, 0, 0.5, 0, 0.5], [0, 0.5, 0, 0.5, 0], [0.5, 0, 0.5, 0, 0.5],
+                    [0, 0.5, 0, 0.5, 0]])
+    ntg_array = np.array([ntg, ntg, ntg])
 
-   por = np.array([[1, 1, 1, 1, 1], [0.5, 0.5, 0.5, 0.5, 0.5], [1, 1, 1, 1, 1], [0.5, 0.5, 0.5, 0.5, 0.5],
-                   [1, 1, 1, 1, 1]])
-   por_array = np.array([por, por, por])
+    por = np.array([[1, 1, 1, 1, 1], [0.5, 0.5, 0.5, 0.5, 0.5], [1, 1, 1, 1, 1], [0.5, 0.5, 0.5, 0.5, 0.5],
+                    [1, 1, 1, 1, 1]])
+    por_array = np.array([por, por, por])
 
-   sat = np.array([[1, 0.5, 1, 0.5, 1], [1, 0.5, 1, 0.5, 1], [1, 0.5, 1, 0.5, 1], [1, 0.5, 1, 0.5, 1],
-                   [1, 0.5, 1, 0.5, 1]])
-   sat_array = np.array([sat, sat, sat])
+    sat = np.array([[1, 0.5, 1, 0.5, 1], [1, 0.5, 1, 0.5, 1], [1, 0.5, 1, 0.5, 1], [1, 0.5, 1, 0.5, 1],
+                    [1, 0.5, 1, 0.5, 1]])
+    sat_array = np.array([sat, sat, sat])
 
-   collection = rqp.GridPropertyCollection()
-   collection.set_grid(grid)
-   for array, name, kind, discrete in zip(
-      [zone_array, vpc_array, fb_array, facies_array, ntg_array, por_array, sat_array],
-      ['Zone', 'VPC', 'Fault block', 'Facies', 'NTG', 'POR', 'SW'],
-      ['discrete', 'discrete', 'discrete', 'discrete', 'net to gross ratio', 'porosity', 'saturation'],
-      [True, True, True, True, False, False, False]):
-      collection.add_cached_array_to_imported_list(cached_array = array,
-                                                   source_info = '',
-                                                   keyword = name,
-                                                   discrete = discrete,
-                                                   uom = None,
-                                                   time_index = None,
-                                                   null_value = None,
-                                                   property_kind = kind,
-                                                   facet_type = None,
-                                                   facet = None,
-                                                   realization = None)
-      collection.write_hdf5_for_imported_list()
-      collection.create_xml_for_imported_list_and_add_parts_to_model()
-   model.store_epc()
+    collection = rqp.GridPropertyCollection()
+    collection.set_grid(grid)
+    for array, name, kind, discrete in zip(
+        [zone_array, vpc_array, fb_array, facies_array, ntg_array, por_array, sat_array],
+        ['Zone', 'VPC', 'Fault block', 'Facies', 'NTG', 'POR', 'SW'],
+        ['discrete', 'discrete', 'discrete', 'discrete', 'net to gross ratio', 'porosity', 'saturation'],
+        [True, True, True, True, False, False, False]):
+        collection.add_cached_array_to_imported_list(cached_array = array,
+                                                     source_info = '',
+                                                     keyword = name,
+                                                     discrete = discrete,
+                                                     uom = None,
+                                                     time_index = None,
+                                                     null_value = None,
+                                                     property_kind = kind,
+                                                     facet_type = None,
+                                                     facet = None,
+                                                     realization = None)
+        collection.write_hdf5_for_imported_list()
+        collection.create_xml_for_imported_list_and_add_parts_to_model()
+    model.store_epc()
 
-   return model
+    return model

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,109 +3,109 @@ from resqpy.olio.base import BaseResqpy
 
 
 class DummyObj(BaseResqpy):
-   resqml_type = 'DummyResqmlInterpretation'
+    resqml_type = 'DummyResqmlInterpretation'
 
 
 class ReusableDummyObj(BaseResqpy):
-   resqml_type = 'ReusableDummyResqmlInterpretation'
+    resqml_type = 'ReusableDummyResqmlInterpretation'
 
-   # a class must have this method to allow meaningful reusability
-   def is_equivalent(self, other):
-      return True
+    # a class must have this method to allow meaningful reusability
+    def is_equivalent(self, other):
+        return True
 
 
 def test_base_creation(tmp_model):
 
-   # Setup new object
-   title = 'Wondermuffin'
-   dummy = DummyObj(model = tmp_model, title = title)
+    # Setup new object
+    title = 'Wondermuffin'
+    dummy = DummyObj(model = tmp_model, title = title)
 
-   # UUID should exist
-   # but root should not exist yet and part name does not exist in the parent model
-   assert dummy.uuid is not None
-   #   assert dummy.part is not None  # this version constructed the part from resqml_type and uuid
-   assert dummy.part is None
-   assert dummy.root is None
+    # UUID should exist
+    # but root should not exist yet and part name does not exist in the parent model
+    assert dummy.uuid is not None
+    #   assert dummy.part is not None  # this version constructed the part from resqml_type and uuid
+    assert dummy.part is None
+    assert dummy.root is None
 
-   # After creating XML, root should exist
-   dummy.create_xml(add_as_part = True)
-   assert dummy.root is not None
+    # After creating XML, root should exist
+    dummy.create_xml(add_as_part = True)
+    assert dummy.root is not None
 
 
 def test_base_save_and_load(tmp_model):
 
-   # Create and save a DummyObj
-   title = 'feefifofum'
-   originator = 'Scruffian'
-   metadata = {"balderdash": "pumpernickel"}
-   dummy1 = DummyObj(model = tmp_model, title = title, originator = originator)
-   dummy1.extra_metadata = metadata
+    # Create and save a DummyObj
+    title = 'feefifofum'
+    originator = 'Scruffian'
+    metadata = {"balderdash": "pumpernickel"}
+    dummy1 = DummyObj(model = tmp_model, title = title, originator = originator)
+    dummy1.extra_metadata = metadata
 
-   # Save to XML
-   dummy1.create_xml(add_as_part = True)
+    # Save to XML
+    dummy1.create_xml(add_as_part = True)
 
-   # Load a new object
-   dummy2 = DummyObj(model = tmp_model, uuid = dummy1.uuid)
+    # Load a new object
+    dummy2 = DummyObj(model = tmp_model, uuid = dummy1.uuid)
 
-   # Properties should match
-   assert bu.matching_uuids(dummy2.uuid, dummy1.uuid)
-   assert dummy2.root is not None
-   assert dummy2.title == title
-   assert dummy2.originator == originator
-   assert dummy2.extra_metadata == metadata
+    # Properties should match
+    assert bu.matching_uuids(dummy2.uuid, dummy1.uuid)
+    assert dummy2.root is not None
+    assert dummy2.title == title
+    assert dummy2.originator == originator
+    assert dummy2.extra_metadata == metadata
 
 
 def test_base_comparison(tmp_model):
 
-   # Setup new object
-   dummy1 = DummyObj(model = tmp_model)
-   dummy2 = DummyObj(model = tmp_model, uuid = dummy1.uuid)  # Same UUID
-   dummy3 = DummyObj(model = tmp_model, title = 'hello')  # Different UUID
+    # Setup new object
+    dummy1 = DummyObj(model = tmp_model)
+    dummy2 = DummyObj(model = tmp_model, uuid = dummy1.uuid)  # Same UUID
+    dummy3 = DummyObj(model = tmp_model, title = 'hello')  # Different UUID
 
-   # Comparison should work by UUID
-   assert dummy1 == dummy2
-   assert dummy1 != dummy3
+    # Comparison should work by UUID
+    assert dummy1 == dummy2
+    assert dummy1 != dummy3
 
 
 def test_base_repr(tmp_model):
 
-   dummy = DummyObj(model = tmp_model)
+    dummy = DummyObj(model = tmp_model)
 
-   # Check repr method produces a string
-   rep = repr(dummy)
-   assert isinstance(rep, str)
-   assert len(rep) > 0
+    # Check repr method produces a string
+    rep = repr(dummy)
+    assert isinstance(rep, str)
+    assert len(rep) > 0
 
-   # Check HTML can be generated
-   html = dummy._repr_html_()
-   assert len(html) > 0
+    # Check HTML can be generated
+    html = dummy._repr_html_()
+    assert len(html) > 0
 
 
 def test_base_reuse_duplicate(tmp_model):
 
-   # Create object and save
-   dummy_1 = ReusableDummyObj(model = tmp_model)
-   assert not dummy_1.try_reuse()
-   dummy_1.create_xml(add_as_part = True)
+    # Create object and save
+    dummy_1 = ReusableDummyObj(model = tmp_model)
+    assert not dummy_1.try_reuse()
+    dummy_1.create_xml(add_as_part = True)
 
-   # Should be present in model
-   uuids = tmp_model.uuids(obj_type = ReusableDummyObj.resqml_type)
-   assert len(uuids) == 1
-   assert dummy_1.try_reuse()  # after a part has had xml created and added to model, it is reusable
+    # Should be present in model
+    uuids = tmp_model.uuids(obj_type = ReusableDummyObj.resqml_type)
+    assert len(uuids) == 1
+    assert dummy_1.try_reuse()  # after a part has had xml created and added to model, it is reusable
 
-   # Create duplicate object
-   dummy_2 = ReusableDummyObj(model = tmp_model)
-   assert not bu.matching_uuids(dummy_1.uuid, dummy_2.uuid)
-   assert dummy_2.try_reuse()  # should have matched dummy_1
-   assert bu.matching_uuids(dummy_1.uuid, dummy_2.uuid)
+    # Create duplicate object
+    dummy_2 = ReusableDummyObj(model = tmp_model)
+    assert not bu.matching_uuids(dummy_1.uuid, dummy_2.uuid)
+    assert dummy_2.try_reuse()  # should have matched dummy_1
+    assert bu.matching_uuids(dummy_1.uuid, dummy_2.uuid)
 
-   # Only one 'RESQML' object should exist in model, despite us having two resqpy objects
-   uuids = tmp_model.uuids(obj_type = ReusableDummyObj.resqml_type)
-   assert len(uuids) == 1
-   assert bu.matching_uuids(uuids[0], dummy_2.uuid)
+    # Only one 'RESQML' object should exist in model, despite us having two resqpy objects
+    uuids = tmp_model.uuids(obj_type = ReusableDummyObj.resqml_type)
+    assert len(uuids) == 1
+    assert bu.matching_uuids(uuids[0], dummy_2.uuid)
 
 
 def test_append_extra_metadata(tmp_model):
-   dummy = ReusableDummyObj(model = tmp_model, extra_metadata = {'fruit': 'apple', 'animal': 'alpaca'})
-   dummy.append_extra_metadata({'fruit': 'pear'})
-   assert dummy.extra_metadata == {'fruit': 'pear', 'animal': 'alpaca'}, 'did not append dictionary correctly'
+    dummy = ReusableDummyObj(model = tmp_model, extra_metadata = {'fruit': 'apple', 'animal': 'alpaca'})
+    dummy.append_extra_metadata({'fruit': 'pear'})
+    assert dummy.extra_metadata == {'fruit': 'pear', 'animal': 'alpaca'}, 'did not append dictionary correctly'

--- a/tests/test_box_utilities.py
+++ b/tests/test_box_utilities.py
@@ -8,89 +8,90 @@ import resqpy.olio.box_utilities as bx
 
 def test_box_utilities():
 
-   # some example boxes to test against, together with expected extents
-   b1 = np.array([[0, 0, 0], [3, 4, 5]], dtype = int)
-   e1 = np.array([4, 5, 6], dtype = int)
-   b2 = np.array([[1, 1, 1], [2, 3, 4]], dtype = int)
-   e2 = np.array([2, 3, 4], dtype = int)
-   b3 = np.array([[5, 3, 2], [5, 5, 5]], dtype = int)
-   e3 = np.array([1, 3, 4], dtype = int)
-   b4 = np.array([[3, 3, 3], [4, 4, 4]], dtype = int)
-   e4 = np.array([2, 2, 2], dtype = int)
+    # some example boxes to test against, together with expected extents
+    b1 = np.array([[0, 0, 0], [3, 4, 5]], dtype = int)
+    e1 = np.array([4, 5, 6], dtype = int)
+    b2 = np.array([[1, 1, 1], [2, 3, 4]], dtype = int)
+    e2 = np.array([2, 3, 4], dtype = int)
+    b3 = np.array([[5, 3, 2], [5, 5, 5]], dtype = int)
+    e3 = np.array([1, 3, 4], dtype = int)
+    b4 = np.array([[3, 3, 3], [4, 4, 4]], dtype = int)
+    e4 = np.array([2, 2, 2], dtype = int)
 
-   # check extents and logical 'volume' of boxes
-   for b, e in zip((b1, b2, b3, b4), (e1, e2, e3, e4)):
-      assert np.all(bx.extent_of_box(b) == e)
-      assert bx.volume_of_box(b) == e[0] * e[1] * e[2]
+    # check extents and logical 'volume' of boxes
+    for b, e in zip((b1, b2, b3, b4), (e1, e2, e3, e4)):
+        assert np.all(bx.extent_of_box(b) == e)
+        assert bx.volume_of_box(b) == e[0] * e[1] * e[2]
 
-   # check logically central cell indices against these expected values
-   c1 = np.array([1, 2, 2], dtype = int)
-   c2 = np.array([1, 2, 2], dtype = int)
-   c3 = np.array([5, 4, 3], dtype = int)
-   c4 = np.array([3, 3, 3], dtype = int)
-   for b, c in zip((b1, b2, b3, b4), (c1, c2, c3, c4)):
-      assert np.all(bx.central_cell(b) == c)
+    # check logically central cell indices against these expected values
+    c1 = np.array([1, 2, 2], dtype = int)
+    c2 = np.array([1, 2, 2], dtype = int)
+    c3 = np.array([5, 4, 3], dtype = int)
+    c4 = np.array([3, 3, 3], dtype = int)
+    for b, c in zip((b1, b2, b3, b4), (c1, c2, c3, c4)):
+        assert np.all(bx.central_cell(b) == c)
 
-   # test functions for converting to and from simulator format strings
-   assert bx.string_iijjkk1_for_box_kji0(b2) == '[2:5, 2:4, 2:3]'
-   assert bx.spaced_string_iijjkk1_for_box_kji0(b1) == '1 6  1 5  1 4'
-   assert bx.spaced_string_iijjkk1_for_box_kji0(b3, colon_separator = '-') == '3-6  4-6  6-6'
-   assert np.all(b4 == bx.box_kji0_from_words_iijjkk1(bx.spaced_string_iijjkk1_for_box_kji0(b4).split()))
+    # test functions for converting to and from simulator format strings
+    assert bx.string_iijjkk1_for_box_kji0(b2) == '[2:5, 2:4, 2:3]'
+    assert bx.spaced_string_iijjkk1_for_box_kji0(b1) == '1 6  1 5  1 4'
+    assert bx.spaced_string_iijjkk1_for_box_kji0(b3, colon_separator = '-') == '3-6  4-6  6-6'
+    assert np.all(b4 == bx.box_kji0_from_words_iijjkk1(bx.spaced_string_iijjkk1_for_box_kji0(b4).split()))
 
-   # test cell inclusion function
-   assert bx.cell_in_box(np.array([0, 0, 0], dtype = int), b1)
-   assert bx.cell_in_box(np.array([2, 4, 3], dtype = int), b1)
-   assert not bx.cell_in_box(np.array([7, 7, 7], dtype = int), b1)
-   assert not bx.cell_in_box(np.array([1, 5, 3], dtype = int), b1)
-   assert not bx.cell_in_box(np.array([0, 0, 0], dtype = int), b2)
+    # test cell inclusion function
+    assert bx.cell_in_box(np.array([0, 0, 0], dtype = int), b1)
+    assert bx.cell_in_box(np.array([2, 4, 3], dtype = int), b1)
+    assert not bx.cell_in_box(np.array([7, 7, 7], dtype = int), b1)
+    assert not bx.cell_in_box(np.array([1, 5, 3], dtype = int), b1)
+    assert not bx.cell_in_box(np.array([0, 0, 0], dtype = int), b2)
 
-   # check behaviour of box validity function, which compares the box against an extent (of a grid)
-   assert bx.valid_box(b1, e1)
-   assert bx.valid_box(b3, np.array([7, 8, 9], dtype = int))
-   assert bx.valid_box(b3, np.array([6, 6, 6], dtype = int))
-   assert not bx.valid_box(b2, np.array([5, 3, 7], dtype = int))
+    # check behaviour of box validity function, which compares the box against an extent (of a grid)
+    assert bx.valid_box(b1, e1)
+    assert bx.valid_box(b3, np.array([7, 8, 9], dtype = int))
+    assert bx.valid_box(b3, np.array([6, 6, 6], dtype = int))
+    assert not bx.valid_box(b2, np.array([5, 3, 7], dtype = int))
 
-   # test the function for creating a box containing a single cell
-   assert np.all(
-      bx.single_cell_box(np.array([8, 0, 10], dtype = int)) == np.array([[8, 0, 10], [8, 0, 10]], dtype = int))
+    # test the function for creating a box containing a single cell
+    assert np.all(
+        bx.single_cell_box(np.array([8, 0, 10], dtype = int)) == np.array([[8, 0, 10], [8, 0, 10]], dtype = int))
 
-   # test the function for generating the box containing a full grid (from its extent)
-   assert np.all(bx.full_extent_box0(e1) == b1)
-   assert np.all(bx.full_extent_box0(np.array([7, 5, 3], dtype = int)) == np.array([[0, 0, 0], [6, 4, 2]], dtype = int))
+    # test the function for generating the box containing a full grid (from its extent)
+    assert np.all(bx.full_extent_box0(e1) == b1)
+    assert np.all(
+        bx.full_extent_box0(np.array([7, 5, 3], dtype = int)) == np.array([[0, 0, 0], [6, 4, 2]], dtype = int))
 
-   # check the function that finds the union of two boxes (the smallest box containing both the boxes)
-   assert np.all(bx.union(b1, b2) == b1)
-   assert np.all(bx.union(b2, b3) == np.array([[1, 1, 1], [5, 5, 5]], dtype = int))
-   assert np.all(bx.union(b3, b4) == np.array([[3, 3, 2], [5, 5, 5]], dtype = int))
-   for ba, bb in ((b1, b2), (b4, b1), (b2, b4)):
-      assert np.all(bx.union(ba, bb) == bx.union(bb, ba))
+    # check the function that finds the union of two boxes (the smallest box containing both the boxes)
+    assert np.all(bx.union(b1, b2) == b1)
+    assert np.all(bx.union(b2, b3) == np.array([[1, 1, 1], [5, 5, 5]], dtype = int))
+    assert np.all(bx.union(b3, b4) == np.array([[3, 3, 2], [5, 5, 5]], dtype = int))
+    for ba, bb in ((b1, b2), (b4, b1), (b2, b4)):
+        assert np.all(bx.union(ba, bb) == bx.union(bb, ba))
 
-   # test function for returning parent grid cell indices from a box and local indices within the box
-   cell = np.array((0, 2, 3), dtype = int)
-   assert np.all(bx.parent_cell_from_local_box_cell(b1, cell) == cell)
-   assert np.all(bx.parent_cell_from_local_box_cell(b2, cell) == cell + 1)
-   assert np.all(bx.parent_cell_from_local_box_cell(b3, cell) == (5, 5, 5))
+    # test function for returning parent grid cell indices from a box and local indices within the box
+    cell = np.array((0, 2, 3), dtype = int)
+    assert np.all(bx.parent_cell_from_local_box_cell(b1, cell) == cell)
+    assert np.all(bx.parent_cell_from_local_box_cell(b2, cell) == cell + 1)
+    assert np.all(bx.parent_cell_from_local_box_cell(b3, cell) == (5, 5, 5))
 
-   # test the inverse function which returns local cell indices within a box, given the parent cell indices
-   for b in (b1, b2, b3):
-      assert np.all(bx.local_box_cell_from_parent_cell(b, bx.parent_cell_from_local_box_cell(b, cell)) == cell)
+    # test the inverse function which returns local cell indices within a box, given the parent cell indices
+    for b in (b1, b2, b3):
+        assert np.all(bx.local_box_cell_from_parent_cell(b, bx.parent_cell_from_local_box_cell(b, cell)) == cell)
 
-   # the parent cell is outside the box in the following test
-   assert bx.local_box_cell_from_parent_cell(b3, cell) is None
+    # the parent cell is outside the box in the following test
+    assert bx.local_box_cell_from_parent_cell(b3, cell) is None
 
-   # test the function that returns a boolean indicating whether two boxes have any overlap
-   assert bx.boxes_overlap(b1, b2)
-   assert bx.boxes_overlap(b2, b1)
-   for ba, bb in ((b1, b3), (b2, b4), (b3, b4)):
-      assert not bx.boxes_overlap(ba, bb)
-      assert not bx.boxes_overlap(bb, ba)
+    # test the function that returns a boolean indicating whether two boxes have any overlap
+    assert bx.boxes_overlap(b1, b2)
+    assert bx.boxes_overlap(b2, b1)
+    for ba, bb in ((b1, b3), (b2, b4), (b3, b4)):
+        assert not bx.boxes_overlap(ba, bb)
+        assert not bx.boxes_overlap(bb, ba)
 
-   by = b1 + 2
-   assert bx.boxes_overlap(b1, by)
-   assert bx.boxes_overlap(by, b1)
+    by = b1 + 2
+    assert bx.boxes_overlap(b1, by)
+    assert bx.boxes_overlap(by, b1)
 
-   bz = b4 + 3
-   assert not bx.boxes_overlap(b1, bz)
-   assert not bx.boxes_overlap(bz, b2)
+    bz = b4 + 3
+    assert not bx.boxes_overlap(b1, bz)
+    assert not bx.boxes_overlap(bz, b2)
 
-   # todo: test box trimming functions
+    # todo: test box trimming functions

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -9,85 +9,85 @@ import resqpy.olio.uuid as bu
 
 def test_crs():
 
-   # create some coordinate reference systems
-   model = rq.Model(new_epc = True, create_basics = True)
-   crs_default = rqc.Crs(model)
-   assert crs_default.null_transform
-   crs_m = rqc.Crs(model, xy_units = 'm', z_units = 'm')
-   crs_ft = rqc.Crs(model, xy_units = 'ft', z_units = 'ft')
-   crs_mixed = rqc.Crs(model, xy_units = 'm', z_units = 'ft')
-   crs_offset = rqc.Crs(model, xy_units = 'm', z_units = 'm', x_offset = 100.0, y_offset = -100.0, z_offset = -50.0)
-   assert not crs_offset.null_transform
-   crs_elevation = rqc.Crs(model, z_inc_down = 'False')
+    # create some coordinate reference systems
+    model = rq.Model(new_epc = True, create_basics = True)
+    crs_default = rqc.Crs(model)
+    assert crs_default.null_transform
+    crs_m = rqc.Crs(model, xy_units = 'm', z_units = 'm')
+    crs_ft = rqc.Crs(model, xy_units = 'ft', z_units = 'ft')
+    crs_mixed = rqc.Crs(model, xy_units = 'm', z_units = 'ft')
+    crs_offset = rqc.Crs(model, xy_units = 'm', z_units = 'm', x_offset = 100.0, y_offset = -100.0, z_offset = -50.0)
+    assert not crs_offset.null_transform
+    crs_elevation = rqc.Crs(model, z_inc_down = 'False')
 
-   # check that distincitveness is recognised
-   assert crs_default.is_equivalent(crs_m)
-   assert not crs_m.is_equivalent(crs_ft)
-   assert not crs_mixed.is_equivalent(crs_m)
-   assert not crs_m.is_equivalent(crs_offset)
-   assert not crs_m.is_equivalent(crs_elevation)
+    # check that distincitveness is recognised
+    assert crs_default.is_equivalent(crs_m)
+    assert not crs_m.is_equivalent(crs_ft)
+    assert not crs_mixed.is_equivalent(crs_m)
+    assert not crs_m.is_equivalent(crs_offset)
+    assert not crs_m.is_equivalent(crs_elevation)
 
-   # create some xml
-   crs_m.create_xml()
-   crs_offset.create_xml()
+    # create some xml
+    crs_m.create_xml()
+    crs_offset.create_xml()
 
-   # test conversion
-   ft_to_m = 0.3048
+    # test conversion
+    ft_to_m = 0.3048
 
-   a = np.empty((10, 3))
-   a[:, 0] = np.random.random(10) * 5.0e5
-   a[:, 1] = np.random.random(10) * 10.0e5
-   a[:, 2] = np.random.random(10) * 4.0e3
+    a = np.empty((10, 3))
+    a[:, 0] = np.random.random(10) * 5.0e5
+    a[:, 1] = np.random.random(10) * 10.0e5
+    a[:, 2] = np.random.random(10) * 4.0e3
 
-   b = a.copy()
-   crs_m.convert_array_from(crs_default, a)
-   assert np.max(np.abs(b - a)) < 1.0e-6
-   a[:] = b
-   crs_m.convert_array_to(crs_m, a)
-   assert np.all(a == b)
-   crs_ft.convert_array_from(crs_m, a)
-   assert np.max(np.abs(b - a * ft_to_m)) < 1.0e-6
-   crs_ft.convert_array_to(crs_m, a)
-   assert np.max(np.abs(b - a)) < 1.0e-6
-   a[:] = b
-   crs_m.local_to_global_array(a)
-   assert np.max(np.abs(b - a)) < 1.0e-6
-   a[:] = b
-   crs_offset.global_to_local_array(a)
-   a[:, 0] += 100.0
-   a[:, 1] -= 100.0
-   a[:, 2] -= 50.0
-   assert np.max(np.abs(b - a)) < 1.0e-6
+    b = a.copy()
+    crs_m.convert_array_from(crs_default, a)
+    assert np.max(np.abs(b - a)) < 1.0e-6
+    a[:] = b
+    crs_m.convert_array_to(crs_m, a)
+    assert np.all(a == b)
+    crs_ft.convert_array_from(crs_m, a)
+    assert np.max(np.abs(b - a * ft_to_m)) < 1.0e-6
+    crs_ft.convert_array_to(crs_m, a)
+    assert np.max(np.abs(b - a)) < 1.0e-6
+    a[:] = b
+    crs_m.local_to_global_array(a)
+    assert np.max(np.abs(b - a)) < 1.0e-6
+    a[:] = b
+    crs_offset.global_to_local_array(a)
+    a[:, 0] += 100.0
+    a[:, 1] -= 100.0
+    a[:, 2] -= 50.0
+    assert np.max(np.abs(b - a)) < 1.0e-6
 
-   # todo: test rotation
+    # todo: test rotation
 
 
 def test_crs_reuse():
-   model = rq.Model(new_epc = True, create_basics = True)
-   crs_a = rqc.Crs(model)
-   crs_a.create_xml()
-   crs_b = rqc.Crs(model)
-   crs_b.create_xml()
-   assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 1
-   assert crs_a == crs_b
-   assert bu.matching_uuids(crs_a.uuid, crs_b.uuid)
-   crs_c = rqc.Crs(model, z_inc_down = False)
-   crs_c.create_xml()
-   assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 2
-   assert crs_c != crs_a
-   assert not bu.matching_uuids(crs_c.uuid, crs_a.uuid)
-   crs_d = rqc.Crs(model, z_units = 'ft')
-   crs_d.create_xml()
-   assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 3
-   crs_e = rqc.Crs(model, z_inc_down = False)
-   crs_e.create_xml()
-   assert len(model.uuids(obj_type = 'LocalDepth3dCrs')) == 3
-   assert crs_e == crs_c
-   assert bu.matching_uuids(crs_e.uuid, crs_c.uuid)
-   crs_f = rqc.Crs(model)
-   crs_f.create_xml(reuse = False)
-   assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 4
-   assert crs_f == crs_a
-   assert not bu.matching_uuids(crs_f.uuid, crs_a.uuid)
+    model = rq.Model(new_epc = True, create_basics = True)
+    crs_a = rqc.Crs(model)
+    crs_a.create_xml()
+    crs_b = rqc.Crs(model)
+    crs_b.create_xml()
+    assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 1
+    assert crs_a == crs_b
+    assert bu.matching_uuids(crs_a.uuid, crs_b.uuid)
+    crs_c = rqc.Crs(model, z_inc_down = False)
+    crs_c.create_xml()
+    assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 2
+    assert crs_c != crs_a
+    assert not bu.matching_uuids(crs_c.uuid, crs_a.uuid)
+    crs_d = rqc.Crs(model, z_units = 'ft')
+    crs_d.create_xml()
+    assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 3
+    crs_e = rqc.Crs(model, z_inc_down = False)
+    crs_e.create_xml()
+    assert len(model.uuids(obj_type = 'LocalDepth3dCrs')) == 3
+    assert crs_e == crs_c
+    assert bu.matching_uuids(crs_e.uuid, crs_c.uuid)
+    crs_f = rqc.Crs(model)
+    crs_f.create_xml(reuse = False)
+    assert len(model.parts(obj_type = 'LocalDepth3dCrs')) == 4
+    assert crs_f == crs_a
+    assert not bu.matching_uuids(crs_f.uuid, crs_a.uuid)
 
-   # todo: test parent epsg code equivalence
+    # todo: test parent epsg code equivalence

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -11,63 +11,63 @@ import resqpy.olio.dataframe as rqdf
 
 def test_dataframe(tmp_path):
 
-   epc = os.path.join(tmp_path, 'dataframe.epc')
+    epc = os.path.join(tmp_path, 'dataframe.epc')
 
-   model = rq.new_model(epc_file = epc)
+    model = rq.new_model(epc_file = epc)
 
-   np_df = np.array([[0.0, 0.0, 0.0], [1000.0, 0.0, 0.0], [1900.0, 100.0, 0.0], [2500.0, 500.0, 800.0],
-                     [3200.0, 1500.0, 1600.0]])
-   df_cols = ['COP', 'CWP', 'CWI']
-   col_units = ['m3', 'ft3', 'm3']
-   ts_list = ['2021-04-22', '2021-04-23', '2021-04-24', '2021-04-25', '2021-04-26']
+    np_df = np.array([[0.0, 0.0, 0.0], [1000.0, 0.0, 0.0], [1900.0, 100.0, 0.0], [2500.0, 500.0, 800.0],
+                      [3200.0, 1500.0, 1600.0]])
+    df_cols = ['COP', 'CWP', 'CWI']
+    col_units = ['m3', 'ft3', 'm3']
+    ts_list = ['2021-04-22', '2021-04-23', '2021-04-24', '2021-04-25', '2021-04-26']
 
-   df = pd.DataFrame(np_df, columns = df_cols)
+    df = pd.DataFrame(np_df, columns = df_cols)
 
-   vanilla = rqdf.DataFrame(model, df = df, title = 'vanilla')
-   vanilla.write_hdf5_and_create_xml()
+    vanilla = rqdf.DataFrame(model, df = df, title = 'vanilla')
+    vanilla.write_hdf5_and_create_xml()
 
-   ts = rqts.time_series_from_list(ts_list)
-   ts.set_model(model)
-   ts.create_xml()
+    ts = rqts.time_series_from_list(ts_list)
+    ts.set_model(model)
+    ts.create_xml()
 
-   timetable = rqdf.TimeTable(model, df = df, title = 'time table', time_series = ts)
-   timetable.write_hdf5_and_create_xml()
+    timetable = rqdf.TimeTable(model, df = df, title = 'time table', time_series = ts)
+    timetable.write_hdf5_and_create_xml()
 
-   propertied = rqdf.TimeTable(model, df = df, realization = 0, title = 'time table realisation', time_series = ts)
-   propertied.write_hdf5_and_create_xml()
+    propertied = rqdf.TimeTable(model, df = df, realization = 0, title = 'time table realisation', time_series = ts)
+    propertied.write_hdf5_and_create_xml()
 
-   united = rqdf.TimeTable(model,
-                           df = df,
-                           realization = 0,
-                           title = 'united realisation',
-                           uom_list = col_units,
-                           time_series = ts)
-   united.write_hdf5_and_create_xml()
+    united = rqdf.TimeTable(model,
+                            df = df,
+                            realization = 0,
+                            title = 'united realisation',
+                            uom_list = col_units,
+                            time_series = ts)
+    united.write_hdf5_and_create_xml()
 
-   model.store_epc()
-   model.h5_release()
-   del model
+    model.store_epc()
+    model.h5_release()
+    del model
 
-   model = rq.Model(epc)
-   df_roots = model.roots(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'})
-   assert len(df_roots) == 4
+    model = rq.Model(epc)
+    df_roots = model.roots(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'})
+    assert len(df_roots) == 4
 
-   v_uuid = model.uuid(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'}, title = 'vanilla')
-   dataframe = rqdf.DataFrame(model, uuid = v_uuid)
-   assert dataframe.n_cols == 3
-   assert dataframe.n_rows == 5
-   assert all(dataframe.dataframe() == df)
-   assert all(dataframe.dataframe().columns == df_cols)
+    v_uuid = model.uuid(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'}, title = 'vanilla')
+    dataframe = rqdf.DataFrame(model, uuid = v_uuid)
+    assert dataframe.n_cols == 3
+    assert dataframe.n_rows == 5
+    assert all(dataframe.dataframe() == df)
+    assert all(dataframe.dataframe().columns == df_cols)
 
-   tt_uuid = model.uuid(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'}, title = 'time table')
-   time_table = rqdf.TimeTable(model, uuid = tt_uuid)
-   assert time_table.time_series().timestamps == ts_list
-   assert all(time_table.dataframe() == df)
+    tt_uuid = model.uuid(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'}, title = 'time table')
+    time_table = rqdf.TimeTable(model, uuid = tt_uuid)
+    assert time_table.time_series().timestamps == ts_list
+    assert all(time_table.dataframe() == df)
 
-   u_uuid = model.uuid(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'}, title = 'united realisation')
-   ur = rqdf.TimeTable(model, uuid = u_uuid)
-   assert ur.uom_list == col_units
-   assert ur.time_series().timestamps == ts_list
+    u_uuid = model.uuid(obj_type = 'Grid2dRepresentation', extra = {'dataframe': 'true'}, title = 'united realisation')
+    ur = rqdf.TimeTable(model, uuid = u_uuid)
+    assert ur.uom_list == col_units
+    assert ur.time_series().timestamps == ts_list
 
-   # only dataframes with a realization number are stored as a property object
-   assert len(model.parts(obj_type = 'ContinuousProperty')) == 2
+    # only dataframes with a realization number are stored as a property object
+    assert len(model.parts(obj_type = 'ContinuousProperty')) == 2

--- a/tests/test_derived_model.py
+++ b/tests/test_derived_model.py
@@ -17,607 +17,608 @@ import resqpy.olio.box_utilities as bx
 
 def test_add_single_cell_grid(tmp_path):
 
-   epc = os.path.join(tmp_path, 'amoeba.epc')
+    epc = os.path.join(tmp_path, 'amoeba.epc')
 
-   points = np.array([(100.0, 250.0, -3500.0), (140.0, 200.0, -3700.0), (300.0, 400.0, -3600.0),
-                      (180.0, 300.0, -3800.0), (220.0, 350.0, -3750.0)])
-   expected_xyz_box = np.array([(100.0, 200.0, -3800.0), (300.0, 400.0, -3500.0)])
+    points = np.array([(100.0, 250.0, -3500.0), (140.0, 200.0, -3700.0), (300.0, 400.0, -3600.0),
+                       (180.0, 300.0, -3800.0), (220.0, 350.0, -3750.0)])
+    expected_xyz_box = np.array([(100.0, 200.0, -3800.0), (300.0, 400.0, -3500.0)])
 
-   # create a single cell grid containing points
-   rqdm.add_single_cell_grid(points, new_grid_title = 'Amoeba', new_epc_file = epc)
+    # create a single cell grid containing points
+    rqdm.add_single_cell_grid(points, new_grid_title = 'Amoeba', new_epc_file = epc)
 
-   # re-open model and have a quick look at the grid
-   model = rq.Model(epc)
-   assert model is not None
-   grid = grr.Grid(model, uuid = model.uuid(title = 'Amoeba'))
-   assert grid is not None
-   assert tuple(grid.extent_kji) == (1, 1, 1)
-   assert_array_almost_equal(grid.xyz_box(lazy = False), expected_xyz_box)
+    # re-open model and have a quick look at the grid
+    model = rq.Model(epc)
+    assert model is not None
+    grid = grr.Grid(model, uuid = model.uuid(title = 'Amoeba'))
+    assert grid is not None
+    assert tuple(grid.extent_kji) == (1, 1, 1)
+    assert_array_almost_equal(grid.xyz_box(lazy = False), expected_xyz_box)
 
 
 def test_add_zone_by_layer_property(tmp_path):
 
-   def check_zone_prop(z_prop):
-      assert z_prop is not None
-      assert not z_prop.is_continuous()
-      assert not z_prop.is_points()
-      assert z_prop.indexable_element() == 'layers'
-      lpk_uuid = z_prop.local_property_kind_uuid()
-      assert lpk_uuid is not None
-      lpk = rqp.PropertyKind(z_prop.model, uuid = lpk_uuid)
-      assert lpk.title == 'zone'
+    def check_zone_prop(z_prop):
+        assert z_prop is not None
+        assert not z_prop.is_continuous()
+        assert not z_prop.is_points()
+        assert z_prop.indexable_element() == 'layers'
+        lpk_uuid = z_prop.local_property_kind_uuid()
+        assert lpk_uuid is not None
+        lpk = rqp.PropertyKind(z_prop.model, uuid = lpk_uuid)
+        assert lpk.title == 'zone'
 
-   epc = os.path.join(tmp_path, 'in the zone.epc')
+    epc = os.path.join(tmp_path, 'in the zone.epc')
 
-   model = rq.new_model(epc)
+    model = rq.new_model(epc)
 
-   # create a basic block grid
-   grid = grr.RegularGrid(model, extent_kji = (4, 3, 2), title = 'In The Zone', set_points_cached = True)
-   grid.write_hdf5()
-   grid.create_xml(write_geometry = True)
-   grid_uuid = grid.uuid
+    # create a basic block grid
+    grid = grr.RegularGrid(model, extent_kji = (4, 3, 2), title = 'In The Zone', set_points_cached = True)
+    grid.write_hdf5()
+    grid.create_xml(write_geometry = True)
+    grid_uuid = grid.uuid
 
-   model.store_epc()
+    model.store_epc()
 
-   # add zone property based on an explicit vector (one value per layer)
-   zone_vector = (2, 7, 5, 7)
-   v, z_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
-                                               zone_by_layer_vector = (2, 7, 5, 7),
-                                               title = 'from vector')
-   assert tuple(v) == zone_vector
+    # add zone property based on an explicit vector (one value per layer)
+    zone_vector = (2, 7, 5, 7)
+    v, z_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
+                                                zone_by_layer_vector = (2, 7, 5, 7),
+                                                title = 'from vector')
+    assert tuple(v) == zone_vector
 
-   # check that zone property looks okay
-   model = rq.Model(epc)
-   z_prop = rqp.Property(model, uuid = z_uuid)
-   check_zone_prop(z_prop)
+    # check that zone property looks okay
+    model = rq.Model(epc)
+    z_prop = rqp.Property(model, uuid = z_uuid)
+    check_zone_prop(z_prop)
 
-   # add a neatly set up grid cells property
-   za = np.array((1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 5, 5, 5, 5, 5, 5),
-                 dtype = int).reshape(grid.extent_kji)
-   za_uuid = rqdm.add_one_grid_property_array(epc,
-                                              za,
-                                              discrete = True,
-                                              property_kind = 'code',
-                                              title = 'clean zone',
-                                              grid_uuid = grid_uuid,
-                                              null_value = -1)
-   assert za_uuid is not None
+    # add a neatly set up grid cells property
+    za = np.array((1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 5, 5, 5, 5, 5, 5),
+                  dtype = int).reshape(grid.extent_kji)
+    za_uuid = rqdm.add_one_grid_property_array(epc,
+                                               za,
+                                               discrete = True,
+                                               property_kind = 'code',
+                                               title = 'clean zone',
+                                               grid_uuid = grid_uuid,
+                                               null_value = -1)
+    assert za_uuid is not None
 
-   # add a zone by layer property based on the neat cells property
-   v, z_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
-                                               zone_by_cell_property_uuid = za_uuid,
-                                               title = 'from cells array')
-   assert tuple(v) == (1, 2, 3, 5)
-
-   # check that zone property looks okay
-   model = rq.Model(epc)
-   z_prop = rqp.Property(model, uuid = z_uuid)
-   check_zone_prop(z_prop)
-
-   # make the cells array less tidy and add another copy
-   za[1, 2, :] = 3
-   za_uuid = rqdm.add_one_grid_property_array(epc,
-                                              za,
-                                              discrete = True,
-                                              property_kind = 'code',
-                                              title = 'messy zone',
-                                              grid_uuid = grid_uuid,
-                                              null_value = -1)
-   assert za_uuid is not None
-
-   # fail to add a zone by layer property based on the messy cells property
-   with pytest.raises(Exception):
-      v, z2_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
-                                                   zone_by_cell_property_uuid = za_uuid,
-                                                   use_dominant_zone = False,
-                                                   title = 'should fail')
-
-   # add a zone by layer property based on the neat cells property
-   v, z3_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
+    # add a zone by layer property based on the neat cells property
+    v, z_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
                                                 zone_by_cell_property_uuid = za_uuid,
-                                                use_dominant_zone = True,
-                                                title = 'from messy cells array')
-   assert tuple(v) == (1, 2, 3, 5)
+                                                title = 'from cells array')
+    assert tuple(v) == (1, 2, 3, 5)
 
-   # check that zone property looks okay
-   model = rq.Model(epc)
-   grid = model.grid()
-   z_prop = rqp.Property(model, uuid = z3_uuid)
-   check_zone_prop(z_prop)
+    # check that zone property looks okay
+    model = rq.Model(epc)
+    z_prop = rqp.Property(model, uuid = z_uuid)
+    check_zone_prop(z_prop)
 
-   # create a zonal grid based on a (neat) zone property array
-   z_grid = rqdm.zonal_grid(epc,
-                            source_grid = grid,
-                            zone_uuid = z_uuid,
-                            use_dominant_zone = False,
-                            inactive_laissez_faire = True,
-                            new_grid_title = 'zonal grid')
-   assert z_grid is not None
-   assert z_grid.nk == 4
+    # make the cells array less tidy and add another copy
+    za[1, 2, :] = 3
+    za_uuid = rqdm.add_one_grid_property_array(epc,
+                                               za,
+                                               discrete = True,
+                                               property_kind = 'code',
+                                               title = 'messy zone',
+                                               grid_uuid = grid_uuid,
+                                               null_value = -1)
+    assert za_uuid is not None
 
-   # and another zonal grid based on the dominant zone
-   z3_grid = rqdm.zonal_grid(epc,
+    # fail to add a zone by layer property based on the messy cells property
+    with pytest.raises(Exception):
+        v, z2_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
+                                                     zone_by_cell_property_uuid = za_uuid,
+                                                     use_dominant_zone = False,
+                                                     title = 'should fail')
+
+    # add a zone by layer property based on the neat cells property
+    v, z3_uuid = rqdm.add_zone_by_layer_property(epc_file = epc,
+                                                 zone_by_cell_property_uuid = za_uuid,
+                                                 use_dominant_zone = True,
+                                                 title = 'from messy cells array')
+    assert tuple(v) == (1, 2, 3, 5)
+
+    # check that zone property looks okay
+    model = rq.Model(epc)
+    grid = model.grid()
+    z_prop = rqp.Property(model, uuid = z3_uuid)
+    check_zone_prop(z_prop)
+
+    # create a zonal grid based on a (neat) zone property array
+    z_grid = rqdm.zonal_grid(epc,
                              source_grid = grid,
-                             zone_uuid = za_uuid,
-                             use_dominant_zone = True,
-                             new_grid_title = 'dominant zone grid')
-   assert z3_grid is not None
-   assert z3_grid.nk == 4
+                             zone_uuid = z_uuid,
+                             use_dominant_zone = False,
+                             inactive_laissez_faire = True,
+                             new_grid_title = 'zonal grid')
+    assert z_grid is not None
+    assert z_grid.nk == 4
+
+    # and another zonal grid based on the dominant zone
+    z3_grid = rqdm.zonal_grid(epc,
+                              source_grid = grid,
+                              zone_uuid = za_uuid,
+                              use_dominant_zone = True,
+                              new_grid_title = 'dominant zone grid')
+    assert z3_grid is not None
+    assert z3_grid.nk == 4
 
 
 def test_single_layer_grid(tmp_path):
 
-   epc = os.path.join(tmp_path, 'squash.epc')
+    epc = os.path.join(tmp_path, 'squash.epc')
 
-   model = rq.new_model(epc)
+    model = rq.new_model(epc)
 
-   # create a basic block grid with geometry
-   grid = grr.RegularGrid(model,
-                          extent_kji = (4, 3, 2),
-                          origin = (1000.0, 2000.0, 3000.0),
-                          dxyz = (100.0, 130.0, 25.0),
-                          title = 'to be squashed',
-                          set_points_cached = True)
-   grid.write_hdf5()
-   grid.create_xml(write_geometry = True)
-   grid_uuid = grid.uuid
-   model.store_epc()
+    # create a basic block grid with geometry
+    grid = grr.RegularGrid(model,
+                           extent_kji = (4, 3, 2),
+                           origin = (1000.0, 2000.0, 3000.0),
+                           dxyz = (100.0, 130.0, 25.0),
+                           title = 'to be squashed',
+                           set_points_cached = True)
+    grid.write_hdf5()
+    grid.create_xml(write_geometry = True)
+    grid_uuid = grid.uuid
+    model.store_epc()
 
-   # create a single layer version of the grid
-   simplified = rqdm.single_layer_grid(epc, source_grid = grid, new_grid_title = 'squashed')
-   assert simplified is not None
-   simplified_uuid = simplified.uuid
+    # create a single layer version of the grid
+    simplified = rqdm.single_layer_grid(epc, source_grid = grid, new_grid_title = 'squashed')
+    assert simplified is not None
+    simplified_uuid = simplified.uuid
 
-   # re-open the model and load the new grid
-   model = rq.Model(epc)
-   s_uuid = model.uuid(obj_type = 'IjkGridRepresentation', title = 'squashed')
-   assert bu.matching_uuids(s_uuid, simplified_uuid)
-   simplified = grr.any_grid(model, uuid = s_uuid)
-   assert simplified.nk == 1
-   simplified.cache_all_geometry_arrays()
-   assert not simplified.has_split_coordinate_lines
-   assert simplified.points_cached.shape == (2, 4, 3, 3)
-   assert_array_almost_equal(simplified.points_cached[0, ..., 2], np.full((4, 3), 3000.0))
-   assert_array_almost_equal(simplified.points_cached[1, ..., 2], np.full((4, 3), 3100.0))
+    # re-open the model and load the new grid
+    model = rq.Model(epc)
+    s_uuid = model.uuid(obj_type = 'IjkGridRepresentation', title = 'squashed')
+    assert bu.matching_uuids(s_uuid, simplified_uuid)
+    simplified = grr.any_grid(model, uuid = s_uuid)
+    assert simplified.nk == 1
+    simplified.cache_all_geometry_arrays()
+    assert not simplified.has_split_coordinate_lines
+    assert simplified.points_cached.shape == (2, 4, 3, 3)
+    assert_array_almost_equal(simplified.points_cached[0, ..., 2], np.full((4, 3), 3000.0))
+    assert_array_almost_equal(simplified.points_cached[1, ..., 2], np.full((4, 3), 3100.0))
 
 
 def test_extract_box_for_well(tmp_path):
 
-   epc = os.path.join(tmp_path, 'tube.epc')
+    epc = os.path.join(tmp_path, 'tube.epc')
 
-   model = rq.new_model(epc)
+    model = rq.new_model(epc)
 
-   # create a basic block grid with geometry
-   grid = grr.RegularGrid(model,
-                          extent_kji = (3, 5, 7),
-                          origin = (0.0, 0.0, 1000.0),
-                          dxyz = (100.0, 100.0, 20.0),
-                          title = 'main grid',
-                          set_points_cached = True)
-   grid.write_hdf5()
-   grid.create_xml(write_geometry = True)
-   grid_uuid = grid.uuid
+    # create a basic block grid with geometry
+    grid = grr.RegularGrid(model,
+                           extent_kji = (3, 5, 7),
+                           origin = (0.0, 0.0, 1000.0),
+                           dxyz = (100.0, 100.0, 20.0),
+                           title = 'main grid',
+                           set_points_cached = True)
+    grid.write_hdf5()
+    grid.create_xml(write_geometry = True)
+    grid_uuid = grid.uuid
 
-   # create a couple of well trajectories
-   cells_visited = [(0, 1, 2), (1, 1, 2), (1, 1, 3), (1, 2, 3), (1, 2, 4), (2, 2, 4)]
-   traj_1 = rqw.Trajectory(model,
-                           grid = grid,
-                           cell_kji0_list = cells_visited,
-                           length_uom = 'm',
-                           spline_mode = 'linear',
-                           well_name = 'well 1')
-   traj_2 = rqw.Trajectory(model,
-                           grid = grid,
-                           cell_kji0_list = cells_visited,
-                           length_uom = 'm',
-                           spline_mode = 'cube',
-                           well_name = 'well 2')
-   for traj in (traj_1, traj_2):
-      traj.write_hdf5()
-      traj.create_xml()
-   traj_1_uuid = traj_1.uuid
-   traj_2_uuid = traj_2.uuid
+    # create a couple of well trajectories
+    cells_visited = [(0, 1, 2), (1, 1, 2), (1, 1, 3), (1, 2, 3), (1, 2, 4), (2, 2, 4)]
+    traj_1 = rqw.Trajectory(model,
+                            grid = grid,
+                            cell_kji0_list = cells_visited,
+                            length_uom = 'm',
+                            spline_mode = 'linear',
+                            well_name = 'well 1')
+    traj_2 = rqw.Trajectory(model,
+                            grid = grid,
+                            cell_kji0_list = cells_visited,
+                            length_uom = 'm',
+                            spline_mode = 'cube',
+                            well_name = 'well 2')
+    for traj in (traj_1, traj_2):
+        traj.write_hdf5()
+        traj.create_xml()
+    traj_1_uuid = traj_1.uuid
+    traj_2_uuid = traj_2.uuid
 
-   # create a blocked well for one of the trajectories
-   assert traj_2.root is not None
-   bw = rqw.BlockedWell(model, grid = grid, trajectory = traj_2)
-   bw.write_hdf5()
-   bw.create_xml()
-   bw_uuid = bw.uuid
+    # create a blocked well for one of the trajectories
+    assert traj_2.root is not None
+    bw = rqw.BlockedWell(model, grid = grid, trajectory = traj_2)
+    bw.write_hdf5()
+    bw.create_xml()
+    bw_uuid = bw.uuid
 
-   # store source model
-   model.store_epc()
+    # store source model
+    model.store_epc()
 
-   # extract box for linear trajectory
-   grid_1, box_1 = rqdm.extract_box_for_well(epc_file = epc,
-                                             source_grid = grid,
-                                             trajectory_uuid = traj_1_uuid,
-                                             radius = 120.0,
-                                             active_cells_shape = 'tube',
-                                             new_grid_title = 'grid 1')
+    # extract box for linear trajectory
+    grid_1, box_1 = rqdm.extract_box_for_well(epc_file = epc,
+                                              source_grid = grid,
+                                              trajectory_uuid = traj_1_uuid,
+                                              radius = 120.0,
+                                              active_cells_shape = 'tube',
+                                              new_grid_title = 'grid 1')
 
-   # check basics of resulting grid
-   assert grid_1 is not None
-   assert box_1 is not None
-   assert tuple(grid_1.extent_kji) == tuple(bx.extent_of_box(box_1))
-   expected_box = np.array([(0, 0, 1), (2, 3, 5)], dtype = int)
-   assert np.all(box_1 == expected_box)
-   #   expected_inactive_1 = np.array(
-   #      [[[1, 0, 1, 1, 1], [0, 0, 0, 1, 1], [1, 0, 1, 1, 1], [1, 1, 1, 1, 1]],
-   #       [[1, 0, 0, 1, 1], [0, 0, 0, 0, 1], [1, 0, 0, 0, 0], [1, 1, 0, 0, 1]],
-   #       [[1, 1, 1, 1, 1], [1, 1, 1, 0, 1], [1, 1, 0, 0, 0], [1, 1, 1, 0, 1]]], dtype = bool)   expected_inactive_1 = np.array(
-   expected_inactive_1 = np.array([[[1, 0, 1, 1, 1], [0, 0, 0, 0, 1], [1, 0, 0, 0, 1], [1, 1, 0, 0, 1]],
-                                   [[1, 0, 0, 1, 1], [0, 0, 0, 0, 1], [1, 0, 0, 0, 0], [1, 1, 0, 0, 1]],
-                                   [[1, 0, 0, 1, 1], [1, 0, 0, 0, 1], [1, 0, 0, 0, 0], [1, 1, 1, 0, 1]]],
-                                  dtype = bool)
-   assert np.all(grid_1.inactive == expected_inactive_1)
+    # check basics of resulting grid
+    assert grid_1 is not None
+    assert box_1 is not None
+    assert tuple(grid_1.extent_kji) == tuple(bx.extent_of_box(box_1))
+    expected_box = np.array([(0, 0, 1), (2, 3, 5)], dtype = int)
+    assert np.all(box_1 == expected_box)
+    #   expected_inactive_1 = np.array(
+    #      [[[1, 0, 1, 1, 1], [0, 0, 0, 1, 1], [1, 0, 1, 1, 1], [1, 1, 1, 1, 1]],
+    #       [[1, 0, 0, 1, 1], [0, 0, 0, 0, 1], [1, 0, 0, 0, 0], [1, 1, 0, 0, 1]],
+    #       [[1, 1, 1, 1, 1], [1, 1, 1, 0, 1], [1, 1, 0, 0, 0], [1, 1, 1, 0, 1]]], dtype = bool)   expected_inactive_1 = np.array(
+    expected_inactive_1 = np.array([[[1, 0, 1, 1, 1], [0, 0, 0, 0, 1], [1, 0, 0, 0, 1], [1, 1, 0, 0, 1]],
+                                    [[1, 0, 0, 1, 1], [0, 0, 0, 0, 1], [1, 0, 0, 0, 0], [1, 1, 0, 0, 1]],
+                                    [[1, 0, 0, 1, 1], [1, 0, 0, 0, 1], [1, 0, 0, 0, 0], [1, 1, 1, 0, 1]]],
+                                   dtype = bool)
+    assert np.all(grid_1.inactive == expected_inactive_1)
 
-   # extract box for blocked well made from splined trajectory
-   grid_2, box_2 = rqdm.extract_box_for_well(epc_file = epc,
-                                             source_grid = grid,
-                                             blocked_well_uuid = bw_uuid,
-                                             radius = 120.0,
-                                             active_cells_shape = 'prism',
-                                             new_grid_title = 'grid 2')
-   assert grid_2 is not None
-   assert box_2 is not None
-   assert tuple(grid_2.extent_kji) == tuple(bx.extent_of_box(box_2))
-   assert np.all(box_2 == expected_box)
-   # active cells should be superset of those for linear trajectory tube box
-   assert np.count_nonzero(grid_2.inactive) <= np.count_nonzero(grid_1.inactive)
-   assert np.all(np.logical_not(grid_2.inactive[np.logical_not(expected_inactive_1)]))
-   # check prism shape to inactive cells
-   assert np.all(grid_2.inactive == grid_2.inactive[0])
+    # extract box for blocked well made from splined trajectory
+    grid_2, box_2 = rqdm.extract_box_for_well(epc_file = epc,
+                                              source_grid = grid,
+                                              blocked_well_uuid = bw_uuid,
+                                              radius = 120.0,
+                                              active_cells_shape = 'prism',
+                                              new_grid_title = 'grid 2')
+    assert grid_2 is not None
+    assert box_2 is not None
+    assert tuple(grid_2.extent_kji) == tuple(bx.extent_of_box(box_2))
+    assert np.all(box_2 == expected_box)
+    # active cells should be superset of those for linear trajectory tube box
+    assert np.count_nonzero(grid_2.inactive) <= np.count_nonzero(grid_1.inactive)
+    assert np.all(np.logical_not(grid_2.inactive[np.logical_not(expected_inactive_1)]))
+    # check prism shape to inactive cells
+    assert np.all(grid_2.inactive == grid_2.inactive[0])
 
 
 def test_add_grid_points_property(tmp_path):
 
-   epc = os.path.join(tmp_path, 'bland.epc')
-   new_epc = os.path.join(tmp_path, 'pointy.epc')
+    epc = os.path.join(tmp_path, 'bland.epc')
+    new_epc = os.path.join(tmp_path, 'pointy.epc')
 
-   model = rq.new_model(epc)
+    model = rq.new_model(epc)
 
-   # create a basic block grid with geometry
-   extent_kji = (3, 5, 2)
-   grid = grr.RegularGrid(model,
-                          extent_kji = extent_kji,
-                          origin = (2000.0, 3000.0, 1000.0),
-                          dxyz = (10.0, 10.0, 20.0),
-                          title = 'the grid',
-                          set_points_cached = True)
-   grid.write_hdf5()
-   grid.create_xml(write_geometry = True, add_cell_length_properties = False)
-   grid_uuid = grid.uuid
+    # create a basic block grid with geometry
+    extent_kji = (3, 5, 2)
+    grid = grr.RegularGrid(model,
+                           extent_kji = extent_kji,
+                           origin = (2000.0, 3000.0, 1000.0),
+                           dxyz = (10.0, 10.0, 20.0),
+                           title = 'the grid',
+                           set_points_cached = True)
+    grid.write_hdf5()
+    grid.create_xml(write_geometry = True, add_cell_length_properties = False)
+    grid_uuid = grid.uuid
 
-   # store grid
-   model.store_epc()
+    # store grid
+    model.store_epc()
 
-   # create a points property array
-   diagonal = grid.axial_lengths_kji()
-   diagonals_extent = tuple(list(extent_kji) + [3])
-   diagonal_array = np.empty(diagonals_extent)
-   diagonal_array[:] = np.array(diagonal).reshape(1, 1, 1, 3)
+    # create a points property array
+    diagonal = grid.axial_lengths_kji()
+    diagonals_extent = tuple(list(extent_kji) + [3])
+    diagonal_array = np.empty(diagonals_extent)
+    diagonal_array[:] = np.array(diagonal).reshape(1, 1, 1, 3)
 
-   # add to model using derived model function but save as new dataset
-   rqdm.add_one_grid_property_array(epc_file = epc,
-                                    a = diagonal_array,
-                                    property_kind = 'length',
-                                    grid_uuid = grid_uuid,
-                                    source_info = 'test',
-                                    title = 'diagonal vectors',
-                                    discrete = False,
-                                    uom = grid.xy_units(),
-                                    points = True,
-                                    extra_metadata = {'test': 'true'},
-                                    new_epc_file = new_epc)
+    # add to model using derived model function but save as new dataset
+    rqdm.add_one_grid_property_array(epc_file = epc,
+                                     a = diagonal_array,
+                                     property_kind = 'length',
+                                     grid_uuid = grid_uuid,
+                                     source_info = 'test',
+                                     title = 'diagonal vectors',
+                                     discrete = False,
+                                     uom = grid.xy_units(),
+                                     points = True,
+                                     extra_metadata = {'test': 'true'},
+                                     new_epc_file = new_epc)
 
-   # re-open the original model and check that the points property is not there
-   model = rq.Model(epc)
-   grid = model.grid()
-   pc = grid.property_collection
-   assert pc is not None
-   assert len(pc.selective_parts_list(points = True)) == 0
+    # re-open the original model and check that the points property is not there
+    model = rq.Model(epc)
+    grid = model.grid()
+    pc = grid.property_collection
+    assert pc is not None
+    assert len(pc.selective_parts_list(points = True)) == 0
 
-   # re-open the new model and load the points property
-   model = rq.Model(new_epc)
-   grid = model.grid()
-   pc = grid.property_collection
-   assert pc is not None
-   assert len(pc.selective_parts_list(points = True)) == 1
-   diag = pc.single_array_ref(points = True)
-   assert_array_almost_equal(diag, diagonal_array)
+    # re-open the new model and load the points property
+    model = rq.Model(new_epc)
+    grid = model.grid()
+    pc = grid.property_collection
+    assert pc is not None
+    assert len(pc.selective_parts_list(points = True)) == 1
+    diag = pc.single_array_ref(points = True)
+    assert_array_almost_equal(diag, diagonal_array)
 
 
 def test_add_edges_per_column_property_array(tmp_path):
 
-   # create a new model with a grid
-   epc = os.path.join(tmp_path, 'edges_per_column.epc')
-   model = rq.new_model(epc)
-   grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
-   grid.write_hdf5()
-   grid.create_xml()
-   model.store_epc()
+    # create a new model with a grid
+    epc = os.path.join(tmp_path, 'edges_per_column.epc')
+    model = rq.new_model(epc)
+    grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
+    grid.write_hdf5()
+    grid.create_xml()
+    model.store_epc()
 
-   # fabricate an edges per column property
-   edge_prop = np.zeros((grid.nj, grid.ni, 2, 2))
-   edge_prop[:] = np.linspace(0.1, 0.9, num = edge_prop.size).reshape(edge_prop.shape)
+    # fabricate an edges per column property
+    edge_prop = np.zeros((grid.nj, grid.ni, 2, 2))
+    edge_prop[:] = np.linspace(0.1, 0.9, num = edge_prop.size).reshape(edge_prop.shape)
 
-   # add the edges per column property
-   prop_uuid = rqdm.add_edges_per_column_property_array(epc,
-                                                        edge_prop,
-                                                        property_kind = 'multiplier',
-                                                        grid_uuid = grid.uuid,
-                                                        source_info = 'unit testing',
-                                                        title = 'test property on column edges',
-                                                        discrete = False,
-                                                        uom = 'm3/m3')
-   assert prop_uuid is not None
+    # add the edges per column property
+    prop_uuid = rqdm.add_edges_per_column_property_array(epc,
+                                                         edge_prop,
+                                                         property_kind = 'multiplier',
+                                                         grid_uuid = grid.uuid,
+                                                         source_info = 'unit testing',
+                                                         title = 'test property on column edges',
+                                                         discrete = False,
+                                                         uom = 'm3/m3')
+    assert prop_uuid is not None
 
-   # re-open the model and inspect the property
-   model = rq.Model(epc)
-   assert len(model.parts(obj_type = 'ContinuousProperty')) > 0
-   edge_property = rqp.Property(model, uuid = prop_uuid)
-   assert edge_property is not None
-   ep_array = edge_property.array_ref()
-   # RESQML holds array with last two dimensions flattened and reordered
-   assert ep_array.shape == (grid.nj, grid.ni, 4)
-   # restore logical resqpy order and shape
-   ep_restored = rqp.reformat_column_edges_from_resqml_format(ep_array)
-   assert_array_almost_equal(ep_restored, edge_prop)
-   assert edge_property.is_continuous()
-   assert not edge_property.is_categorical()
-   assert edge_property.indexable_element() == 'edges per column'
-   assert edge_property.uom() == 'm3/m3'
-   assert edge_property.property_kind() == 'multiplier'
-   assert edge_property.facet() is None
+    # re-open the model and inspect the property
+    model = rq.Model(epc)
+    assert len(model.parts(obj_type = 'ContinuousProperty')) > 0
+    edge_property = rqp.Property(model, uuid = prop_uuid)
+    assert edge_property is not None
+    ep_array = edge_property.array_ref()
+    # RESQML holds array with last two dimensions flattened and reordered
+    assert ep_array.shape == (grid.nj, grid.ni, 4)
+    # restore logical resqpy order and shape
+    ep_restored = rqp.reformat_column_edges_from_resqml_format(ep_array)
+    assert_array_almost_equal(ep_restored, edge_prop)
+    assert edge_property.is_continuous()
+    assert not edge_property.is_categorical()
+    assert edge_property.indexable_element() == 'edges per column'
+    assert edge_property.uom() == 'm3/m3'
+    assert edge_property.property_kind() == 'multiplier'
+    assert edge_property.facet() is None
 
 
 def test_add_one_blocked_well_property(example_model_with_well):
-   model, well_interp, datum, traj = example_model_with_well
-   epc = model.epc_file
-   # make a grid positioned in the area of the well
-   grid = grr.RegularGrid(model,
-                          crs_uuid = model.crs_uuid,
-                          origin = (-150.0, -150.0, 1500.0),
-                          extent_kji = (5, 3, 3),
-                          dxyz = (100.0, 100.0, 50.0),
-                          set_points_cached = True)
-   grid.write_hdf5()
-   grid.create_xml(write_geometry = True, add_cell_length_properties = False)
-   # create a blocked well
-   bw = rqw.BlockedWell(model, grid = grid, trajectory = traj)
-   bw.write_hdf5()
-   bw.create_xml()
-   model.store_epc()
-   assert bw is not None
-   assert bw.cell_count == grid.nk
-   # fabricate a blocked well property holding the depths of the centres of penetrated cells
-   wb_prop = np.zeros(grid.nk,)
-   cells_kji = bw.cell_indices_kji0()
-   for i, cell_kji in enumerate(cells_kji):
-      wb_prop[i] = grid.centre_point(cell_kji)[2]
-   # add the property
-   p_uuid = rqdm.add_one_blocked_well_property(epc,
-                                               wb_prop,
-                                               'depth',
-                                               bw.uuid,
-                                               source_info = 'unit test',
-                                               title = 'DEPTH',
-                                               discrete = False,
-                                               uom = 'm',
-                                               indexable_element = 'cells')
-   assert p_uuid is not None
-   # re-open the model and check the wellbore property
-   model = rq.Model(epc)
-   prop = rqp.Property(model, uuid = p_uuid)
-   assert prop is not None
-   assert bu.matching_uuids(model.supporting_representation_for_part(model.part(uuid = prop.uuid)), bw.uuid)
-   assert prop.title == 'DEPTH'
-   assert prop.property_kind() == 'depth'
-   assert prop.uom() == 'm'
-   assert prop.is_continuous()
-   assert not prop.is_categorical()
-   assert prop.minimum_value() is not None and prop.maximum_value() is not None
-   assert prop.minimum_value() > grid.xyz_box(lazy = True)[0, 2]  # minimum z
-   assert prop.maximum_value() < grid.xyz_box(lazy = True)[1, 2]  # maximum z
+    model, well_interp, datum, traj = example_model_with_well
+    epc = model.epc_file
+    # make a grid positioned in the area of the well
+    grid = grr.RegularGrid(model,
+                           crs_uuid = model.crs_uuid,
+                           origin = (-150.0, -150.0, 1500.0),
+                           extent_kji = (5, 3, 3),
+                           dxyz = (100.0, 100.0, 50.0),
+                           set_points_cached = True)
+    grid.write_hdf5()
+    grid.create_xml(write_geometry = True, add_cell_length_properties = False)
+    # create a blocked well
+    bw = rqw.BlockedWell(model, grid = grid, trajectory = traj)
+    bw.write_hdf5()
+    bw.create_xml()
+    model.store_epc()
+    assert bw is not None
+    assert bw.cell_count == grid.nk
+    # fabricate a blocked well property holding the depths of the centres of penetrated cells
+    wb_prop = np.zeros(grid.nk,)
+    cells_kji = bw.cell_indices_kji0()
+    for i, cell_kji in enumerate(cells_kji):
+        wb_prop[i] = grid.centre_point(cell_kji)[2]
+    # add the property
+    p_uuid = rqdm.add_one_blocked_well_property(epc,
+                                                wb_prop,
+                                                'depth',
+                                                bw.uuid,
+                                                source_info = 'unit test',
+                                                title = 'DEPTH',
+                                                discrete = False,
+                                                uom = 'm',
+                                                indexable_element = 'cells')
+    assert p_uuid is not None
+    # re-open the model and check the wellbore property
+    model = rq.Model(epc)
+    prop = rqp.Property(model, uuid = p_uuid)
+    assert prop is not None
+    assert bu.matching_uuids(model.supporting_representation_for_part(model.part(uuid = prop.uuid)), bw.uuid)
+    assert prop.title == 'DEPTH'
+    assert prop.property_kind() == 'depth'
+    assert prop.uom() == 'm'
+    assert prop.is_continuous()
+    assert not prop.is_categorical()
+    assert prop.minimum_value() is not None and prop.maximum_value() is not None
+    assert prop.minimum_value() > grid.xyz_box(lazy = True)[0, 2]  # minimum z
+    assert prop.maximum_value() < grid.xyz_box(lazy = True)[1, 2]  # maximum z
 
 
 def test_add_wells_from_ascii_file(tmp_path):
-   # create an empty model and add a crs
-   epc = os.path.join(tmp_path, 'well_model.epc')
-   model = rq.new_model(epc)
-   crs = rqc.Crs(model)
-   crs.create_xml()
-   model.store_epc()
-   # fabricate some test data as an ascii table
-   well_file = os.path.join(tmp_path, 'well_table.txt')
-   df = pd.DataFrame(columns = ['WELL', 'MD', 'X', 'Y', 'Z'])
-   well_count = 3
-   for wi in range(well_count):
-      well_name = 'Hole_' + str(wi + 1)
-      wdf = pd.DataFrame(columns = ['WELL', 'MD', 'X', 'Y', 'Z'])
-      row_count = 3 + wi
-      wdf['MD'] = np.linspace(0.0, 1000.0, num = row_count)
-      wdf['X'] = np.linspace(100.0 * wi, 100.0 * wi + 10.0 * row_count, num = row_count)
-      wdf['Y'] = np.linspace(500.0 * wi, 500.0 * wi - 15.0 * row_count, num = row_count)
-      wdf['Z'] = np.linspace(0.0, 1000.0 + 5.0 * row_count, num = row_count)
-      wdf['WELL'] = well_name
-      df = df.append(wdf)
-   df.to_csv(well_file, sep = ' ', index = False)
-   # call the derived model function to add the wells
-   added = rqdm.add_wells_from_ascii_file(epc,
-                                          crs.uuid,
-                                          well_file,
-                                          space_separated_instead_of_csv = True,
-                                          length_uom = 'ft',
-                                          md_domain = ['driller', 'logger'][wi % 2],
-                                          drilled = True,
-                                          z_inc_down = True)
-   assert added == well_count
-   # re-open the model and check that all expected objects have appeared
-   model = rq.Model(epc)
-   assert len(model.parts(obj_type = 'WellboreTrajectoryRepresentation')) == well_count
-   assert len(model.parts(obj_type = 'MdDatum')) == well_count
-   assert len(model.parts(obj_type = 'WellboreInterpretation')) == well_count
-   assert len(model.parts(obj_type = 'WellboreFeature')) == well_count
-   for wi in range(well_count):
-      well_name = 'Hole_' + str(wi + 1)
-      traj = rqw.Trajectory(model, uuid = model.uuid(obj_type = 'WellboreTrajectoryRepresentation', title = well_name))
-      assert traj is not None
-      assert traj.knot_count == 3 + wi
+    # create an empty model and add a crs
+    epc = os.path.join(tmp_path, 'well_model.epc')
+    model = rq.new_model(epc)
+    crs = rqc.Crs(model)
+    crs.create_xml()
+    model.store_epc()
+    # fabricate some test data as an ascii table
+    well_file = os.path.join(tmp_path, 'well_table.txt')
+    df = pd.DataFrame(columns = ['WELL', 'MD', 'X', 'Y', 'Z'])
+    well_count = 3
+    for wi in range(well_count):
+        well_name = 'Hole_' + str(wi + 1)
+        wdf = pd.DataFrame(columns = ['WELL', 'MD', 'X', 'Y', 'Z'])
+        row_count = 3 + wi
+        wdf['MD'] = np.linspace(0.0, 1000.0, num = row_count)
+        wdf['X'] = np.linspace(100.0 * wi, 100.0 * wi + 10.0 * row_count, num = row_count)
+        wdf['Y'] = np.linspace(500.0 * wi, 500.0 * wi - 15.0 * row_count, num = row_count)
+        wdf['Z'] = np.linspace(0.0, 1000.0 + 5.0 * row_count, num = row_count)
+        wdf['WELL'] = well_name
+        df = df.append(wdf)
+    df.to_csv(well_file, sep = ' ', index = False)
+    # call the derived model function to add the wells
+    added = rqdm.add_wells_from_ascii_file(epc,
+                                           crs.uuid,
+                                           well_file,
+                                           space_separated_instead_of_csv = True,
+                                           length_uom = 'ft',
+                                           md_domain = ['driller', 'logger'][wi % 2],
+                                           drilled = True,
+                                           z_inc_down = True)
+    assert added == well_count
+    # re-open the model and check that all expected objects have appeared
+    model = rq.Model(epc)
+    assert len(model.parts(obj_type = 'WellboreTrajectoryRepresentation')) == well_count
+    assert len(model.parts(obj_type = 'MdDatum')) == well_count
+    assert len(model.parts(obj_type = 'WellboreInterpretation')) == well_count
+    assert len(model.parts(obj_type = 'WellboreFeature')) == well_count
+    for wi in range(well_count):
+        well_name = 'Hole_' + str(wi + 1)
+        traj = rqw.Trajectory(model,
+                              uuid = model.uuid(obj_type = 'WellboreTrajectoryRepresentation', title = well_name))
+        assert traj is not None
+        assert traj.knot_count == 3 + wi
 
 
 def test_interpolated_grid(tmp_path):
-   # create an empty model and add a crs
-   epc = os.path.join(tmp_path, 'interpolation.epc')
-   model = rq.new_model(epc)
-   crs = rqc.Crs(model)
-   crs.create_xml()
-   # create a pair of grids to act as boundary case geometries
-   grid0 = grr.RegularGrid(model,
-                           crs_uuid = model.crs_uuid,
-                           origin = (0.0, 0.0, 1000.0),
-                           extent_kji = (5, 4, 3),
-                           dxyz = (100.0, 150.0, 50.0),
-                           set_points_cached = True)
-   grid0.grid_representation = 'IjkGrid'  # overwrite block grid setting
-   grid0.write_hdf5()
-   grid0.create_xml(write_geometry = True, add_cell_length_properties = False)
-   grid1 = grr.RegularGrid(model,
-                           crs_uuid = model.crs_uuid,
-                           origin = (15.0, 35.0, 1030.0),
-                           extent_kji = (5, 4, 3),
-                           dxyz = (97.0, 145.0, 47.0),
-                           set_points_cached = True)
-   grid1.grid_representation = 'IjkGrid'  # overwrite block grid setting
-   grid1.write_hdf5()
-   grid1.create_xml(write_geometry = True, add_cell_length_properties = False)
-   model.store_epc()
-   # interpolate between the two grids
-   between_grid_uuids = []
-   for f in [0.0, 0.23, 0.5, 1.0]:
-      grid = rqdm.interpolated_grid(epc,
-                                    grid0,
-                                    grid1,
-                                    a_to_b_0_to_1 = f,
-                                    split_tolerance = 0.01,
-                                    inherit_properties = False,
-                                    inherit_realization = None,
-                                    inherit_all_realizations = False,
-                                    new_grid_title = 'between_' + str(f))
-      assert grid is not None
-      between_grid_uuids.append(grid.uuid)
-   # re-open model and check interpolated grid geometries
-   model = rq.Model(epc)
-   for i, g_uuid in enumerate(between_grid_uuids):
-      grid = grr.Grid(model, uuid = g_uuid)
-      assert grid is not None
-      grid.cache_all_geometry_arrays()
-      assert hasattr(grid, 'points_cached') and grid.points_cached is not None
-      assert np.all(grid.points_cached >= grid0.points_cached)
-      assert np.all(grid.points_cached <= grid1.points_cached)
-      if i == 0:
-         assert_array_almost_equal(grid.points_cached, grid0.points_cached)
-      elif i == len(between_grid_uuids) - 1:
-         assert_array_almost_equal(grid.points_cached, grid1.points_cached)
-      else:
-         assert not np.any(np.isclose(grid.points_cached, grid0.points_cached))
-         assert not np.any(np.isclose(grid.points_cached, grid1.points_cached))
+    # create an empty model and add a crs
+    epc = os.path.join(tmp_path, 'interpolation.epc')
+    model = rq.new_model(epc)
+    crs = rqc.Crs(model)
+    crs.create_xml()
+    # create a pair of grids to act as boundary case geometries
+    grid0 = grr.RegularGrid(model,
+                            crs_uuid = model.crs_uuid,
+                            origin = (0.0, 0.0, 1000.0),
+                            extent_kji = (5, 4, 3),
+                            dxyz = (100.0, 150.0, 50.0),
+                            set_points_cached = True)
+    grid0.grid_representation = 'IjkGrid'  # overwrite block grid setting
+    grid0.write_hdf5()
+    grid0.create_xml(write_geometry = True, add_cell_length_properties = False)
+    grid1 = grr.RegularGrid(model,
+                            crs_uuid = model.crs_uuid,
+                            origin = (15.0, 35.0, 1030.0),
+                            extent_kji = (5, 4, 3),
+                            dxyz = (97.0, 145.0, 47.0),
+                            set_points_cached = True)
+    grid1.grid_representation = 'IjkGrid'  # overwrite block grid setting
+    grid1.write_hdf5()
+    grid1.create_xml(write_geometry = True, add_cell_length_properties = False)
+    model.store_epc()
+    # interpolate between the two grids
+    between_grid_uuids = []
+    for f in [0.0, 0.23, 0.5, 1.0]:
+        grid = rqdm.interpolated_grid(epc,
+                                      grid0,
+                                      grid1,
+                                      a_to_b_0_to_1 = f,
+                                      split_tolerance = 0.01,
+                                      inherit_properties = False,
+                                      inherit_realization = None,
+                                      inherit_all_realizations = False,
+                                      new_grid_title = 'between_' + str(f))
+        assert grid is not None
+        between_grid_uuids.append(grid.uuid)
+    # re-open model and check interpolated grid geometries
+    model = rq.Model(epc)
+    for i, g_uuid in enumerate(between_grid_uuids):
+        grid = grr.Grid(model, uuid = g_uuid)
+        assert grid is not None
+        grid.cache_all_geometry_arrays()
+        assert hasattr(grid, 'points_cached') and grid.points_cached is not None
+        assert np.all(grid.points_cached >= grid0.points_cached)
+        assert np.all(grid.points_cached <= grid1.points_cached)
+        if i == 0:
+            assert_array_almost_equal(grid.points_cached, grid0.points_cached)
+        elif i == len(between_grid_uuids) - 1:
+            assert_array_almost_equal(grid.points_cached, grid1.points_cached)
+        else:
+            assert not np.any(np.isclose(grid.points_cached, grid0.points_cached))
+            assert not np.any(np.isclose(grid.points_cached, grid1.points_cached))
 
 
 def test_refined_and_coarsened_grid(tmp_path):
 
-   # create a model and a coarse grid
-   epc = os.path.join(tmp_path, 'refinement.epc')
-   model = rq.new_model(epc)
-   crs = rqc.Crs(model)
-   crs.create_xml()
+    # create a model and a coarse grid
+    epc = os.path.join(tmp_path, 'refinement.epc')
+    model = rq.new_model(epc)
+    crs = rqc.Crs(model)
+    crs.create_xml()
 
-   # create a coarse grid
-   c_dxyz = (100.0, 150.0, 50.0)
-   c_grid = grr.RegularGrid(model,
-                            crs_uuid = model.crs_uuid,
-                            extent_kji = (5, 3, 4),
-                            dxyz = c_dxyz,
-                            as_irregular_grid = True)
-   c_grid.write_hdf5()
-   c_grid.create_xml(write_geometry = True, add_cell_length_properties = True, expand_const_arrays = True)
-   model.store_epc()
+    # create a coarse grid
+    c_dxyz = (100.0, 150.0, 50.0)
+    c_grid = grr.RegularGrid(model,
+                             crs_uuid = model.crs_uuid,
+                             extent_kji = (5, 3, 4),
+                             dxyz = c_dxyz,
+                             as_irregular_grid = True)
+    c_grid.write_hdf5()
+    c_grid.create_xml(write_geometry = True, add_cell_length_properties = True, expand_const_arrays = True)
+    model.store_epc()
 
-   # set up a coarse to fine mapping
-   fine_extent = np.array(c_grid.extent_kji)
-   fine_extent[0] *= 2
-   fine_extent[1] *= 4
-   fine_extent[2] *= 3
-   fc = rqfc.FineCoarse(fine_extent, c_grid.extent_kji)
-   fc.set_all_ratios_constant()
+    # set up a coarse to fine mapping
+    fine_extent = np.array(c_grid.extent_kji)
+    fine_extent[0] *= 2
+    fine_extent[1] *= 4
+    fine_extent[2] *= 3
+    fc = rqfc.FineCoarse(fine_extent, c_grid.extent_kji)
+    fc.set_all_ratios_constant()
 
-   # make the refinement
-   f_grid = rqdm.refined_grid(epc,
-                              source_grid = None,
-                              fine_coarse = fc,
-                              inherit_properties = True,
-                              inherit_realization = None,
-                              inherit_all_realizations = False,
-                              source_grid_uuid = c_grid.uuid,
-                              set_parent_window = None,
-                              infill_missing_geometry = True,
-                              new_grid_title = 'fine grid')
-   assert f_grid is not None
+    # make the refinement
+    f_grid = rqdm.refined_grid(epc,
+                               source_grid = None,
+                               fine_coarse = fc,
+                               inherit_properties = True,
+                               inherit_realization = None,
+                               inherit_all_realizations = False,
+                               source_grid_uuid = c_grid.uuid,
+                               set_parent_window = None,
+                               infill_missing_geometry = True,
+                               new_grid_title = 'fine grid')
+    assert f_grid is not None
 
-   # re-open model and check some things about the refined grid
-   model = rq.Model(epc)
-   f_grid = grr.Grid(model, uuid = f_grid.uuid)
-   assert tuple(f_grid.extent_kji) == tuple(fine_extent)
-   f_grid.cache_all_geometry_arrays()
-   assert_array_almost_equal(c_grid.xyz_box(lazy = False), f_grid.xyz_box(lazy = False))
-   assert not f_grid.has_split_coordinate_lines
-   assert f_grid.points_cached is not None
-   assert f_grid.points_cached.shape == (c_grid.nk * 2 + 1, c_grid.nj * 4 + 1, c_grid.ni * 3 + 1, 3)
-   # check that refined grid geometry is monotonic in each of the three axes
-   p = f_grid.points_ref(masked = False)
-   assert np.all(p[:-1, :, :, 2] < p[1:, :, :, 2])
-   assert np.all(p[:, :-1, :, 1] < p[:, 1:, :, 1])
-   assert np.all(p[:, :, :-1, 0] < p[:, :, 1:, 0])
+    # re-open model and check some things about the refined grid
+    model = rq.Model(epc)
+    f_grid = grr.Grid(model, uuid = f_grid.uuid)
+    assert tuple(f_grid.extent_kji) == tuple(fine_extent)
+    f_grid.cache_all_geometry_arrays()
+    assert_array_almost_equal(c_grid.xyz_box(lazy = False), f_grid.xyz_box(lazy = False))
+    assert not f_grid.has_split_coordinate_lines
+    assert f_grid.points_cached is not None
+    assert f_grid.points_cached.shape == (c_grid.nk * 2 + 1, c_grid.nj * 4 + 1, c_grid.ni * 3 + 1, 3)
+    # check that refined grid geometry is monotonic in each of the three axes
+    p = f_grid.points_ref(masked = False)
+    assert np.all(p[:-1, :, :, 2] < p[1:, :, :, 2])
+    assert np.all(p[:, :-1, :, 1] < p[:, 1:, :, 1])
+    assert np.all(p[:, :, :-1, 0] < p[:, :, 1:, 0])
 
-   # check property inheritance of cell lengths
-   pc = f_grid.extract_property_collection()
-   assert pc is not None and pc.number_of_parts() >= 3
-   lpc = rqp.selective_version_of_collection(pc, property_kind = 'cell length')
-   assert lpc.number_of_parts() == 3
-   for axis in range(3):
-      length_array = lpc.single_array_ref(facet_type = 'direction', facet = 'KJI'[axis])
-      assert length_array is not None
-      assert np.allclose(length_array, c_dxyz[2 - axis] / (2, 4, 3)[axis])
+    # check property inheritance of cell lengths
+    pc = f_grid.extract_property_collection()
+    assert pc is not None and pc.number_of_parts() >= 3
+    lpc = rqp.selective_version_of_collection(pc, property_kind = 'cell length')
+    assert lpc.number_of_parts() == 3
+    for axis in range(3):
+        length_array = lpc.single_array_ref(facet_type = 'direction', facet = 'KJI'[axis])
+        assert length_array is not None
+        assert np.allclose(length_array, c_dxyz[2 - axis] / (2, 4, 3)[axis])
 
-   # make a (re-)coarsened version of the fine grid
-   cfc_grid = rqdm.coarsened_grid(epc,
-                                  f_grid,
-                                  fc,
-                                  inherit_properties = True,
-                                  set_parent_window = None,
-                                  infill_missing_geometry = True,
-                                  new_grid_title = 're-coarsened grid')
-   assert cfc_grid is not None
+    # make a (re-)coarsened version of the fine grid
+    cfc_grid = rqdm.coarsened_grid(epc,
+                                   f_grid,
+                                   fc,
+                                   inherit_properties = True,
+                                   set_parent_window = None,
+                                   infill_missing_geometry = True,
+                                   new_grid_title = 're-coarsened grid')
+    assert cfc_grid is not None
 
-   # re-open the model and re-load the new grid
-   model = rq.Model(epc)
-   assert len(model.parts(obj_type = 'IjkGridRepresentation')) == 3
-   cfc_grid = grr.Grid(model, uuid = cfc_grid.uuid)
+    # re-open the model and re-load the new grid
+    model = rq.Model(epc)
+    assert len(model.parts(obj_type = 'IjkGridRepresentation')) == 3
+    cfc_grid = grr.Grid(model, uuid = cfc_grid.uuid)
 
-   # compare the re-coarsened grid with the original coarse grid
-   assert tuple(cfc_grid.extent_kji) == tuple(c_grid.extent_kji)
-   assert not cfc_grid.has_split_coordinate_lines
-   cfc_grid.cache_all_geometry_arrays()
-   assert_array_almost_equal(c_grid.points_cached, cfc_grid.points_cached)
+    # compare the re-coarsened grid with the original coarse grid
+    assert tuple(cfc_grid.extent_kji) == tuple(c_grid.extent_kji)
+    assert not cfc_grid.has_split_coordinate_lines
+    cfc_grid.cache_all_geometry_arrays()
+    assert_array_almost_equal(c_grid.points_cached, cfc_grid.points_cached)
 
-   # see how the cell length properties have fared
-   cfc_pc = cfc_grid.extract_property_collection()
-   assert cfc_grid is not None
-   assert cfc_pc.number_of_parts() >= 3
-   cfc_lpc = rqp.selective_version_of_collection(cfc_pc, property_kind = 'cell length')
-   assert cfc_lpc.number_of_parts() == 3
-   for axis in range(3):
-      length_array = cfc_lpc.single_array_ref(facet_type = 'direction', facet = 'KJI'[axis])
-      assert length_array is not None
-      assert np.allclose(length_array, c_dxyz[2 - axis])
+    # see how the cell length properties have fared
+    cfc_pc = cfc_grid.extract_property_collection()
+    assert cfc_grid is not None
+    assert cfc_pc.number_of_parts() >= 3
+    cfc_lpc = rqp.selective_version_of_collection(cfc_pc, property_kind = 'cell length')
+    assert cfc_lpc.number_of_parts() == 3
+    for axis in range(3):
+        length_array = cfc_lpc.single_array_ref(facet_type = 'direction', facet = 'KJI'[axis])
+        assert length_array is not None
+        assert np.allclose(length_array, c_dxyz[2 - axis])

--- a/tests/test_factors.py
+++ b/tests/test_factors.py
@@ -6,12 +6,12 @@ import resqpy.olio.factors as f
 
 
 def test_factors():
-   assert f.factorize(20) == [2, 2, 5]
-   assert f.factorize(29) == [29]
-   assert f.all_factors_from_primes(f.factorize(12)) == [1, 2, 3, 4, 6, 12]
-   f60 = f.all_factors(60)
-   assert f60 == [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60]
-   f6 = f.all_factors(6)
-   assert f6 == [1, 2, 3, 6]
-   f.remove_subset(f60, f6)
-   assert f60 == [4, 5, 10, 12, 15, 20, 30, 60]
+    assert f.factorize(20) == [2, 2, 5]
+    assert f.factorize(29) == [29]
+    assert f.all_factors_from_primes(f.factorize(12)) == [1, 2, 3, 4, 6, 12]
+    f60 = f.all_factors(60)
+    assert f60 == [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60]
+    f6 = f.all_factors(6)
+    assert f6 == [1, 2, 3, 6]
+    f.remove_subset(f60, f6)
+    assert f60 == [4, 5, 10, 12, 15, 20, 30, 60]

--- a/tests/test_fault.py
+++ b/tests/test_fault.py
@@ -18,128 +18,128 @@ import resqpy.olio.xml_et as rqet
 # yapf: enable
 def test_add_connection_set_and_tmults(example_model_with_properties, test_data_path, inc_list, tmult_dict,
                                        expected_mult):
-   model = example_model_with_properties
+    model = example_model_with_properties
 
-   inc_list = [os.path.join(test_data_path, inc) for inc in inc_list]
+    inc_list = [os.path.join(test_data_path, inc) for inc in inc_list]
 
-   gcs_uuid = rqf.add_connection_set_and_tmults(model, inc_list, tmult_dict)
+    gcs_uuid = rqf.add_connection_set_and_tmults(model, inc_list, tmult_dict)
 
-   assert gcs_uuid is not None, 'Grid connection set not generated'
+    assert gcs_uuid is not None, 'Grid connection set not generated'
 
-   reload_model = rq.Model(epc_file = model.epc_file)
+    reload_model = rq.Model(epc_file = model.epc_file)
 
-   faults = reload_model.parts_list_of_type(('obj_FaultInterpretation'))
-   assert len(faults) == len(
-      expected_mult.keys()), f'Expected a {len(expected_mult.keys())} faults, found {len(faults)}'
-   for fault in faults:
-      metadata = rqet.load_metadata_from_xml(reload_model.root_for_part(fault))
-      title = reload_model.citation_title_for_part(fault)
-      assert metadata["Transmissibility multiplier"] == str(
-         float(expected_mult[title])
-      ), f'Expected mult for fault {title} to be {float(expected_mult[title])}, found {metadata["Transmissibility multiplier"]}'
+    faults = reload_model.parts_list_of_type(('obj_FaultInterpretation'))
+    assert len(faults) == len(
+        expected_mult.keys()), f'Expected a {len(expected_mult.keys())} faults, found {len(faults)}'
+    for fault in faults:
+        metadata = rqet.load_metadata_from_xml(reload_model.root_for_part(fault))
+        title = reload_model.citation_title_for_part(fault)
+        assert metadata["Transmissibility multiplier"] == str(
+            float(expected_mult[title])
+        ), f'Expected mult for fault {title} to be {float(expected_mult[title])}, found {metadata["Transmissibility multiplier"]}'
 
-   # check that a transmissibility multiplier property has been created
-   gcs = rqf.GridConnectionSet(reload_model, uuid = gcs_uuid, find_properties = True)
-   assert gcs is not None
-   pc = gcs.property_collection
-   assert pc is not None and pc.number_of_parts() > 0
-   part = pc.singleton(property_kind = 'transmissibility multiplier')
-   assert part is not None
-   # check property values are in expected set
-   a = pc.cached_part_array_ref(part)
-   assert a is not None and a.ndim == 1
-   expect = [x for x in expected_mult.values()]
-   assert all([v in expect for v in a])
-   # see if a local property kind has been set up correctly
-   pku = pc.local_property_kind_uuid(part)
-   assert pku is not None
-   pk = rqp.PropertyKind(reload_model, uuid = pku)
-   assert pk is not None
-   assert pk.title == 'transmissibility multiplier'
+    # check that a transmissibility multiplier property has been created
+    gcs = rqf.GridConnectionSet(reload_model, uuid = gcs_uuid, find_properties = True)
+    assert gcs is not None
+    pc = gcs.property_collection
+    assert pc is not None and pc.number_of_parts() > 0
+    part = pc.singleton(property_kind = 'transmissibility multiplier')
+    assert part is not None
+    # check property values are in expected set
+    a = pc.cached_part_array_ref(part)
+    assert a is not None and a.ndim == 1
+    expect = [x for x in expected_mult.values()]
+    assert all([v in expect for v in a])
+    # see if a local property kind has been set up correctly
+    pku = pc.local_property_kind_uuid(part)
+    assert pku is not None
+    pk = rqp.PropertyKind(reload_model, uuid = pku)
+    assert pk is not None
+    assert pk.title == 'transmissibility multiplier'
 
 
 def test_gcs_property_inheritance(tmp_path):
 
-   epc = os.path.join(tmp_path)
+    epc = os.path.join(tmp_path)
 
-   model = rq.Model(epc, new_epc = True, create_basics = True, create_hdf5_ext = True)
+    model = rq.Model(epc, new_epc = True, create_basics = True, create_hdf5_ext = True)
 
-   # create a grid
-   g = grr.RegularGrid(model, (5, 3, 3), dxyz = (10.0, 10.0, 1.0))
-   g.write_hdf5()
-   g.create_xml(title = 'unsplit grid')
+    # create a grid
+    g = grr.RegularGrid(model, (5, 3, 3), dxyz = (10.0, 10.0, 1.0))
+    g.write_hdf5()
+    g.create_xml(title = 'unsplit grid')
 
-   # define an L shaped (in plan view) fault
-   j_faces = np.zeros((g.nk, g.nj - 1, g.ni), dtype = bool)
-   j_faces[:, 0, 1:] = True
-   i_faces = np.zeros((g.nk, g.nj, g.ni - 1), dtype = bool)
-   i_faces[:, 1:, 0] = True
-   gcs = rqf.GridConnectionSet(model,
-                               grid = g,
-                               j_faces = j_faces,
-                               i_faces = i_faces,
-                               feature_name = 'L fault',
-                               create_organizing_objects_where_needed = True,
-                               create_transmissibility_multiplier_property = False)
-   # check that connection set has the right number of cell face pairs
-   assert gcs.count == g.nk * ((g.nj - 1) + (g.ni - 1))
+    # define an L shaped (in plan view) fault
+    j_faces = np.zeros((g.nk, g.nj - 1, g.ni), dtype = bool)
+    j_faces[:, 0, 1:] = True
+    i_faces = np.zeros((g.nk, g.nj, g.ni - 1), dtype = bool)
+    i_faces[:, 1:, 0] = True
+    gcs = rqf.GridConnectionSet(model,
+                                grid = g,
+                                j_faces = j_faces,
+                                i_faces = i_faces,
+                                feature_name = 'L fault',
+                                create_organizing_objects_where_needed = True,
+                                create_transmissibility_multiplier_property = False)
+    # check that connection set has the right number of cell face pairs
+    assert gcs.count == g.nk * ((g.nj - 1) + (g.ni - 1))
 
-   # create a transmissibility multiplier property
-   tm = np.arange(gcs.count).astype(float)
-   if gcs.property_collection is None:
-      gcs.property_collection = rqp.PropertyCollection()
-      gcs.property_collection.set_support(support = gcs)
-   pc = gcs.property_collection
-   pc.add_cached_array_to_imported_list(
-      tm,
-      'unit test',
-      'TMULT',
-      uom = 'Euc',  # actually a ratio of transmissibilities
-      property_kind = 'transmissibility multiplier',
-      local_property_kind_uuid = None,
-      realization = None,
-      indexable_element = 'faces')
-   # write gcs which should also write property collection and create a local property kind
-   gcs.write_hdf5()
-   gcs.create_xml(write_new_properties = True)
+    # create a transmissibility multiplier property
+    tm = np.arange(gcs.count).astype(float)
+    if gcs.property_collection is None:
+        gcs.property_collection = rqp.PropertyCollection()
+        gcs.property_collection.set_support(support = gcs)
+    pc = gcs.property_collection
+    pc.add_cached_array_to_imported_list(
+        tm,
+        'unit test',
+        'TMULT',
+        uom = 'Euc',  # actually a ratio of transmissibilities
+        property_kind = 'transmissibility multiplier',
+        local_property_kind_uuid = None,
+        realization = None,
+        indexable_element = 'faces')
+    # write gcs which should also write property collection and create a local property kind
+    gcs.write_hdf5()
+    gcs.create_xml(write_new_properties = True)
 
-   # check that a local property kind has materialised
-   pk_uuid = model.uuid(obj_type = 'PropertyKind', title = 'transmissibility multiplier')
-   assert pk_uuid is not None
+    # check that a local property kind has materialised
+    pk_uuid = model.uuid(obj_type = 'PropertyKind', title = 'transmissibility multiplier')
+    assert pk_uuid is not None
 
-   # create a derived grid connection set using a layer range
-   thin_gcs, thin_indices = gcs.filtered_by_layer_range(min_k0 = 1, max_k0 = 3, return_indices = True)
-   assert thin_gcs is not None and thin_indices is not None
-   assert thin_gcs.count == 3 * ((g.nj - 1) + (g.ni - 1))
-   # inherit the transmissibility multiplier property
-   thin_gcs.inherit_properties_for_selected_indices(gcs, thin_indices)
-   thin_gcs.write_hdf5()
-   thin_gcs.create_xml()  # by default will include write of new properties
+    # create a derived grid connection set using a layer range
+    thin_gcs, thin_indices = gcs.filtered_by_layer_range(min_k0 = 1, max_k0 = 3, return_indices = True)
+    assert thin_gcs is not None and thin_indices is not None
+    assert thin_gcs.count == 3 * ((g.nj - 1) + (g.ni - 1))
+    # inherit the transmissibility multiplier property
+    thin_gcs.inherit_properties_for_selected_indices(gcs, thin_indices)
+    thin_gcs.write_hdf5()
+    thin_gcs.create_xml()  # by default will include write of new properties
 
-   # check that the inheritance has worked
-   assert thin_gcs.property_collection is not None and thin_gcs.property_collection.number_of_parts() > 0
-   thin_pc = thin_gcs.property_collection
-   tm_part = thin_pc.singleton(property_kind = 'transmissibility multiplier')
-   assert tm_part is not None
-   thin_tm = thin_pc.cached_part_array_ref(tm_part)
-   assert thin_tm is not None and thin_tm.ndim == 1
-   assert thin_tm.size == thin_gcs.count
-   assert_array_almost_equal(thin_tm, tm[thin_indices])
+    # check that the inheritance has worked
+    assert thin_gcs.property_collection is not None and thin_gcs.property_collection.number_of_parts() > 0
+    thin_pc = thin_gcs.property_collection
+    tm_part = thin_pc.singleton(property_kind = 'transmissibility multiplier')
+    assert tm_part is not None
+    thin_tm = thin_pc.cached_part_array_ref(tm_part)
+    assert thin_tm is not None and thin_tm.ndim == 1
+    assert thin_tm.size == thin_gcs.count
+    assert_array_almost_equal(thin_tm, tm[thin_indices])
 
-   # check that get_combined...() method can execute using property collection
-   b_a, i_a, f_a = gcs.get_combined_fault_mask_index_value_arrays(min_k = 1,
-                                                                  max_k = 3,
-                                                                  property_name = 'Transmissibility multiplier',
-                                                                  ref_k = 2)
-   assert b_a is not None and i_a is not None and f_a is not None
-   # check that transmissibility multiplier values have been sampled correctly from property array
-   assert f_a.shape == (g.nj, g.ni, 2, 2)
-   assert np.count_nonzero(np.isnan(f_a)) == 4 * g.nj * g.ni - 2 * ((g.nj - 1) + (g.ni - 1))
-   assert np.nanmax(f_a) > np.nanmin(f_a)
-   restore = np.seterr(all = 'ignore')
-   assert np.all(np.logical_or(np.isnan(f_a), f_a >= np.nanmin(thin_tm)))
-   assert np.all(np.logical_or(np.isnan(f_a), f_a <= np.nanmax(thin_tm)))
-   np.seterr(**restore)
+    # check that get_combined...() method can execute using property collection
+    b_a, i_a, f_a = gcs.get_combined_fault_mask_index_value_arrays(min_k = 1,
+                                                                   max_k = 3,
+                                                                   property_name = 'Transmissibility multiplier',
+                                                                   ref_k = 2)
+    assert b_a is not None and i_a is not None and f_a is not None
+    # check that transmissibility multiplier values have been sampled correctly from property array
+    assert f_a.shape == (g.nj, g.ni, 2, 2)
+    assert np.count_nonzero(np.isnan(f_a)) == 4 * g.nj * g.ni - 2 * ((g.nj - 1) + (g.ni - 1))
+    assert np.nanmax(f_a) > np.nanmin(f_a)
+    restore = np.seterr(all = 'ignore')
+    assert np.all(np.logical_or(np.isnan(f_a), f_a >= np.nanmin(thin_tm)))
+    assert np.all(np.logical_or(np.isnan(f_a), f_a <= np.nanmax(thin_tm)))
+    np.seterr(**restore)
 
 
 # no longer a failure mode

--- a/tests/test_fault_connection_set.py
+++ b/tests/test_fault_connection_set.py
@@ -13,1406 +13,1411 @@ import resqpy.olio.transmission as rqtr
 
 def test_fault_connection_set(tmp_path):
 
-   gm = os.path.join(tmp_path, 'resqpy_test_fgcs.epc')
-
-   model = rq.new_model(gm)
-   crs = rqc.Crs(model)
-   crs.create_xml()
-
-   # unsplit grid
-
-   g0 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
-   g0.write_hdf5()
-   g0.create_xml(title = 'G0 unsplit')
-   g0_fcs, g0_fa = rqtr.fault_connection_set(g0)
+    gm = os.path.join(tmp_path, 'resqpy_test_fgcs.epc')
+
+    model = rq.new_model(gm)
+    crs = rqc.Crs(model)
+    crs.create_xml()
+
+    # unsplit grid
+
+    g0 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g0.write_hdf5()
+    g0.create_xml(title = 'G0 unsplit')
+    g0_fcs, g0_fa = rqtr.fault_connection_set(g0)
 
-   assert g0_fcs is None
-   assert g0_fa is None
+    assert g0_fcs is None
+    assert g0_fa is None
 
-   # J face split with no juxtaposition
-   throw = 2.0
+    # J face split with no juxtaposition
+    throw = 2.0
 
-   g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   g1.grid_representation = 'IjkGrid'
+    g1.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
-   pu = g1.points_ref(masked = False).reshape(g1.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((g1.nk + 1, pu_pillar_count + g1.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, g1.ni + 1:2 * (g1.ni + 1), :]
-   p[:, 2 * (g1.ni + 1):, 2] += throw
-   g1.points_cached = p
-   g1.has_split_coordinate_lines = True
-   g1.split_pillars_count = g1.ni + 1
-   g1.split_pillar_indices_cached = np.array([i for i in range(g1.ni + 1, 2 * (g1.ni + 1))], dtype = int)
-   g1.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   g1.write_hdf5()
-   g1.create_xml(title = 'G1 J no juxtaposition')
-
-   # model.store_epc()
-   # model.h5_release()
-
-   g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
-
-   assert g1_fcs is None
-   assert g1_fa is None
-
-   # I face split with no juxtaposition
-   throw = 2.0
+    pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
+    pu = g1.points_ref(masked = False).reshape(g1.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((g1.nk + 1, pu_pillar_count + g1.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, g1.ni + 1:2 * (g1.ni + 1), :]
+    p[:, 2 * (g1.ni + 1):, 2] += throw
+    g1.points_cached = p
+    g1.has_split_coordinate_lines = True
+    g1.split_pillars_count = g1.ni + 1
+    g1.split_pillar_indices_cached = np.array([i for i in range(g1.ni + 1, 2 * (g1.ni + 1))], dtype = int)
+    g1.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    g1.write_hdf5()
+    g1.create_xml(title = 'G1 J no juxtaposition')
+
+    # model.store_epc()
+    # model.h5_release()
+
+    g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
+
+    assert g1_fcs is None
+    assert g1_fa is None
+
+    # I face split with no juxtaposition
+    throw = 2.0
 
-   g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   g1.grid_representation = 'IjkGrid'
+    g1.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
-   pr = g1.points_ref(masked = False)
-   pr[:, :, -1, 2] += throw
-   pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
-   p[:, pu_pillar_count:, 2] += throw
-   g1.points_cached = p
-   g1.has_split_coordinate_lines = True
-   g1.split_pillars_count = g1.ni + 1
-   g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
-   g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
-   g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   g1.write_hdf5()
-   g1.create_xml(title = 'G1 I no juxtaposition')
+    pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
+    pr = g1.points_ref(masked = False)
+    pr[:, :, -1, 2] += throw
+    pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
+    p[:, pu_pillar_count:, 2] += throw
+    g1.points_cached = p
+    g1.has_split_coordinate_lines = True
+    g1.split_pillars_count = g1.ni + 1
+    g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
+    g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
+    g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    g1.write_hdf5()
+    g1.create_xml(title = 'G1 I no juxtaposition')
 
-   # model.store_epc()
+    # model.store_epc()
 
-   g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
-
-   assert g1_fcs is None
-   assert g1_fa is None
+    g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
+
+    assert g1_fcs is None
+    assert g1_fa is None
 
-   # J face split with full juxtaposition of kji0 (1, 0, *) with (0, 1, *)
-   # pattern 4, 4 (or 3, 3)
+    # J face split with full juxtaposition of kji0 (1, 0, *) with (0, 1, *)
+    # pattern 4, 4 (or 3, 3)
 
-   throw = 1.0
+    throw = 1.0
 
-   g2 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g2 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   g2.grid_representation = 'IjkGrid'
+    g2.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (g2.nj + 1) * (g2.ni + 1)
-   pu = g2.points_ref(masked = False).reshape(g2.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((g2.nk + 1, pu_pillar_count + g2.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, g2.ni + 1:2 * (g2.ni + 1), :]
-   p[:, 2 * (g2.ni + 1):, 2] += throw
-   g2.points_cached = p
-   g2.has_split_coordinate_lines = True
-   g2.split_pillars_count = g2.ni + 1
-   g2.split_pillar_indices_cached = np.array([i for i in range(g2.ni + 1, 2 * (g2.ni + 1))], dtype = int)
-   g2.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   g2.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   g2.write_hdf5()
-   g2.create_xml(title = 'G2 J full juxtaposition of kji0 (1, 0, *) with (0, 1, *)')
+    pu_pillar_count = (g2.nj + 1) * (g2.ni + 1)
+    pu = g2.points_ref(masked = False).reshape(g2.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((g2.nk + 1, pu_pillar_count + g2.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, g2.ni + 1:2 * (g2.ni + 1), :]
+    p[:, 2 * (g2.ni + 1):, 2] += throw
+    g2.points_cached = p
+    g2.has_split_coordinate_lines = True
+    g2.split_pillars_count = g2.ni + 1
+    g2.split_pillar_indices_cached = np.array([i for i in range(g2.ni + 1, 2 * (g2.ni + 1))], dtype = int)
+    g2.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    g2.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    g2.write_hdf5()
+    g2.create_xml(title = 'G2 J full juxtaposition of kji0 (1, 0, *) with (0, 1, *)')
 
-   # model.store_epc()
+    # model.store_epc()
 
-   g2_fcs, g2_fa = rqtr.fault_connection_set(g2)
+    g2_fcs, g2_fa = rqtr.fault_connection_set(g2)
 
-   assert g2_fcs is not None
-   assert g2_fa is not None
+    assert g2_fcs is not None
+    assert g2_fa is not None
 
-   # show_fa(g2, g2_fcs, g2_fa)
+    # show_fa(g2, g2_fcs, g2_fa)
 
-   assert g2_fcs.count == 2
-   assert np.all(np.isclose(g2_fa, 1.0, atol = 0.01))
+    assert g2_fcs.count == 2
+    assert np.all(np.isclose(g2_fa, 1.0, atol = 0.01))
 
-   # I face split with full juxtaposition of kji0 (1, *, 0) with (0, *, 1)
-   # pattern 4, 4 (or 3, 3) diagram 1
+    # I face split with full juxtaposition of kji0 (1, *, 0) with (0, *, 1)
+    # pattern 4, 4 (or 3, 3) diagram 1
 
-   throw = 1.0
+    throw = 1.0
 
-   g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   g1.grid_representation = 'IjkGrid'
+    g1.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
-   pr = g1.points_ref(masked = False)
-   pr[:, :, -1, 2] += throw
-   pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
-   p[:, pu_pillar_count:, 2] += throw
-   g1.points_cached = p
-   g1.has_split_coordinate_lines = True
-   g1.split_pillars_count = g1.ni + 1
-   g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
-   g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
-   g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   g1.write_hdf5()
-   g1.create_xml(title = 'G2 I full juxtaposition of kji0 (1, *, 0) with (0, *, 1)')
+    pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
+    pr = g1.points_ref(masked = False)
+    pr[:, :, -1, 2] += throw
+    pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
+    p[:, pu_pillar_count:, 2] += throw
+    g1.points_cached = p
+    g1.has_split_coordinate_lines = True
+    g1.split_pillars_count = g1.ni + 1
+    g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
+    g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
+    g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    g1.write_hdf5()
+    g1.create_xml(title = 'G2 I full juxtaposition of kji0 (1, *, 0) with (0, *, 1)')
 
-   # model.store_epc()
+    # model.store_epc()
 
-   g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
+    g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
 
-   assert g1_fcs is not None
-   assert g1_fa is not None
+    assert g1_fcs is not None
+    assert g1_fa is not None
 
-   # show_fa(g1, g1_fcs, g1_fa)
+    # show_fa(g1, g1_fcs, g1_fa)
 
-   assert g1_fcs.count == 2
-   assert np.all(np.isclose(g1_fa, 1.0, atol = 0.01))
+    assert g1_fcs.count == 2
+    assert np.all(np.isclose(g1_fa, 1.0, atol = 0.01))
 
-   # J face split with half juxtaposition of kji0 (*, 0, *) with (*, 1, *); and (1, 0, *) with (0, 1, *)
-   # pattern 5, 5 (or 2, 2) diagram 2
+    # J face split with half juxtaposition of kji0 (*, 0, *) with (*, 1, *); and (1, 0, *) with (0, 1, *)
+    # pattern 5, 5 (or 2, 2) diagram 2
 
-   throw = 0.5
+    throw = 0.5
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G3 J half juxtaposition of kji0 (*, 0, *) with (*, 1, *); and (1, 0, *) with (0, 1, *)')
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G3 J half juxtaposition of kji0 (*, 0, *) with (*, 1, *); and (1, 0, *) with (0, 1, *)')
 
-   # model.store_epc()
+    # model.store_epc()
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(np.isclose(grid_fa, 0.5, atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(np.isclose(grid_fa, 0.5, atol = 0.01))
 
-   # I face split with half juxtaposition of kji0 (*, *, 0) with (*, *, 1); and (1, *, 0) with (0, *, 1)
-   # pattern 5, 5 (or 2, 2) diagram 2
+    # I face split with half juxtaposition of kji0 (*, *, 0) with (*, *, 1); and (1, *, 0) with (0, *, 1)
+    # pattern 5, 5 (or 2, 2) diagram 2
 
-   throw = 0.5
+    throw = 0.5
 
-   g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   g1.grid_representation = 'IjkGrid'
+    g1.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
-   pr = g1.points_ref(masked = False)
-   pr[:, :, -1, 2] += throw
-   pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
-   p[:, pu_pillar_count:, 2] += throw
-   g1.points_cached = p
-   g1.has_split_coordinate_lines = True
-   g1.split_pillars_count = g1.ni + 1
-   g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
-   g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
-   g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   g1.write_hdf5()
-   g1.create_xml(title = 'G3 I half juxtaposition of kji0 (*, *, 0) with (*, *, 1); and (1, *, 0) with (0, *, 1)')
+    pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
+    pr = g1.points_ref(masked = False)
+    pr[:, :, -1, 2] += throw
+    pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
+    p[:, pu_pillar_count:, 2] += throw
+    g1.points_cached = p
+    g1.has_split_coordinate_lines = True
+    g1.split_pillars_count = g1.ni + 1
+    g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
+    g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
+    g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    g1.write_hdf5()
+    g1.create_xml(title = 'G3 I half juxtaposition of kji0 (*, *, 0) with (*, *, 1); and (1, *, 0) with (0, *, 1)')
 
-   # model.store_epc()
+    # model.store_epc()
 
-   g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
+    g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
 
-   assert g1_fcs is not None
-   assert g1_fa is not None
+    assert g1_fcs is not None
+    assert g1_fa is not None
 
-   # show_fa(g1, g1_fcs, g1_fa)
+    # show_fa(g1, g1_fcs, g1_fa)
 
-   assert g1_fcs.count == 6
-   assert np.all(np.isclose(g1_fa, 0.5, atol = 0.01))
+    assert g1_fcs.count == 6
+    assert np.all(np.isclose(g1_fa, 0.5, atol = 0.01))
 
-   # J face split with 0.25 juxtaposition of kji0 (*, 0, *) with (*, 1, *); and 0.75 of (1, 0, *) with (0, 1, *)
-   # pattern 5, 5 (or 2, 2) diagram 2
+    # J face split with 0.25 juxtaposition of kji0 (*, 0, *) with (*, 1, *); and 0.75 of (1, 0, *) with (0, 1, *)
+    # pattern 5, 5 (or 2, 2) diagram 2
 
-   throw = 0.75
+    throw = 0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(
-      title = 'G4 J 0.25 juxtaposition of kji0 (*, 0, *) with (*, 1, *); and 0.75 of (1, 0, *) with (0, 1, *)')
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(
+        title = 'G4 J 0.25 juxtaposition of kji0 (*, 0, *) with (*, 1, *); and 0.75 of (1, 0, *) with (0, 1, *)')
 
-   # model.store_epc()
+    # model.store_epc()
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   # following assertion assumes lists are in certain order, which is not a functional requirement
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[0.25, 0.25], [0.75, 0.75], [0.25, 0.25], [0.25, 0.25], [0.75, 0.75], [0.25, 0.25]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 6
+    # following assertion assumes lists are in certain order, which is not a functional requirement
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[0.25, 0.25], [0.75, 0.75], [0.25, 0.25], [0.25, 0.25], [0.75, 0.75], [0.25, 0.25]]),
+                   atol = 0.01))
 
-   # I face split with 0.25 juxtaposition of kji0 (*, *, 0) with (*, *, 1); and 0.75 of (1, *, 0) with (0, *, 1)
-   # pattern 5, 5 (or 2, 2) diagram 2
+    # I face split with 0.25 juxtaposition of kji0 (*, *, 0) with (*, *, 1); and 0.75 of (1, *, 0) with (0, *, 1)
+    # pattern 5, 5 (or 2, 2) diagram 2
 
-   throw = 0.75
+    throw = 0.75
 
-   g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   g1.grid_representation = 'IjkGrid'
+    g1.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
-   pr = g1.points_ref(masked = False)
-   pr[:, :, -1, 2] += throw
-   pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
-   p[:, pu_pillar_count:, 2] += throw
-   g1.points_cached = p
-   g1.has_split_coordinate_lines = True
-   g1.split_pillars_count = g1.ni + 1
-   g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
-   g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
-   g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   g1.write_hdf5()
-   g1.create_xml(
-      title = 'G4 I 0.25 juxtaposition of kji0 (*, *, 0) with (*, *, 1); and 0.75 of (1, *, 0) with (0, *, 1)')
+    pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
+    pr = g1.points_ref(masked = False)
+    pr[:, :, -1, 2] += throw
+    pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
+    p[:, pu_pillar_count:, 2] += throw
+    g1.points_cached = p
+    g1.has_split_coordinate_lines = True
+    g1.split_pillars_count = g1.ni + 1
+    g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
+    g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
+    g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    g1.write_hdf5()
+    g1.create_xml(
+        title = 'G4 I 0.25 juxtaposition of kji0 (*, *, 0) with (*, *, 1); and 0.75 of (1, *, 0) with (0, *, 1)')
 
-   g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
+    g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
 
-   assert g1_fcs is not None
-   assert g1_fa is not None
+    assert g1_fcs is not None
+    assert g1_fa is not None
 
-   # show_fa(g1, g1_fcs, g1_fa)
+    # show_fa(g1, g1_fcs, g1_fa)
 
-   assert g1_fcs.count == 6
-   # following assertion assumes lists are in certain order, which is not a functional requirement
-   assert np.all(
-      np.isclose(g1_fa,
-                 np.array([[0.25, 0.25], [0.75, 0.75], [0.25, 0.25], [0.25, 0.25], [0.75, 0.75], [0.25, 0.25]]),
-                 atol = 0.01))
+    assert g1_fcs.count == 6
+    # following assertion assumes lists are in certain order, which is not a functional requirement
+    assert np.all(
+        np.isclose(g1_fa,
+                   np.array([[0.25, 0.25], [0.75, 0.75], [0.25, 0.25], [0.25, 0.25], [0.75, 0.75], [0.25, 0.25]]),
+                   atol = 0.01))
 
-   # J face split with full full (1, 0, 0) with (0, 1, 0); and 0.5 of (*, 0, 1) with (*, 1, 1) and layer crossover
-   # diagrams 4 & 2
+    # J face split with full full (1, 0, 0) with (0, 1, 0); and 0.5 of (*, 0, 1) with (*, 1, 1) and layer crossover
+    # diagrams 4 & 2
 
-   throw = 1.0
+    throw = 1.0
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
-   p[:, 2 * (grid.ni + 1):-1, 2] += throw
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(
-      title = 'G5 J full (1, 0, 0) with (0, 1, 0); and 0.5 of (*, 0, 1) with (*, 1, 1) and layer crossover')
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    p[:, 2 * (grid.ni + 1):-1, 2] += throw
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(
+        title = 'G5 J full (1, 0, 0) with (0, 1, 0); and 0.5 of (*, 0, 1) with (*, 1, 1) and layer crossover')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 4
-   # following assertion assumes lists are in certain order, which is not a functional requirement
-   assert np.all(np.isclose(grid_fa, np.array([[1., 1.], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]]), atol = 0.01))
+    assert grid_fcs.count == 4
+    # following assertion assumes lists are in certain order, which is not a functional requirement
+    assert np.all(np.isclose(grid_fa, np.array([[1., 1.], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]]), atol = 0.01))
 
-   # I face split with full (1, 0, 0) with (0, 0, 1); and 0.5 of (*, 1, 0) with (*, 1, 1) and layer crossover
+    # I face split with full (1, 0, 0) with (0, 0, 1); and 0.5 of (*, 1, 0) with (*, 1, 1) and layer crossover
 
-   throw = 1.0
+    throw = 1.0
 
-   g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    g1 = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   g1.grid_representation = 'IjkGrid'
+    g1.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
-   pr = g1.points_ref(masked = False)
-   pr[:, :, -1, 2] += throw
-   pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
-   p[:, pu_pillar_count:-1, 2] += throw
-   g1.points_cached = p
-   g1.has_split_coordinate_lines = True
-   g1.split_pillars_count = g1.ni + 1
-   g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
-   g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
-   g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   g1.write_hdf5()
-   g1.create_xml(title = 'G5 I full (1, 0, 0) with (0, 0, 1); and 0.5 of (*, 1, 0) with (*, 1, 1) and layer crossover')
+    pu_pillar_count = (g1.nj + 1) * (g1.ni + 1)
+    pr = g1.points_ref(masked = False)
+    pr[:, :, -1, 2] += throw
+    pu = pr.reshape(g1.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((g1.nk + 1, pu_pillar_count + g1.nj + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pr[:, :, 1, :].reshape(g1.nk + 1, g1.nj + 1, 3)
+    p[:, pu_pillar_count:-1, 2] += throw
+    g1.points_cached = p
+    g1.has_split_coordinate_lines = True
+    g1.split_pillars_count = g1.ni + 1
+    g1.split_pillar_indices_cached = np.array([i for i in range(1, (g1.nj + 1) * (g1.ni + 1), g1.nj + 1)], dtype = int)
+    g1.cols_for_split_pillars = np.array((1, 1, 3, 3), dtype = int)
+    g1.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    g1.write_hdf5()
+    g1.create_xml(title = 'G5 I full (1, 0, 0) with (0, 0, 1); and 0.5 of (*, 1, 0) with (*, 1, 1) and layer crossover')
 
-   g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
+    g1_fcs, g1_fa = rqtr.fault_connection_set(g1)
 
-   assert g1_fcs is not None
-   assert g1_fa is not None
+    assert g1_fcs is not None
+    assert g1_fa is not None
 
-   # show_fa(g1, g1_fcs, g1_fa)
+    # show_fa(g1, g1_fcs, g1_fa)
 
-   assert g1_fcs.count == 4
-   # following assertion assumes lists are in certain order, which is not a functional requirement
-   assert np.all(np.isclose(g1_fa, np.array([[1., 1.], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]]), atol = 0.01))
+    assert g1_fcs.count == 4
+    # following assertion assumes lists are in certain order, which is not a functional requirement
+    assert np.all(np.isclose(g1_fa, np.array([[1., 1.], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]]), atol = 0.01))
 
-   grid_fa
+    grid_fa
 
-   # J face split diagram 4
+    # J face split diagram 4
 
-   throw = 0.5
+    throw = 0.5
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):-1, 2] += throw
+    p[:, 2 * (grid.ni + 1):-1, 2] += throw
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G6 J diagram 4')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G6 J diagram 4')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   # following assertion assumes lists are in certain order, which is not a functional requirement
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.75, 0.75], [0.25, 0.25], [0.75, 0.75]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 6
+    # following assertion assumes lists are in certain order, which is not a functional requirement
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.75, 0.75], [0.25, 0.25], [0.75, 0.75]]),
+                   atol = 0.01))
 
-   # J face split
-   # diagram 5
+    # J face split
+    # diagram 5
 
-   throw = 0.5
+    throw = 0.5
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[1:, 2 * (grid.ni + 1), 2] -= 0.9
-   p[1:, 3 * (grid.ni + 1), 2] -= 1.0
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[1:, 2 * (grid.ni + 1), 2] -= 0.9
+    p[1:, 3 * (grid.ni + 1), 2] -= 1.0
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G7 diagram 5')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G7 diagram 5')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 7
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[0.375, 0.75], [0.125, 0.125], [0.125, 0.25], [0.75, 0.75], [0.5, 0.5], [0.5, 0.5],
-                           [0.5, 0.5]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 7
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[0.375, 0.75], [0.125, 0.125], [0.125, 0.25], [0.75, 0.75], [0.5, 0.5], [0.5, 0.5],
+                             [0.5, 0.5]]),
+                   atol = 0.01))
 
-   # bl.set_log_level('info')
+    # bl.set_log_level('info')
 
-   # J face split
-   # diagram 5m
+    # J face split
+    # diagram 5m
 
-   throw = 0.5
+    throw = 0.5
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[1:, 3 * (grid.ni + 1) - 1, 2] -= 0.9
-   p[1:, 4 * (grid.ni + 1) - 1, 2] -= 1.0
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[1:, 3 * (grid.ni + 1) - 1, 2] -= 0.9
+    p[1:, 4 * (grid.ni + 1) - 1, 2] -= 1.0
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G7m diagram 5m')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G7m diagram 5m')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 7
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.375, 0.75], [0.125, 0.125], [0.125, 0.25],
-                           [0.75, 0.75]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 7
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.375, 0.75], [0.125, 0.125], [0.125, 0.25],
+                             [0.75, 0.75]]),
+                   atol = 0.01))
 
-   # bl.set_log_level('info')
+    # bl.set_log_level('info')
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = 0.5
+    throw = 0.5
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G8 lower layer half thickness; throw 0.5')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G8 lower layer half thickness; throw 0.5')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 4
-   assert np.all(np.isclose(grid_fa, np.array([[0.5, 0.5], [1.0, 0.5], [0.5, 0.5], [1.0, 0.5]]), atol = 0.01))
+    assert grid_fcs.count == 4
+    assert np.all(np.isclose(grid_fa, np.array([[0.5, 0.5], [1.0, 0.5], [0.5, 0.5], [1.0, 0.5]]), atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = 0.75
+    throw = 0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G9 lower layer half thickness; throw 0.75')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G9 lower layer half thickness; throw 0.75')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 4
-   assert np.all(np.isclose(grid_fa, np.array([[0.25, 0.25], [1.0, 0.5], [0.25, 0.25], [1.0, 0.5]]), atol = 0.01))
+    assert grid_fcs.count == 4
+    assert np.all(np.isclose(grid_fa, np.array([[0.25, 0.25], [1.0, 0.5], [0.25, 0.25], [1.0, 0.5]]), atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = 0.25
+    throw = 0.25
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G10 lower layer half thickness; throw 0.25')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G10 lower layer half thickness; throw 0.25')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[0.75, 0.75], [0.5, 0.25], [0.5, 0.5], [0.75, 0.75], [0.5, 0.25], [0.5, 0.5]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[0.75, 0.75], [0.5, 0.25], [0.5, 0.5], [0.75, 0.75], [0.5, 0.25], [0.5, 0.5]]),
+                   atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = 0.75
+    throw = 0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:, 2 * (grid.ni + 1), 2] -= 1.0
-   p[:, 3 * (grid.ni + 1), 2] -= 1.0
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:, 2 * (grid.ni + 1), 2] -= 1.0
+    p[:, 3 * (grid.ni + 1), 2] -= 1.0
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G11 lower layer half thickness; throw 0.75 except for -0.25 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G11 lower layer half thickness; throw 0.75 except for -0.25 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(
-      np.isclose(
-         grid_fa,
-         np.array([
-            [11.0 / 16, 11.0 / 16],  # 0.6875, 0.6875
-            [1.0 / 32, 1.0 / 16],  # 0.03125, 0.0625
-            [0.5, 0.25],
-            [0.4375, 0.4375],
-            [0.25, 0.25],
-            [1.0, 0.5]
-         ]),
-         atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(
+        np.isclose(
+            grid_fa,
+            np.array([
+                [11.0 / 16, 11.0 / 16],  # 0.6875, 0.6875
+                [1.0 / 32, 1.0 / 16],  # 0.03125, 0.0625
+                [0.5, 0.25],
+                [0.4375, 0.4375],
+                [0.25, 0.25],
+                [1.0, 0.5]
+            ]),
+            atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = 0.75
+    throw = 0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:, 3 * (grid.ni + 1) - 1, 2] -= 1.0
-   p[:, 4 * (grid.ni + 1) - 1, 2] -= 1.0
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:, 3 * (grid.ni + 1) - 1, 2] -= 1.0
+    p[:, 4 * (grid.ni + 1) - 1, 2] -= 1.0
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G12 lower layer half thickness; throw 0.75 except for -0.25 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G12 lower layer half thickness; throw 0.75 except for -0.25 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(
-      np.isclose(
-         grid_fa,
-         np.array([
-            [0.25, 0.25],
-            [1.0, 0.5],
-            [11.0 / 16, 11.0 / 16],  # 0.6875, 0.6875
-            [1.0 / 32, 1.0 / 16],  # 0.03125, 0.0625
-            [0.5, 0.25],
-            [0.4375, 0.4375]
-         ]),
-         atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(
+        np.isclose(
+            grid_fa,
+            np.array([
+                [0.25, 0.25],
+                [1.0, 0.5],
+                [11.0 / 16, 11.0 / 16],  # 0.6875, 0.6875
+                [1.0 / 32, 1.0 / 16],  # 0.03125, 0.0625
+                [0.5, 0.25],
+                [0.4375, 0.4375]
+            ]),
+            atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = 0.75
+    throw = 0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:, 3 * (grid.ni + 1) - 1, 2] -= 1.5
-   p[:, 4 * (grid.ni + 1) - 1, 2] -= 1.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:, 3 * (grid.ni + 1) - 1, 2] -= 1.5
+    p[:, 4 * (grid.ni + 1) - 1, 2] -= 1.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G13 lower layer half thickness; throw 0.75 except for -0.25 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G13 lower layer half thickness; throw 0.75 except for -0.25 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(
-      np.isclose(
-         grid_fa,
-         np.array([
-            [0.25, 0.25],
-            [1.0, 0.5],
-            [5.0 / 8, 5.0 / 8],  # 0.625, 0.625
-            [1.0 / 6, 1.0 / 3],
-            [1.0 / 3, 1.0 / 6],
-            [1.0 / 3, 1.0 / 3]
-         ]),
-         atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(
+        np.isclose(
+            grid_fa,
+            np.array([
+                [0.25, 0.25],
+                [1.0, 0.5],
+                [5.0 / 8, 5.0 / 8],  # 0.625, 0.625
+                [1.0 / 6, 1.0 / 3],
+                [1.0 / 3, 1.0 / 6],
+                [1.0 / 3, 1.0 / 3]
+            ]),
+            atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = 0.75
+    throw = 0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[0, 2 * (grid.ni + 1), 2] += 0.5
-   p[0, 3 * (grid.ni + 1), 2] += 0.5
-   p[1:, 2 * (grid.ni + 1), 2] -= 0.5
-   p[1:, 3 * (grid.ni + 1), 2] -= 0.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[0, 2 * (grid.ni + 1), 2] += 0.5
+    p[0, 3 * (grid.ni + 1), 2] += 0.5
+    p[1:, 2 * (grid.ni + 1), 2] -= 0.5
+    p[1:, 3 * (grid.ni + 1), 2] -= 0.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G14 lower layer half thickness; throw 0.75 except for top layer pinching on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G14 lower layer half thickness; throw 0.75 except for top layer pinching on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 5
-   assert np.all(
-      np.isclose(
-         grid_fa,
-         np.array([
-            [1.0 / 16, 1.0 / 8],  # 0.0625, 0.125
-            [0.75, 0.75],
-            [0.125, 0.125],
-            [0.25, 0.25],
-            [1.0, 0.5]
-         ]),
-         atol = 0.01))
+    assert grid_fcs.count == 5
+    assert np.all(
+        np.isclose(
+            grid_fa,
+            np.array([
+                [1.0 / 16, 1.0 / 8],  # 0.0625, 0.125
+                [0.75, 0.75],
+                [0.125, 0.125],
+                [0.25, 0.25],
+                [1.0, 0.5]
+            ]),
+            atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = -0.25
+    throw = -0.25
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[0, 2 * (grid.ni + 1), 2] += 0.5
-   p[0, 3 * (grid.ni + 1), 2] += 0.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[0, 2 * (grid.ni + 1), 2] += 0.5
+    p[0, 3 * (grid.ni + 1), 2] += 0.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G15 lower layer half thickness; throw -0.25 except for top layer pinching on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G15 lower layer half thickness; throw -0.25 except for top layer pinching on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[11.0 / 16, 11.0 / 12], [0.25, 0.5], [0.5, 0.5], [0.75, 0.75], [0.25, 0.5], [0.5, 0.5]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[11.0 / 16, 11.0 / 12], [0.25, 0.5], [0.5, 0.5], [0.75, 0.75], [0.25, 0.5], [0.5, 0.5]]),
+                   atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = -0.75
+    throw = -0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:, 2 * (grid.ni + 1), 2] -= 1.0
-   p[:, 3 * (grid.ni + 1), 2] -= 1.0
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:, 2 * (grid.ni + 1), 2] -= 1.0
+    p[:, 3 * (grid.ni + 1), 2] -= 1.0
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G16 lower layer half thickness; throw -0.75 except for -1.75 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G16 lower layer half thickness; throw -0.75 except for -1.75 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 4
-   assert np.all(
-      np.isclose(grid_fa, np.array([[1.0 / 32, 1.0 / 32], [0.25, 0.5], [0.25, 0.25], [0.5, 1.0]]), atol = 0.01))
+    assert grid_fcs.count == 4
+    assert np.all(
+        np.isclose(grid_fa, np.array([[1.0 / 32, 1.0 / 32], [0.25, 0.5], [0.25, 0.25], [0.5, 1.0]]), atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = +0.75
+    throw = +0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:, 2 * (grid.ni + 1), 2] += 1.0
-   p[:, 3 * (grid.ni + 1), 2] += 1.0
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:, 2 * (grid.ni + 1), 2] += 1.0
+    p[:, 3 * (grid.ni + 1), 2] += 1.0
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G17 lower layer half thickness; throw +0.75 except for +1.75 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G17 lower layer half thickness; throw +0.75 except for +1.75 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 4
-   assert np.all(
-      np.isclose(grid_fa, np.array([[1.0 / 32, 1.0 / 32], [0.5, 0.25], [0.25, 0.25], [1.0, 0.5]]), atol = 0.01))
+    assert grid_fcs.count == 4
+    assert np.all(
+        np.isclose(grid_fa, np.array([[1.0 / 32, 1.0 / 32], [0.5, 0.25], [0.25, 0.25], [1.0, 0.5]]), atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = +0.75
+    throw = +0.75
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:, 3 * (grid.ni + 1) - 1, 2] += 1.0
-   p[:, 4 * (grid.ni + 1) - 1, 2] += 1.0
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:, 3 * (grid.ni + 1) - 1, 2] += 1.0
+    p[:, 4 * (grid.ni + 1) - 1, 2] += 1.0
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G18 lower layer half thickness; throw +0.75 except for +1.75 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G18 lower layer half thickness; throw +0.75 except for +1.75 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 4
-   assert np.all(
-      np.isclose(grid_fa, np.array([[0.25, 0.25], [1.0, 0.5], [1.0 / 32, 1.0 / 32], [0.5, 0.25]]), atol = 0.01))
+    assert grid_fcs.count == 4
+    assert np.all(
+        np.isclose(grid_fa, np.array([[0.25, 0.25], [1.0, 0.5], [1.0 / 32, 1.0 / 32], [0.5, 0.25]]), atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = +0.25
+    throw = +0.25
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[0, 2 * (grid.ni + 1), 2] -= 0.5
-   p[0, 3 * (grid.ni + 1), 2] -= 0.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[0, 2 * (grid.ni + 1), 2] -= 0.5
+    p[0, 3 * (grid.ni + 1), 2] -= 0.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G19 lower layer half thickness; throw +0.25 except for top edge -0.25 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G19 lower layer half thickness; throw +0.25 except for top edge -0.25 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[15.0 / 16, 0.75], [0.5, 0.2], [0.5, 0.5], [0.75, 0.75], [0.5, 0.25], [0.5, 0.5]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[15.0 / 16, 0.75], [0.5, 0.2], [0.5, 0.5], [0.75, 0.75], [0.5, 0.25], [0.5, 0.5]]),
+                   atol = 0.01))
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = +0.25
+    throw = +0.25
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[0, 3 * (grid.ni + 1) - 1, 2] -= 0.5
-   p[0, 4 * (grid.ni + 1) - 1, 2] -= 0.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[0, 3 * (grid.ni + 1) - 1, 2] -= 0.5
+    p[0, 4 * (grid.ni + 1) - 1, 2] -= 0.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G20 lower layer half thickness; throw +0.25 except for top edge -0.25 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G20 lower layer half thickness; throw +0.25 except for top edge -0.25 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 6
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[0.75, 0.75], [0.5, 0.25], [0.5, 0.5], [15.0 / 16, 0.75], [0.5, 0.2], [0.5, 0.5]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 6
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[0.75, 0.75], [0.5, 0.25], [0.5, 0.5], [15.0 / 16, 0.75], [0.5, 0.2], [0.5, 0.5]]),
+                   atol = 0.01))
 
-   # bl.set_log_level('info')
+    # bl.set_log_level('info')
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = +0.25
+    throw = +0.25
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[1, 2 * (grid.ni + 1), 2] -= 0.5
-   p[1, 3 * (grid.ni + 1), 2] -= 0.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[1, 2 * (grid.ni + 1), 2] -= 0.5
+    p[1, 3 * (grid.ni + 1), 2] -= 0.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G21 lower layer half thickness; throw +0.25 except for mid edge -0.25 on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G21 lower layer half thickness; throw +0.25 except for mid edge -0.25 on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 7
-   assert np.all(
-      np.isclose(grid_fa,
-                 np.array([[11.0 / 16, 11.0 / 12], [1.0 / 16, 1.0 / 12], [1.0 / 8, 1.0 / 12], [7.0 / 8, 7.0 / 12],
-                           [0.75, 0.75], [0.5, 0.25], [0.5, 0.5]]),
-                 atol = 0.01))
+    assert grid_fcs.count == 7
+    assert np.all(
+        np.isclose(grid_fa,
+                   np.array([[11.0 / 16, 11.0 / 12], [1.0 / 16, 1.0 / 12], [1.0 / 8, 1.0 / 12], [7.0 / 8, 7.0 / 12],
+                             [0.75, 0.75], [0.5, 0.25], [0.5, 0.5]]),
+                   atol = 0.01))
 
-   # bl.set_log_level('info')
+    # bl.set_log_level('info')
 
-   # bl.set_log_level('debug')
-   # local_log_out = bl.log_fresh()
-   # display(local_log_out)
+    # bl.set_log_level('debug')
+    # local_log_out = bl.log_fresh()
+    # display(local_log_out)
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = +0.5
+    throw = +0.5
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:2, 2 * (grid.ni + 1), 2] -= 0.5
-   p[:2, 3 * (grid.ni + 1), 2] -= 0.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:2, 2 * (grid.ni + 1), 2] -= 0.5
+    p[:2, 3 * (grid.ni + 1), 2] -= 0.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G22 lower layer half thickness; throw +0.5 except for top, mid edge on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G22 lower layer half thickness; throw +0.5 except for top, mid edge on one wing')
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 5
-   assert np.all(
-      np.isclose(grid_fa, np.array([[0.75, 0.75], [0.5, 0.25], [0.5, 1.0 / 3], [0.5, 0.5], [1.0, 0.5]]), atol = 0.01))
+    assert grid_fcs.count == 5
+    assert np.all(
+        np.isclose(grid_fa, np.array([[0.75, 0.75], [0.5, 0.25], [0.5, 1.0 / 3], [0.5, 0.5], [1.0, 0.5]]), atol = 0.01))
 
-   # bl.set_log_level('debug')
-   # local_log_out = bl.log_fresh()
-   # display(local_log_out)
+    # bl.set_log_level('debug')
+    # local_log_out = bl.log_fresh()
+    # display(local_log_out)
 
-   # J face split
-   # deeper layer half thickness of top layer
+    # J face split
+    # deeper layer half thickness of top layer
 
-   throw = +0.5
+    throw = +0.5
 
-   grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
+    grid = grr.RegularGrid(model, (2, 2, 2), dxyz = (10.0, 10.0, 1.0))
 
-   grid.grid_representation = 'IjkGrid'
+    grid.grid_representation = 'IjkGrid'
 
-   pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
-   pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
-   p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
-   p[:, :pu_pillar_count, :] = pu
-   p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
+    pu_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+    pu = grid.points_ref(masked = False).reshape(grid.nk + 1, pu_pillar_count, 3)
+    p = np.zeros((grid.nk + 1, pu_pillar_count + grid.ni + 1, 3))
+    p[:, :pu_pillar_count, :] = pu
+    p[:, pu_pillar_count:, :] = pu[:, grid.ni + 1:2 * (grid.ni + 1), :]
 
-   p[:, 2 * (grid.ni + 1):, 2] += throw
-   p[:2, 3 * (grid.ni + 1) - 1, 2] -= 0.5
-   p[:2, 4 * (grid.ni + 1) - 1, 2] -= 0.5
-   p[-1, :, 2] -= 0.5
+    p[:, 2 * (grid.ni + 1):, 2] += throw
+    p[:2, 3 * (grid.ni + 1) - 1, 2] -= 0.5
+    p[:2, 4 * (grid.ni + 1) - 1, 2] -= 0.5
+    p[-1, :, 2] -= 0.5
 
-   grid.points_cached = p
-   grid.has_split_coordinate_lines = True
-   grid.split_pillars_count = grid.ni + 1
-   grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
-   grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
-   grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
-   grid.write_hdf5()
-   grid.create_xml(title = 'G23 lower layer half thickness; throw +0.5 except for top, mid edge on one wing')
+    grid.points_cached = p
+    grid.has_split_coordinate_lines = True
+    grid.split_pillars_count = grid.ni + 1
+    grid.split_pillar_indices_cached = np.array([i for i in range(grid.ni + 1, 2 * (grid.ni + 1))], dtype = int)
+    grid.cols_for_split_pillars = np.array((2, 2, 3, 3), dtype = int)
+    grid.cols_for_split_pillars_cl = np.array((1, 3, 4), dtype = int)
+    grid.write_hdf5()
+    grid.create_xml(title = 'G23 lower layer half thickness; throw +0.5 except for top, mid edge on one wing')
 
-   model.store_epc()
-   model.h5_release()
+    model.store_epc()
+    model.h5_release()
 
-   grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
+    grid_fcs, grid_fa = rqtr.fault_connection_set(grid)
 
-   assert grid_fcs is not None
-   assert grid_fa is not None
+    assert grid_fcs is not None
+    assert grid_fa is not None
 
-   # show_fa(grid, grid_fcs, grid_fa)
+    # show_fa(grid, grid_fcs, grid_fa)
 
-   assert grid_fcs.count == 5
-   assert np.all(
-      np.isclose(grid_fa, np.array([[0.5, 0.5], [1.0, 0.5], [0.75, 0.75], [0.5, 0.25], [0.5, 1.0 / 3]]), atol = 0.01))
+    assert grid_fcs.count == 5
+    assert np.all(
+        np.isclose(grid_fa, np.array([[0.5, 0.5], [1.0, 0.5], [0.75, 0.75], [0.5, 0.25], [0.5, 1.0 / 3]]), atol = 0.01))
 
 
 def test_add_faults(tmp_path):
 
-   def write_poly(filename, a, mode = 'w'):
-      nines = 999.0
-      with open(filename, mode = mode) as fp:
-         for row in range(len(a)):
-            fp.write(f'{a[row, 0]:8.3f} {a[row, 1]:8.3f} {a[row, 2]:8.3f}\n')
-         fp.write(f'{nines:8.3f} {nines:8.3f} {nines:8.3f}\n')
+    def write_poly(filename, a, mode = 'w'):
+        nines = 999.0
+        with open(filename, mode = mode) as fp:
+            for row in range(len(a)):
+                fp.write(f'{a[row, 0]:8.3f} {a[row, 1]:8.3f} {a[row, 2]:8.3f}\n')
+            fp.write(f'{nines:8.3f} {nines:8.3f} {nines:8.3f}\n')
 
-   def make_poly(model, a, title, crs):
-      return [
-         rql.Polyline(model, set_bool = False, set_coord = a, set_crs = crs.uuid, set_crsroot = crs.root, title = title)
-      ]
+    def make_poly(model, a, title, crs):
+        return [
+            rql.Polyline(model,
+                         set_bool = False,
+                         set_coord = a,
+                         set_crs = crs.uuid,
+                         set_crsroot = crs.root,
+                         title = title)
+        ]
 
-   epc = os.path.join(tmp_path, 'tic_tac_toe.epc')
+    epc = os.path.join(tmp_path, 'tic_tac_toe.epc')
 
-   for test_mode in ['file', 'polyline']:
+    for test_mode in ['file', 'polyline']:
 
-      model = rq.new_model(epc)
-      grid = grr.RegularGrid(model, extent_kji = (1, 3, 3), set_points_cached = True)
-      grid.write_hdf5()
-      grid.create_xml(write_geometry = True)
-      crs = rqc.Crs(model, uuid = grid.crs_uuid)
-      model.store_epc()
-      # add a permeability array for the grid
-      grid_pc = grid.extract_property_collection()
-      perm = np.linspace(start = 20.0, stop = 200.0, num = grid.cell_count()).reshape(tuple(grid.extent_kji))
-      rqdm.add_one_grid_property_array(epc,
-                                       perm,
-                                       property_kind = 'permeability rock',
-                                       grid_uuid = grid.uuid,
-                                       title = 'PERM',
-                                       uom = 'mD')
+        model = rq.new_model(epc)
+        grid = grr.RegularGrid(model, extent_kji = (1, 3, 3), set_points_cached = True)
+        grid.write_hdf5()
+        grid.create_xml(write_geometry = True)
+        crs = rqc.Crs(model, uuid = grid.crs_uuid)
+        model.store_epc()
+        # add a permeability array for the grid
+        grid_pc = grid.extract_property_collection()
+        perm = np.linspace(start = 20.0, stop = 200.0, num = grid.cell_count()).reshape(tuple(grid.extent_kji))
+        rqdm.add_one_grid_property_array(epc,
+                                         perm,
+                                         property_kind = 'permeability rock',
+                                         grid_uuid = grid.uuid,
+                                         title = 'PERM',
+                                         uom = 'mD')
 
-      # single straight fault
-      a = np.array([[-0.2, 2.0, -0.1], [3.2, 2.0, -0.1]])
-      f = os.path.join(tmp_path, 'ttt_f1.dat')
-      if test_mode == 'file':
-         write_poly(f, a)
-         lines_file_list = [f]
-         polylines = None
-      else:
-         lines_file_list = None
-         polylines = make_poly(model, a, 'ttt_f1', crs)
-      g = rqdm.add_faults(epc,
-                          source_grid = None,
-                          polylines = polylines,
-                          lines_file_list = lines_file_list,
-                          inherit_properties = True,
-                          new_grid_title = 'ttt_f1 straight')
+        # single straight fault
+        a = np.array([[-0.2, 2.0, -0.1], [3.2, 2.0, -0.1]])
+        f = os.path.join(tmp_path, 'ttt_f1.dat')
+        if test_mode == 'file':
+            write_poly(f, a)
+            lines_file_list = [f]
+            polylines = None
+        else:
+            lines_file_list = None
+            polylines = make_poly(model, a, 'ttt_f1', crs)
+        g = rqdm.add_faults(epc,
+                            source_grid = None,
+                            polylines = polylines,
+                            lines_file_list = lines_file_list,
+                            inherit_properties = True,
+                            new_grid_title = 'ttt_f1 straight')
 
-      # single zig-zag fault
-      a = np.array([[-0.2, 1.0, -0.1], [1.0, 1.0, -0.1], [1.0, 2.0, -0.1], [3.2, 2.0, -0.1]])
-      f = os.path.join(tmp_path, 'ttt_f2.dat')
-      if test_mode == 'file':
-         write_poly(f, a)
-         lines_file_list = [f]
-         polylines = None
-      else:
-         lines_file_list = None
-         polylines = make_poly(model, a, 'ttt_f2', crs)
-      g = rqdm.add_faults(epc,
-                          source_grid = None,
-                          polylines = polylines,
-                          lines_file_list = lines_file_list,
-                          inherit_properties = True,
-                          new_grid_title = 'ttt_f2 zig_zag')
+        # single zig-zag fault
+        a = np.array([[-0.2, 1.0, -0.1], [1.0, 1.0, -0.1], [1.0, 2.0, -0.1], [3.2, 2.0, -0.1]])
+        f = os.path.join(tmp_path, 'ttt_f2.dat')
+        if test_mode == 'file':
+            write_poly(f, a)
+            lines_file_list = [f]
+            polylines = None
+        else:
+            lines_file_list = None
+            polylines = make_poly(model, a, 'ttt_f2', crs)
+        g = rqdm.add_faults(epc,
+                            source_grid = None,
+                            polylines = polylines,
+                            lines_file_list = lines_file_list,
+                            inherit_properties = True,
+                            new_grid_title = 'ttt_f2 zig_zag')
 
-      # single zig-zag-zig fault
-      a = np.array([[-0.2, 1.0, -0.1], [1.0, 1.0, -0.1], [1.0, 2.0, -0.1], [2.0, 2.0, -0.1], [2.0, 1.0, -0.1],
-                    [3.2, 1.0, -0.1]])
-      f = os.path.join(tmp_path, 'ttt_f3.dat')
-      if test_mode == 'file':
-         write_poly(f, a)
-         lines_file_list = [f]
-         polylines = None
-      else:
-         lines_file_list = None
-         polylines = make_poly(model, a, 'ttt_f3', crs)
-      g = rqdm.add_faults(epc,
-                          source_grid = None,
-                          polylines = polylines,
-                          lines_file_list = lines_file_list,
-                          inherit_properties = True,
-                          new_grid_title = 'ttt_f3 zig_zag_zig')
+        # single zig-zag-zig fault
+        a = np.array([[-0.2, 1.0, -0.1], [1.0, 1.0, -0.1], [1.0, 2.0, -0.1], [2.0, 2.0, -0.1], [2.0, 1.0, -0.1],
+                      [3.2, 1.0, -0.1]])
+        f = os.path.join(tmp_path, 'ttt_f3.dat')
+        if test_mode == 'file':
+            write_poly(f, a)
+            lines_file_list = [f]
+            polylines = None
+        else:
+            lines_file_list = None
+            polylines = make_poly(model, a, 'ttt_f3', crs)
+        g = rqdm.add_faults(epc,
+                            source_grid = None,
+                            polylines = polylines,
+                            lines_file_list = lines_file_list,
+                            inherit_properties = True,
+                            new_grid_title = 'ttt_f3 zig_zag_zig')
 
-      # horst block
-      a = np.array([[-0.2, 1.0, -0.1], [3.2, 1.0, -0.1]])
-      b = np.array([[3.2, 2.0, -0.1], [-0.2, 2.0, -0.1]])
-      fa = os.path.join(tmp_path, 'ttt_f4a.dat')
-      fb = os.path.join(tmp_path, 'ttt_f4b.dat')
-      if test_mode == 'file':
-         write_poly(fa, a)
-         write_poly(fb, b)
-         lines_file_list = [fa, fb]
-         polylines = None
-      else:
-         lines_file_list = None
-         polylines = make_poly(model, a, 'ttt_f4a', crs) + make_poly(model, b, 'ttt_f4b', crs)
-      g = rqdm.add_faults(epc,
-                          source_grid = None,
-                          polylines = polylines,
-                          lines_file_list = lines_file_list,
-                          inherit_properties = True,
-                          new_grid_title = 'ttt_f4 horst')
+        # horst block
+        a = np.array([[-0.2, 1.0, -0.1], [3.2, 1.0, -0.1]])
+        b = np.array([[3.2, 2.0, -0.1], [-0.2, 2.0, -0.1]])
+        fa = os.path.join(tmp_path, 'ttt_f4a.dat')
+        fb = os.path.join(tmp_path, 'ttt_f4b.dat')
+        if test_mode == 'file':
+            write_poly(fa, a)
+            write_poly(fb, b)
+            lines_file_list = [fa, fb]
+            polylines = None
+        else:
+            lines_file_list = None
+            polylines = make_poly(model, a, 'ttt_f4a', crs) + make_poly(model, b, 'ttt_f4b', crs)
+        g = rqdm.add_faults(epc,
+                            source_grid = None,
+                            polylines = polylines,
+                            lines_file_list = lines_file_list,
+                            inherit_properties = True,
+                            new_grid_title = 'ttt_f4 horst')
 
-      # asymmetrical horst block
-      lr_throw_dict = {'ttt_f4a': (0.0, -0.3), 'ttt_f4b': (0.0, -0.6)}
-      g = rqdm.add_faults(epc,
-                          source_grid = None,
-                          polylines = polylines,
-                          lines_file_list = lines_file_list,
-                          left_right_throw_dict = lr_throw_dict,
-                          inherit_properties = True,
-                          new_grid_title = 'ttt_f5 horst')
-      assert g is not None
+        # asymmetrical horst block
+        lr_throw_dict = {'ttt_f4a': (0.0, -0.3), 'ttt_f4b': (0.0, -0.6)}
+        g = rqdm.add_faults(epc,
+                            source_grid = None,
+                            polylines = polylines,
+                            lines_file_list = lines_file_list,
+                            left_right_throw_dict = lr_throw_dict,
+                            inherit_properties = True,
+                            new_grid_title = 'ttt_f5 horst')
+        assert g is not None
 
-      # scaled version of asymmetrical horst block; with some testing of grid connection set properties
-      model = rq.Model(epc)
-      grid = model.grid(title = 'ttt_f5 horst')
-      assert grid is not None
-      gcs_uuids = model.uuids(obj_type = 'GridConnectionSetRepresentation', related_uuid = grid.uuid)
-      assert gcs_uuids
-      scaling_dict = {'ttt_f4a': 3.0, 'ttt_f4b': 1.7}
-      for i, gcs_uuid in enumerate(gcs_uuids):
-         gcs = rqf.GridConnectionSet(model, uuid = gcs_uuid)
-         # scale the fault throw
-         rqdm.fault_throw_scaling(epc,
-                                  source_grid = grid,
-                                  scaling_factor = None,
-                                  connection_set = gcs,
-                                  scaling_dict = scaling_dict,
-                                  ref_k0 = 0,
-                                  ref_k_faces = 'top',
-                                  cell_range = 0,
-                                  offset_decay = 0.5,
-                                  store_displacement = False,
-                                  inherit_properties = True,
-                                  inherit_realization = None,
-                                  inherit_all_realizations = False,
-                                  new_grid_title = f'ttt_f6 scaled {i+1}',
-                                  new_epc_file = None)
-         model = rq.Model(epc)
-         grid = model.grid(title = f'ttt_f6 scaled {i+1}')
-         assert grid is not None
-      # generate a new grid connection set based on juxtaposition
-      juxta_gcs, fa = rqtr.fault_connection_set(grid)
-      assert len(fa) == juxta_gcs.count
-      # add some (arbitrary) transmissibility multiplier data for each gcs
-      trm = np.linspace(start = 0.0, stop = float(i + 1), num = juxta_gcs.count)
-      gcs_pc = juxta_gcs.extract_property_collection()
-      gcs_pc.add_cached_array_to_imported_list(trm,
-                                               'unit test',
-                                               'TMULT',
-                                               uom = 'Euc',
-                                               property_kind = 'transmissibility multiplier',
-                                               indexable_element = 'faces')
-      juxta_gcs.write_hdf5_and_create_xml_for_new_properties()
-      # calculate transmissibility across the connection set cell face pairs
-      tr = juxta_gcs.tr_property_array(fa = fa, apply_multipliers = True)
-      assert tr is not None
-      assert tr.shape == (juxta_gcs.count,)
-      model.store_epc()
+        # scaled version of asymmetrical horst block; with some testing of grid connection set properties
+        model = rq.Model(epc)
+        grid = model.grid(title = 'ttt_f5 horst')
+        assert grid is not None
+        gcs_uuids = model.uuids(obj_type = 'GridConnectionSetRepresentation', related_uuid = grid.uuid)
+        assert gcs_uuids
+        scaling_dict = {'ttt_f4a': 3.0, 'ttt_f4b': 1.7}
+        for i, gcs_uuid in enumerate(gcs_uuids):
+            gcs = rqf.GridConnectionSet(model, uuid = gcs_uuid)
+            # scale the fault throw
+            rqdm.fault_throw_scaling(epc,
+                                     source_grid = grid,
+                                     scaling_factor = None,
+                                     connection_set = gcs,
+                                     scaling_dict = scaling_dict,
+                                     ref_k0 = 0,
+                                     ref_k_faces = 'top',
+                                     cell_range = 0,
+                                     offset_decay = 0.5,
+                                     store_displacement = False,
+                                     inherit_properties = True,
+                                     inherit_realization = None,
+                                     inherit_all_realizations = False,
+                                     new_grid_title = f'ttt_f6 scaled {i+1}',
+                                     new_epc_file = None)
+            model = rq.Model(epc)
+            grid = model.grid(title = f'ttt_f6 scaled {i+1}')
+            assert grid is not None
+        # generate a new grid connection set based on juxtaposition
+        juxta_gcs, fa = rqtr.fault_connection_set(grid)
+        assert len(fa) == juxta_gcs.count
+        # add some (arbitrary) transmissibility multiplier data for each gcs
+        trm = np.linspace(start = 0.0, stop = float(i + 1), num = juxta_gcs.count)
+        gcs_pc = juxta_gcs.extract_property_collection()
+        gcs_pc.add_cached_array_to_imported_list(trm,
+                                                 'unit test',
+                                                 'TMULT',
+                                                 uom = 'Euc',
+                                                 property_kind = 'transmissibility multiplier',
+                                                 indexable_element = 'faces')
+        juxta_gcs.write_hdf5_and_create_xml_for_new_properties()
+        # calculate transmissibility across the connection set cell face pairs
+        tr = juxta_gcs.tr_property_array(fa = fa, apply_multipliers = True)
+        assert tr is not None
+        assert tr.shape == (juxta_gcs.count,)
+        model.store_epc()
 
-      # two intersecting straight faults
-      a = np.array([[-0.2, 2.0, -0.1], [3.2, 2.0, -0.1]])
-      b = np.array([[1.0, -0.2, -0.1], [1.0, 3.2, -0.1]])
-      f = os.path.join(tmp_path, 'ttt_f7.dat')
-      write_poly(f, a)
-      write_poly(f, b, mode = 'a')
-      if test_mode == 'file':
-         write_poly(f, a)
-         write_poly(f, b, mode = 'a')
-         lines_file_list = [f]
-         polylines = None
-      else:
-         lines_file_list = None
-         polylines = make_poly(model, a, 'ttt_f7_1', crs) + make_poly(model, b, 'ttt_f7_2', crs)
-      g = rqdm.add_faults(epc,
-                          source_grid = None,
-                          polylines = polylines,
-                          lines_file_list = lines_file_list,
-                          inherit_properties = True,
-                          new_grid_title = 'ttt_f7')
+        # two intersecting straight faults
+        a = np.array([[-0.2, 2.0, -0.1], [3.2, 2.0, -0.1]])
+        b = np.array([[1.0, -0.2, -0.1], [1.0, 3.2, -0.1]])
+        f = os.path.join(tmp_path, 'ttt_f7.dat')
+        write_poly(f, a)
+        write_poly(f, b, mode = 'a')
+        if test_mode == 'file':
+            write_poly(f, a)
+            write_poly(f, b, mode = 'a')
+            lines_file_list = [f]
+            polylines = None
+        else:
+            lines_file_list = None
+            polylines = make_poly(model, a, 'ttt_f7_1', crs) + make_poly(model, b, 'ttt_f7_2', crs)
+        g = rqdm.add_faults(epc,
+                            source_grid = None,
+                            polylines = polylines,
+                            lines_file_list = lines_file_list,
+                            inherit_properties = True,
+                            new_grid_title = 'ttt_f7')
 
-      # re-open and check a few things
-      model = rq.Model(epc)
-      assert len(model.titles(obj_type = 'IjkGridRepresentation')) == 8
-      g1 = model.grid(title = 'ttt_f7')
-      assert g1.split_pillars_count == 5
-      cpm = g1.create_column_pillar_mapping()
-      assert cpm.shape == (3, 3, 2, 2)
-      extras = (cpm >= 16)
-      assert np.count_nonzero(extras) == 7
-      assert np.all(np.sort(np.unique(cpm)) == np.arange(21))
+        # re-open and check a few things
+        model = rq.Model(epc)
+        assert len(model.titles(obj_type = 'IjkGridRepresentation')) == 8
+        g1 = model.grid(title = 'ttt_f7')
+        assert g1.split_pillars_count == 5
+        cpm = g1.create_column_pillar_mapping()
+        assert cpm.shape == (3, 3, 2, 2)
+        extras = (cpm >= 16)
+        assert np.count_nonzero(extras) == 7
+        assert np.all(np.sort(np.unique(cpm)) == np.arange(21))

--- a/tests/test_fine_coarse.py
+++ b/tests/test_fine_coarse.py
@@ -9,53 +9,53 @@ import resqpy.olio.fine_coarse as rqfc
 
 def test_fine_coarse():
 
-   fc1 = rqfc.FineCoarse((3, 4, 5), (3, 4, 5))
-   assert fc1 is not None
-   fc1.set_all_ratios_constant()
-   fc1.assert_valid()
-   assert fc1.ratios((2, 2, 2)) == (1, 1, 1)
+    fc1 = rqfc.FineCoarse((3, 4, 5), (3, 4, 5))
+    assert fc1 is not None
+    fc1.set_all_ratios_constant()
+    fc1.assert_valid()
+    assert fc1.ratios((2, 2, 2)) == (1, 1, 1)
 
-   fc2 = rqfc.FineCoarse((9, 16, 10), (3, 4, 5))
-   assert fc2 is not None
-   fc2.set_all_ratios_constant()
-   fc2.set_all_proprtions_equal()
-   fc2.assert_valid()
-   assert fc2.ratios((2, 2, 2)) == (3, 4, 2)
+    fc2 = rqfc.FineCoarse((9, 16, 10), (3, 4, 5))
+    assert fc2 is not None
+    fc2.set_all_ratios_constant()
+    fc2.set_all_proprtions_equal()
+    fc2.assert_valid()
+    assert fc2.ratios((2, 2, 2)) == (3, 4, 2)
 
-   assert fc2.coarse_for_fine_kji0((5, 5, 5)) == (1, 1, 2)
-   assert fc2.coarse_for_fine_axial(1, 13) == 3
-   assert fc2.fine_base_for_coarse_axial(0, 1) == 3
-   assert fc2.fine_base_for_coarse((2, 2, 2)) == (6, 8, 4)
-   assert np.all(fc2.fine_box_for_coarse((1, 2, 3)) == np.array([[3, 8, 6], [5, 11, 7]], dtype = int))
+    assert fc2.coarse_for_fine_kji0((5, 5, 5)) == (1, 1, 2)
+    assert fc2.coarse_for_fine_axial(1, 13) == 3
+    assert fc2.fine_base_for_coarse_axial(0, 1) == 3
+    assert fc2.fine_base_for_coarse((2, 2, 2)) == (6, 8, 4)
+    assert np.all(fc2.fine_box_for_coarse((1, 2, 3)) == np.array([[3, 8, 6], [5, 11, 7]], dtype = int))
 
-   assert_array_almost_equal(fc2.proportion(1, 1), (0.25, 0.25, 0.25, 0.25))
-   assert_array_almost_equal(fc2.interpolation(1, 1), (0.0, 0.25, 0.5, 0.75))
+    assert_array_almost_equal(fc2.proportion(1, 1), (0.25, 0.25, 0.25, 0.25))
+    assert_array_almost_equal(fc2.interpolation(1, 1), (0.0, 0.25, 0.5, 0.75))
 
-   # todo: several more methods to test
+    # todo: several more methods to test
 
 
 def test_fine_coarse_functions():
 
-   assert rqfc.axis_for_letter('k') == 0
-   assert rqfc.axis_for_letter('J') == 1
-   assert rqfc.axis_for_letter('i') == 2
-   assert rqfc.letter_for_axis(0) == 'K'
-   assert rqfc.letter_for_axis(2) == 'I'
+    assert rqfc.axis_for_letter('k') == 0
+    assert rqfc.axis_for_letter('J') == 1
+    assert rqfc.axis_for_letter('i') == 2
+    assert rqfc.letter_for_axis(0) == 'K'
+    assert rqfc.letter_for_axis(2) == 'I'
 
-   fct = rqfc.tartan_refinement(coarse_extent_kji = (5, 7, 7),
-                                coarse_fovea_box = np.array([[0, 2, 2], [1, 4, 4]], dtype = int),
-                                fovea_ratios_kji = (3, 3, 4),
-                                decay_rates_kji = (1, 1, 1),
-                                decay_mode = 'linear')
-   assert fct is not None
-   fct.assert_valid()
+    fct = rqfc.tartan_refinement(coarse_extent_kji = (5, 7, 7),
+                                 coarse_fovea_box = np.array([[0, 2, 2], [1, 4, 4]], dtype = int),
+                                 fovea_ratios_kji = (3, 3, 4),
+                                 decay_rates_kji = (1, 1, 1),
+                                 decay_mode = 'linear')
+    assert fct is not None
+    fct.assert_valid()
 
-   assert fct.coarse_extent_kji == (5, 7, 7)
-   assert fct.fine_extent_kji == (10, 15, 22)
-   assert np.all(fct.coarse_for_fine_axial_vector(0) == (0, 0, 0, 1, 1, 1, 2, 2, 3, 4))
-   for const in fct.constant_ratios:
-      assert const is None
-   assert np.all(fct.vector_ratios[1] == (1, 2, 3, 3, 3, 2, 1))
-   assert np.all(fct.vector_ratios[2] == (2, 3, 4, 4, 4, 3, 2))
+    assert fct.coarse_extent_kji == (5, 7, 7)
+    assert fct.fine_extent_kji == (10, 15, 22)
+    assert np.all(fct.coarse_for_fine_axial_vector(0) == (0, 0, 0, 1, 1, 1, 2, 2, 3, 4))
+    for const in fct.constant_ratios:
+        assert const is None
+    assert np.all(fct.vector_ratios[1] == (1, 2, 3, 3, 3, 2, 1))
+    assert np.all(fct.vector_ratios[2] == (2, 3, 4, 4, 4, 3, 2))
 
-   # todo: add test of tartan refinement in exponential mode
+    # todo: add test of tartan refinement in exponential mode

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -8,46 +8,46 @@ import resqpy.grid as grr
 
 
 def test_regular_grid_no_geometry(tmp_path):
-   # issue #222
+    # issue #222
 
-   epc = os.path.join(tmp_path, 'abstract.epc')
+    epc = os.path.join(tmp_path, 'abstract.epc')
 
-   model = rq.new_model(epc)
+    model = rq.new_model(epc)
 
-   # create a basic block grid
-   grid = grr.RegularGrid(model, extent_kji = (4, 3, 2), title = 'spaced out')
-   grid.create_xml(add_cell_length_properties = False)
-   grid_uuid = grid.uuid
+    # create a basic block grid
+    grid = grr.RegularGrid(model, extent_kji = (4, 3, 2), title = 'spaced out')
+    grid.create_xml(add_cell_length_properties = False)
+    grid_uuid = grid.uuid
 
-   model.store_epc()
+    model.store_epc()
 
-   # check that the grid can be read
-   model = rq.Model(epc)
+    # check that the grid can be read
+    model = rq.Model(epc)
 
-   grid = grr.any_grid(model, uuid = grid_uuid)
+    grid = grr.any_grid(model, uuid = grid_uuid)
 
 
 def test_regular_grid_with_geometry(tmp_path):
 
-   epc = os.path.join(tmp_path, 'concrete.epc')
+    epc = os.path.join(tmp_path, 'concrete.epc')
 
-   model = rq.new_model(epc)
+    model = rq.new_model(epc)
 
-   # create a basic block grid
-   dxyz = (55.0, 65.0, 27.0)
-   grid = grr.RegularGrid(model, extent_kji = (4, 3, 2), title = 'concrete', origin = (0.0, 0.0, 1000.0), dxyz = dxyz)
-   grid.create_xml(add_cell_length_properties = True)
-   grid_uuid = grid.uuid
+    # create a basic block grid
+    dxyz = (55.0, 65.0, 27.0)
+    grid = grr.RegularGrid(model, extent_kji = (4, 3, 2), title = 'concrete', origin = (0.0, 0.0, 1000.0), dxyz = dxyz)
+    grid.create_xml(add_cell_length_properties = True)
+    grid_uuid = grid.uuid
 
-   # store with constant arrays (no hdf5 data)
-   model.store_epc()
+    # store with constant arrays (no hdf5 data)
+    model.store_epc()
 
-   # check that the grid can be read
-   model = rq.Model(epc)
-   grid = grr.any_grid(model, uuid = grid_uuid)
+    # check that the grid can be read
+    model = rq.Model(epc)
+    grid = grr.any_grid(model, uuid = grid_uuid)
 
-   # check that the cell size has been preserved
-   expected_dxyz_dkji = np.zeros((3, 3))
-   for i in range(3):
-      expected_dxyz_dkji[2 - i, i] = dxyz[i]
-   assert_array_almost_equal(expected_dxyz_dkji, grid.block_dxyz_dkji)
+    # check that the cell size has been preserved
+    expected_dxyz_dkji = np.zeros((3, 3))
+    for i in range(3):
+        expected_dxyz_dkji[2 - i, i] = dxyz[i]
+    assert_array_almost_equal(expected_dxyz_dkji, grid.block_dxyz_dkji)

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -11,178 +11,179 @@ from numpy.testing import assert_array_almost_equal
 
 def test_lines(example_model_and_crs):
 
-   # Set up a Polyline
-   title = 'Nazca'
-   model, crs = example_model_and_crs
-   line = resqpy.lines.Polyline(parent_model = model,
-                                title = title,
-                                set_crs = crs.uuid,
-                                set_crsroot = crs.root,
-                                set_bool = True,
-                                set_coord = np.array([[0, 0, 0], [1, 1, 1]]))
-   line.write_hdf5()
-   line.create_xml()
-
-   # Add a interpretation
-   assert line.rep_int_root is None
-   line.create_interpretation_and_feature(kind = 'fault')
-   assert line.rep_int_root is not None
-
-   # Check fault can be loaded in again
-   model.store_epc()
-   model = rq.Model(epc_file = model.epc_file)
-   reload = resqpy.lines.Polyline(parent_model = model, uuid = line.uuid)
-   assert reload.citation_title == title
-
-   fault_interp = resqpy.organize.FaultInterpretation(model, uuid = line.rep_int_uuid)
-   fault_feature = resqpy.organize.TectonicBoundaryFeature(model, uuid = fault_interp.feature_uuid)
-
-   # Check title matches expected title
-   assert fault_feature.feature_name == title
-
-
-def test_lineset(example_model_and_crs):
-
-   # Set up a PolylineSet
-   title = 'Nazcas'
-   model, crs = example_model_and_crs
-   line1 = resqpy.lines.Polyline(parent_model = model,
+    # Set up a Polyline
+    title = 'Nazca'
+    model, crs = example_model_and_crs
+    line = resqpy.lines.Polyline(parent_model = model,
                                  title = title,
                                  set_crs = crs.uuid,
                                  set_crsroot = crs.root,
                                  set_bool = True,
                                  set_coord = np.array([[0, 0, 0], [1, 1, 1]]))
+    line.write_hdf5()
+    line.create_xml()
 
-   line2 = resqpy.lines.Polyline(parent_model = model,
-                                 title = title,
-                                 set_crs = crs.uuid,
-                                 set_crsroot = crs.root,
-                                 set_bool = True,
-                                 set_coord = np.array([[0, 0, 0], [2, 2, 2]]))
+    # Add a interpretation
+    assert line.rep_int_root is None
+    line.create_interpretation_and_feature(kind = 'fault')
+    assert line.rep_int_root is not None
 
-   lines = resqpy.lines.PolylineSet(parent_model = model, title = title, polylines = [line1, line2])
+    # Check fault can be loaded in again
+    model.store_epc()
+    model = rq.Model(epc_file = model.epc_file)
+    reload = resqpy.lines.Polyline(parent_model = model, uuid = line.uuid)
+    assert reload.citation_title == title
 
-   lines.write_hdf5()
-   lines.create_xml()
+    fault_interp = resqpy.organize.FaultInterpretation(model, uuid = line.rep_int_uuid)
+    fault_feature = resqpy.organize.TectonicBoundaryFeature(model, uuid = fault_interp.feature_uuid)
 
-   # Check lines can be loaded in again
-   model.store_epc()
-   model = rq.Model(epc_file = model.epc_file)
-   reload = resqpy.lines.PolylineSet(parent_model = model, uuid = lines.uuid)
-   assert len(reload.polys) == 2, f'Expected two polylines in the polylineset, found {len(reload.polys)}'
-   assert (reload.count_perpol == [2, 2]).all(), f'Expected count per polyline to be [2,2], found {reload.count_perpol}'
+    # Check title matches expected title
+    assert fault_feature.feature_name == title
+
+
+def test_lineset(example_model_and_crs):
+
+    # Set up a PolylineSet
+    title = 'Nazcas'
+    model, crs = example_model_and_crs
+    line1 = resqpy.lines.Polyline(parent_model = model,
+                                  title = title,
+                                  set_crs = crs.uuid,
+                                  set_crsroot = crs.root,
+                                  set_bool = True,
+                                  set_coord = np.array([[0, 0, 0], [1, 1, 1]]))
+
+    line2 = resqpy.lines.Polyline(parent_model = model,
+                                  title = title,
+                                  set_crs = crs.uuid,
+                                  set_crsroot = crs.root,
+                                  set_bool = True,
+                                  set_coord = np.array([[0, 0, 0], [2, 2, 2]]))
+
+    lines = resqpy.lines.PolylineSet(parent_model = model, title = title, polylines = [line1, line2])
+
+    lines.write_hdf5()
+    lines.create_xml()
+
+    # Check lines can be loaded in again
+    model.store_epc()
+    model = rq.Model(epc_file = model.epc_file)
+    reload = resqpy.lines.PolylineSet(parent_model = model, uuid = lines.uuid)
+    assert len(reload.polys) == 2, f'Expected two polylines in the polylineset, found {len(reload.polys)}'
+    assert (reload.count_perpol == [2,
+                                    2]).all(), f'Expected count per polyline to be [2,2], found {reload.count_perpol}'
 
 
 def test_charisma(example_model_and_crs, test_data_path):
-   # Set up a PolylineSet
-   model, crs = example_model_and_crs
-   charisma_file = test_data_path / "Charisma_example.txt"
-   lines = resqpy.lines.PolylineSet(parent_model = model, charisma_file = str(charisma_file))
-   lines.write_hdf5()
-   lines.create_xml()
+    # Set up a PolylineSet
+    model, crs = example_model_and_crs
+    charisma_file = test_data_path / "Charisma_example.txt"
+    lines = resqpy.lines.PolylineSet(parent_model = model, charisma_file = str(charisma_file))
+    lines.write_hdf5()
+    lines.create_xml()
 
-   model.store_epc()
-   model = rq.Model(epc_file = model.epc_file)
-   reload = resqpy.lines.PolylineSet(parent_model = model, uuid = lines.uuid)
+    model.store_epc()
+    model = rq.Model(epc_file = model.epc_file)
+    reload = resqpy.lines.PolylineSet(parent_model = model, uuid = lines.uuid)
 
-   assert reload.title == 'Charisma_example'
-   assert (reload.count_perpol == [
-      4, 5, 4, 5, 5
-   ]).all(), f"Expected count per polyline to be [4,5,4,5,5], found {reload.count_perpol}"
-   assert len(reload.coordinates) == 23, f"Expected length of coordinates to be 23, found {len(reload.coordinates)}"
+    assert reload.title == 'Charisma_example'
+    assert (reload.count_perpol == [
+        4, 5, 4, 5, 5
+    ]).all(), f"Expected count per polyline to be [4,5,4,5,5], found {reload.count_perpol}"
+    assert len(reload.coordinates) == 23, f"Expected length of coordinates to be 23, found {len(reload.coordinates)}"
 
 
 def test_irap(example_model_and_crs, test_data_path):
-   # Set up a PolylineSet
-   model, crs = example_model_and_crs
-   irap_file = test_data_path / "IRAP_example.txt"
-   lines = resqpy.lines.PolylineSet(parent_model = model, irap_file = str(irap_file))
-   lines.write_hdf5()
-   lines.create_xml()
+    # Set up a PolylineSet
+    model, crs = example_model_and_crs
+    irap_file = test_data_path / "IRAP_example.txt"
+    lines = resqpy.lines.PolylineSet(parent_model = model, irap_file = str(irap_file))
+    lines.write_hdf5()
+    lines.create_xml()
 
-   model.store_epc()
-   model = rq.Model(epc_file = model.epc_file)
-   reload = resqpy.lines.PolylineSet(parent_model = model, uuid = lines.uuid)
+    model.store_epc()
+    model = rq.Model(epc_file = model.epc_file)
+    reload = resqpy.lines.PolylineSet(parent_model = model, uuid = lines.uuid)
 
-   assert reload.title == 'IRAP_example'
-   assert (reload.count_perpol == [15]).all(), f"Expected count per polyline to be [15], found {reload.count_perpol}"
-   assert len(reload.coordinates) == 15, f"Expected length of coordinates to be 15, found {len(reload.coordinates)}"
+    assert reload.title == 'IRAP_example'
+    assert (reload.count_perpol == [15]).all(), f"Expected count per polyline to be [15], found {reload.count_perpol}"
+    assert len(reload.coordinates) == 15, f"Expected length of coordinates to be 15, found {len(reload.coordinates)}"
 
 
 def test_is_clockwise(example_model_and_crs):
-   # Set up a Polyline
-   title = 'diamond'
-   model, crs = example_model_and_crs
-   line = resqpy.lines.Polyline(
-      parent_model = model,
-      title = title,
-      set_crs = crs.uuid,
-      set_bool = True,
-      set_coord = np.array([
-         (3.0, 2.0, 4.3),  # z values are ignored for clockwise test
-         (2.0, 1.0, -13.5),
-         (1.0, 2.5, 7.8),
-         (2.1, 3.9, -2.0)
-      ]))
-   assert line is not None
-   for trust in [False, True]:
-      assert line.is_clockwise(trust_metadata = trust)
-   # reverse the order of the coordinates
-   line.coordinates = np.flip(line.coordinates, axis = 0)
-   assert line.is_clockwise(trust_metadata = True)
-   assert not line.is_clockwise(trust_metadata = False)  # should reset metadata
-   assert not line.is_clockwise(trust_metadata = True)
+    # Set up a Polyline
+    title = 'diamond'
+    model, crs = example_model_and_crs
+    line = resqpy.lines.Polyline(
+        parent_model = model,
+        title = title,
+        set_crs = crs.uuid,
+        set_bool = True,
+        set_coord = np.array([
+            (3.0, 2.0, 4.3),  # z values are ignored for clockwise test
+            (2.0, 1.0, -13.5),
+            (1.0, 2.5, 7.8),
+            (2.1, 3.9, -2.0)
+        ]))
+    assert line is not None
+    for trust in [False, True]:
+        assert line.is_clockwise(trust_metadata = trust)
+    # reverse the order of the coordinates
+    line.coordinates = np.flip(line.coordinates, axis = 0)
+    assert line.is_clockwise(trust_metadata = True)
+    assert not line.is_clockwise(trust_metadata = False)  # should reset metadata
+    assert not line.is_clockwise(trust_metadata = True)
 
 
 def test_is_convex(example_model_and_crs):
-   # Set up a Polyline
-   title = 'pentagon'
-   model, crs = example_model_and_crs
-   line = resqpy.lines.Polyline(
-      parent_model = model,
-      title = title,
-      set_crs = crs.uuid,
-      set_bool = True,
-      set_coord = np.array([
-         (3.0, 2.0, 4.3),  # z values are ignored for convexity
-         (2.0, 1.0, -13.5),
-         (1.0, 2.5, 7.8),
-         (1.5, 3.0, -2.0),
-         (2.5, 3.0, 23.4)
-      ]))
-   assert line is not None
-   for trust in [False, True]:
-      assert line.is_convex(trust_metadata = trust)
-   # adjust one point to make shape concave
-   line.coordinates[4, 1] = 1.9
-   assert line.is_convex(trust_metadata = True)
-   assert not line.is_convex(trust_metadata = False)  # should reset metadata
-   assert not line.is_convex(trust_metadata = True)
+    # Set up a Polyline
+    title = 'pentagon'
+    model, crs = example_model_and_crs
+    line = resqpy.lines.Polyline(
+        parent_model = model,
+        title = title,
+        set_crs = crs.uuid,
+        set_bool = True,
+        set_coord = np.array([
+            (3.0, 2.0, 4.3),  # z values are ignored for convexity
+            (2.0, 1.0, -13.5),
+            (1.0, 2.5, 7.8),
+            (1.5, 3.0, -2.0),
+            (2.5, 3.0, 23.4)
+        ]))
+    assert line is not None
+    for trust in [False, True]:
+        assert line.is_convex(trust_metadata = trust)
+    # adjust one point to make shape concave
+    line.coordinates[4, 1] = 1.9
+    assert line.is_convex(trust_metadata = True)
+    assert not line.is_convex(trust_metadata = False)  # should reset metadata
+    assert not line.is_convex(trust_metadata = True)
 
 
 def test_from_scaled_polyline(example_model_and_crs):
-   # Set up an original Polyline
-   title = 'rectangle'
-   model, crs = example_model_and_crs
-   line = resqpy.lines.Polyline(parent_model = model,
-                                title = title,
-                                set_crs = crs.uuid,
-                                set_bool = True,
-                                set_coord = np.array([(0.0, 0.0, 10.0), (0.0, 3.0, 10.0), (12.0, 3.0, 10.0),
-                                                      (12.0, 0.0, 10.0)]))
-   assert line is not None
+    # Set up an original Polyline
+    title = 'rectangle'
+    model, crs = example_model_and_crs
+    line = resqpy.lines.Polyline(parent_model = model,
+                                 title = title,
+                                 set_crs = crs.uuid,
+                                 set_bool = True,
+                                 set_coord = np.array([(0.0, 0.0, 10.0), (0.0, 3.0, 10.0), (12.0, 3.0, 10.0),
+                                                       (12.0, 0.0, 10.0)]))
+    assert line is not None
 
-   # test scaling up to a larger polyline
-   bigger = resqpy.lines.Polyline.from_scaled_polyline(line, 1.5, originator = 'testing')
-   expected = np.array([(-3.0, -0.75, 10.0), (-3.0, 3.75, 10.0), (15.0, 3.75, 10.0), (15.0, -0.75, 10.0)])
-   assert bigger.isclosed
-   assert bigger.is_convex()
-   assert bigger.title == 'rectangle'
-   assert bigger.originator == 'testing'
-   assert_array_almost_equal(bigger.coordinates, expected)
+    # test scaling up to a larger polyline
+    bigger = resqpy.lines.Polyline.from_scaled_polyline(line, 1.5, originator = 'testing')
+    expected = np.array([(-3.0, -0.75, 10.0), (-3.0, 3.75, 10.0), (15.0, 3.75, 10.0), (15.0, -0.75, 10.0)])
+    assert bigger.isclosed
+    assert bigger.is_convex()
+    assert bigger.title == 'rectangle'
+    assert bigger.originator == 'testing'
+    assert_array_almost_equal(bigger.coordinates, expected)
 
-   # test scaling to a smaller polyline
-   smaller = resqpy.lines.Polyline.from_scaled_polyline(line, 2.0 / 3.0, title = 'small')
-   expected = np.array([(2.0, 0.5, 10.0), (2.0, 2.5, 10.0), (10.0, 2.5, 10.0), (10.0, 0.5, 10.0)])
-   assert smaller.title == 'small'
-   assert_array_almost_equal(smaller.coordinates, expected)
+    # test scaling to a smaller polyline
+    smaller = resqpy.lines.Polyline.from_scaled_polyline(line, 2.0 / 3.0, title = 'small')
+    expected = np.array([(2.0, 0.5, 10.0), (2.0, 2.5, 10.0), (10.0, 2.5, 10.0), (10.0, 0.5, 10.0)])
+    assert smaller.title == 'small'
+    assert_array_almost_equal(smaller.coordinates, expected)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,226 +14,226 @@ import resqpy.olio.write_hdf5 as rwh5
 
 def test_model(tmp_path):
 
-   epc = os.path.join(tmp_path, 'model.epc')
-   model = rq.new_model(epc)
-   assert model is not None
-   crs = rqc.Crs(model)
-   crs_root = crs.create_xml()
-   model.store_epc()
-   assert os.path.exists(epc)
-   md_datum_1 = rqw.MdDatum(model, location = (0.0, 0.0, -50.0), crs_uuid = crs.uuid)
-   md_datum_1.create_xml(title = 'Datum 1')
-   md_datum_2 = rqw.MdDatum(model, location = (3.0, 0.0, -50.0), crs_uuid = crs.uuid)
-   md_datum_2.create_xml(title = 'Datum 2')
-   assert len(model.uuids(obj_type = 'MdDatum')) == 2
-   model.store_epc()
+    epc = os.path.join(tmp_path, 'model.epc')
+    model = rq.new_model(epc)
+    assert model is not None
+    crs = rqc.Crs(model)
+    crs_root = crs.create_xml()
+    model.store_epc()
+    assert os.path.exists(epc)
+    md_datum_1 = rqw.MdDatum(model, location = (0.0, 0.0, -50.0), crs_uuid = crs.uuid)
+    md_datum_1.create_xml(title = 'Datum 1')
+    md_datum_2 = rqw.MdDatum(model, location = (3.0, 0.0, -50.0), crs_uuid = crs.uuid)
+    md_datum_2.create_xml(title = 'Datum 2')
+    assert len(model.uuids(obj_type = 'MdDatum')) == 2
+    model.store_epc()
 
-   model = rq.Model(epc)
-   assert model is not None
-   assert len(model.uuids(obj_type = 'MdDatum')) == 2
-   datum_part_1 = model.part(obj_type = 'MdDatum', title = '1', title_mode = 'ends')
-   datum_part_2 = model.part(obj_type = 'MdDatum', title = '2', title_mode = 'ends')
-   assert datum_part_1 is not None and datum_part_2 is not None and datum_part_1 != datum_part_2
-   datum_uuid_1 = rqet.uuid_in_part_name(datum_part_1)
-   datum_uuid_2 = rqet.uuid_in_part_name(datum_part_2)
-   assert not bu.matching_uuids(datum_uuid_1, datum_uuid_2)
-   p1 = model.uuid_part_dict[bu.uuid_as_int(datum_uuid_1)]
-   p2 = model.uuid_part_dict[bu.uuid_as_int(datum_uuid_2)]
-   assert p1 == datum_part_1 and p2 == datum_part_2
+    model = rq.Model(epc)
+    assert model is not None
+    assert len(model.uuids(obj_type = 'MdDatum')) == 2
+    datum_part_1 = model.part(obj_type = 'MdDatum', title = '1', title_mode = 'ends')
+    datum_part_2 = model.part(obj_type = 'MdDatum', title = '2', title_mode = 'ends')
+    assert datum_part_1 is not None and datum_part_2 is not None and datum_part_1 != datum_part_2
+    datum_uuid_1 = rqet.uuid_in_part_name(datum_part_1)
+    datum_uuid_2 = rqet.uuid_in_part_name(datum_part_2)
+    assert not bu.matching_uuids(datum_uuid_1, datum_uuid_2)
+    p1 = model.uuid_part_dict[bu.uuid_as_int(datum_uuid_1)]
+    p2 = model.uuid_part_dict[bu.uuid_as_int(datum_uuid_2)]
+    assert p1 == datum_part_1 and p2 == datum_part_2
 
 
 def test_model_iterators(example_model_with_well):
 
-   model, well_interp, datum, traj = example_model_with_well
+    model, well_interp, datum, traj = example_model_with_well
 
-   w = next(model.iter_wellbore_interpretations())
-   d = next(model.iter_md_datums())
-   t = next(model.iter_trajectories())
+    w = next(model.iter_wellbore_interpretations())
+    d = next(model.iter_md_datums())
+    t = next(model.iter_trajectories())
 
-   assert bu.matching_uuids(w.uuid, well_interp.uuid)
-   assert bu.matching_uuids(d.uuid, datum.uuid)
-   assert bu.matching_uuids(t.uuid, traj.uuid)
-   assert w == well_interp
-   assert d == datum
-   assert t == traj
+    assert bu.matching_uuids(w.uuid, well_interp.uuid)
+    assert bu.matching_uuids(d.uuid, datum.uuid)
+    assert bu.matching_uuids(t.uuid, traj.uuid)
+    assert w == well_interp
+    assert d == datum
+    assert t == traj
 
 
 def test_model_iterate_objects(example_model_with_well):
 
-   from resqpy.organize import WellboreFeature, WellboreInterpretation
+    from resqpy.organize import WellboreFeature, WellboreInterpretation
 
-   model, well_interp, _, _ = example_model_with_well
+    model, well_interp, _, _ = example_model_with_well
 
-   # Try iterating over wellbore features
+    # Try iterating over wellbore features
 
-   wells = model.iter_objs(WellboreFeature)
-   wells = list(wells)
-   w = wells[0]
-   assert len(wells) == 1
-   assert isinstance(wells[0], WellboreFeature)
-   assert wells[0].title == "well A"
+    wells = model.iter_objs(WellboreFeature)
+    wells = list(wells)
+    w = wells[0]
+    assert len(wells) == 1
+    assert isinstance(wells[0], WellboreFeature)
+    assert wells[0].title == "well A"
 
-   # Try iterating over wellbore interpretations
+    # Try iterating over wellbore interpretations
 
-   interps = model.iter_objs(WellboreInterpretation)
-   interps = list(interps)
-   assert len(interps) == 1
-   assert isinstance(interps[0], WellboreInterpretation)
-   assert interps[0] == well_interp
+    interps = model.iter_objs(WellboreInterpretation)
+    interps = list(interps)
+    assert len(interps) == 1
+    assert isinstance(interps[0], WellboreInterpretation)
+    assert interps[0] == well_interp
 
 
 def test_model_iter_crs(example_model_and_crs):
 
-   model, crs_1 = example_model_and_crs
+    model, crs_1 = example_model_and_crs
 
-   crs_list = list(model.iter_crs())
-   assert len(crs_list) == 1
+    crs_list = list(model.iter_crs())
+    assert len(crs_list) == 1
 
-   crs_2 = crs_list[0]
-   assert crs_2 == crs_1
+    crs_2 = crs_list[0]
+    assert crs_2 == crs_1
 
 
 def test_model_iter_crs_empty(tmp_model):
 
-   # Should raise an exception if no CRS exists
-   with pytest.raises(StopIteration):
-      next(tmp_model.iter_crs())
+    # Should raise an exception if no CRS exists
+    with pytest.raises(StopIteration):
+        next(tmp_model.iter_crs())
 
 
 def test_model_as_graph(example_model_with_well):
 
-   model, well_interp, datum, traj = example_model_with_well
-   crs = next(model.iter_crs())
+    model, well_interp, datum, traj = example_model_with_well
+    crs = next(model.iter_crs())
 
-   nodes, edges = model.as_graph()
+    nodes, edges = model.as_graph()
 
-   # Check nodes
-   for obj in [well_interp, datum, traj, crs]:
-      assert str(obj.uuid) in nodes.keys()
-      if hasattr(obj, 'title'):  # TODO: remove this when all objects have this attribute
-         assert obj.title == nodes[str(obj.uuid)]['title']
+    # Check nodes
+    for obj in [well_interp, datum, traj, crs]:
+        assert str(obj.uuid) in nodes.keys()
+        if hasattr(obj, 'title'):  # TODO: remove this when all objects have this attribute
+            assert obj.title == nodes[str(obj.uuid)]['title']
 
-   # Check edges
-   assert frozenset([str(traj.uuid), str(datum.uuid)]) in edges
-   assert frozenset([str(traj.uuid), str(crs.uuid)]) in edges
-   assert frozenset([str(traj.uuid), str(well_interp.uuid)]) in edges
-   assert frozenset([str(datum.uuid), str(traj.uuid)]) in edges
+    # Check edges
+    assert frozenset([str(traj.uuid), str(datum.uuid)]) in edges
+    assert frozenset([str(traj.uuid), str(crs.uuid)]) in edges
+    assert frozenset([str(traj.uuid), str(well_interp.uuid)]) in edges
+    assert frozenset([str(datum.uuid), str(traj.uuid)]) in edges
 
-   # Test uuid subset
-   nodes, edges = model.as_graph(uuids_subset = [datum.uuid])
-   assert len(nodes.keys()) == 1
-   assert len(edges) == 0
+    # Test uuid subset
+    nodes, edges = model.as_graph(uuids_subset = [datum.uuid])
+    assert len(nodes.keys()) == 1
+    assert len(edges) == 0
 
 
 def test_model_copy_all_parts(example_model_with_properties):
 
-   epc = example_model_with_properties.epc_file
-   dir = example_model_with_properties.epc_directory
-   copied_epc = os.path.join(dir, 'copied.epc')
+    epc = example_model_with_properties.epc_file
+    dir = example_model_with_properties.epc_directory
+    copied_epc = os.path.join(dir, 'copied.epc')
 
-   # test copying without consolidation
-   original = rq.Model(epc)
-   assert original is not None
-   copied = rq.new_model(copied_epc)
-   copied.copy_all_parts_from_other_model(original, consolidate = False)
+    # test copying without consolidation
+    original = rq.Model(epc)
+    assert original is not None
+    copied = rq.new_model(copied_epc)
+    copied.copy_all_parts_from_other_model(original, consolidate = False)
 
-   assert set(original.uuids()) == set(copied.uuids())
-   assert set(original.parts()) == set(copied.parts())
+    assert set(original.uuids()) == set(copied.uuids())
+    assert set(original.parts()) == set(copied.parts())
 
-   # test without consolidation of two crs objects
-   copied = rq.new_model(copied_epc)
-   new_crs = rqc.Crs(copied)
-   new_crs.create_xml()
+    # test without consolidation of two crs objects
+    copied = rq.new_model(copied_epc)
+    new_crs = rqc.Crs(copied)
+    new_crs.create_xml()
 
-   copied.copy_all_parts_from_other_model(original, consolidate = False)
+    copied.copy_all_parts_from_other_model(original, consolidate = False)
 
-   assert len(copied.parts()) == len(original.parts()) + 1
-   assert set(original.parts()).issubset(set(copied.parts()))
-   assert len(copied.parts(obj_type = 'LocalDepth3dCrs')) == 2
+    assert len(copied.parts()) == len(original.parts()) + 1
+    assert set(original.parts()).issubset(set(copied.parts()))
+    assert len(copied.parts(obj_type = 'LocalDepth3dCrs')) == 2
 
-   # test with consolidation of two crs objects
-   copied = rq.new_model(copied_epc)
-   new_crs = rqc.Crs(copied)
-   new_crs.create_xml()
+    # test with consolidation of two crs objects
+    copied = rq.new_model(copied_epc)
+    new_crs = rqc.Crs(copied)
+    new_crs.create_xml()
 
-   copied.copy_all_parts_from_other_model(original, consolidate = True)
+    copied.copy_all_parts_from_other_model(original, consolidate = True)
 
-   assert len(copied.parts()) == len(original.parts())
-   assert len(copied.parts(obj_type = 'LocalDepth3dCrs')) == 1
+    assert len(copied.parts()) == len(original.parts())
+    assert len(copied.parts(obj_type = 'LocalDepth3dCrs')) == 1
 
-   crs_uuid = copied.uuid(obj_type = 'LocalDepth3dCrs')
-   assert (bu.matching_uuids(crs_uuid, new_crs.uuid) or
-           bu.matching_uuids(crs_uuid, original.uuid(obj_type = 'LocalDepth3dCrs')))
+    crs_uuid = copied.uuid(obj_type = 'LocalDepth3dCrs')
+    assert (bu.matching_uuids(crs_uuid, new_crs.uuid) or
+            bu.matching_uuids(crs_uuid, original.uuid(obj_type = 'LocalDepth3dCrs')))
 
-   # test write and re-load of copied model
-   copied.store_epc()
-   re_opened = rq.Model(copied_epc)
-   assert re_opened is not None
+    # test write and re-load of copied model
+    copied.store_epc()
+    re_opened = rq.Model(copied_epc)
+    assert re_opened is not None
 
-   assert len(copied.parts()) == len(original.parts())
+    assert len(copied.parts()) == len(original.parts())
 
-   crs_uuid = re_opened.uuid(obj_type = 'LocalDepth3dCrs')
-   assert (bu.matching_uuids(crs_uuid, new_crs.uuid) or
-           bu.matching_uuids(crs_uuid, original.uuid(obj_type = 'LocalDepth3dCrs')))
+    crs_uuid = re_opened.uuid(obj_type = 'LocalDepth3dCrs')
+    assert (bu.matching_uuids(crs_uuid, new_crs.uuid) or
+            bu.matching_uuids(crs_uuid, original.uuid(obj_type = 'LocalDepth3dCrs')))
 
 
 def test_model_copy_all_parts_non_resqpy_hdf5_paths(example_model_with_properties):
-   # this test uses low level methods to override the hdf5 internal paths for some new objects
+    # this test uses low level methods to override the hdf5 internal paths for some new objects
 
-   epc = example_model_with_properties.epc_file
-   dir = example_model_with_properties.epc_directory
-   copied_epc = os.path.join(dir, 'copied.epc')
-   extent_kji = (3, 5, 5)  # needs to match extent of grid in example model
+    epc = example_model_with_properties.epc_file
+    dir = example_model_with_properties.epc_directory
+    copied_epc = os.path.join(dir, 'copied.epc')
+    extent_kji = (3, 5, 5)  # needs to match extent of grid in example model
 
-   # add some properties with bespoke internal hdf5 paths
-   original = rq.Model(epc)
-   assert original is not None
-   grid_uuid = original.uuid(obj_type = 'IjkGridRepresentation')
-   assert grid_uuid is not None
-   data = np.linspace(0.0, 1000.0, num = 75).reshape(extent_kji)
+    # add some properties with bespoke internal hdf5 paths
+    original = rq.Model(epc)
+    assert original is not None
+    grid_uuid = original.uuid(obj_type = 'IjkGridRepresentation')
+    assert grid_uuid is not None
+    data = np.linspace(0.0, 1000.0, num = 75).reshape(extent_kji)
 
-   hdf5_paths = [
-      '/RESQML/uuid_waffle/values', '/RESQML/waffle_uuid/unusual_name', 'RESQML/class_uuid_waffle/values0',
-      'RESQML/something_interesting/array', '/RESQML/abrupt', 'no_resqml/uuid/values'
-   ]
+    hdf5_paths = [
+        '/RESQML/uuid_waffle/values', '/RESQML/waffle_uuid/unusual_name', 'RESQML/class_uuid_waffle/values0',
+        'RESQML/something_interesting/array', '/RESQML/abrupt', 'no_resqml/uuid/values'
+    ]
 
-   prop_list = []
-   path_list = []  # elements will have 'uuid' replaced with uuid string
-   h5_reg = rwh5.H5Register(original)
-   for i, hdf5_path in enumerate(hdf5_paths):
-      prop = rqp.Property(original, support_uuid = grid_uuid)
-      if 'uuid' in hdf5_path:
-         path = hdf5_path.replace('uuid', str(prop.uuid))
-      else:
-         path = hdf5_path
-      prop.prepare_import(cached_array = data,
-                          source_info = 'test data',
-                          keyword = f'TEST{i}',
-                          property_kind = 'continuous',
-                          uom = 'm')
-      for entry in prop.collection.imported_list:  # only one entry
-         # override internal hdf5 path
-         h5_reg.register_dataset(entry[0], 'values_patch0', prop.collection.__dict__[entry[3]], hdf5_path = path)
-      prop_list.append(prop)
-      path_list.append(path)
-   h5_reg.write(mode = 'a')
+    prop_list = []
+    path_list = []  # elements will have 'uuid' replaced with uuid string
+    h5_reg = rwh5.H5Register(original)
+    for i, hdf5_path in enumerate(hdf5_paths):
+        prop = rqp.Property(original, support_uuid = grid_uuid)
+        if 'uuid' in hdf5_path:
+            path = hdf5_path.replace('uuid', str(prop.uuid))
+        else:
+            path = hdf5_path
+        prop.prepare_import(cached_array = data,
+                            source_info = 'test data',
+                            keyword = f'TEST{i}',
+                            property_kind = 'continuous',
+                            uom = 'm')
+        for entry in prop.collection.imported_list:  # only one entry
+            # override internal hdf5 path
+            h5_reg.register_dataset(entry[0], 'values_patch0', prop.collection.__dict__[entry[3]], hdf5_path = path)
+        prop_list.append(prop)
+        path_list.append(path)
+    h5_reg.write(mode = 'a')
 
-   for prop, hdf5_path in zip(prop_list, path_list):
-      root_node = prop.create_xml(find_local_property_kind = False)
-      assert root_node is not None
-      # override the hdf5 internal path in the xml tree
-      path_node = rqet.find_nested_tags(root_node, ['PatchOfValues', 'Values', 'Values', 'PathInHdfFile'])
-      assert path_node is not None
-      path_node.text = hdf5_path
+    for prop, hdf5_path in zip(prop_list, path_list):
+        root_node = prop.create_xml(find_local_property_kind = False)
+        assert root_node is not None
+        # override the hdf5 internal path in the xml tree
+        path_node = rqet.find_nested_tags(root_node, ['PatchOfValues', 'Values', 'Values', 'PathInHdfFile'])
+        assert path_node is not None
+        path_node.text = hdf5_path
 
-   # rewrite model
-   original.store_epc()
+    # rewrite model
+    original.store_epc()
 
-   # re-open model and test copying
-   original = rq.Model(epc)
-   assert original is not None
-   copied = rq.new_model(copied_epc)
-   copied.copy_all_parts_from_other_model(original, consolidate = False)
+    # re-open model and test copying
+    original = rq.Model(epc)
+    assert original is not None
+    copied = rq.new_model(copied_epc)
+    copied.copy_all_parts_from_other_model(original, consolidate = False)
 
-   assert set(original.uuids()) == set(copied.uuids())
-   assert set(original.parts()) == set(copied.parts())
+    assert set(original.uuids()) == set(copied.uuids())
+    assert set(original.parts()) == set(copied.parts())

--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -6,168 +6,168 @@ from resqpy.model import Model
 
 # Test saving and loading from disk
 @pytest.mark.parametrize(
-   "cls, data",
-   [
-      (
-         rqo.OrganizationFeature,
-         dict(feature_name = 'hello', organization_kind = 'stratigraphic'),
-      ),
-      (
-         rqo.GeobodyFeature,
-         dict(feature_name = 'hi'),
-      ),
-      (
-         rqo.BoundaryFeature,
-         dict(feature_name = 'foobar'),
-      ),
-      (
-         rqo.FrontierFeature,
-         dict(feature_name = 'foobar'),
-      ),
-      (
-         rqo.GeologicUnitFeature,
-         dict(feature_name = 'foobar'),
-      ),
-      (
-         rqo.FluidBoundaryFeature,
-         dict(feature_name = 'foobar', kind = 'gas oil contact'),
-      ),
-      (
-         rqo.TectonicBoundaryFeature,
-         dict(feature_name = 'foobar', kind = 'fracture'),
-      ),
-      (
-         rqo.GeneticBoundaryFeature,
-         dict(feature_name = 'foobar', kind = 'geobody boundary'),  # Age as well?
-      ),
-      (
-         rqo.WellboreFeature,
-         dict(feature_name = 'foobar'),
-      ),
-   ])
+    "cls, data",
+    [
+        (
+            rqo.OrganizationFeature,
+            dict(feature_name = 'hello', organization_kind = 'stratigraphic'),
+        ),
+        (
+            rqo.GeobodyFeature,
+            dict(feature_name = 'hi'),
+        ),
+        (
+            rqo.BoundaryFeature,
+            dict(feature_name = 'foobar'),
+        ),
+        (
+            rqo.FrontierFeature,
+            dict(feature_name = 'foobar'),
+        ),
+        (
+            rqo.GeologicUnitFeature,
+            dict(feature_name = 'foobar'),
+        ),
+        (
+            rqo.FluidBoundaryFeature,
+            dict(feature_name = 'foobar', kind = 'gas oil contact'),
+        ),
+        (
+            rqo.TectonicBoundaryFeature,
+            dict(feature_name = 'foobar', kind = 'fracture'),
+        ),
+        (
+            rqo.GeneticBoundaryFeature,
+            dict(feature_name = 'foobar', kind = 'geobody boundary'),  # Age as well?
+        ),
+        (
+            rqo.WellboreFeature,
+            dict(feature_name = 'foobar'),
+        ),
+    ])
 def test_organize_classes(tmp_model, cls, data):
 
-   # Load example model from a fixture
-   model = tmp_model
-   epc = model.epc_file
+    # Load example model from a fixture
+    model = tmp_model
+    epc = model.epc_file
 
-   # Create the feature
-   obj = cls(parent_model = model, **data)
-   uuid = obj.uuid
+    # Create the feature
+    obj = cls(parent_model = model, **data)
+    uuid = obj.uuid
 
-   # Save to disk
-   obj.create_xml()
-   model.store_epc()
-   model.h5_release()
+    # Save to disk
+    obj.create_xml()
+    model.store_epc()
+    model.h5_release()
 
-   # Reload from disk
-   del model, obj
-   model2 = Model(epc_file = epc)
-   obj2 = cls(parent_model = model2, uuid = uuid)
+    # Reload from disk
+    del model, obj
+    model2 = Model(epc_file = epc)
+    obj2 = cls(parent_model = model2, uuid = uuid)
 
-   # Check all attributes were loaded correctly
-   for key, expected_value in data.items():
-      assert getattr(obj2, key) == expected_value, f"Error for {key}"
+    # Check all attributes were loaded correctly
+    for key, expected_value in data.items():
+        assert getattr(obj2, key) == expected_value, f"Error for {key}"
 
 
 def test_RockFluidUnitFeature(tmp_model):
 
-   # Create the features
-   top = rqo.BoundaryFeature(tmp_model, feature_name = 'the top')
-   base = rqo.BoundaryFeature(tmp_model, feature_name = 'the base')
-   rfuf_1 = rqo.RockFluidUnitFeature(parent_model = tmp_model,
-                                     feature_name = 'foobar',
-                                     phase = 'seal',
-                                     top_boundary_feature = top,
-                                     base_boundary_feature = base)
-   uuid = rfuf_1.uuid
+    # Create the features
+    top = rqo.BoundaryFeature(tmp_model, feature_name = 'the top')
+    base = rqo.BoundaryFeature(tmp_model, feature_name = 'the base')
+    rfuf_1 = rqo.RockFluidUnitFeature(parent_model = tmp_model,
+                                      feature_name = 'foobar',
+                                      phase = 'seal',
+                                      top_boundary_feature = top,
+                                      base_boundary_feature = base)
+    uuid = rfuf_1.uuid
 
-   # Save to disk
-   top.create_xml()
-   base.create_xml()
-   rfuf_1.create_xml()
-   tmp_model.store_epc()
+    # Save to disk
+    top.create_xml()
+    base.create_xml()
+    rfuf_1.create_xml()
+    tmp_model.store_epc()
 
-   # Reload from disk
-   rfuf_2 = rqo.RockFluidUnitFeature(parent_model = tmp_model, uuid = uuid)
+    # Reload from disk
+    rfuf_2 = rqo.RockFluidUnitFeature(parent_model = tmp_model, uuid = uuid)
 
-   # Check properties the same
-   assert rfuf_2.feature_name == 'foobar'
-   assert rfuf_2.phase == 'seal'
-   assert rfuf_2.top_boundary_feature.feature_name == 'the top'
-   assert rfuf_2.base_boundary_feature.feature_name == 'the base'
+    # Check properties the same
+    assert rfuf_2.feature_name == 'foobar'
+    assert rfuf_2.phase == 'seal'
+    assert rfuf_2.top_boundary_feature.feature_name == 'the top'
+    assert rfuf_2.base_boundary_feature.feature_name == 'the base'
 
 
 def test_FaultInterp(tmp_model):
 
-   title = "not my fault"
-   tect_boundary = rqo.TectonicBoundaryFeature(tmp_model, kind = 'fault')
-   fault_interp = rqo.FaultInterpretation(
-      tmp_model,
-      tectonic_boundary_feature = tect_boundary,
-      title = title,
-      domain = "depth",
-      is_normal = True,
-      maximum_throw = 3,
-   )
+    title = "not my fault"
+    tect_boundary = rqo.TectonicBoundaryFeature(tmp_model, kind = 'fault')
+    fault_interp = rqo.FaultInterpretation(
+        tmp_model,
+        tectonic_boundary_feature = tect_boundary,
+        title = title,
+        domain = "depth",
+        is_normal = True,
+        maximum_throw = 3,
+    )
 
-   tect_boundary.create_xml()
-   fault_interp.create_xml()
+    tect_boundary.create_xml()
+    fault_interp.create_xml()
 
-   fault_interp_2 = rqo.FaultInterpretation(tmp_model, uuid = fault_interp.uuid)
-   assert fault_interp_2.title == title
-   assert fault_interp_2.maximum_throw == 3
+    fault_interp_2 = rqo.FaultInterpretation(tmp_model, uuid = fault_interp.uuid)
+    assert fault_interp_2.title == title
+    assert fault_interp_2.maximum_throw == 3
 
 
 def test_EarthModel(tmp_model):
 
-   title = 'gaia'
-   org_feat = rqo.OrganizationFeature(tmp_model, feature_name = 'marie kondo', organization_kind = "earth model")
-   em1 = rqo.EarthModelInterpretation(tmp_model, title = title, organization_feature = org_feat)
+    title = 'gaia'
+    org_feat = rqo.OrganizationFeature(tmp_model, feature_name = 'marie kondo', organization_kind = "earth model")
+    em1 = rqo.EarthModelInterpretation(tmp_model, title = title, organization_feature = org_feat)
 
-   org_feat.create_xml()
-   em1.create_xml()
+    org_feat.create_xml()
+    em1.create_xml()
 
-   em2 = rqo.EarthModelInterpretation(tmp_model, uuid = em1.uuid)
-   assert em2.title == title
+    em2 = rqo.EarthModelInterpretation(tmp_model, uuid = em1.uuid)
+    assert em2.title == title
 
 
 def test_Horizon(tmp_model):
 
-   gen = rqo.GeneticBoundaryFeature(tmp_model, kind = 'horizon')
-   hor = rqo.HorizonInterpretation(tmp_model,
-                                   genetic_boundary_feature = gen,
-                                   sequence_stratigraphy_surface = 'maximum flooding')
+    gen = rqo.GeneticBoundaryFeature(tmp_model, kind = 'horizon')
+    hor = rqo.HorizonInterpretation(tmp_model,
+                                    genetic_boundary_feature = gen,
+                                    sequence_stratigraphy_surface = 'maximum flooding')
 
-   gen.create_xml()
-   hor.create_xml()
+    gen.create_xml()
+    hor.create_xml()
 
-   hor2 = rqo.HorizonInterpretation(tmp_model, uuid = hor.uuid)
-   assert hor2.sequence_stratigraphy_surface == hor.sequence_stratigraphy_surface
+    hor2 = rqo.HorizonInterpretation(tmp_model, uuid = hor.uuid)
+    assert hor2.sequence_stratigraphy_surface == hor.sequence_stratigraphy_surface
 
 
 def test_GeobodyBoundary(tmp_model):
 
-   gen = rqo.GeneticBoundaryFeature(tmp_model, kind = 'geobody boundary')
-   gb = rqo.GeobodyBoundaryInterpretation(tmp_model, genetic_boundary_feature = gen)
+    gen = rqo.GeneticBoundaryFeature(tmp_model, kind = 'geobody boundary')
+    gb = rqo.GeobodyBoundaryInterpretation(tmp_model, genetic_boundary_feature = gen)
 
-   gen.create_xml()
-   gb.create_xml()
-   gb2 = rqo.GeobodyBoundaryInterpretation(tmp_model, uuid = gb.uuid)
-   assert gb == gb2
+    gen.create_xml()
+    gb.create_xml()
+    gb2 = rqo.GeobodyBoundaryInterpretation(tmp_model, uuid = gb.uuid)
+    assert gb == gb2
 
 
 def test_wellbore_interp_title(tmp_model):
-   # Create a feature and interp objects
-   feature_name = 'well A'
-   well_feature = rqo.WellboreFeature(tmp_model, feature_name = feature_name)
-   well_feature.create_xml()
-   well_interp_1 = rqo.WellboreInterpretation(tmp_model, wellbore_feature = well_feature, is_drilled = True)
-   well_interp_1.create_xml()
+    # Create a feature and interp objects
+    feature_name = 'well A'
+    well_feature = rqo.WellboreFeature(tmp_model, feature_name = feature_name)
+    well_feature.create_xml()
+    well_interp_1 = rqo.WellboreInterpretation(tmp_model, wellbore_feature = well_feature, is_drilled = True)
+    well_interp_1.create_xml()
 
-   # Create a duplicate object, loading from XML
-   well_interp_2 = rqo.WellboreInterpretation(tmp_model, uuid = well_interp_1.uuid)
+    # Create a duplicate object, loading from XML
+    well_interp_2 = rqo.WellboreInterpretation(tmp_model, uuid = well_interp_1.uuid)
 
-   # Check feature name is present
-   assert well_interp_1.title == feature_name
-   assert well_interp_2.title == feature_name
+    # Check feature name is present
+    assert well_interp_1.title == feature_name
+    assert well_interp_2.title == feature_name

--- a/tests/test_point_inclusion.py
+++ b/tests/test_point_inclusion.py
@@ -9,60 +9,60 @@ import resqpy.olio.point_inclusion as pip
 
 
 def test_pip_cn_and_wn():
-   # unit square polygon
-   poly = np.array([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
-   p_in = np.array([(0.00001, 0.00001), (0.00001, 0.99999), (0.99999, 0.00001), (0.99999, 0.99999)])
-   p_out = np.array([(1.1, 0.1), (-0.1, 0.2), (0.5, 1.00001), (0.4, -0.0001), (1.00001, 1.00001), (1.00001, -0.00001)])
-   for pip_fn in [pip.pip_cn, pip.pip_wn]:
-      assert pip_fn((0.5, 0.5), poly)
-      for p in p_in:
-         assert pip_fn(p, poly)
-      for p in p_out:
-         assert not pip_fn(p, poly)
-   assert np.all(pip.pip_array_cn(p_in, poly))
-   assert not np.any(pip.pip_array_cn(p_out, poly))
+    # unit square polygon
+    poly = np.array([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
+    p_in = np.array([(0.00001, 0.00001), (0.00001, 0.99999), (0.99999, 0.00001), (0.99999, 0.99999)])
+    p_out = np.array([(1.1, 0.1), (-0.1, 0.2), (0.5, 1.00001), (0.4, -0.0001), (1.00001, 1.00001), (1.00001, -0.00001)])
+    for pip_fn in [pip.pip_cn, pip.pip_wn]:
+        assert pip_fn((0.5, 0.5), poly)
+        for p in p_in:
+            assert pip_fn(p, poly)
+        for p in p_out:
+            assert not pip_fn(p, poly)
+    assert np.all(pip.pip_array_cn(p_in, poly))
+    assert not np.any(pip.pip_array_cn(p_out, poly))
 
 
 def test_figure_of_eight():
-   fig_8 = np.array([(-100.0, -200.0), (100.0, 200.0), (-100.0, 200.0), (100.0, -200, 0)])
-   p_in = np.array([(-99.0, -199.0), (0.0, -1.0), (99.0, 199.0), (0.0, 1.0), (49.9, -100.0)])
-   p_out = np.array([(1000.0, -23.0), (1.0, 0.0), (-0.001, 0.0), (-50.1, 100.0)])
-   for pip_fn in (pip.pip_cn, pip.pip_wn):
-      for p in p_in:
-         assert pip_fn(p, fig_8)
-      for p in p_out:
-         assert not pip_fn(p, fig_8)
-   assert np.all(pip.pip_array_cn(p_in, fig_8))
-   assert not np.any(pip.pip_array_cn(p_out, fig_8))
+    fig_8 = np.array([(-100.0, -200.0), (100.0, 200.0), (-100.0, 200.0), (100.0, -200, 0)])
+    p_in = np.array([(-99.0, -199.0), (0.0, -1.0), (99.0, 199.0), (0.0, 1.0), (49.9, -100.0)])
+    p_out = np.array([(1000.0, -23.0), (1.0, 0.0), (-0.001, 0.0), (-50.1, 100.0)])
+    for pip_fn in (pip.pip_cn, pip.pip_wn):
+        for p in p_in:
+            assert pip_fn(p, fig_8)
+        for p in p_out:
+            assert not pip_fn(p, fig_8)
+    assert np.all(pip.pip_array_cn(p_in, fig_8))
+    assert not np.any(pip.pip_array_cn(p_out, fig_8))
 
 
 def test_points_in_polygon(tmp_path):
-   # create an ascii file holding vertices of a polygon
-   poly_file = os.path.join(tmp_path, 'diamond.txt')
-   diamond = np.array([(0.0, 3.0, 0.0), (3.0, 6.0, -1.3), (6.0, 3.0, 12.5), (3.0, 0.0, 0.0)])
-   with open(poly_file, 'w') as fp:
-      for xyz in diamond:
-         fp.write(f'{xyz[0]} {xyz[1]} {xyz[2]}\n')
-      fp.write('999.0 999.0 999.0\n')
-   # test some points with no multiplier applied to polygon geometry
-   p_in = np.array([(3.0, 3.0), (0.1, 3.0), (1.55, 1.55), (4.49, 4.49), (5.99, 3.0), (3.1, 0.11)])
-   p_out = np.array([(-3.0, -3.0), (2.0, 0.99), (4.51, 4.51), (6.01, 3.0)])
-   assert np.all(pip.points_in_polygon(p_in[:, 0], p_in[:, 1], poly_file))
-   assert not np.any(pip.points_in_polygon(p_out[:, 0], p_out[:, 1], poly_file))
-   # test some points with multiplier applied to polygon geometry
-   multiplier = 2.0 / 3.0
-   p_in *= multiplier
-   p_out *= multiplier
-   assert np.all(pip.points_in_polygon(p_in[:, 0], p_in[:, 1], poly_file, poly_unit_multiplier = multiplier))
-   assert not np.any(pip.points_in_polygon(p_out[:, 0], p_out[:, 1], poly_file, poly_unit_multiplier = multiplier))
+    # create an ascii file holding vertices of a polygon
+    poly_file = os.path.join(tmp_path, 'diamond.txt')
+    diamond = np.array([(0.0, 3.0, 0.0), (3.0, 6.0, -1.3), (6.0, 3.0, 12.5), (3.0, 0.0, 0.0)])
+    with open(poly_file, 'w') as fp:
+        for xyz in diamond:
+            fp.write(f'{xyz[0]} {xyz[1]} {xyz[2]}\n')
+        fp.write('999.0 999.0 999.0\n')
+    # test some points with no multiplier applied to polygon geometry
+    p_in = np.array([(3.0, 3.0), (0.1, 3.0), (1.55, 1.55), (4.49, 4.49), (5.99, 3.0), (3.1, 0.11)])
+    p_out = np.array([(-3.0, -3.0), (2.0, 0.99), (4.51, 4.51), (6.01, 3.0)])
+    assert np.all(pip.points_in_polygon(p_in[:, 0], p_in[:, 1], poly_file))
+    assert not np.any(pip.points_in_polygon(p_out[:, 0], p_out[:, 1], poly_file))
+    # test some points with multiplier applied to polygon geometry
+    multiplier = 2.0 / 3.0
+    p_in *= multiplier
+    p_out *= multiplier
+    assert np.all(pip.points_in_polygon(p_in[:, 0], p_in[:, 1], poly_file, poly_unit_multiplier = multiplier))
+    assert not np.any(pip.points_in_polygon(p_out[:, 0], p_out[:, 1], poly_file, poly_unit_multiplier = multiplier))
 
 
 def test_scan():
-   kite = np.array([(0.1, 3.0, 0.0), (3.0, 4.9, 0.0), (5.9, 3.0, 0.0), (3.0, 0.1, 0.0)])
-   origin = (-1.0, 0.0)
-   ncol = 8
-   nrow = 6
-   expected = np.array([(0, 0, 0, 0, 0, 0, 0, 0), (0, 0, 0, 0, 1, 0, 0, 0), (0, 0, 0, 1, 1, 1, 0, 0),
-                        (0, 0, 1, 1, 1, 1, 1, 0), (0, 0, 0, 1, 1, 1, 0, 0), (0, 0, 0, 0, 0, 0, 0, 0)],
-                       dtype = bool)
-   assert np.all(pip.scan(origin, ncol, nrow, 1.0, 1.0, kite) == expected)
+    kite = np.array([(0.1, 3.0, 0.0), (3.0, 4.9, 0.0), (5.9, 3.0, 0.0), (3.0, 0.1, 0.0)])
+    origin = (-1.0, 0.0)
+    ncol = 8
+    nrow = 6
+    expected = np.array([(0, 0, 0, 0, 0, 0, 0, 0), (0, 0, 0, 0, 1, 0, 0, 0), (0, 0, 0, 1, 1, 1, 0, 0),
+                         (0, 0, 1, 1, 1, 1, 1, 0), (0, 0, 0, 1, 1, 1, 0, 0), (0, 0, 0, 0, 0, 0, 0, 0)],
+                        dtype = bool)
+    assert np.all(pip.scan(origin, ncol, nrow, 1.0, 1.0, kite) == expected)

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -20,485 +20,485 @@ import resqpy.olio.uuid as bu
 
 
 def test_property(tmp_path):
-   epc = os.path.join(tmp_path, 'test_prop.epc')
-   model = rq.new_model(epc)
-   grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
-   grid.write_hdf5()
-   grid.create_xml()
-   a1 = np.random.random(grid.extent_kji)
-   p1 = rqp.Property.from_array(model,
-                                a1,
-                                source_info = 'random',
-                                keyword = 'NETGRS',
-                                support_uuid = grid.uuid,
-                                property_kind = 'net to gross ratio',
-                                indexable_element = 'cells',
-                                uom = 'm3/m3')
-   a3 = np.random.random((grid.nk + 1, grid.nj + 1, grid.ni + 1))
-   p3 = rqp.Property.from_array(model,
-                                a3,
-                                source_info = 'random',
-                                keyword = 'jiggle shared nodes',
-                                support_uuid = grid.uuid,
-                                property_kind = 'length',
-                                indexable_element = 'nodes',
-                                uom = 'm3')
-   a4 = np.random.random((grid.nk, grid.nj, grid.ni, 2, 2, 2))
-   p4 = rqp.Property.from_array(model,
-                                a4,
-                                source_info = 'random',
-                                keyword = 'jiggle nodes per cell',
-                                support_uuid = grid.uuid,
-                                property_kind = 'length',
-                                indexable_element = 'nodes per cell',
-                                uom = 'm3')
-   pk = rqp.PropertyKind(model, title = 'facies', parent_property_kind = 'discrete')
-   pk.create_xml()
-   facies_dict = {0: 'background'}
-   for i in range(1, 10):
-      facies_dict[i] = 'facies ' + str(i)
-   sl = rqp.StringLookup(model, int_to_str_dict = facies_dict, title = 'facies table')
-   sl.create_xml()
-   shape2 = tuple(list(grid.extent_kji) + [2])
-   a2 = (np.random.random(shape2) * 10.0).astype(int)
-   p2 = rqp.Property.from_array(model,
-                                a2,
-                                source_info = 'random',
-                                keyword = 'FACIES',
-                                support_uuid = grid.uuid,
-                                local_property_kind_uuid = pk.uuid,
-                                indexable_element = 'cells',
-                                discrete = True,
-                                null_value = 0,
-                                count = 2,
-                                string_lookup_uuid = sl.uuid)
-   model.store_epc()
-   model = rq.Model(epc)
-   ntg_uuid = model.uuid(obj_type = p1.resqml_type, title = 'NETGRS')
-   assert ntg_uuid is not None
-   p1p = rqp.Property(model, uuid = ntg_uuid)
-   assert np.all(p1p.array_ref() == p1.array_ref())
-   assert p1p.uom() == 'm3/m3'
-   facies_uuid = model.uuid(obj_type = p2.resqml_type, title = 'FACIES')
-   assert facies_uuid is not None
-   p2p = rqp.Property(model, uuid = facies_uuid)
-   assert np.all(p2p.array_ref() == p2.array_ref())
-   assert p2p.null_value() is not None and p2p.null_value() == 0
-   grid = model.grid()
-   jiggle_parts = model.parts(title = 'jiggle', title_mode = 'starts')
-   assert len(jiggle_parts) == 2
-   jiggle_shared_uuid = model.uuid(parts_list = jiggle_parts, title = 'shared', title_mode = 'contains')
-   assert jiggle_shared_uuid is not None
-   p3p = rqp.Property(model, uuid = jiggle_shared_uuid)
-   assert p3p is not None
-   assert p3p.array_ref().shape == (grid.nk + 1, grid.nj + 1, grid.ni + 1)
-   jiggle_per_cell_uuid = model.uuid(parts_list = jiggle_parts, title = 'per cell', title_mode = 'ends')
-   assert jiggle_per_cell_uuid is not None
-   # four properties created here, plus 3 regular grid cell lengths properties
-   assert grid.property_collection.number_of_parts() == 7
-   collection = rqp.selective_version_of_collection(grid.property_collection,
-                                                    property_kind = 'length',
-                                                    uuid = jiggle_per_cell_uuid)
-   assert collection is not None
-   assert collection.number_of_parts() == 1
-   p4p = rqp.Property.from_singleton_collection(collection)
-   assert p4p is not None
-   assert p4p.array_ref().shape == (grid.nk, grid.nj, grid.ni, 2, 2, 2)
+    epc = os.path.join(tmp_path, 'test_prop.epc')
+    model = rq.new_model(epc)
+    grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
+    grid.write_hdf5()
+    grid.create_xml()
+    a1 = np.random.random(grid.extent_kji)
+    p1 = rqp.Property.from_array(model,
+                                 a1,
+                                 source_info = 'random',
+                                 keyword = 'NETGRS',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'net to gross ratio',
+                                 indexable_element = 'cells',
+                                 uom = 'm3/m3')
+    a3 = np.random.random((grid.nk + 1, grid.nj + 1, grid.ni + 1))
+    p3 = rqp.Property.from_array(model,
+                                 a3,
+                                 source_info = 'random',
+                                 keyword = 'jiggle shared nodes',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'length',
+                                 indexable_element = 'nodes',
+                                 uom = 'm3')
+    a4 = np.random.random((grid.nk, grid.nj, grid.ni, 2, 2, 2))
+    p4 = rqp.Property.from_array(model,
+                                 a4,
+                                 source_info = 'random',
+                                 keyword = 'jiggle nodes per cell',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'length',
+                                 indexable_element = 'nodes per cell',
+                                 uom = 'm3')
+    pk = rqp.PropertyKind(model, title = 'facies', parent_property_kind = 'discrete')
+    pk.create_xml()
+    facies_dict = {0: 'background'}
+    for i in range(1, 10):
+        facies_dict[i] = 'facies ' + str(i)
+    sl = rqp.StringLookup(model, int_to_str_dict = facies_dict, title = 'facies table')
+    sl.create_xml()
+    shape2 = tuple(list(grid.extent_kji) + [2])
+    a2 = (np.random.random(shape2) * 10.0).astype(int)
+    p2 = rqp.Property.from_array(model,
+                                 a2,
+                                 source_info = 'random',
+                                 keyword = 'FACIES',
+                                 support_uuid = grid.uuid,
+                                 local_property_kind_uuid = pk.uuid,
+                                 indexable_element = 'cells',
+                                 discrete = True,
+                                 null_value = 0,
+                                 count = 2,
+                                 string_lookup_uuid = sl.uuid)
+    model.store_epc()
+    model = rq.Model(epc)
+    ntg_uuid = model.uuid(obj_type = p1.resqml_type, title = 'NETGRS')
+    assert ntg_uuid is not None
+    p1p = rqp.Property(model, uuid = ntg_uuid)
+    assert np.all(p1p.array_ref() == p1.array_ref())
+    assert p1p.uom() == 'm3/m3'
+    facies_uuid = model.uuid(obj_type = p2.resqml_type, title = 'FACIES')
+    assert facies_uuid is not None
+    p2p = rqp.Property(model, uuid = facies_uuid)
+    assert np.all(p2p.array_ref() == p2.array_ref())
+    assert p2p.null_value() is not None and p2p.null_value() == 0
+    grid = model.grid()
+    jiggle_parts = model.parts(title = 'jiggle', title_mode = 'starts')
+    assert len(jiggle_parts) == 2
+    jiggle_shared_uuid = model.uuid(parts_list = jiggle_parts, title = 'shared', title_mode = 'contains')
+    assert jiggle_shared_uuid is not None
+    p3p = rqp.Property(model, uuid = jiggle_shared_uuid)
+    assert p3p is not None
+    assert p3p.array_ref().shape == (grid.nk + 1, grid.nj + 1, grid.ni + 1)
+    jiggle_per_cell_uuid = model.uuid(parts_list = jiggle_parts, title = 'per cell', title_mode = 'ends')
+    assert jiggle_per_cell_uuid is not None
+    # four properties created here, plus 3 regular grid cell lengths properties
+    assert grid.property_collection.number_of_parts() == 7
+    collection = rqp.selective_version_of_collection(grid.property_collection,
+                                                     property_kind = 'length',
+                                                     uuid = jiggle_per_cell_uuid)
+    assert collection is not None
+    assert collection.number_of_parts() == 1
+    p4p = rqp.Property.from_singleton_collection(collection)
+    assert p4p is not None
+    assert p4p.array_ref().shape == (grid.nk, grid.nj, grid.ni, 2, 2, 2)
 
 
 def test_create_Property_from_singleton_collection(tmp_model):
 
-   # Arrange
-   grid = grr.RegularGrid(tmp_model, extent_kji = (2, 3, 4))
-   grid.write_hdf5()
-   grid.create_xml(add_cell_length_properties = True)
-   collection = rqp.selective_version_of_collection(grid.property_collection,
-                                                    property_kind = 'cell length',
-                                                    facet_type = 'direction',
-                                                    facet = 'J')
-   assert collection.number_of_parts() == 1
-   # Check property can be created
-   prop = rqp.Property.from_singleton_collection(collection)
-   assert np.all(np.isclose(prop.array_ref(), 1.0))
+    # Arrange
+    grid = grr.RegularGrid(tmp_model, extent_kji = (2, 3, 4))
+    grid.write_hdf5()
+    grid.create_xml(add_cell_length_properties = True)
+    collection = rqp.selective_version_of_collection(grid.property_collection,
+                                                     property_kind = 'cell length',
+                                                     facet_type = 'direction',
+                                                     facet = 'J')
+    assert collection.number_of_parts() == 1
+    # Check property can be created
+    prop = rqp.Property.from_singleton_collection(collection)
+    assert np.all(np.isclose(prop.array_ref(), 1.0))
 
 
 # ---- Test property kind parsing ---
 
 
 def test_property_kinds():
-   prop_kinds = bwam.valid_property_kinds()
-   assert "angle per time" in prop_kinds
-   assert "foobar" not in prop_kinds
+    prop_kinds = bwam.valid_property_kinds()
+    assert "angle per time" in prop_kinds
+    assert "foobar" not in prop_kinds
 
 
 # ---- Test infer_property_kind ---
 
 
 @pytest.mark.parametrize(
-   "input_name, input_unit, kind, facet_type, facet",
-   [
-      ('gamma ray API unit', 'gAPI', 'gamma ray API unit', None, None),  # Just a placeholder for now
-      ('', '', 'Unknown', None, None),  # What should default return?
-   ])
+    "input_name, input_unit, kind, facet_type, facet",
+    [
+        ('gamma ray API unit', 'gAPI', 'gamma ray API unit', None, None),  # Just a placeholder for now
+        ('', '', 'Unknown', None, None),  # What should default return?
+    ])
 def test_infer_property_kind(input_name, input_unit, kind, facet_type, facet):
-   kind_, facet_type_, facet_ = rqp.infer_property_kind(input_name, input_unit)
-   assert kind == kind_
-   assert facet_type == facet_type_
-   assert facet == facet_
+    kind_, facet_type_, facet_ = rqp.infer_property_kind(input_name, input_unit)
+    assert kind == kind_
+    assert facet_type == facet_type_
+    assert facet == facet_
 
 
 def test_bespoke_property_kind():
-   model = rq.Model(create_basics = True)
-   em = {'something': 'important', 'and_another_thing': 42}
-   pk1 = rqp.PropertyKind(model, title = 'my kind of property', extra_metadata = em)
-   pk1.create_xml()
-   assert len(model.uuids(obj_type = 'PropertyKind')) == 1
-   pk2 = rqp.PropertyKind(model, title = 'my kind of property', extra_metadata = em)
-   pk2.create_xml()
-   assert len(model.uuids(obj_type = 'PropertyKind')) == 1
-   pk3 = rqp.PropertyKind(model, title = 'your kind of property', extra_metadata = em)
-   pk3.create_xml()
-   assert len(model.uuids(obj_type = 'PropertyKind')) == 2
-   pk4 = rqp.PropertyKind(model, title = 'my kind of property')
-   pk4.create_xml()
-   assert len(model.uuids(obj_type = 'PropertyKind')) == 3
-   pk5 = rqp.PropertyKind(model, title = 'my kind of property', parent_property_kind = 'discrete', extra_metadata = em)
-   pk5.create_xml()
-   assert len(model.uuids(obj_type = 'PropertyKind')) == 4
-   pk6 = rqp.PropertyKind(model, title = 'my kind of property', parent_property_kind = 'continuous')
-   pk6.create_xml()
-   assert len(model.uuids(obj_type = 'PropertyKind')) == 4
-   assert pk6 == pk4
+    model = rq.Model(create_basics = True)
+    em = {'something': 'important', 'and_another_thing': 42}
+    pk1 = rqp.PropertyKind(model, title = 'my kind of property', extra_metadata = em)
+    pk1.create_xml()
+    assert len(model.uuids(obj_type = 'PropertyKind')) == 1
+    pk2 = rqp.PropertyKind(model, title = 'my kind of property', extra_metadata = em)
+    pk2.create_xml()
+    assert len(model.uuids(obj_type = 'PropertyKind')) == 1
+    pk3 = rqp.PropertyKind(model, title = 'your kind of property', extra_metadata = em)
+    pk3.create_xml()
+    assert len(model.uuids(obj_type = 'PropertyKind')) == 2
+    pk4 = rqp.PropertyKind(model, title = 'my kind of property')
+    pk4.create_xml()
+    assert len(model.uuids(obj_type = 'PropertyKind')) == 3
+    pk5 = rqp.PropertyKind(model, title = 'my kind of property', parent_property_kind = 'discrete', extra_metadata = em)
+    pk5.create_xml()
+    assert len(model.uuids(obj_type = 'PropertyKind')) == 4
+    pk6 = rqp.PropertyKind(model, title = 'my kind of property', parent_property_kind = 'continuous')
+    pk6.create_xml()
+    assert len(model.uuids(obj_type = 'PropertyKind')) == 4
+    assert pk6 == pk4
 
 
 def test_string_lookup():
-   model = rq.Model(create_basics = True)
-   d = {1: 'peaty', 2: 'muddy', 3: 'sandy', 4: 'granite'}
-   sl = rqp.StringLookup(model, int_to_str_dict = d, title = 'stargazing')
-   sl.create_xml()
-   assert sl.length() == 5 if sl.stored_as_list else 4
-   assert sl.get_string(3) == 'sandy'
-   assert sl.get_index_for_string('muddy') == 2
-   d2 = {0: 'nothing', 27: 'something', 173: 'amazing', 1072: 'brilliant'}
-   sl2 = rqp.StringLookup(model, int_to_str_dict = d2, title = 'head in the clouds')
-   assert not sl2.stored_as_list
-   assert sl2.length() == 4
-   assert sl2.get_string(1072) == 'brilliant'
-   assert sl2.get_string(555) is None
-   assert sl2.get_index_for_string('amazing') == 173
-   sl2.create_xml()
-   assert set(model.titles(obj_type = 'StringTableLookup')) == set(['stargazing', 'head in the clouds'])
-   assert sl != sl2
+    model = rq.Model(create_basics = True)
+    d = {1: 'peaty', 2: 'muddy', 3: 'sandy', 4: 'granite'}
+    sl = rqp.StringLookup(model, int_to_str_dict = d, title = 'stargazing')
+    sl.create_xml()
+    assert sl.length() == 5 if sl.stored_as_list else 4
+    assert sl.get_string(3) == 'sandy'
+    assert sl.get_index_for_string('muddy') == 2
+    d2 = {0: 'nothing', 27: 'something', 173: 'amazing', 1072: 'brilliant'}
+    sl2 = rqp.StringLookup(model, int_to_str_dict = d2, title = 'head in the clouds')
+    assert not sl2.stored_as_list
+    assert sl2.length() == 4
+    assert sl2.get_string(1072) == 'brilliant'
+    assert sl2.get_string(555) is None
+    assert sl2.get_index_for_string('amazing') == 173
+    sl2.create_xml()
+    assert set(model.titles(obj_type = 'StringTableLookup')) == set(['stargazing', 'head in the clouds'])
+    assert sl != sl2
 
 
 def test_constant_array_expansion(tmp_path):
-   epc = os.path.join(tmp_path, 'boring.epc')
-   model = rq.new_model(epc)
-   grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
-   grid.write_hdf5()
-   grid.create_xml()
-   p1 = rqp.Property.from_array(model,
-                                cached_array = None,
-                                source_info = 'test',
-                                keyword = 'constant pi',
-                                support_uuid = grid.uuid,
-                                property_kind = 'continuous',
-                                indexable_element = 'cells',
-                                const_value = maths.pi,
-                                expand_const_arrays = True)
-   p2 = rqp.Property.from_array(model,
-                                cached_array = None,
-                                source_info = 'test',
-                                keyword = 'constant three',
-                                support_uuid = grid.uuid,
-                                property_kind = 'discrete',
-                                discrete = True,
-                                indexable_element = 'cells',
-                                const_value = 3,
-                                expand_const_arrays = False)
-   model.store_epc()
-   # re-open the model and check that p1 appears as an ordinary array whilst p2 is still a constant
-   model = rq.Model(epc)
-   p1p = rqp.Property(model, uuid = p1.uuid)
-   p2p = rqp.Property(model, uuid = p2.uuid)
-   assert p1p.constant_value() is None
-   assert p2p.constant_value() == 3
-   assert_array_almost_equal(p1p.array_ref(), np.full(grid.extent_kji, maths.pi))
-   assert np.all(p2p.array_ref() == 3) and p2p.array_ref().shape == tuple(grid.extent_kji)
+    epc = os.path.join(tmp_path, 'boring.epc')
+    model = rq.new_model(epc)
+    grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
+    grid.write_hdf5()
+    grid.create_xml()
+    p1 = rqp.Property.from_array(model,
+                                 cached_array = None,
+                                 source_info = 'test',
+                                 keyword = 'constant pi',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'continuous',
+                                 indexable_element = 'cells',
+                                 const_value = maths.pi,
+                                 expand_const_arrays = True)
+    p2 = rqp.Property.from_array(model,
+                                 cached_array = None,
+                                 source_info = 'test',
+                                 keyword = 'constant three',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'discrete',
+                                 discrete = True,
+                                 indexable_element = 'cells',
+                                 const_value = 3,
+                                 expand_const_arrays = False)
+    model.store_epc()
+    # re-open the model and check that p1 appears as an ordinary array whilst p2 is still a constant
+    model = rq.Model(epc)
+    p1p = rqp.Property(model, uuid = p1.uuid)
+    p2p = rqp.Property(model, uuid = p2.uuid)
+    assert p1p.constant_value() is None
+    assert p2p.constant_value() == 3
+    assert_array_almost_equal(p1p.array_ref(), np.full(grid.extent_kji, maths.pi))
+    assert np.all(p2p.array_ref() == 3) and p2p.array_ref().shape == tuple(grid.extent_kji)
 
 
 def test_property_extra_metadata(tmp_path):
-   # set up test model with a grid
-   epc = os.path.join(tmp_path, 'em_test.epc')
-   model = rq.new_model(epc)
-   grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
-   grid.write_hdf5()
-   grid.create_xml()
-   model.store_epc()
-   # add a grid property with some extra metadata
-   a = np.arange(24).astype(float).reshape((2, 3, 4))
-   em = {'important': 'something', 'also': 'nothing'}
-   uuid = rqdm.add_one_grid_property_array(epc, a, 'length', title = 'nonsense', uom = 'm', extra_metadata = em)
-   # re-open the model and check that extra metadata has been preserved
-   model = rq.Model(epc)
-   p = rqp.Property(model, uuid = uuid)
-   for item in em.items():
-      assert item in p.extra_metadata.items()
+    # set up test model with a grid
+    epc = os.path.join(tmp_path, 'em_test.epc')
+    model = rq.new_model(epc)
+    grid = grr.RegularGrid(model, extent_kji = (2, 3, 4))
+    grid.write_hdf5()
+    grid.create_xml()
+    model.store_epc()
+    # add a grid property with some extra metadata
+    a = np.arange(24).astype(float).reshape((2, 3, 4))
+    em = {'important': 'something', 'also': 'nothing'}
+    uuid = rqdm.add_one_grid_property_array(epc, a, 'length', title = 'nonsense', uom = 'm', extra_metadata = em)
+    # re-open the model and check that extra metadata has been preserved
+    model = rq.Model(epc)
+    p = rqp.Property(model, uuid = uuid)
+    for item in em.items():
+        assert item in p.extra_metadata.items()
 
 
 def test_points_properties(tmp_path):
 
-   epc = os.path.join(tmp_path, 'points_test.epc')
-   model = rq.new_model(epc)
+    epc = os.path.join(tmp_path, 'points_test.epc')
+    model = rq.new_model(epc)
 
-   extent_kji = (2, 3, 4)
-   ensemble_size = 5
-   faulted_ensemble_size = 2
-   time_series_size = 6
+    extent_kji = (2, 3, 4)
+    ensemble_size = 5
+    faulted_ensemble_size = 2
+    time_series_size = 6
 
-   # create a geological time series
-   years = [int(t) for t in np.linspace(-252170000, -66000000, num = time_series_size, dtype = int)]
-   ts = rqts.GeologicTimeSeries.from_year_list(model, year_list = years, title = 'Mesozoic time series')
-   ts.create_xml()
-   ts_uuid = ts.uuid
-   assert ts.timeframe == 'geologic'
+    # create a geological time series
+    years = [int(t) for t in np.linspace(-252170000, -66000000, num = time_series_size, dtype = int)]
+    ts = rqts.GeologicTimeSeries.from_year_list(model, year_list = years, title = 'Mesozoic time series')
+    ts.create_xml()
+    ts_uuid = ts.uuid
+    assert ts.timeframe == 'geologic'
 
-   # create a simple grid without an explicit geometry and ensure it has a property collection initialised
-   grid = grr.RegularGrid(model,
-                          extent_kji = extent_kji,
-                          origin = (0.0, 0.0, 1000.0),
-                          dxyz = (100.0, 100.0, -10.0),
-                          title = 'unfaulted grid')
-   # patch K direction, even though it won't be stored in xml
-   grid.k_direction_is_down = False
-   grid.grid_is_right_handed = not grid.grid_is_right_handed
-   # generate xml and establish a property collection for the grid
-   grid.create_xml()
-   if grid.property_collection is None:
-      grid.property_collection = rqp.PropertyCollection(support = grid)
-   pc = grid.property_collection
+    # create a simple grid without an explicit geometry and ensure it has a property collection initialised
+    grid = grr.RegularGrid(model,
+                           extent_kji = extent_kji,
+                           origin = (0.0, 0.0, 1000.0),
+                           dxyz = (100.0, 100.0, -10.0),
+                           title = 'unfaulted grid')
+    # patch K direction, even though it won't be stored in xml
+    grid.k_direction_is_down = False
+    grid.grid_is_right_handed = not grid.grid_is_right_handed
+    # generate xml and establish a property collection for the grid
+    grid.create_xml()
+    if grid.property_collection is None:
+        grid.property_collection = rqp.PropertyCollection(support = grid)
+    pc = grid.property_collection
 
-   # shape of points property arrays
-   points_shape = tuple(list(extent_kji) + [3])
+    # shape of points property arrays
+    points_shape = tuple(list(extent_kji) + [3])
 
-   # create a static points property with multiple realisations
-   for r in range(ensemble_size):
-      stress = vec.unit_vectors(np.random.random(points_shape) + 0.1)
-      pc.add_cached_array_to_imported_list(stress,
-                                           'random stress vectors',
-                                           'stress direction',
-                                           uom = 'm',
-                                           property_kind = 'length',
-                                           realization = r,
-                                           indexable_element = 'cells',
-                                           points = True)
-   pc.write_hdf5_for_imported_list()
-   pc.create_xml_for_imported_list_and_add_parts_to_model()
+    # create a static points property with multiple realisations
+    for r in range(ensemble_size):
+        stress = vec.unit_vectors(np.random.random(points_shape) + 0.1)
+        pc.add_cached_array_to_imported_list(stress,
+                                             'random stress vectors',
+                                             'stress direction',
+                                             uom = 'm',
+                                             property_kind = 'length',
+                                             realization = r,
+                                             indexable_element = 'cells',
+                                             points = True)
+    pc.write_hdf5_for_imported_list()
+    pc.create_xml_for_imported_list_and_add_parts_to_model()
 
-   # create a dynamic points property (indexable cells) related to the geological time series
-   for r in range(ensemble_size):
-      centres = grid.centre_point().copy()
-      for time_index in range(time_series_size):
-         pc.add_cached_array_to_imported_list(centres,
-                                              'dynamic cell centres',
-                                              'centres',
-                                              uom = 'm',
-                                              property_kind = 'length',
-                                              realization = r,
-                                              time_index = time_index,
-                                              indexable_element = 'cells',
-                                              points = True)
-         centres[..., 2] += 100.0 * (r + 1)
-   pc.write_hdf5_for_imported_list()
-   pc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = ts_uuid)
+    # create a dynamic points property (indexable cells) related to the geological time series
+    for r in range(ensemble_size):
+        centres = grid.centre_point().copy()
+        for time_index in range(time_series_size):
+            pc.add_cached_array_to_imported_list(centres,
+                                                 'dynamic cell centres',
+                                                 'centres',
+                                                 uom = 'm',
+                                                 property_kind = 'length',
+                                                 realization = r,
+                                                 time_index = time_index,
+                                                 indexable_element = 'cells',
+                                                 points = True)
+            centres[..., 2] += 100.0 * (r + 1)
+    pc.write_hdf5_for_imported_list()
+    pc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = ts_uuid)
 
-   # create a dynamic points property (indexable nodes) related to the geological time series
-   # also create a parallel set of active cell properties
-   for r in range(ensemble_size):
-      nodes = grid.points_ref().copy()
-      for time_index in range(time_series_size):
-         pc.add_cached_array_to_imported_list(nodes,
-                                              'dynamic nodes',
-                                              'points',
-                                              uom = 'm',
-                                              property_kind = 'length',
-                                              realization = r,
-                                              time_index = time_index,
-                                              indexable_element = 'nodes',
-                                              points = True)
-         nodes[..., 2] += 100.0 * (r + 1)
-         active_array = np.ones(extent_kji, dtype = bool)
-         # de-activate some cells
-         if extent_kji[0] > 1 and time_index < time_series_size // 2:
-            active_array[extent_kji[0] // 2:] = False
-         if extent_kji[2] > 1:
-            active_array[:, :, r % extent_kji[2]] = False
-         rqp.write_hdf5_and_create_xml_for_active_property(model,
-                                                           active_array,
-                                                           grid.uuid,
-                                                           title = 'ACTIVE',
-                                                           realization = r,
-                                                           time_series_uuid = ts_uuid,
-                                                           time_index = time_index)
-   pc.write_hdf5_for_imported_list()
-   pc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = ts_uuid)
+    # create a dynamic points property (indexable nodes) related to the geological time series
+    # also create a parallel set of active cell properties
+    for r in range(ensemble_size):
+        nodes = grid.points_ref().copy()
+        for time_index in range(time_series_size):
+            pc.add_cached_array_to_imported_list(nodes,
+                                                 'dynamic nodes',
+                                                 'points',
+                                                 uom = 'm',
+                                                 property_kind = 'length',
+                                                 realization = r,
+                                                 time_index = time_index,
+                                                 indexable_element = 'nodes',
+                                                 points = True)
+            nodes[..., 2] += 100.0 * (r + 1)
+            active_array = np.ones(extent_kji, dtype = bool)
+            # de-activate some cells
+            if extent_kji[0] > 1 and time_index < time_series_size // 2:
+                active_array[extent_kji[0] // 2:] = False
+            if extent_kji[2] > 1:
+                active_array[:, :, r % extent_kji[2]] = False
+            rqp.write_hdf5_and_create_xml_for_active_property(model,
+                                                              active_array,
+                                                              grid.uuid,
+                                                              title = 'ACTIVE',
+                                                              realization = r,
+                                                              time_series_uuid = ts_uuid,
+                                                              time_index = time_index)
+    pc.write_hdf5_for_imported_list()
+    pc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = ts_uuid)
 
-   # store the xml
-   model.store_epc()
+    # store the xml
+    model.store_epc()
 
-   # create a second grid being a copy of the first grid but with a fault
-   fault_pillar_dict = {'the fault': [(2, 0), (2, 1), (2, 2), (1, 2), (1, 3), (1, 4)]}
-   rqdm.add_faults(epc, source_grid = grid, full_pillar_list_dict = fault_pillar_dict, new_grid_title = 'faulted grid')
+    # create a second grid being a copy of the first grid but with a fault
+    fault_pillar_dict = {'the fault': [(2, 0), (2, 1), (2, 2), (1, 2), (1, 3), (1, 4)]}
+    rqdm.add_faults(epc, source_grid = grid, full_pillar_list_dict = fault_pillar_dict, new_grid_title = 'faulted grid')
 
-   # re-open the model and build a dynamic points property for the faulted grid
-   # NB. this test implicitly has the oldest geometry as the 'official' grid geometry whereas
-   # the RESQML documentation states that the geometry stored for the grid should be 'current' (ie. youngest)
-   model = rq.Model(epc)
-   f_grid = model.grid(title = 'faulted grid')
-   assert f_grid is not None
-   pc = f_grid.property_collection
-   for r in range(faulted_ensemble_size):
-      nodes = f_grid.points_ref().copy()
-      for time_index in range(time_series_size):
-         pc.add_cached_array_to_imported_list(nodes,
-                                              'faulted dynamic nodes',
-                                              'faulted points',
-                                              uom = 'm',
-                                              property_kind = 'length',
-                                              realization = r,
-                                              time_index = time_index,
-                                              indexable_element = 'nodes',
-                                              points = True)
-         nodes[..., 2] += 101.0 * (r + 1)  # add more and more depth for each realisation
-   pc.write_hdf5_for_imported_list()
-   pc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = ts_uuid)
+    # re-open the model and build a dynamic points property for the faulted grid
+    # NB. this test implicitly has the oldest geometry as the 'official' grid geometry whereas
+    # the RESQML documentation states that the geometry stored for the grid should be 'current' (ie. youngest)
+    model = rq.Model(epc)
+    f_grid = model.grid(title = 'faulted grid')
+    assert f_grid is not None
+    pc = f_grid.property_collection
+    for r in range(faulted_ensemble_size):
+        nodes = f_grid.points_ref().copy()
+        for time_index in range(time_series_size):
+            pc.add_cached_array_to_imported_list(nodes,
+                                                 'faulted dynamic nodes',
+                                                 'faulted points',
+                                                 uom = 'm',
+                                                 property_kind = 'length',
+                                                 realization = r,
+                                                 time_index = time_index,
+                                                 indexable_element = 'nodes',
+                                                 points = True)
+            nodes[..., 2] += 101.0 * (r + 1)  # add more and more depth for each realisation
+    pc.write_hdf5_for_imported_list()
+    pc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = ts_uuid)
 
-   # store the xml again
-   model.store_epc()
+    # store the xml again
+    model.store_epc()
 
-   # re-open the model and access the grid properties
-   model = rq.Model(epc)
-   grid = model.grid(title = 'unfaulted grid')
-   pc = grid.property_collection
+    # re-open the model and access the grid properties
+    model = rq.Model(epc)
+    grid = model.grid(title = 'unfaulted grid')
+    pc = grid.property_collection
 
-   # check that the grid as stored has all cells active
-   assert grid.inactive is None or np.count_nonzero(grid.inactive) == 0
+    # check that the grid as stored has all cells active
+    assert grid.inactive is None or np.count_nonzero(grid.inactive) == 0
 
-   # load a static points property for a single realisation
-   sample_stress_part = pc.singleton(realization = ensemble_size // 2,
-                                     citation_title = 'stress direction',
-                                     points = True)
-   assert sample_stress_part is not None
-   sample_stress = pc.single_array_ref(realization = ensemble_size // 2,
-                                       citation_title = 'stress direction',
-                                       points = True)
-   assert sample_stress is not None and sample_stress.ndim == 4
-   assert np.all(sample_stress.shape[:3] == extent_kji)
-   assert sample_stress.shape[3] == 3
-   assert np.count_nonzero(np.isnan(sample_stress)) == 0
-   stress_uuid = pc.uuid_for_part(sample_stress_part)
+    # load a static points property for a single realisation
+    sample_stress_part = pc.singleton(realization = ensemble_size // 2,
+                                      citation_title = 'stress direction',
+                                      points = True)
+    assert sample_stress_part is not None
+    sample_stress = pc.single_array_ref(realization = ensemble_size // 2,
+                                        citation_title = 'stress direction',
+                                        points = True)
+    assert sample_stress is not None and sample_stress.ndim == 4
+    assert np.all(sample_stress.shape[:3] == extent_kji)
+    assert sample_stress.shape[3] == 3
+    assert np.count_nonzero(np.isnan(sample_stress)) == 0
+    stress_uuid = pc.uuid_for_part(sample_stress_part)
 
-   # load the same property using the Property class
-   stress_p = rqp.Property(model, uuid = stress_uuid)
-   assert stress_p is not None
-   assert stress_p.is_points()
-   sample_stress = stress_p.array_ref()
-   assert sample_stress is not None and sample_stress.ndim == 4
+    # load the same property using the Property class
+    stress_p = rqp.Property(model, uuid = stress_uuid)
+    assert stress_p is not None
+    assert stress_p.is_points()
+    sample_stress = stress_p.array_ref()
+    assert sample_stress is not None and sample_stress.ndim == 4
 
-   # select the dynamic points properties related to the geological time series and indexable by cells
-   cc = rqp.selective_version_of_collection(grid.property_collection,
-                                            indexable = 'cells',
-                                            points = True,
-                                            time_series_uuid = ts_uuid)
-   assert cc.number_of_parts() == ensemble_size * time_series_size
+    # select the dynamic points properties related to the geological time series and indexable by cells
+    cc = rqp.selective_version_of_collection(grid.property_collection,
+                                             indexable = 'cells',
+                                             points = True,
+                                             time_series_uuid = ts_uuid)
+    assert cc.number_of_parts() == ensemble_size * time_series_size
 
-   # check that 5 dimensional numpy arrays can be set up, each covering time indices for a single realisation
-   for r in range(ensemble_size):
-      rcc = rqp.selective_version_of_collection(cc, realization = r)
-      assert rcc.number_of_parts() == time_series_size
-      dynamic_nodes = rcc.time_series_array_ref()
-      assert dynamic_nodes.ndim == 5
-      assert dynamic_nodes.shape[0] == time_series_size
-      assert np.all(dynamic_nodes.shape[1:4] == np.array(extent_kji))
-      assert dynamic_nodes.shape[-1] == 3
-      mean_depth = np.nanmean(dynamic_nodes[..., 2])
-      assert mean_depth > 1000.0
+    # check that 5 dimensional numpy arrays can be set up, each covering time indices for a single realisation
+    for r in range(ensemble_size):
+        rcc = rqp.selective_version_of_collection(cc, realization = r)
+        assert rcc.number_of_parts() == time_series_size
+        dynamic_nodes = rcc.time_series_array_ref()
+        assert dynamic_nodes.ndim == 5
+        assert dynamic_nodes.shape[0] == time_series_size
+        assert np.all(dynamic_nodes.shape[1:4] == np.array(extent_kji))
+        assert dynamic_nodes.shape[-1] == 3
+        mean_depth = np.nanmean(dynamic_nodes[..., 2])
+        assert mean_depth > 1000.0
 
-   # select the dynamic points properties related to the geological time series and indexable by nodes
-   nc = rqp.selective_version_of_collection(grid.property_collection,
-                                            indexable = 'nodes',
-                                            points = True,
-                                            time_series_uuid = ts_uuid)
-   assert nc.number_of_parts() == ensemble_size * time_series_size
-
-   # check that the cached points for the grid can be populated from a points property
-   grid.make_regular_points_cached()
-   r = ensemble_size // 2
-   ti = time_series_size // 2
-   a = nc.single_array_ref(realization = r, time_index = ti)
-   grid.set_cached_points_from_property(property_collection = nc,
-                                        realization = r,
-                                        time_index = ti,
-                                        set_inactive = True,
-                                        active_collection = grid.property_collection)
-   assert_array_almost_equal(grid.points_cached, nc.single_array_ref(realization = r, time_index = ti))
-   # check that grid's time index has been set
-   assert grid.time_index == ti
-   assert bu.matching_uuids(grid.time_series_uuid, ts_uuid)
-   # and that the inactive array now indicates some cells are inactive
-   assert grid.inactive is not None and np.count_nonzero(grid.inactive) > 0
-
-   # check that 5 dimensional numpy arrays can be set up, each covering realisations for a single time index
-   for ti in range(time_series_size):
-      tnc = rqp.selective_version_of_collection(nc, time_index = ti)
-      assert tnc.number_of_parts() == ensemble_size
-      dynamic_nodes = tnc.realizations_array_ref()
-      assert dynamic_nodes.ndim == 5
-      assert dynamic_nodes.shape[0] == ensemble_size
-      assert np.all(dynamic_nodes.shape[1:4] == np.array(extent_kji) + 1)
-      assert dynamic_nodes.shape[-1] == 3
-      mean_depth = np.nanmean(dynamic_nodes[..., 2])
-      assert mean_depth > 1000.0
-
-   # check the faulted grid properties
-   f_grid = model.grid(title = 'faulted grid')
-   assert f_grid is not None
-   assert not f_grid.k_direction_is_down
-   f_grid.set_k_direction_from_points()
-   assert not f_grid.k_direction_is_down
-
-   # compute and cache cell centre points
-   older_centres = f_grid.centre_point()
-   assert hasattr(f_grid, 'array_centre_point') and f_grid.array_centre_point is not None
-
-   # select the dynamic points properties related to the geological time series and indexable by nodes
-   fnc = rqp.selective_version_of_collection(f_grid.property_collection,
+    # select the dynamic points properties related to the geological time series and indexable by nodes
+    nc = rqp.selective_version_of_collection(grid.property_collection,
                                              indexable = 'nodes',
                                              points = True,
                                              time_series_uuid = ts_uuid)
-   assert fnc.number_of_parts() == faulted_ensemble_size * time_series_size
+    assert nc.number_of_parts() == ensemble_size * time_series_size
 
-   # check that the cached points for the faulted grid can be populated from a points property
-   r = faulted_ensemble_size // 2
-   ti = time_series_size - 1
-   p_uuid = fnc.uuid_for_part(fnc.singleton(realization = r, time_index = ti))
-   assert p_uuid is not None
-   f_grid.set_cached_points_from_property(points_property_uuid = p_uuid,
-                                          set_grid_time_index = True,
-                                          set_inactive = False)
-   assert_array_almost_equal(f_grid.points_cached, fnc.single_array_ref(realization = r, time_index = ti))
+    # check that the cached points for the grid can be populated from a points property
+    grid.make_regular_points_cached()
+    r = ensemble_size // 2
+    ti = time_series_size // 2
+    a = nc.single_array_ref(realization = r, time_index = ti)
+    grid.set_cached_points_from_property(property_collection = nc,
+                                         realization = r,
+                                         time_index = ti,
+                                         set_inactive = True,
+                                         active_collection = grid.property_collection)
+    assert_array_almost_equal(grid.points_cached, nc.single_array_ref(realization = r, time_index = ti))
+    # check that grid's time index has been set
+    assert grid.time_index == ti
+    assert bu.matching_uuids(grid.time_series_uuid, ts_uuid)
+    # and that the inactive array now indicates some cells are inactive
+    assert grid.inactive is not None and np.count_nonzero(grid.inactive) > 0
 
-   # check that grid's time index has been set
-   assert f_grid.time_index == ti
-   assert bu.matching_uuids(f_grid.time_series_uuid, ts_uuid)
-   # and that the centre point cache has been invalidated
-   assert not hasattr(f_grid, 'array_centre_point') or f_grid.array_centre_point is None
+    # check that 5 dimensional numpy arrays can be set up, each covering realisations for a single time index
+    for ti in range(time_series_size):
+        tnc = rqp.selective_version_of_collection(nc, time_index = ti)
+        assert tnc.number_of_parts() == ensemble_size
+        dynamic_nodes = tnc.realizations_array_ref()
+        assert dynamic_nodes.ndim == 5
+        assert dynamic_nodes.shape[0] == ensemble_size
+        assert np.all(dynamic_nodes.shape[1:4] == np.array(extent_kji) + 1)
+        assert dynamic_nodes.shape[-1] == 3
+        mean_depth = np.nanmean(dynamic_nodes[..., 2])
+        assert mean_depth > 1000.0
 
-   # re-compute centre points based on the dynamically loaded geometry
-   younger_centres = f_grid.centre_point()
-   assert hasattr(f_grid, 'array_centre_point') and f_grid.array_centre_point is not None
+    # check the faulted grid properties
+    f_grid = model.grid(title = 'faulted grid')
+    assert f_grid is not None
+    assert not f_grid.k_direction_is_down
+    f_grid.set_k_direction_from_points()
+    assert not f_grid.k_direction_is_down
 
-   # check that later centres are vertically below the earlier centres
-   # (in this example, the depths of all cells are increasing with time)
-   assert_array_almost_equal(older_centres[..., :2], younger_centres[..., :2])  # xy
-   assert np.all(older_centres[..., 2] < younger_centres[..., 2])  # depths
+    # compute and cache cell centre points
+    older_centres = f_grid.centre_point()
+    assert hasattr(f_grid, 'array_centre_point') and f_grid.array_centre_point is not None
+
+    # select the dynamic points properties related to the geological time series and indexable by nodes
+    fnc = rqp.selective_version_of_collection(f_grid.property_collection,
+                                              indexable = 'nodes',
+                                              points = True,
+                                              time_series_uuid = ts_uuid)
+    assert fnc.number_of_parts() == faulted_ensemble_size * time_series_size
+
+    # check that the cached points for the faulted grid can be populated from a points property
+    r = faulted_ensemble_size // 2
+    ti = time_series_size - 1
+    p_uuid = fnc.uuid_for_part(fnc.singleton(realization = r, time_index = ti))
+    assert p_uuid is not None
+    f_grid.set_cached_points_from_property(points_property_uuid = p_uuid,
+                                           set_grid_time_index = True,
+                                           set_inactive = False)
+    assert_array_almost_equal(f_grid.points_cached, fnc.single_array_ref(realization = r, time_index = ti))
+
+    # check that grid's time index has been set
+    assert f_grid.time_index == ti
+    assert bu.matching_uuids(f_grid.time_series_uuid, ts_uuid)
+    # and that the centre point cache has been invalidated
+    assert not hasattr(f_grid, 'array_centre_point') or f_grid.array_centre_point is None
+
+    # re-compute centre points based on the dynamically loaded geometry
+    younger_centres = f_grid.centre_point()
+    assert hasattr(f_grid, 'array_centre_point') and f_grid.array_centre_point is not None
+
+    # check that later centres are vertically below the earlier centres
+    # (in this example, the depths of all cells are increasing with time)
+    assert_array_almost_equal(older_centres[..., :2], younger_centres[..., :2])  # xy
+    assert np.all(older_centres[..., 2] < younger_centres[..., 2])  # depths

--- a/tests/test_relperm.py
+++ b/tests/test_relperm.py
@@ -12,138 +12,138 @@ from resqpy.olio.relperm import RelPerm, text_to_relperm_dict, relperm_parts_in_
 
 
 def test_col_headers(tmp_path):
-   epc = os.path.join(tmp_path, 'model.epc')
-   model = rq.new_model(epc)
-   np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.683, np.nan],
-                     [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.018, np.nan], [0.74, 1.0, 0.0, 1e-06]])
-   df_cols1 = ['Sw', 'Krg', 'Kro', 'Pc']
-   df_cols2 = ['Sg', 'Krg', 'Krw', 'Pc']
-   df_cols3 = ['Sg', 'Krg', 'Pc', 'Kro']
-   df_cols4 = ['Sg', 'krg', 'Kro', 'pC']
-   df1 = pd.DataFrame(np_df, columns = df_cols1)
-   df2 = pd.DataFrame(np_df, columns = df_cols2)
-   df3 = pd.DataFrame(np_df, columns = df_cols3)
-   df4 = pd.DataFrame(np_df, columns = df_cols4)
-   phase_combo1 = 'gas-oil'
-   phase_combo2 = None
+    epc = os.path.join(tmp_path, 'model.epc')
+    model = rq.new_model(epc)
+    np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.683, np.nan],
+                      [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.018, np.nan], [0.74, 1.0, 0.0, 1e-06]])
+    df_cols1 = ['Sw', 'Krg', 'Kro', 'Pc']
+    df_cols2 = ['Sg', 'Krg', 'Krw', 'Pc']
+    df_cols3 = ['Sg', 'Krg', 'Pc', 'Kro']
+    df_cols4 = ['Sg', 'krg', 'Kro', 'pC']
+    df1 = pd.DataFrame(np_df, columns = df_cols1)
+    df2 = pd.DataFrame(np_df, columns = df_cols2)
+    df3 = pd.DataFrame(np_df, columns = df_cols3)
+    df4 = pd.DataFrame(np_df, columns = df_cols4)
+    phase_combo1 = 'gas-oil'
+    phase_combo2 = None
 
-   with pytest.raises(ValueError) as excval1:
-      RelPerm(model = model, df = df1, phase_combo = phase_combo1)
-   assert "incorrect saturation column name and/or multiple saturation columns exist" in str(excval1.value)
+    with pytest.raises(ValueError) as excval1:
+        RelPerm(model = model, df = df1, phase_combo = phase_combo1)
+    assert "incorrect saturation column name and/or multiple saturation columns exist" in str(excval1.value)
 
-   with pytest.raises(ValueError) as excval2:
-      RelPerm(model = model, df = df2, phase_combo = phase_combo1)
-   assert "incorrect column name(s) {'Krw'}" in str(excval2.value)
+    with pytest.raises(ValueError) as excval2:
+        RelPerm(model = model, df = df2, phase_combo = phase_combo1)
+    assert "incorrect column name(s) {'Krw'}" in str(excval2.value)
 
-   with pytest.raises(ValueError) as excval3:
-      RelPerm(model = model, df = df3, phase_combo = phase_combo1)
-   assert "capillary pressure data should be in the last column of the dataframe" in str(excval3.value)
+    with pytest.raises(ValueError) as excval3:
+        RelPerm(model = model, df = df3, phase_combo = phase_combo1)
+    assert "capillary pressure data should be in the last column of the dataframe" in str(excval3.value)
 
-   relperm_obj = RelPerm(model = model, df = df4, phase_combo = phase_combo2)
-   assert relperm_obj.phase_combo == 'gas-oil'
+    relperm_obj = RelPerm(model = model, df = df4, phase_combo = phase_combo2)
+    assert relperm_obj.phase_combo == 'gas-oil'
 
 
 def test_missing_vals(tmp_path):
-   epc = os.path.join(tmp_path, 'model.epc')
-   model = rq.new_model(epc)
-   np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, np.nan, 0.683, np.nan],
-                     [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.018, np.nan], [0.74, 1.0, np.nan, 1e-06]])
-   df_cols = ['Sg', 'Krg', 'Kro', 'Pc']
-   df = pd.DataFrame(np_df, columns = df_cols)
-   phase_combo = 'gas-oil'
+    epc = os.path.join(tmp_path, 'model.epc')
+    model = rq.new_model(epc)
+    np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, np.nan, 0.683, np.nan],
+                      [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.018, np.nan], [0.74, 1.0, np.nan, 1e-06]])
+    df_cols = ['Sg', 'Krg', 'Kro', 'Pc']
+    df = pd.DataFrame(np_df, columns = df_cols)
+    phase_combo = 'gas-oil'
 
-   with pytest.raises(Exception) as excval:
-      RelPerm(model = model, df = df, phase_combo = phase_combo)
-   assert "missing values found in Krg column" in str(excval.value)
+    with pytest.raises(Exception) as excval:
+        RelPerm(model = model, df = df, phase_combo = phase_combo)
+    assert "missing values found in Krg column" in str(excval.value)
 
 
 def test_monotonicity(tmp_path):
-   epc = os.path.join(tmp_path, 'model.epc')
-   model = rq.new_model(epc)
-   np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.683, np.nan],
-                     [0.25, 0.205, 0.35, np.nan], [0.85, 0.55, 0.018, 1e-06], [0.74, 1.0, 0.0, 1e-07]])
-   df_cols = ['Sg', 'Krg', 'Kro', 'Pc']
-   df = pd.DataFrame(np_df, columns = df_cols)
-   phase_combo = 'gas-oil'
+    epc = os.path.join(tmp_path, 'model.epc')
+    model = rq.new_model(epc)
+    np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.683, np.nan],
+                      [0.25, 0.205, 0.35, np.nan], [0.85, 0.55, 0.018, 1e-06], [0.74, 1.0, 0.0, 1e-07]])
+    df_cols = ['Sg', 'Krg', 'Kro', 'Pc']
+    df = pd.DataFrame(np_df, columns = df_cols)
+    phase_combo = 'gas-oil'
 
-   with pytest.raises(ValueError) as excval:
-      RelPerm(model = model, df = df, phase_combo = phase_combo)
-   assert "('Sg', 'Krg', 'Kro') combo is not monotonic" in str(excval.value)
+    with pytest.raises(ValueError) as excval:
+        RelPerm(model = model, df = df, phase_combo = phase_combo)
+    assert "('Sg', 'Krg', 'Kro') combo is not monotonic" in str(excval.value)
 
-   df['Sg'] = [0.0, 0.04, 0.12, 0.25, 0.45, 0.74]
-   with pytest.raises(ValueError) as excval1:
-      RelPerm(model = model, df = df, phase_combo = phase_combo)
-   assert "Pc values are not monotonic" in str(excval1.value)
+    df['Sg'] = [0.0, 0.04, 0.12, 0.25, 0.45, 0.74]
+    with pytest.raises(ValueError) as excval1:
+        RelPerm(model = model, df = df, phase_combo = phase_combo)
+    assert "Pc values are not monotonic" in str(excval1.value)
 
 
 def test_range(tmp_path):
-   epc = os.path.join(tmp_path, 'model.epc')
-   model = rq.new_model(epc)
-   np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.683, np.nan],
-                     [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.018, np.nan], [0.74, 1.1, -0.001, 1e-06]])
-   df_cols = ['Sg', 'Krg', 'Kro', 'Pc']
-   df = pd.DataFrame(np_df, columns = df_cols)
-   phase_combo = 'gas-oil'
+    epc = os.path.join(tmp_path, 'model.epc')
+    model = rq.new_model(epc)
+    np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.683, np.nan],
+                      [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.018, np.nan], [0.74, 1.1, -0.001, 1e-06]])
+    df_cols = ['Sg', 'Krg', 'Kro', 'Pc']
+    df = pd.DataFrame(np_df, columns = df_cols)
+    phase_combo = 'gas-oil'
 
-   with pytest.raises(ValueError) as excval:
-      RelPerm(model = model, df = df, phase_combo = phase_combo)
-   assert "Krg is not within the range 0-1" in str(excval.value)
+    with pytest.raises(ValueError) as excval:
+        RelPerm(model = model, df = df, phase_combo = phase_combo)
+    assert "Krg is not within the range 0-1" in str(excval.value)
 
 
 def test_relperm(tmp_path):
-   epc = os.path.join(tmp_path, 'model.epc')
-   model = rq.new_model(epc)
-   np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.689, np.nan],
-                     [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.019, np.nan], [0.74, 1.0, 0.0, 0.000001]])
-   df_cols1 = ['Sw', 'Krw', 'Kro', 'Pc']
-   df1 = pd.DataFrame(np_df, columns = df_cols1)
-   phase_combo1 = 'oil-water'
-   uom_list = ['Euc', 'Euc', 'Euc', 'psi']
-   df_cols2 = ['Sg', 'Krg', 'Kro', 'Pc']
-   df2 = pd.DataFrame(np_df, columns = df_cols2)
-   phase_combo2 = 'gas-oil'
-   dataframe1 = RelPerm(model = model,
-                        df = df1,
-                        uom_list = uom_list,
-                        phase_combo = phase_combo1,
-                        low_sal = True,
-                        table_index = 1,
-                        title = 'table1')
-   dataframe2 = RelPerm(model = model,
-                        df = df2,
-                        uom_list = uom_list,
-                        phase_combo = phase_combo2,
-                        low_sal = False,
-                        title = 'table2')
-   assert dataframe1.n_cols == 4
-   assert dataframe1.n_rows == 6
-   assert_frame_equal(dataframe1.dataframe(), df1)
-   assert all(dataframe1.dataframe().columns == df_cols1)
-   assert round(dataframe1.interpolate_point(saturation = 0.55, kr_or_pc_col = 'Kro')[1], 3) == 0.012
-   dataframe1.write_hdf5_and_create_xml()
-   dataframe2.write_hdf5_and_create_xml()
-   assert model.part(extra = {'relperm_table': 'true', 'low_sal': 'true'}) == model.part(title = 'table1')
-   assert len(relperm_parts_in_model(model, low_sal = False)) == 1
-   dataframe1.df_to_text(filepath = tmp_path, filename = 'oil_water_test_table')
-   # reconstruct a dataframe of rel. perm. data from a text file
-   df1_reconstructed_from_file = text_to_relperm_dict(os.path.join(tmp_path,
-                                                                   'oil_water_test_table.dat'))['relperm_table1']['df']
-   assert_frame_equal(df1, df1_reconstructed_from_file)
-   assert df1_reconstructed_from_file.iloc[3]['Kro'] == 0.350
-   # reconstruct a dataframe of rel. perm. data from a string
-   with open(os.path.join(tmp_path, 'oil_water_test_table.dat')) as f:
-      relperm_string = f.read()
-   df1_reconstructed_from_string = text_to_relperm_dict(relperm_string, is_file = False)['relperm_table1']['df']
-   assert_frame_equal(df1, df1_reconstructed_from_string)
-   # initialize a RelPerm object from an existing uuid
-   new_wo_obj = RelPerm(model, uuid = model.uuid(title = 'table1'))
-   assert new_wo_obj.phase_combo == phase_combo1
-   assert new_wo_obj.low_sal == 'true'
-   assert new_wo_obj.table_index == '1'
-   assert new_wo_obj.extra_metadata == {
-      'dataframe': 'true',
-      'low_sal': 'true',
-      'phase_combo': 'oil-water',
-      'relperm_table': 'true',
-      'table_index': '1'
-   }
+    epc = os.path.join(tmp_path, 'model.epc')
+    model = rq.new_model(epc)
+    np_df = np.array([[0.0, 0.0, 1.0, 0], [0.04, 0.015, 0.87, np.nan], [0.12, 0.065, 0.689, np.nan],
+                      [0.25, 0.205, 0.35, np.nan], [0.45, 0.55, 0.019, np.nan], [0.74, 1.0, 0.0, 0.000001]])
+    df_cols1 = ['Sw', 'Krw', 'Kro', 'Pc']
+    df1 = pd.DataFrame(np_df, columns = df_cols1)
+    phase_combo1 = 'oil-water'
+    uom_list = ['Euc', 'Euc', 'Euc', 'psi']
+    df_cols2 = ['Sg', 'Krg', 'Kro', 'Pc']
+    df2 = pd.DataFrame(np_df, columns = df_cols2)
+    phase_combo2 = 'gas-oil'
+    dataframe1 = RelPerm(model = model,
+                         df = df1,
+                         uom_list = uom_list,
+                         phase_combo = phase_combo1,
+                         low_sal = True,
+                         table_index = 1,
+                         title = 'table1')
+    dataframe2 = RelPerm(model = model,
+                         df = df2,
+                         uom_list = uom_list,
+                         phase_combo = phase_combo2,
+                         low_sal = False,
+                         title = 'table2')
+    assert dataframe1.n_cols == 4
+    assert dataframe1.n_rows == 6
+    assert_frame_equal(dataframe1.dataframe(), df1)
+    assert all(dataframe1.dataframe().columns == df_cols1)
+    assert round(dataframe1.interpolate_point(saturation = 0.55, kr_or_pc_col = 'Kro')[1], 3) == 0.012
+    dataframe1.write_hdf5_and_create_xml()
+    dataframe2.write_hdf5_and_create_xml()
+    assert model.part(extra = {'relperm_table': 'true', 'low_sal': 'true'}) == model.part(title = 'table1')
+    assert len(relperm_parts_in_model(model, low_sal = False)) == 1
+    dataframe1.df_to_text(filepath = tmp_path, filename = 'oil_water_test_table')
+    # reconstruct a dataframe of rel. perm. data from a text file
+    df1_reconstructed_from_file = text_to_relperm_dict(os.path.join(tmp_path,
+                                                                    'oil_water_test_table.dat'))['relperm_table1']['df']
+    assert_frame_equal(df1, df1_reconstructed_from_file)
+    assert df1_reconstructed_from_file.iloc[3]['Kro'] == 0.350
+    # reconstruct a dataframe of rel. perm. data from a string
+    with open(os.path.join(tmp_path, 'oil_water_test_table.dat')) as f:
+        relperm_string = f.read()
+    df1_reconstructed_from_string = text_to_relperm_dict(relperm_string, is_file = False)['relperm_table1']['df']
+    assert_frame_equal(df1, df1_reconstructed_from_string)
+    # initialize a RelPerm object from an existing uuid
+    new_wo_obj = RelPerm(model, uuid = model.uuid(title = 'table1'))
+    assert new_wo_obj.phase_combo == phase_combo1
+    assert new_wo_obj.low_sal == 'true'
+    assert new_wo_obj.table_index == '1'
+    assert new_wo_obj.extra_metadata == {
+        'dataframe': 'true',
+        'low_sal': 'true',
+        'phase_combo': 'oil-water',
+        'relperm_table': 'true',
+        'table_index': '1'
+    }

--- a/tests/test_resqpy.py
+++ b/tests/test_resqpy.py
@@ -3,12 +3,12 @@ from resqpy import model
 
 
 def test_empty_model():
-   _ = model.Model()
-   return
+    _ = model.Model()
+    return
 
 
 def test_all_imports():
-   from resqpy import crs, derived_model, fault, grid, grid_surface, lines, organize
-   from resqpy import property, rq_import, surface, time_series, well
-   #    from resqpy.olio import *
-   return
+    from resqpy import crs, derived_model, fault, grid, grid_surface, lines, organize
+    from resqpy import property, rq_import, surface, time_series, well
+    #    from resqpy.olio import *
+    return

--- a/tests/test_s_bend.py
+++ b/tests/test_s_bend.py
@@ -25,370 +25,371 @@ import resqpy.olio.xml_et as rqet
 
 def test_s_bend_fn(tmp_path, epc = None):
 
-   if epc is None:
-      # use pytest temporary directory fixture
-      # https://docs.pytest.org/en/stable/tmpdir.html
-      epc = str(os.path.join(tmp_path, f"{bu.new_uuid()}.epc"))
-
-   # create s-bend grid
-
-   nk = 5
-   nj = 12
-   ni_tail = 5
-   ni_bend = 18
-   ni_half_mid = 2
-   ni = 2 * (ni_tail + ni_bend + ni_half_mid)
-
-   total_thickness = 12.0
-   layer_thickness = total_thickness / float(nk)
-   flat_dx_di = 10.0
-   horst_dx_dk = 0.25 * flat_dx_di / float(nk)
-   horst_dz = 1.73 * layer_thickness
-   horst_half_dx = horst_dx_dk * horst_dz / layer_thickness
-   dy_dj = 8.0
-   top_depth = 100.0
-
-   assert ni_bend % 2 == 0, 'ni_bend must be even for horizontal faulting'
-   assert ni_tail >= 5, 'ni_tail must be at least 5 for horst blocks'
-
-   bend_theta_di = maths.pi / float(ni_bend)
-   outer_radius = 2.0 * total_thickness
-
-   bend_a_centre_xz = (flat_dx_di * float(ni_tail), top_depth + outer_radius)
-   bend_b_centre_xz = (flat_dx_di * float(ni_tail - 2.0 * ni_half_mid),
-                       top_depth + 3.0 * outer_radius - total_thickness)
-
-   points = np.empty((nk + 1, nj + 1, ni + 1, 3))
-
-   for k in range(nk + 1):
-      if k == nk // 2 + 1:
-         points[k] = points[k - 1]  # pinched out layer
-      else:
-         for i in range(ni + 1):
-            if i < ni_tail + 1:
-               x = flat_dx_di * float(i)
-               z = top_depth + float(k) * layer_thickness  # will introduce a thick layer after pinchout
-            elif i < ni_tail + ni_bend:
-               theta = (i - ni_tail) * bend_theta_di
-               radius = outer_radius - float(k) * layer_thickness
-               x = bend_a_centre_xz[0] + radius * maths.sin(theta)
-               z = bend_a_centre_xz[1] - radius * maths.cos(theta)
-            elif i < ni_tail + ni_bend + 2 * ni_half_mid + 1:
-               x = flat_dx_di * float(ni_tail - (i - (ni_tail + ni_bend)))
-               z = top_depth + 2.0 * outer_radius - float(k) * layer_thickness
-            elif i < ni_tail + 2 * ni_bend + 2 * ni_half_mid:
-               theta = (i - (ni_tail + ni_bend + 2 * ni_half_mid)) * bend_theta_di
-               radius = outer_radius - float(nk - k) * layer_thickness
-               x = bend_b_centre_xz[0] - radius * maths.sin(theta)
-               z = bend_b_centre_xz[1] - radius * maths.cos(theta)
-            else:
-               x = flat_dx_di * float((i - (ni - ni_tail)) + ni_tail - 2 * ni_half_mid)
-               if i == ni - 1 or i == ni - 4:
-                  x += horst_dx_dk * float(k)
-               elif i == ni - 2 or i == ni - 3:
-                  x -= horst_dx_dk * float(k)
-               z = top_depth + 4.0 * outer_radius + float(k) * layer_thickness - 2.0 * total_thickness
-            points[k, :, i] = (x, 0.0, z)
-
-   for j in range(nj + 1):
-      points[:, j, :, 1] = dy_dj * float(j)
-
-   model = rq.Model(epc_file = epc, new_epc = True, create_basics = True, create_hdf5_ext = True)
-
-   grid = grr.Grid(model)
-
-   crs = rqc.Crs(model)
-   crs_node = crs.create_xml()
-   if model.crs_root is None:
-      model.crs_root = crs_node
-
-   grid.grid_representation = 'IjkGrid'
-   grid.extent_kji = np.array((nk, nj, ni), dtype = 'int')
-   grid.nk, grid.nj, grid.ni = nk, nj, ni
-   grid.k_direction_is_down = True  # dominant layer direction, or paleo-direction
-   grid.pillar_shape = 'straight'
-   grid.has_split_coordinate_lines = False
-   grid.k_gaps = None
-   grid.crs_uuid = crs.uuid
-   grid.crs_root = crs_node
-
-   grid.points_cached = points
-
-   grid.geometry_defined_for_all_pillars_cached = True
-   grid.geometry_defined_for_all_cells_cached = True
-   grid.grid_is_right_handed = crs.is_right_handed_xyz()
-
-   grid.write_hdf5_from_caches()
-   grid.create_xml()
-
-   # create a well trajectory and md datum
-
-   def df_trajectory(x, y, z):
-      N = len(x)
-      assert len(y) == N and len(z) == N
-      df = pd.DataFrame(columns = ['MD', 'X', 'Y', 'Z'])
-      md = np.zeros(N)
-      for n in range(N - 1):
-         md[n + 1] = md[n] + vec.naive_length((x[n + 1] - x[n], y[n + 1] - y[n], z[n + 1] - z[n]))
-      df.MD = md
-      df.X = x
-      df.Y = y
-      df.Z = z
-      return df
-
-   x = np.array(
-      [0.0, flat_dx_di * float(ni_tail) + outer_radius, flat_dx_di * (float(ni_tail) - 0.5), 0.0, -outer_radius])
-   y = np.array([0.0, dy_dj * 0.5, dy_dj * float(nj) / 2.0, dy_dj * (float(nj) - 0.5), dy_dj * float(nj)])
-   z = np.array([
-      0.0, top_depth - total_thickness, top_depth + 2.0 * outer_radius - total_thickness / 2.0,
-      top_depth + 3.0 * outer_radius - total_thickness, top_depth + 4.0 * outer_radius
-   ])
-
-   df = df_trajectory(x, y, z)
-
-   datum = rqw.MdDatum(model, crs_uuid = crs.uuid, location = (x[0], y[0], z[0]))
-   datum.create_xml()
-
-   trajectory = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'ANGLED_WELL')
-
-   rqc.Crs(model, uuid = rqet.uuid_for_part_root(trajectory.crs_root)).uuid == crs.uuid
-
-   trajectory.write_hdf5()
-   trajectory.create_xml()
-
-   # add more wells
-
-   x = np.array(
-      [0.0, flat_dx_di * float(ni_tail), flat_dx_di * 2.0 * float(ni_tail - ni_half_mid) + outer_radius, -outer_radius])
-   y = np.array([0.0, dy_dj * float(nj) * 0.59, dy_dj * 0.67, dy_dj * 0.5])
-   z = np.array([
-      0.0, top_depth - total_thickness, top_depth + 4.0 * outer_radius - 1.7 * total_thickness,
-      top_depth + 4.0 * outer_radius - 1.7 * total_thickness
-   ])
-
-   df = df_trajectory(x, y, z)
-
-   traj_2 = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'HORST_WELL')
-   traj_2.write_hdf5()
-   traj_2.create_xml()
-   traj_2.control_points
-
-   x = np.array([0.0, 0.0, 0.0])
-   y = np.array([0.0, dy_dj * float(nj) * 0.53, dy_dj * float(nj) * 0.53])
-   z = np.array([0.0, top_depth - total_thickness, top_depth + 4.0 * outer_radius])
-
-   df = df_trajectory(x, y, z)
-
-   traj_3 = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'VERTICAL_WELL')
-   traj_3.write_hdf5()
-   traj_3.create_xml()
-   traj_3.control_points
-
-   n_x = flat_dx_di * float(ni_tail) * 0.48
-   n_y = dy_dj * float(nj) / 9.1
-   o_y = -dy_dj * 0.45
-   nd_x = n_y / 3.0
-   x = np.array([
-      0.0, n_x, n_x, n_x + nd_x, n_x + 2.0 * nd_x, n_x + 3.0 * nd_x, n_x + 4.0 * nd_x, n_x + 5.0 * nd_x,
-      n_x + 6.0 * nd_x, n_x + 7.0 * nd_x, n_x + 8.0 * nd_x, n_x + 8.0 * nd_x
-   ])
-   y = np.array([
-      0.0, o_y, o_y + n_y, o_y + 2.0 * n_y, o_y + 3.0 * n_y, o_y + 4.0 * n_y, o_y + 5.0 * n_y, o_y + 6.0 * n_y,
-      o_y + 7.0 * n_y, o_y + 8.0 * n_y, o_y + 9.0 * n_y, o_y + 10.0 * n_y
-   ])
-   n_z1 = top_depth + total_thickness * 0.82
-   n_z2 = top_depth - total_thickness * 0.17
-   z = np.array([0.0, n_z1, n_z1, n_z2, n_z2, n_z1, n_z1, n_z2, n_z2, n_z1, n_z1, n_z2])
-
-   df = df_trajectory(x, y, z)
-
-   traj_4 = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'NESSIE_WELL')
-   traj_4.write_hdf5()
-   traj_4.create_xml()
-   traj_4.control_points
-
-   # block wells against grid geometry
-
-   log.info('unfaulted grid blocking of well ' + str(rqw.well_name(trajectory)))
-   bw = rqw.BlockedWell(model, grid = grid, trajectory = trajectory)
-   bw.write_hdf5()
-   bw.create_xml()
-   assert bw.cell_count == 19
-
-   log.info('unfaulted grid blocking of well ' + str(rqw.well_name(traj_2)))
-   bw_2 = rqw.BlockedWell(model, grid = grid, trajectory = traj_2)
-   bw_2.write_hdf5()
-   bw_2.create_xml()
-   assert bw_2.cell_count == 33
-
-   log.info('unfaulted grid blocking of well ' + str(rqw.well_name(traj_3)))
-   bw_3 = rqw.BlockedWell(model, grid = grid, trajectory = traj_3)
-   bw_3.write_hdf5()
-   bw_3.create_xml()
-   assert bw_3.cell_count == 18
-
-   log.info('unfaulted grid blocking of well ' + str(rqw.well_name(traj_4)))
-   bw_4 = rqw.BlockedWell(model, grid = grid, trajectory = traj_4)
-   bw_4.write_hdf5()
-   bw_4.create_xml()
-   assert bw_4.cell_count == 26
-
-   # derive a faulted version of the grid
-
-   cp = grid.corner_points(cache_cp_array = True).copy()
-
-   # IK plane faults
-   cp[:, 3:, :, :, :, :, :] += (flat_dx_di * 0.7, 0.0, layer_thickness * 1.3)
-   cp[:, 5:, :, :, :, :, :] += (flat_dx_di * 0.4, 0.0, layer_thickness * 0.9)
-   cp[:, 8:, :, :, :, :, :] += (flat_dx_di * 0.3, 0.0, layer_thickness * 0.6)
-
-   # JK plane faults
-   cp[:, :, ni_tail + ni_bend // 2:, :, :, :, 0] -= flat_dx_di * 0.57  # horizontal break mid top bend
-   cp[:, :, ni_tail + ni_bend + ni_half_mid:, :, :, :, 2] += layer_thickness * 1.27  # vertical break in mid section
-
-   # zig-zag fault
-   j_step = nj // (ni_tail - 2)
-   for i in range(ni_tail - 1):
-      j_start = i * j_step
-      if j_start >= nj:
-         break
-      cp[:, j_start:, i, :, :, :, 2] += 1.1 * total_thickness
-
-   # JK horst blocks
-   cp[:, :, ni - 4, :, :, :, :] -= (horst_half_dx, 0.0, horst_dz)
-   cp[:, :, ni - 3:, :, :, :, 0] -= 2.0 * horst_half_dx
-   cp[:, :, ni - 2, :, :, :, :] += (-horst_half_dx, 0.0, horst_dz)
-   cp[:, :, ni - 1:, :, :, :, 0] -= 2.0 * horst_half_dx
-
-   # JK horst block mid lower bend
-   bend_horst_dz = horst_dz * maths.tan(bend_theta_di)
-   cp[:, :,
-      ni - (ni_tail + ni_bend // 2 + 1):ni - (ni_tail + ni_bend // 2 - 1), :, :, :, :] -= (horst_dz, 0.0, bend_horst_dz)
-   cp[:, :, ni - (ni_tail + ni_bend // 2 - 1):, :, :, :, 2] -= 2.0 * bend_horst_dz
-
-   faulted_grid = rqi.grid_from_cp(model,
-                                   cp,
-                                   crs.uuid,
-                                   max_z_void = 0.01,
-                                   split_pillars = True,
-                                   split_tolerance = 0.01,
-                                   ijk_handedness = 'right' if grid.grid_is_right_handed else 'left',
-                                   known_to_be_straight = True)
-
-   faulted_grid.write_hdf5_from_caches()
-   faulted_grid.create_xml()
-
-   # block wells against faulted grid
-
-   log.info('faulted grid blocking of well ' + str(rqw.well_name(trajectory)))
-   fbw = rqw.BlockedWell(model, grid = faulted_grid, trajectory = trajectory)
-   fbw.write_hdf5()
-   fbw.create_xml()
-   assert fbw.cell_count == 32
-
-   log.info('faulted grid blocking of well ' + str(rqw.well_name(traj_2)))
-   fbw_2 = rqw.BlockedWell(model, grid = faulted_grid, trajectory = traj_2)
-   fbw_2.write_hdf5()
-   fbw_2.create_xml()
-   assert fbw_2.cell_count == 26
-
-   log.info('faulted grid blocking of well ' + str(rqw.well_name(traj_3)))
-   fbw_3 = rqw.BlockedWell(model, grid = faulted_grid, trajectory = traj_3)
-   fbw_3.write_hdf5()
-   fbw_3.create_xml()
-   assert fbw_3.cell_count == 14
-
-   log.info('faulted grid blocking of well ' + str(rqw.well_name(traj_4)))
-   fbw_4 = rqw.BlockedWell(model, grid = faulted_grid, trajectory = traj_4)
-   fbw_4.write_hdf5()
-   fbw_4.create_xml()
-   assert fbw_4.cell_count == 16
-
-   # create a version of the faulted grid with a k gap
-
-   k_gap_grid = rqi.grid_from_cp(model,
-                                 cp,
-                                 crs.uuid,
-                                 max_z_void = 0.01,
-                                 split_pillars = True,
-                                 split_tolerance = 0.01,
-                                 ijk_handedness = 'right' if grid.grid_is_right_handed else 'left',
-                                 known_to_be_straight = True)
-
-   # convert second layer to a K gap
-   k_gap_grid.nk -= 1
-   k_gap_grid.extent_kji[0] = k_gap_grid.nk
-   k_gap_grid.k_gaps = 1
-   k_gap_grid.k_gap_after_array = np.zeros(k_gap_grid.nk - 1, dtype = bool)
-   k_gap_grid.k_gap_after_array[0] = True
-   k_gap_grid.k_raw_index_array = np.zeros(k_gap_grid.nk, dtype = int)
-   for k in range(1, k_gap_grid.nk):
-      k_gap_grid.k_raw_index_array[k] = k + 1
-
-   # clear some attributes which may no longer be valid
-   k_gap_grid.pinchout = None
-   k_gap_grid.inactive = None
-   k_gap_grid.grid_skin = None
-   if hasattr(k_gap_grid, 'array_thickness'):
-      delattr(k_gap_grid, 'array_thickness')
-
-   k_gap_grid.write_hdf5_from_caches()
-   k_gap_grid.create_xml()
-
-   k_gap_grid_uuid = k_gap_grid.uuid
-
-   # reload k gap grid object to ensure it is properly initialised
-
-   k_gap_grid = None
-   k_gap_grid = grr.Grid(model, uuid = k_gap_grid_uuid)
-
-   # block wells against faulted grid with k gap
-
-   log.info('k gap grid blocking of well ' + str(rqw.well_name(trajectory)))
-   try:
-      gbw = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = trajectory)
-      gbw.write_hdf5()
-      gbw.create_xml()
-      assert gbw.cell_count == 24
-   except Exception:
-      log.exception('failed to block well against k gap grid')
-
-   log.info('k gap grid blocking of well ' + str(rqw.well_name(traj_2)))
-   try:
-      gbw_2 = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = traj_2)
-      gbw_2.write_hdf5()
-      gbw_2.create_xml()
-      assert gbw_2.cell_count == 20
-   except Exception:
-      log.exception('failed to block well against k gap grid')
-
-   log.info('k gap grid blocking of well ' + str(rqw.well_name(traj_3)))
-   try:
-      gbw_3 = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = traj_3)
-      gbw_3.write_hdf5()
-      gbw_3.create_xml()
-      assert gbw_3.cell_count == 10
-   except Exception:
-      log.exception('failed to block well against k gap grid')
-
-   log.info('k gap grid blocking of well ' + str(rqw.well_name(traj_4)))
-   try:
-      gbw_4 = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = traj_4)
-      gbw_4.write_hdf5()
-      gbw_4.create_xml()
-      assert gbw_4.cell_count == 10
-   except Exception:
-      log.exception('failed to block well against k gap grid')
-
-   # store model
-
-   model.store_epc()
-
-   assert k_gap_grid.k_gaps
-   assert len(k_gap_grid.k_raw_index_array) == k_gap_grid.nk
-   assert len(k_gap_grid.k_gap_after_array) == k_gap_grid.nk - 1
-   assert k_gap_grid.pinched_out((1, 0, 2))
-
-   # clean up
-   model.h5_release()
-   os.remove(model.h5_file_name())
+    if epc is None:
+        # use pytest temporary directory fixture
+        # https://docs.pytest.org/en/stable/tmpdir.html
+        epc = str(os.path.join(tmp_path, f"{bu.new_uuid()}.epc"))
+
+    # create s-bend grid
+
+    nk = 5
+    nj = 12
+    ni_tail = 5
+    ni_bend = 18
+    ni_half_mid = 2
+    ni = 2 * (ni_tail + ni_bend + ni_half_mid)
+
+    total_thickness = 12.0
+    layer_thickness = total_thickness / float(nk)
+    flat_dx_di = 10.0
+    horst_dx_dk = 0.25 * flat_dx_di / float(nk)
+    horst_dz = 1.73 * layer_thickness
+    horst_half_dx = horst_dx_dk * horst_dz / layer_thickness
+    dy_dj = 8.0
+    top_depth = 100.0
+
+    assert ni_bend % 2 == 0, 'ni_bend must be even for horizontal faulting'
+    assert ni_tail >= 5, 'ni_tail must be at least 5 for horst blocks'
+
+    bend_theta_di = maths.pi / float(ni_bend)
+    outer_radius = 2.0 * total_thickness
+
+    bend_a_centre_xz = (flat_dx_di * float(ni_tail), top_depth + outer_radius)
+    bend_b_centre_xz = (flat_dx_di * float(ni_tail - 2.0 * ni_half_mid),
+                        top_depth + 3.0 * outer_radius - total_thickness)
+
+    points = np.empty((nk + 1, nj + 1, ni + 1, 3))
+
+    for k in range(nk + 1):
+        if k == nk // 2 + 1:
+            points[k] = points[k - 1]  # pinched out layer
+        else:
+            for i in range(ni + 1):
+                if i < ni_tail + 1:
+                    x = flat_dx_di * float(i)
+                    z = top_depth + float(k) * layer_thickness  # will introduce a thick layer after pinchout
+                elif i < ni_tail + ni_bend:
+                    theta = (i - ni_tail) * bend_theta_di
+                    radius = outer_radius - float(k) * layer_thickness
+                    x = bend_a_centre_xz[0] + radius * maths.sin(theta)
+                    z = bend_a_centre_xz[1] - radius * maths.cos(theta)
+                elif i < ni_tail + ni_bend + 2 * ni_half_mid + 1:
+                    x = flat_dx_di * float(ni_tail - (i - (ni_tail + ni_bend)))
+                    z = top_depth + 2.0 * outer_radius - float(k) * layer_thickness
+                elif i < ni_tail + 2 * ni_bend + 2 * ni_half_mid:
+                    theta = (i - (ni_tail + ni_bend + 2 * ni_half_mid)) * bend_theta_di
+                    radius = outer_radius - float(nk - k) * layer_thickness
+                    x = bend_b_centre_xz[0] - radius * maths.sin(theta)
+                    z = bend_b_centre_xz[1] - radius * maths.cos(theta)
+                else:
+                    x = flat_dx_di * float((i - (ni - ni_tail)) + ni_tail - 2 * ni_half_mid)
+                    if i == ni - 1 or i == ni - 4:
+                        x += horst_dx_dk * float(k)
+                    elif i == ni - 2 or i == ni - 3:
+                        x -= horst_dx_dk * float(k)
+                    z = top_depth + 4.0 * outer_radius + float(k) * layer_thickness - 2.0 * total_thickness
+                points[k, :, i] = (x, 0.0, z)
+
+    for j in range(nj + 1):
+        points[:, j, :, 1] = dy_dj * float(j)
+
+    model = rq.Model(epc_file = epc, new_epc = True, create_basics = True, create_hdf5_ext = True)
+
+    grid = grr.Grid(model)
+
+    crs = rqc.Crs(model)
+    crs_node = crs.create_xml()
+    if model.crs_root is None:
+        model.crs_root = crs_node
+
+    grid.grid_representation = 'IjkGrid'
+    grid.extent_kji = np.array((nk, nj, ni), dtype = 'int')
+    grid.nk, grid.nj, grid.ni = nk, nj, ni
+    grid.k_direction_is_down = True  # dominant layer direction, or paleo-direction
+    grid.pillar_shape = 'straight'
+    grid.has_split_coordinate_lines = False
+    grid.k_gaps = None
+    grid.crs_uuid = crs.uuid
+    grid.crs_root = crs_node
+
+    grid.points_cached = points
+
+    grid.geometry_defined_for_all_pillars_cached = True
+    grid.geometry_defined_for_all_cells_cached = True
+    grid.grid_is_right_handed = crs.is_right_handed_xyz()
+
+    grid.write_hdf5_from_caches()
+    grid.create_xml()
+
+    # create a well trajectory and md datum
+
+    def df_trajectory(x, y, z):
+        N = len(x)
+        assert len(y) == N and len(z) == N
+        df = pd.DataFrame(columns = ['MD', 'X', 'Y', 'Z'])
+        md = np.zeros(N)
+        for n in range(N - 1):
+            md[n + 1] = md[n] + vec.naive_length((x[n + 1] - x[n], y[n + 1] - y[n], z[n + 1] - z[n]))
+        df.MD = md
+        df.X = x
+        df.Y = y
+        df.Z = z
+        return df
+
+    x = np.array(
+        [0.0, flat_dx_di * float(ni_tail) + outer_radius, flat_dx_di * (float(ni_tail) - 0.5), 0.0, -outer_radius])
+    y = np.array([0.0, dy_dj * 0.5, dy_dj * float(nj) / 2.0, dy_dj * (float(nj) - 0.5), dy_dj * float(nj)])
+    z = np.array([
+        0.0, top_depth - total_thickness, top_depth + 2.0 * outer_radius - total_thickness / 2.0,
+        top_depth + 3.0 * outer_radius - total_thickness, top_depth + 4.0 * outer_radius
+    ])
+
+    df = df_trajectory(x, y, z)
+
+    datum = rqw.MdDatum(model, crs_uuid = crs.uuid, location = (x[0], y[0], z[0]))
+    datum.create_xml()
+
+    trajectory = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'ANGLED_WELL')
+
+    rqc.Crs(model, uuid = rqet.uuid_for_part_root(trajectory.crs_root)).uuid == crs.uuid
+
+    trajectory.write_hdf5()
+    trajectory.create_xml()
+
+    # add more wells
+
+    x = np.array([
+        0.0, flat_dx_di * float(ni_tail), flat_dx_di * 2.0 * float(ni_tail - ni_half_mid) + outer_radius, -outer_radius
+    ])
+    y = np.array([0.0, dy_dj * float(nj) * 0.59, dy_dj * 0.67, dy_dj * 0.5])
+    z = np.array([
+        0.0, top_depth - total_thickness, top_depth + 4.0 * outer_radius - 1.7 * total_thickness,
+        top_depth + 4.0 * outer_radius - 1.7 * total_thickness
+    ])
+
+    df = df_trajectory(x, y, z)
+
+    traj_2 = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'HORST_WELL')
+    traj_2.write_hdf5()
+    traj_2.create_xml()
+    traj_2.control_points
+
+    x = np.array([0.0, 0.0, 0.0])
+    y = np.array([0.0, dy_dj * float(nj) * 0.53, dy_dj * float(nj) * 0.53])
+    z = np.array([0.0, top_depth - total_thickness, top_depth + 4.0 * outer_radius])
+
+    df = df_trajectory(x, y, z)
+
+    traj_3 = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'VERTICAL_WELL')
+    traj_3.write_hdf5()
+    traj_3.create_xml()
+    traj_3.control_points
+
+    n_x = flat_dx_di * float(ni_tail) * 0.48
+    n_y = dy_dj * float(nj) / 9.1
+    o_y = -dy_dj * 0.45
+    nd_x = n_y / 3.0
+    x = np.array([
+        0.0, n_x, n_x, n_x + nd_x, n_x + 2.0 * nd_x, n_x + 3.0 * nd_x, n_x + 4.0 * nd_x, n_x + 5.0 * nd_x,
+        n_x + 6.0 * nd_x, n_x + 7.0 * nd_x, n_x + 8.0 * nd_x, n_x + 8.0 * nd_x
+    ])
+    y = np.array([
+        0.0, o_y, o_y + n_y, o_y + 2.0 * n_y, o_y + 3.0 * n_y, o_y + 4.0 * n_y, o_y + 5.0 * n_y, o_y + 6.0 * n_y,
+        o_y + 7.0 * n_y, o_y + 8.0 * n_y, o_y + 9.0 * n_y, o_y + 10.0 * n_y
+    ])
+    n_z1 = top_depth + total_thickness * 0.82
+    n_z2 = top_depth - total_thickness * 0.17
+    z = np.array([0.0, n_z1, n_z1, n_z2, n_z2, n_z1, n_z1, n_z2, n_z2, n_z1, n_z1, n_z2])
+
+    df = df_trajectory(x, y, z)
+
+    traj_4 = rqw.Trajectory(model, md_datum = datum, data_frame = df, length_uom = 'm', well_name = 'NESSIE_WELL')
+    traj_4.write_hdf5()
+    traj_4.create_xml()
+    traj_4.control_points
+
+    # block wells against grid geometry
+
+    log.info('unfaulted grid blocking of well ' + str(rqw.well_name(trajectory)))
+    bw = rqw.BlockedWell(model, grid = grid, trajectory = trajectory)
+    bw.write_hdf5()
+    bw.create_xml()
+    assert bw.cell_count == 19
+
+    log.info('unfaulted grid blocking of well ' + str(rqw.well_name(traj_2)))
+    bw_2 = rqw.BlockedWell(model, grid = grid, trajectory = traj_2)
+    bw_2.write_hdf5()
+    bw_2.create_xml()
+    assert bw_2.cell_count == 33
+
+    log.info('unfaulted grid blocking of well ' + str(rqw.well_name(traj_3)))
+    bw_3 = rqw.BlockedWell(model, grid = grid, trajectory = traj_3)
+    bw_3.write_hdf5()
+    bw_3.create_xml()
+    assert bw_3.cell_count == 18
+
+    log.info('unfaulted grid blocking of well ' + str(rqw.well_name(traj_4)))
+    bw_4 = rqw.BlockedWell(model, grid = grid, trajectory = traj_4)
+    bw_4.write_hdf5()
+    bw_4.create_xml()
+    assert bw_4.cell_count == 26
+
+    # derive a faulted version of the grid
+
+    cp = grid.corner_points(cache_cp_array = True).copy()
+
+    # IK plane faults
+    cp[:, 3:, :, :, :, :, :] += (flat_dx_di * 0.7, 0.0, layer_thickness * 1.3)
+    cp[:, 5:, :, :, :, :, :] += (flat_dx_di * 0.4, 0.0, layer_thickness * 0.9)
+    cp[:, 8:, :, :, :, :, :] += (flat_dx_di * 0.3, 0.0, layer_thickness * 0.6)
+
+    # JK plane faults
+    cp[:, :, ni_tail + ni_bend // 2:, :, :, :, 0] -= flat_dx_di * 0.57  # horizontal break mid top bend
+    cp[:, :, ni_tail + ni_bend + ni_half_mid:, :, :, :, 2] += layer_thickness * 1.27  # vertical break in mid section
+
+    # zig-zag fault
+    j_step = nj // (ni_tail - 2)
+    for i in range(ni_tail - 1):
+        j_start = i * j_step
+        if j_start >= nj:
+            break
+        cp[:, j_start:, i, :, :, :, 2] += 1.1 * total_thickness
+
+    # JK horst blocks
+    cp[:, :, ni - 4, :, :, :, :] -= (horst_half_dx, 0.0, horst_dz)
+    cp[:, :, ni - 3:, :, :, :, 0] -= 2.0 * horst_half_dx
+    cp[:, :, ni - 2, :, :, :, :] += (-horst_half_dx, 0.0, horst_dz)
+    cp[:, :, ni - 1:, :, :, :, 0] -= 2.0 * horst_half_dx
+
+    # JK horst block mid lower bend
+    bend_horst_dz = horst_dz * maths.tan(bend_theta_di)
+    cp[:, :, ni - (ni_tail + ni_bend // 2 + 1):ni - (ni_tail + ni_bend // 2 - 1), :, :, :, :] -= (horst_dz, 0.0,
+                                                                                                  bend_horst_dz)
+    cp[:, :, ni - (ni_tail + ni_bend // 2 - 1):, :, :, :, 2] -= 2.0 * bend_horst_dz
+
+    faulted_grid = rqi.grid_from_cp(model,
+                                    cp,
+                                    crs.uuid,
+                                    max_z_void = 0.01,
+                                    split_pillars = True,
+                                    split_tolerance = 0.01,
+                                    ijk_handedness = 'right' if grid.grid_is_right_handed else 'left',
+                                    known_to_be_straight = True)
+
+    faulted_grid.write_hdf5_from_caches()
+    faulted_grid.create_xml()
+
+    # block wells against faulted grid
+
+    log.info('faulted grid blocking of well ' + str(rqw.well_name(trajectory)))
+    fbw = rqw.BlockedWell(model, grid = faulted_grid, trajectory = trajectory)
+    fbw.write_hdf5()
+    fbw.create_xml()
+    assert fbw.cell_count == 32
+
+    log.info('faulted grid blocking of well ' + str(rqw.well_name(traj_2)))
+    fbw_2 = rqw.BlockedWell(model, grid = faulted_grid, trajectory = traj_2)
+    fbw_2.write_hdf5()
+    fbw_2.create_xml()
+    assert fbw_2.cell_count == 26
+
+    log.info('faulted grid blocking of well ' + str(rqw.well_name(traj_3)))
+    fbw_3 = rqw.BlockedWell(model, grid = faulted_grid, trajectory = traj_3)
+    fbw_3.write_hdf5()
+    fbw_3.create_xml()
+    assert fbw_3.cell_count == 14
+
+    log.info('faulted grid blocking of well ' + str(rqw.well_name(traj_4)))
+    fbw_4 = rqw.BlockedWell(model, grid = faulted_grid, trajectory = traj_4)
+    fbw_4.write_hdf5()
+    fbw_4.create_xml()
+    assert fbw_4.cell_count == 16
+
+    # create a version of the faulted grid with a k gap
+
+    k_gap_grid = rqi.grid_from_cp(model,
+                                  cp,
+                                  crs.uuid,
+                                  max_z_void = 0.01,
+                                  split_pillars = True,
+                                  split_tolerance = 0.01,
+                                  ijk_handedness = 'right' if grid.grid_is_right_handed else 'left',
+                                  known_to_be_straight = True)
+
+    # convert second layer to a K gap
+    k_gap_grid.nk -= 1
+    k_gap_grid.extent_kji[0] = k_gap_grid.nk
+    k_gap_grid.k_gaps = 1
+    k_gap_grid.k_gap_after_array = np.zeros(k_gap_grid.nk - 1, dtype = bool)
+    k_gap_grid.k_gap_after_array[0] = True
+    k_gap_grid.k_raw_index_array = np.zeros(k_gap_grid.nk, dtype = int)
+    for k in range(1, k_gap_grid.nk):
+        k_gap_grid.k_raw_index_array[k] = k + 1
+
+    # clear some attributes which may no longer be valid
+    k_gap_grid.pinchout = None
+    k_gap_grid.inactive = None
+    k_gap_grid.grid_skin = None
+    if hasattr(k_gap_grid, 'array_thickness'):
+        delattr(k_gap_grid, 'array_thickness')
+
+    k_gap_grid.write_hdf5_from_caches()
+    k_gap_grid.create_xml()
+
+    k_gap_grid_uuid = k_gap_grid.uuid
+
+    # reload k gap grid object to ensure it is properly initialised
+
+    k_gap_grid = None
+    k_gap_grid = grr.Grid(model, uuid = k_gap_grid_uuid)
+
+    # block wells against faulted grid with k gap
+
+    log.info('k gap grid blocking of well ' + str(rqw.well_name(trajectory)))
+    try:
+        gbw = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = trajectory)
+        gbw.write_hdf5()
+        gbw.create_xml()
+        assert gbw.cell_count == 24
+    except Exception:
+        log.exception('failed to block well against k gap grid')
+
+    log.info('k gap grid blocking of well ' + str(rqw.well_name(traj_2)))
+    try:
+        gbw_2 = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = traj_2)
+        gbw_2.write_hdf5()
+        gbw_2.create_xml()
+        assert gbw_2.cell_count == 20
+    except Exception:
+        log.exception('failed to block well against k gap grid')
+
+    log.info('k gap grid blocking of well ' + str(rqw.well_name(traj_3)))
+    try:
+        gbw_3 = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = traj_3)
+        gbw_3.write_hdf5()
+        gbw_3.create_xml()
+        assert gbw_3.cell_count == 10
+    except Exception:
+        log.exception('failed to block well against k gap grid')
+
+    log.info('k gap grid blocking of well ' + str(rqw.well_name(traj_4)))
+    try:
+        gbw_4 = rqw.BlockedWell(model, grid = k_gap_grid, trajectory = traj_4)
+        gbw_4.write_hdf5()
+        gbw_4.create_xml()
+        assert gbw_4.cell_count == 10
+    except Exception:
+        log.exception('failed to block well against k gap grid')
+
+    # store model
+
+    model.store_epc()
+
+    assert k_gap_grid.k_gaps
+    assert len(k_gap_grid.k_raw_index_array) == k_gap_grid.nk
+    assert len(k_gap_grid.k_gap_after_array) == k_gap_grid.nk - 1
+    assert k_gap_grid.pinched_out((1, 0, 2))
+
+    # clean up
+    model.h5_release()
+    os.remove(model.h5_file_name())

--- a/tests/test_strata.py
+++ b/tests/test_strata.py
@@ -16,170 +16,170 @@ import resqpy.olio.uuid as bu
 
 def test_strata(tmp_path):
 
-   epc = os.path.join(tmp_path, 'strata.epc')
+    epc = os.path.join(tmp_path, 'strata.epc')
 
-   model = rq.new_model(epc_file = epc)
+    model = rq.new_model(epc_file = epc)
 
-   # earth model organisational objects
+    # earth model organisational objects
 
-   emf = rqo.OrganizationFeature(model, feature_name = 'strata model', organization_kind = 'earth model')
-   emf.create_xml()
+    emf = rqo.OrganizationFeature(model, feature_name = 'strata model', organization_kind = 'earth model')
+    emf.create_xml()
 
-   emi = rqo.EarthModelInterpretation(model, organization_feature = emf)
-   emi.create_xml()
+    emi = rqo.EarthModelInterpretation(model, organization_feature = emf)
+    emi.create_xml()
 
-   # stratigraphic organisational objects
-   # note: 'intrusive mud' has a spurious trailing space in the RESQML 2.0.1 xsd; resqpy accepts with or without
+    # stratigraphic organisational objects
+    # note: 'intrusive mud' has a spurious trailing space in the RESQML 2.0.1 xsd; resqpy accepts with or without
 
-   unit_list = ['deep unit', 'mudstone unit', 'middle unit', 'shallow unit']
-   composition_list = ['sedimentary siliclastic', 'intrusive mud', 'carbonate', 'sedimentary turbidite']
-   implacement_list = ['autochtonous', 'allochtonous', 'autochtonous', 'autochtonous']
-   mode_list = ['parallel to bottom', None, 'proportional between top and bottom', 'parallel to top']
-   suf_list = []
-   sui_list = []
+    unit_list = ['deep unit', 'mudstone unit', 'middle unit', 'shallow unit']
+    composition_list = ['sedimentary siliclastic', 'intrusive mud', 'carbonate', 'sedimentary turbidite']
+    implacement_list = ['autochtonous', 'allochtonous', 'autochtonous', 'autochtonous']
+    mode_list = ['parallel to bottom', None, 'proportional between top and bottom', 'parallel to top']
+    suf_list = []
+    sui_list = []
 
-   for unit_name, composition, implacement, mode in zip(unit_list, composition_list, implacement_list, mode_list):
-      suf = strata.StratigraphicUnitFeature(model, title = unit_name)
-      suf.create_xml()
-      suf_list.append(suf)
-      min_thick, max_thick = (250.0, 300.0) if unit_name == 'mudstone unit' else (None, None)
-      sui = strata.StratigraphicUnitInterpretation(model,
-                                                   title = unit_name,
-                                                   stratigraphic_unit_feature = suf,
-                                                   composition = composition,
-                                                   material_implacement = implacement,
-                                                   deposition_mode = mode,
-                                                   min_thickness = min_thick,
-                                                   max_thickness = max_thick,
-                                                   thickness_uom = 'cm')
-      sui.create_xml()
-      sui_list.append(sui)
+    for unit_name, composition, implacement, mode in zip(unit_list, composition_list, implacement_list, mode_list):
+        suf = strata.StratigraphicUnitFeature(model, title = unit_name)
+        suf.create_xml()
+        suf_list.append(suf)
+        min_thick, max_thick = (250.0, 300.0) if unit_name == 'mudstone unit' else (None, None)
+        sui = strata.StratigraphicUnitInterpretation(model,
+                                                     title = unit_name,
+                                                     stratigraphic_unit_feature = suf,
+                                                     composition = composition,
+                                                     material_implacement = implacement,
+                                                     deposition_mode = mode,
+                                                     min_thickness = min_thick,
+                                                     max_thickness = max_thick,
+                                                     thickness_uom = 'cm')
+        sui.create_xml()
+        sui_list.append(sui)
 
-   # horizon organisational objects
+    # horizon organisational objects
 
-   hf_list = []
-   hi_list = []
+    hf_list = []
+    hi_list = []
 
-   for unit_name in unit_list:
-      base_horizon_name = 'base ' + unit_name
-      hf = rqo.GeneticBoundaryFeature(model, feature_name = base_horizon_name, kind = 'horizon')
-      hf.create_xml()
-      hf_list.append(hf)
-      hi = rqo.HorizonInterpretation(model,
-                                     title = base_horizon_name,
-                                     genetic_boundary_feature = hf,
-                                     sequence_stratigraphy_surface = 'maximum flooding')
-      hi.create_xml()
-      hi_list.append(hi)
+    for unit_name in unit_list:
+        base_horizon_name = 'base ' + unit_name
+        hf = rqo.GeneticBoundaryFeature(model, feature_name = base_horizon_name, kind = 'horizon')
+        hf.create_xml()
+        hf_list.append(hf)
+        hi = rqo.HorizonInterpretation(model,
+                                       title = base_horizon_name,
+                                       genetic_boundary_feature = hf,
+                                       sequence_stratigraphy_surface = 'maximum flooding')
+        hi.create_xml()
+        hi_list.append(hi)
 
-   # the main stratigraphic column rank interpretation
+    # the main stratigraphic column rank interpretation
 
-   scri = strata.StratigraphicColumnRank(model,
-                                         earth_model_feature_uuid = emf.uuid,
-                                         strata_uuid_list = [sui.uuid for sui in sui_list],
-                                         title = 'stratigraphy')
-   scri.set_contacts_from_horizons(horizon_uuids = [hi.uuid for hi in hi_list[1:]],
-                                   older_contact_mode = 'erosion',
-                                   younger_contact_mode = 'baselap')
-   scri.create_xml()
+    scri = strata.StratigraphicColumnRank(model,
+                                          earth_model_feature_uuid = emf.uuid,
+                                          strata_uuid_list = [sui.uuid for sui in sui_list],
+                                          title = 'stratigraphy')
+    scri.set_contacts_from_horizons(horizon_uuids = [hi.uuid for hi in hi_list[1:]],
+                                    older_contact_mode = 'erosion',
+                                    younger_contact_mode = 'baselap')
+    scri.create_xml()
 
-   # the all encompassing stratigraphic column (in case of multiple ranks)
+    # the all encompassing stratigraphic column (in case of multiple ranks)
 
-   sc = strata.StratigraphicColumn(model, rank_uuid_list = [scri.uuid], title = scri.title)
-   sc.create_xml()
+    sc = strata.StratigraphicColumn(model, rank_uuid_list = [scri.uuid], title = scri.title)
+    sc.create_xml()
 
-   # a small grid to relate to the stratigraphy, with a few layers per strata but a K gap for the mudstone
+    # a small grid to relate to the stratigraphy, with a few layers per strata but a K gap for the mudstone
 
-   crs = rqc.Crs(model)
-   crs.create_xml()
+    crs = rqc.Crs(model)
+    crs.create_xml()
 
-   grid = grr.RegularGrid(model,
-                          extent_kji = (10, 2, 3),
-                          dxyz = (50.0, 50.0, 3.0),
-                          origin = (0.0, 0.0, 1000.0),
-                          crs_uuid = crs.uuid,
-                          set_points_cached = True,
-                          find_properties = False,
-                          title = 'tiny grid')
+    grid = grr.RegularGrid(model,
+                           extent_kji = (10, 2, 3),
+                           dxyz = (50.0, 50.0, 3.0),
+                           origin = (0.0, 0.0, 1000.0),
+                           crs_uuid = crs.uuid,
+                           set_points_cached = True,
+                           find_properties = False,
+                           title = 'tiny grid')
 
-   # convert one layer into a K gap
-   grid.nk -= 1
-   grid.extent_kji = np.array((grid.nk, grid.nj, grid.ni), dtype = int)
-   grid.k_gaps = 1
-   grid.k_gap_after_array = np.array([False, False, False, False, False, True, False, False], dtype = bool)
-   grid._set_k_raw_index_array()
+    # convert one layer into a K gap
+    grid.nk -= 1
+    grid.extent_kji = np.array((grid.nk, grid.nj, grid.ni), dtype = int)
+    grid.k_gaps = 1
+    grid.k_gap_after_array = np.array([False, False, False, False, False, True, False, False], dtype = bool)
+    grid._set_k_raw_index_array()
 
-   # set the stratigraphy mapping for the grid's layers (and K gap)
-   # note that stratigraphic unit indices start deep (old) and increase with shallowness (young)
-   grid.stratigraphic_column_rank_uuid = scri.uuid
-   grid.stratigraphic_units = np.array([3, 3, 3, 3, 2, 2, 1, 0, 0, 0], dtype = int)
+    # set the stratigraphy mapping for the grid's layers (and K gap)
+    # note that stratigraphic unit indices start deep (old) and increase with shallowness (young)
+    grid.stratigraphic_column_rank_uuid = scri.uuid
+    grid.stratigraphic_units = np.array([3, 3, 3, 3, 2, 2, 1, 0, 0, 0], dtype = int)
 
-   # write the grid array data and create grid xml, including geometry
-   # True is the default for the new stratigraphy argument anyway but included here for emphasis!
-   grid.write_hdf5_from_caches(write_active = False, stratigraphy = True)
-   grid.create_xml(write_geometry = True, write_active = False)
+    # write the grid array data and create grid xml, including geometry
+    # True is the default for the new stratigraphy argument anyway but included here for emphasis!
+    grid.write_hdf5_from_caches(write_active = False, stratigraphy = True)
+    grid.create_xml(write_geometry = True, write_active = False)
 
-   # now write the epc
+    # now write the epc
 
-   model.store_epc()
+    model.store_epc()
 
-   # re-open the model and check relationships are as they should be
+    # re-open the model and check relationships are as they should be
 
-   model = rq.Model(epc)
-   assert model is not None
-   grid = model.grid()
-   assert grid is not None
-   assert grid.stratigraphic_column_rank_uuid is not None
-   assert grid.stratigraphic_units is not None
-   assert len(grid.stratigraphic_units) == grid.nk_plus_k_gaps
-   strata_column_uuid = model.uuid(obj_type = 'StratigraphicColumn')
-   assert strata_column_uuid is not None and bu.matching_uuids(strata_column_uuid, sc.uuid)
-   strata_column = strata.StratigraphicColumn(model, uuid = strata_column_uuid)
-   assert strata_column is not None
-   assert len(strata_column.ranks) == 1
-   strata_column_ri_uuid = model.uuid(obj_type = 'StratigraphicColumnRankInterpretation',
-                                      related_uuid = strata_column_uuid)
-   assert strata_column_ri_uuid is not None and bu.matching_uuids(strata_column_ri_uuid, scri.uuid)
-   assert bu.matching_uuids(strata_column_ri_uuid, strata_column.ranks[0].uuid)
-   assert bu.matching_uuids(strata_column_ri_uuid, grid.stratigraphic_column_rank_uuid)
-   earth_model_feature_uuid = model.uuid(obj_type = 'OrganizationFeature', related_uuid = strata_column_ri_uuid)
-   assert earth_model_feature_uuid is not None
-   earth_model_feature = rqo.OrganizationFeature(model, uuid = earth_model_feature_uuid)
-   assert earth_model_feature.organization_kind == 'earth model'
-   strata_column_ri = strata.StratigraphicColumnRank(model, uuid = strata_column_ri_uuid)
-   assert strata_column_ri is not None
-   sui_uuid_set = set(model.uuids(obj_type = 'StratigraphicUnitInterpretation', related_uuid = strata_column_ri_uuid))
-   assert len(sui_uuid_set) == 4
-   assert sui_uuid_set == set([sui.uuid for sui in strata_column_ri.iter_units()])
-   hi_uuid_set = set(model.uuids(obj_type = 'HorizonInterpretation', related_uuid = strata_column_ri_uuid))
-   assert len(hi_uuid_set) == 3
-   pou_set = set()
-   for contact in strata_column_ri.iter_contacts():
-      if contact.part_of_uuid is not None:
-         pou_set.add(contact.part_of_uuid)
-   assert hi_uuid_set == pou_set
+    model = rq.Model(epc)
+    assert model is not None
+    grid = model.grid()
+    assert grid is not None
+    assert grid.stratigraphic_column_rank_uuid is not None
+    assert grid.stratigraphic_units is not None
+    assert len(grid.stratigraphic_units) == grid.nk_plus_k_gaps
+    strata_column_uuid = model.uuid(obj_type = 'StratigraphicColumn')
+    assert strata_column_uuid is not None and bu.matching_uuids(strata_column_uuid, sc.uuid)
+    strata_column = strata.StratigraphicColumn(model, uuid = strata_column_uuid)
+    assert strata_column is not None
+    assert len(strata_column.ranks) == 1
+    strata_column_ri_uuid = model.uuid(obj_type = 'StratigraphicColumnRankInterpretation',
+                                       related_uuid = strata_column_uuid)
+    assert strata_column_ri_uuid is not None and bu.matching_uuids(strata_column_ri_uuid, scri.uuid)
+    assert bu.matching_uuids(strata_column_ri_uuid, strata_column.ranks[0].uuid)
+    assert bu.matching_uuids(strata_column_ri_uuid, grid.stratigraphic_column_rank_uuid)
+    earth_model_feature_uuid = model.uuid(obj_type = 'OrganizationFeature', related_uuid = strata_column_ri_uuid)
+    assert earth_model_feature_uuid is not None
+    earth_model_feature = rqo.OrganizationFeature(model, uuid = earth_model_feature_uuid)
+    assert earth_model_feature.organization_kind == 'earth model'
+    strata_column_ri = strata.StratigraphicColumnRank(model, uuid = strata_column_ri_uuid)
+    assert strata_column_ri is not None
+    sui_uuid_set = set(model.uuids(obj_type = 'StratigraphicUnitInterpretation', related_uuid = strata_column_ri_uuid))
+    assert len(sui_uuid_set) == 4
+    assert sui_uuid_set == set([sui.uuid for sui in strata_column_ri.iter_units()])
+    hi_uuid_set = set(model.uuids(obj_type = 'HorizonInterpretation', related_uuid = strata_column_ri_uuid))
+    assert len(hi_uuid_set) == 3
+    pou_set = set()
+    for contact in strata_column_ri.iter_contacts():
+        if contact.part_of_uuid is not None:
+            pou_set.add(contact.part_of_uuid)
+    assert hi_uuid_set == pou_set
 
-   # check column rank units and contacts are well ordered
+    # check column rank units and contacts are well ordered
 
-   previous_unit_index = -1
-   for i, sui_uuid in strata_column_ri.units:
-      assert i > previous_unit_index
-      previous_unit_index = i
-      assert sui_uuid is not None
+    previous_unit_index = -1
+    for i, sui_uuid in strata_column_ri.units:
+        assert i > previous_unit_index
+        previous_unit_index = i
+        assert sui_uuid is not None
 
-   previous_contact_index = -1
-   for contact in strata_column_ri.contacts:
-      assert contact.index > previous_contact_index
-      previous_contact_index = contact.index
+    previous_contact_index = -1
+    for contact in strata_column_ri.contacts:
+        assert contact.index > previous_contact_index
+        previous_contact_index = contact.index
 
-   # check that stratigraphy for grid layers is as expected
+    # check that stratigraphy for grid layers is as expected
 
-   # note: K gap is skipped over here
-   expected_unit_names_per_layer = 4 * ['shallow unit'] + 2 * ['middle unit'] + 3 * ['deep unit']
+    # note: K gap is skipped over here
+    expected_unit_names_per_layer = 4 * ['shallow unit'] + 2 * ['middle unit'] + 3 * ['deep unit']
 
-   sui_name_list = [sui.title for sui in strata_column_ri.iter_units()]
+    sui_name_list = [sui.title for sui in strata_column_ri.iter_units()]
 
-   for k in range(grid.nk):
-      unit = strata_column_ri.unit_for_unit_index(grid.stratigraphic_units[grid.k_raw_index_array[k]])
-      assert unit is not None
-      assert unit.title == expected_unit_names_per_layer[k]
+    for k in range(grid.nk):
+        unit = strata_column_ri.unit_for_unit_index(grid.stratigraphic_units[grid.k_raw_index_array[k]])
+        assert unit is not None
+        assert unit.title == expected_unit_names_per_layer[k]

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -12,164 +12,164 @@ import resqpy.olio.uuid as bu
 
 def test_surface(tmp_model):
 
-   # Set up a Surface
-   title = 'Mountbatten'
-   model = tmp_model
-   surf = resqpy.surface.Surface(parent_model = model, title = title)
-   surf.create_xml()
+    # Set up a Surface
+    title = 'Mountbatten'
+    model = tmp_model
+    surf = resqpy.surface.Surface(parent_model = model, title = title)
+    surf.create_xml()
 
-   # Add a interpretation
-   assert surf.represented_interpretation_root is None
-   surf.create_interpretation_and_feature(kind = 'fault')
-   assert surf.represented_interpretation_root is not None
+    # Add a interpretation
+    assert surf.represented_interpretation_root is None
+    surf.create_interpretation_and_feature(kind = 'fault')
+    assert surf.represented_interpretation_root is not None
 
-   # Check fault can be loaded in again
-   model.store_epc()
-   fault_interp = resqpy.organize.FaultInterpretation(model, uuid = surf.represented_interpretation_uuid)
-   fault_feature = resqpy.organize.TectonicBoundaryFeature(model, uuid = fault_interp.tectonic_boundary_feature.uuid)
+    # Check fault can be loaded in again
+    model.store_epc()
+    fault_interp = resqpy.organize.FaultInterpretation(model, uuid = surf.represented_interpretation_uuid)
+    fault_feature = resqpy.organize.TectonicBoundaryFeature(model, uuid = fault_interp.tectonic_boundary_feature.uuid)
 
-   # Check title matches expected title
-   assert fault_feature.feature_name == title
+    # Check title matches expected title
+    assert fault_feature.feature_name == title
 
 
 def test_faces_for_surface(tmp_model):
-   crs = resqpy.crs.Crs(tmp_model)
-   crs.create_xml()
-   grid = resqpy.grid.RegularGrid(tmp_model, extent_kji = (3, 3, 3), crs_uuid = crs.uuid, set_points_cached = True)
-   grid.write_hdf5()
-   grid.create_xml(write_geometry = True)
-   # todo: create sloping planar surface
-   # call find faces for each of 3 different methods
-   points = np.zeros((2, 2, 3))
-   points[1, :, 1] = 3.0
-   points[:, 1, 0] = 3.0
-   points[:, 1, 2] = 3.0
-   points[:, :, 2] += 0.25
-   triangles = np.zeros((2, 3), dtype = int)
-   triangles[0] = (0, 1, 2)
-   triangles[1] = (3, 1, 2)
-   surf = resqpy.surface.Surface(tmp_model, crs_uuid = crs.uuid)
-   surf.set_from_triangles_and_points(triangles, points.reshape((-1, 3)))
-   assert surf is not None
-   gcs = rqgs.find_faces_to_represent_surface(grid, surf, 'staffa', mode = 'staffa')
-   assert gcs is not None
-   assert gcs.count == 12
-   cip = set([tuple(pair) for pair in gcs.cell_index_pairs])
-   expected_cip = grid.natural_cell_indices(
-      np.array([[[0, 0, 0], [1, 0, 0]], [[0, 1, 0], [1, 1, 0]], [[0, 2, 0], [1, 2, 0]], [[1, 0, 0], [1, 0, 1]],
-                [[1, 1, 0], [1, 1, 1]], [[1, 2, 0], [1, 2, 1]], [[1, 0, 1], [2, 0, 1]], [[1, 1, 1], [2, 1, 1]],
-                [[1, 2, 1], [2, 2, 1]], [[2, 0, 1], [2, 0, 2]], [[2, 1, 1], [2, 1, 2]], [[2, 2, 1], [2, 2, 2]]],
-               dtype = int))
-   e_cip = set([tuple(pair) for pair in expected_cip])
-   assert cip == e_cip  # note: this assumes lower cell index is first, which happens to be true
-   # todo: check face indices
-   gcs.write_hdf5()
-   gcs.create_xml()
-   assert bu.matching_uuids(tmp_model.uuid(obj_type = 'GridConnectionSetRepresentation'), gcs.uuid)
+    crs = resqpy.crs.Crs(tmp_model)
+    crs.create_xml()
+    grid = resqpy.grid.RegularGrid(tmp_model, extent_kji = (3, 3, 3), crs_uuid = crs.uuid, set_points_cached = True)
+    grid.write_hdf5()
+    grid.create_xml(write_geometry = True)
+    # todo: create sloping planar surface
+    # call find faces for each of 3 different methods
+    points = np.zeros((2, 2, 3))
+    points[1, :, 1] = 3.0
+    points[:, 1, 0] = 3.0
+    points[:, 1, 2] = 3.0
+    points[:, :, 2] += 0.25
+    triangles = np.zeros((2, 3), dtype = int)
+    triangles[0] = (0, 1, 2)
+    triangles[1] = (3, 1, 2)
+    surf = resqpy.surface.Surface(tmp_model, crs_uuid = crs.uuid)
+    surf.set_from_triangles_and_points(triangles, points.reshape((-1, 3)))
+    assert surf is not None
+    gcs = rqgs.find_faces_to_represent_surface(grid, surf, 'staffa', mode = 'staffa')
+    assert gcs is not None
+    assert gcs.count == 12
+    cip = set([tuple(pair) for pair in gcs.cell_index_pairs])
+    expected_cip = grid.natural_cell_indices(
+        np.array([[[0, 0, 0], [1, 0, 0]], [[0, 1, 0], [1, 1, 0]], [[0, 2, 0], [1, 2, 0]], [[1, 0, 0], [1, 0, 1]],
+                  [[1, 1, 0], [1, 1, 1]], [[1, 2, 0], [1, 2, 1]], [[1, 0, 1], [2, 0, 1]], [[1, 1, 1], [2, 1, 1]],
+                  [[1, 2, 1], [2, 2, 1]], [[2, 0, 1], [2, 0, 2]], [[2, 1, 1], [2, 1, 2]], [[2, 2, 1], [2, 2, 2]]],
+                 dtype = int))
+    e_cip = set([tuple(pair) for pair in expected_cip])
+    assert cip == e_cip  # note: this assumes lower cell index is first, which happens to be true
+    # todo: check face indices
+    gcs.write_hdf5()
+    gcs.create_xml()
+    assert bu.matching_uuids(tmp_model.uuid(obj_type = 'GridConnectionSetRepresentation'), gcs.uuid)
 
 
 def test_delaunay_triangulation(example_model_and_crs):
 
-   model, crs = example_model_and_crs
+    model, crs = example_model_and_crs
 
-   # number of random points to use
-   n = 20
+    # number of random points to use
+    n = 20
 
-   # create a set of random points
-   x = np.random.random(n) * 1000.0
-   y = np.random.random(n) * 1000.0
-   z = np.random.random(n)  # note: triangulation does not use z values
-   p = np.stack((x, y, z), axis = -1)
+    # create a set of random points
+    x = np.random.random(n) * 1000.0
+    y = np.random.random(n) * 1000.0
+    z = np.random.random(n)  # note: triangulation does not use z values
+    p = np.stack((x, y, z), axis = -1)
 
-   # make a PointSet object
-   ps = resqpy.surface.PointSet(model, crs_uuid = crs.uuid, points_array = p, title = 'random points in square')
+    # make a PointSet object
+    ps = resqpy.surface.PointSet(model, crs_uuid = crs.uuid, points_array = p, title = 'random points in square')
 
-   # make another PointSet as random points within a closed polyline
-   vertices = np.array(
-      ((50.0, 99.0, 13.0), (85.0, 60.0, 17.5), (62.7, 11.0, 10.0), (33.3, 15.3, 19.2), (12.8, 57.8, 15.0)))
-   polygon = rql.Polyline(model, set_crs = crs.uuid, set_bool = True, set_coord = vertices, title = 'the pentagon')
-   polygon.write_hdf5()
-   polygon.create_xml()
-   ps2 = resqpy.surface.PointSet(model,
-                                 crs_uuid = crs.uuid,
-                                 polyline = polygon,
-                                 random_point_count = n,
-                                 title = 'random points in polygon')
+    # make another PointSet as random points within a closed polyline
+    vertices = np.array(
+        ((50.0, 99.0, 13.0), (85.0, 60.0, 17.5), (62.7, 11.0, 10.0), (33.3, 15.3, 19.2), (12.8, 57.8, 15.0)))
+    polygon = rql.Polyline(model, set_crs = crs.uuid, set_bool = True, set_coord = vertices, title = 'the pentagon')
+    polygon.write_hdf5()
+    polygon.create_xml()
+    ps2 = resqpy.surface.PointSet(model,
+                                  crs_uuid = crs.uuid,
+                                  polyline = polygon,
+                                  random_point_count = n,
+                                  title = 'random points in polygon')
 
-   # process the point sets into triangulated surfaces
-   for point_set in (ps, ps2):
-      point_set.write_hdf5()
-      point_set.create_xml()
-      surf = resqpy.surface.Surface(model, point_set = point_set, title = 'surface from ' + str(point_set.title))
-      assert surf is not None
-      surf.write_hdf5()
-      surf.create_xml()
-      # check that coordinate range of points looks okay
-      triangles, points = surf.triangles_and_points()
-      assert len(points) == n
-      original_points = point_set.full_array_ref()
-      assert_array_almost_equal(np.nanmin(original_points, axis = 0), np.nanmin(points, axis = 0))
-      assert_array_almost_equal(np.nanmax(original_points, axis = 0), np.nanmax(points, axis = 0))
+    # process the point sets into triangulated surfaces
+    for point_set in (ps, ps2):
+        point_set.write_hdf5()
+        point_set.create_xml()
+        surf = resqpy.surface.Surface(model, point_set = point_set, title = 'surface from ' + str(point_set.title))
+        assert surf is not None
+        surf.write_hdf5()
+        surf.create_xml()
+        # check that coordinate range of points looks okay
+        triangles, points = surf.triangles_and_points()
+        assert len(points) == n
+        original_points = point_set.full_array_ref()
+        assert_array_almost_equal(np.nanmin(original_points, axis = 0), np.nanmin(points, axis = 0))
+        assert_array_almost_equal(np.nanmax(original_points, axis = 0), np.nanmax(points, axis = 0))
 
 
 def test_regular_mesh(example_model_and_crs):
 
-   model, crs = example_model_and_crs
+    model, crs = example_model_and_crs
 
-   # number of points in mesh, origin spacing
-   ni = 7
-   nj = 5
-   origin = (409000.0, 1605000.0, 0.0)
-   di = dj = 50.0
+    # number of points in mesh, origin spacing
+    ni = 7
+    nj = 5
+    origin = (409000.0, 1605000.0, 0.0)
+    di = dj = 50.0
 
-   # create some random depths
-   z = (np.random.random(ni * nj) * 20.0 + 1000.0).reshape((nj, ni))
+    # create some random depths
+    z = (np.random.random(ni * nj) * 20.0 + 1000.0).reshape((nj, ni))
 
-   # make a regular mesh representation
-   mesh = resqpy.surface.Mesh(model,
-                              crs_uuid = crs.uuid,
-                              mesh_flavour = 'reg&z',
-                              ni = ni,
-                              nj = nj,
-                              origin = origin,
-                              dxyz_dij = np.array([[di, 0.0, 0.0], [0.0, dj, 0.0]]),
-                              z_values = z,
-                              title = 'random mesh',
-                              originator = 'Andy',
-                              extra_metadata = {'testing mode': 'automated'})
-   assert mesh is not None
-   mesh.write_hdf5()
-   mesh.create_xml()
-   mesh_uuid = mesh.uuid
+    # make a regular mesh representation
+    mesh = resqpy.surface.Mesh(model,
+                               crs_uuid = crs.uuid,
+                               mesh_flavour = 'reg&z',
+                               ni = ni,
+                               nj = nj,
+                               origin = origin,
+                               dxyz_dij = np.array([[di, 0.0, 0.0], [0.0, dj, 0.0]]),
+                               z_values = z,
+                               title = 'random mesh',
+                               originator = 'Andy',
+                               extra_metadata = {'testing mode': 'automated'})
+    assert mesh is not None
+    mesh.write_hdf5()
+    mesh.create_xml()
+    mesh_uuid = mesh.uuid
 
-   # fully write model to disc
-   model.store_epc()
-   epc = model.epc_file
+    # fully write model to disc
+    model.store_epc()
+    epc = model.epc_file
 
-   # re-open model and check the mesh object is there
-   model = rq.Model(epc)
-   assert bu.matching_uuids(model.uuid(obj_type = 'Grid2dRepresentation', title = 'random mesh'), mesh_uuid)
+    # re-open model and check the mesh object is there
+    model = rq.Model(epc)
+    assert bu.matching_uuids(model.uuid(obj_type = 'Grid2dRepresentation', title = 'random mesh'), mesh_uuid)
 
-   # establish a resqpy Mesh from the object in the RESQML dataset
-   peristent_mesh = resqpy.surface.Mesh(model, uuid = mesh_uuid)
+    # establish a resqpy Mesh from the object in the RESQML dataset
+    peristent_mesh = resqpy.surface.Mesh(model, uuid = mesh_uuid)
 
-   # check some of the metadata
-   assert peristent_mesh.ni == ni and peristent_mesh.nj == nj
-   assert peristent_mesh.flavour == 'reg&z'
-   assert_array_almost_equal(np.array(peristent_mesh.regular_origin), np.array(origin))
-   assert_array_almost_equal(np.array(peristent_mesh.regular_dxyz_dij), np.array([[di, 0.0, 0.0], [0.0, dj, 0.0]]))
+    # check some of the metadata
+    assert peristent_mesh.ni == ni and peristent_mesh.nj == nj
+    assert peristent_mesh.flavour == 'reg&z'
+    assert_array_almost_equal(np.array(peristent_mesh.regular_origin), np.array(origin))
+    assert_array_almost_equal(np.array(peristent_mesh.regular_dxyz_dij), np.array([[di, 0.0, 0.0], [0.0, dj, 0.0]]))
 
-   # check a fully expanded version of the points
-   assert_array_almost_equal(peristent_mesh.full_array_ref(), mesh.full_array_ref())
+    # check a fully expanded version of the points
+    assert_array_almost_equal(peristent_mesh.full_array_ref(), mesh.full_array_ref())
 
-   # check that we can build a Surface from the Mesh
-   surf = peristent_mesh.surface(quad_triangles = True)
-   assert surf is not None
+    # check that we can build a Surface from the Mesh
+    surf = peristent_mesh.surface(quad_triangles = True)
+    assert surf is not None
 
-   # do some basic checks that the surface looks consistent with the mesh
-   t, p = surf.triangles_and_points()
-   assert len(p) == (ni * nj) + ((ni - 1) * (nj - 1))  # quad triangles mode introduces the extra points
-   assert len(t) == 4 * (ni - 1) * (nj - 1)
-   assert_array_almost_equal(np.min(p, axis = 0), np.min(peristent_mesh.full_array_ref().reshape(-1, 3), axis = 0))
-   assert_array_almost_equal(np.max(p, axis = 0), np.max(peristent_mesh.full_array_ref().reshape(-1, 3), axis = 0))
-   assert len(surf.distinct_edges()) == 6 * (ni - 1) * (nj - 1) + (ni - 1) + (nj - 1)
+    # do some basic checks that the surface looks consistent with the mesh
+    t, p = surf.triangles_and_points()
+    assert len(p) == (ni * nj) + ((ni - 1) * (nj - 1))  # quad triangles mode introduces the extra points
+    assert len(t) == 4 * (ni - 1) * (nj - 1)
+    assert_array_almost_equal(np.min(p, axis = 0), np.min(peristent_mesh.full_array_ref().reshape(-1, 3), axis = 0))
+    assert_array_almost_equal(np.max(p, axis = 0), np.max(peristent_mesh.full_array_ref().reshape(-1, 3), axis = 0))
+    assert len(surf.distinct_edges()) == 6 * (ni - 1) * (nj - 1) + (ni - 1) + (nj - 1)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -10,111 +10,111 @@ import resqpy.time_series as rqts
 
 #@pytest.mark.parametrize("reversemode", [True, False])
 def test_merge_timeseries():
-   model = rq.Model(create_basics = True)
+    model = rq.Model(create_basics = True)
 
-   timestamps1 = ['2020-01-01T00:00:00Z', '2015-01-01T00:00:00Z']
-   timestamps2 = ['2021-01-01T00:00:00Z', '2014-01-01T00:00:00Z']
+    timestamps1 = ['2020-01-01T00:00:00Z', '2015-01-01T00:00:00Z']
+    timestamps2 = ['2021-01-01T00:00:00Z', '2014-01-01T00:00:00Z']
 
-   timeseries1 = rqts.time_series_from_list(timestamps1, parent_model = model)
-   timeseries1.set_model(model)
-   timeseries1.create_xml()
-   timeseries2 = rqts.time_series_from_list(timestamps2, parent_model = model)
-   timeseries2.set_model(model)
-   timeseries2.create_xml()
+    timeseries1 = rqts.time_series_from_list(timestamps1, parent_model = model)
+    timeseries1.set_model(model)
+    timeseries1.create_xml()
+    timeseries2 = rqts.time_series_from_list(timestamps2, parent_model = model)
+    timeseries2.set_model(model)
+    timeseries2.create_xml()
 
-   sortedtimestamps = sorted(timeseries1.datetimes() + timeseries2.datetimes())
+    sortedtimestamps = sorted(timeseries1.datetimes() + timeseries2.datetimes())
 
-   timeseries_uuids = (timeseries1.uuid, timeseries2.uuid)
+    timeseries_uuids = (timeseries1.uuid, timeseries2.uuid)
 
-   newts, newtsuuid, timeserieslist = rqts.merge_timeseries_from_uuid(model, timeseries_uuids)
+    newts, newtsuuid, timeserieslist = rqts.merge_timeseries_from_uuid(model, timeseries_uuids)
 
-   assert len(newts.timestamps) == len(timeseries1.timestamps) + len(timeseries2.timestamps)
+    assert len(newts.timestamps) == len(timeseries1.timestamps) + len(timeseries2.timestamps)
 
-   for idx, timestamp in enumerate(newts.datetimes()):
-      assert timestamp == sortedtimestamps[idx]
+    for idx, timestamp in enumerate(newts.datetimes()):
+        assert timestamp == sortedtimestamps[idx]
 
-   #Now test duplication doesn't create duplicate timestamps during merge, I want a unique set of merged timestamps
+    #Now test duplication doesn't create duplicate timestamps during merge, I want a unique set of merged timestamps
 
-   timestamps3 = [timestamp for timestamp in timestamps1]
-   timeseries3 = rqts.time_series_from_list(timestamps3, parent_model = model)
-   timeseries3.set_model(model)
-   timeseries3.create_xml()
+    timestamps3 = [timestamp for timestamp in timestamps1]
+    timeseries3 = rqts.time_series_from_list(timestamps3, parent_model = model)
+    timeseries3.set_model(model)
+    timeseries3.create_xml()
 
-   timeseries_uuids = (timeseries1.uuid, timeseries2.uuid, timeseries3.uuid)
+    timeseries_uuids = (timeseries1.uuid, timeseries2.uuid, timeseries3.uuid)
 
-   newts2, _, _ = rqts.merge_timeseries_from_uuid(model, timeseries_uuids)
+    newts2, _, _ = rqts.merge_timeseries_from_uuid(model, timeseries_uuids)
 
-   assert len(newts.timestamps) == len(newts2.timestamps)
+    assert len(newts.timestamps) == len(newts2.timestamps)
 
-   for idx, timestamp in enumerate(newts2.datetimes()):
-      assert timestamp == sortedtimestamps[idx]
+    for idx, timestamp in enumerate(newts2.datetimes()):
+        assert timestamp == sortedtimestamps[idx]
 
-   return True
+    return True
 
 
 def test_time_series_from_list(tmp_path):
-   epc = os.path.join(tmp_path, 'ts_list.epc')
-   model = rq.new_model(epc)
-   ts_list = ['2022-01-01', '2022-02-01', '2022-03-01', '2022-04-01']
-   ts = rqts.time_series_from_list(ts_list, parent_model = model)
-   assert ts.number_of_timestamps() == 4
-   assert ts.days_between_timestamps(0, 3) == 31 + 28 + 31
-   ts.create_xml()
-   model.store_epc()
-   model = rq.Model(epc)
-   ts_uuid = model.uuid(obj_type = 'TimeSeries')
-   assert ts_uuid is not None
-   ts = rqts.any_time_series(model, uuid = ts_uuid)
-   assert isinstance(ts, rqts.TimeSeries)
-   assert ts.number_of_timestamps() == 4
-   assert ts.days_between_timestamps(0, 3) == 31 + 28 + 31
-   assert ts.timeframe == 'human'
+    epc = os.path.join(tmp_path, 'ts_list.epc')
+    model = rq.new_model(epc)
+    ts_list = ['2022-01-01', '2022-02-01', '2022-03-01', '2022-04-01']
+    ts = rqts.time_series_from_list(ts_list, parent_model = model)
+    assert ts.number_of_timestamps() == 4
+    assert ts.days_between_timestamps(0, 3) == 31 + 28 + 31
+    ts.create_xml()
+    model.store_epc()
+    model = rq.Model(epc)
+    ts_uuid = model.uuid(obj_type = 'TimeSeries')
+    assert ts_uuid is not None
+    ts = rqts.any_time_series(model, uuid = ts_uuid)
+    assert isinstance(ts, rqts.TimeSeries)
+    assert ts.number_of_timestamps() == 4
+    assert ts.days_between_timestamps(0, 3) == 31 + 28 + 31
+    assert ts.timeframe == 'human'
 
 
 def test_time_series_from_args(tmp_path):
-   epc = os.path.join(tmp_path, 'ts_args.epc')
-   model = rq.new_model(epc)
-   ts = rqts.TimeSeries(model,
-                        first_timestamp = '1963-08-23',
-                        daily = 8,
-                        monthly = 4,
-                        quarterly = 8,
-                        yearly = 5,
-                        title = 'late 60s')
-   assert ts.number_of_timestamps() == 26
-   assert ts.days_between_timestamps(2, 3) == 1
-   assert ts.days_between_timestamps(0, 25) == 8 + 4 * 30 + 8 * 90 + 5 * 365
-   ts.create_xml()
-   model.store_epc()
-   model = rq.Model(epc)
-   ts_uuid = model.uuid(obj_type = 'TimeSeries')
-   assert ts_uuid is not None
-   ts = rqts.TimeSeries(model, uuid = ts_uuid)
-   assert ts.number_of_timestamps() == 26
-   assert ts.days_between_timestamps(2, 3) == 1
-   assert ts.days_between_timestamps(0, 25) == 8 + 4 * 30 + 8 * 90 + 5 * 365
+    epc = os.path.join(tmp_path, 'ts_args.epc')
+    model = rq.new_model(epc)
+    ts = rqts.TimeSeries(model,
+                         first_timestamp = '1963-08-23',
+                         daily = 8,
+                         monthly = 4,
+                         quarterly = 8,
+                         yearly = 5,
+                         title = 'late 60s')
+    assert ts.number_of_timestamps() == 26
+    assert ts.days_between_timestamps(2, 3) == 1
+    assert ts.days_between_timestamps(0, 25) == 8 + 4 * 30 + 8 * 90 + 5 * 365
+    ts.create_xml()
+    model.store_epc()
+    model = rq.Model(epc)
+    ts_uuid = model.uuid(obj_type = 'TimeSeries')
+    assert ts_uuid is not None
+    ts = rqts.TimeSeries(model, uuid = ts_uuid)
+    assert ts.number_of_timestamps() == 26
+    assert ts.days_between_timestamps(2, 3) == 1
+    assert ts.days_between_timestamps(0, 25) == 8 + 4 * 30 + 8 * 90 + 5 * 365
 
 
 def test_geologic_time_series(tmp_path):
-   epc = os.path.join(tmp_path, 'ts_geologic.epc')
-   model = rq.new_model(epc)
-   # Cretaceous Age start times, in Ma, with random use of sign to check it is ignored
-   ma_list = (145, 72.1, -83.6, 86.3, 89.8, 93.9, 100.5, -113, -125, 129.4, 132.9, 139.8)
-   ts_list = [int(round(ma * 1000000)) for ma in ma_list]
-   ts_list_2 = [int(round(ma * 2000000)) for ma in ma_list]
-   ts = rqts.time_series_from_list(ts_list, parent_model = model)
-   assert ts.number_of_timestamps() == 12
-   ts.create_xml()
-   ts_2 = rqts.GeologicTimeSeries.from_year_list(model, year_list = ts_list_2, title = 'using class method')
-   ts_2.create_xml()
-   model.store_epc()
-   model = rq.Model(epc)
-   ts_uuids = model.uuids(obj_type = 'TimeSeries')
-   assert ts_uuids is not None and len(ts_uuids) == 2
-   for ts_uuid in ts_uuids:
-      ts = rqts.any_time_series(model, uuid = ts_uuid)
-      assert isinstance(ts, rqts.GeologicTimeSeries)
-      assert ts.timeframe == 'geologic'
-      assert ts.number_of_timestamps() == 12
-      assert ((ts.timestamps[0] == -145000000 and ts.timestamps[-1] == -72100000) or
-              (ts.timestamps[0] == -145000000 * 2 and ts.timestamps[-1] == -72100000 * 2))
+    epc = os.path.join(tmp_path, 'ts_geologic.epc')
+    model = rq.new_model(epc)
+    # Cretaceous Age start times, in Ma, with random use of sign to check it is ignored
+    ma_list = (145, 72.1, -83.6, 86.3, 89.8, 93.9, 100.5, -113, -125, 129.4, 132.9, 139.8)
+    ts_list = [int(round(ma * 1000000)) for ma in ma_list]
+    ts_list_2 = [int(round(ma * 2000000)) for ma in ma_list]
+    ts = rqts.time_series_from_list(ts_list, parent_model = model)
+    assert ts.number_of_timestamps() == 12
+    ts.create_xml()
+    ts_2 = rqts.GeologicTimeSeries.from_year_list(model, year_list = ts_list_2, title = 'using class method')
+    ts_2.create_xml()
+    model.store_epc()
+    model = rq.Model(epc)
+    ts_uuids = model.uuids(obj_type = 'TimeSeries')
+    assert ts_uuids is not None and len(ts_uuids) == 2
+    for ts_uuid in ts_uuids:
+        ts = rqts.any_time_series(model, uuid = ts_uuid)
+        assert isinstance(ts, rqts.GeologicTimeSeries)
+        assert ts.timeframe == 'geologic'
+        assert ts.number_of_timestamps() == 12
+        assert ((ts.timestamps[0] == -145000000 and ts.timestamps[-1] == -72100000) or
+                (ts.timestamps[0] == -145000000 * 2 and ts.timestamps[-1] == -72100000 * 2))

--- a/tests/test_transmission.py
+++ b/tests/test_transmission.py
@@ -16,71 +16,71 @@ import resqpy.olio.uuid as bu
 
 def test_regular_grid_half_cell_transmission(tmp_path):
 
-   def try_one_half_t_regular(model,
-                              extent_kji = (2, 2, 2),
-                              dxyz = (1.0, 1.0, 1.0),
-                              perm_kji = (1.0, 1.0, 1.0),
-                              ntg = 1.0,
-                              darcy_constant = 1.0,
-                              rotate = None,
-                              dip = None):
-      ones = np.ones(extent_kji)
-      grid = grr.RegularGrid(model, extent_kji = extent_kji, dxyz = dxyz)
-      if dip is not None:  # dip positive x axis downwards
-         r_matrix = vec.rotation_matrix_3d_axial(1, dip)
-         p = grid.points_ref(masked = False)
-         p[:] = vec.rotate_array(r_matrix, p)
-      if rotate is not None:  # rotate anticlockwise in xy plane (viewed from above)
-         r_matrix = vec.rotation_matrix_3d_axial(2, rotate)
-         p = grid.points_ref(masked = False)
-         p[:] = vec.rotate_array(r_matrix, p)
-      half_t = rqtr.half_cell_t(grid,
-                                perm_k = perm_kji[0] * ones,
-                                perm_j = perm_kji[1] * ones,
-                                perm_i = perm_kji[2] * ones,
-                                ntg = ntg * ones,
-                                darcy_constant = darcy_constant)
-      expected = 2.0 * darcy_constant * np.array(
-         (perm_kji[0] * dxyz[0] * dxyz[1] / dxyz[2], ntg * perm_kji[1] * dxyz[0] * dxyz[2] / dxyz[1],
-          ntg * perm_kji[2] * dxyz[1] * dxyz[2] / dxyz[0]))
-      assert np.all(np.isclose(half_t, expected.reshape(1, 1, 1, 3)))
+    def try_one_half_t_regular(model,
+                               extent_kji = (2, 2, 2),
+                               dxyz = (1.0, 1.0, 1.0),
+                               perm_kji = (1.0, 1.0, 1.0),
+                               ntg = 1.0,
+                               darcy_constant = 1.0,
+                               rotate = None,
+                               dip = None):
+        ones = np.ones(extent_kji)
+        grid = grr.RegularGrid(model, extent_kji = extent_kji, dxyz = dxyz)
+        if dip is not None:  # dip positive x axis downwards
+            r_matrix = vec.rotation_matrix_3d_axial(1, dip)
+            p = grid.points_ref(masked = False)
+            p[:] = vec.rotate_array(r_matrix, p)
+        if rotate is not None:  # rotate anticlockwise in xy plane (viewed from above)
+            r_matrix = vec.rotation_matrix_3d_axial(2, rotate)
+            p = grid.points_ref(masked = False)
+            p[:] = vec.rotate_array(r_matrix, p)
+        half_t = rqtr.half_cell_t(grid,
+                                  perm_k = perm_kji[0] * ones,
+                                  perm_j = perm_kji[1] * ones,
+                                  perm_i = perm_kji[2] * ones,
+                                  ntg = ntg * ones,
+                                  darcy_constant = darcy_constant)
+        expected = 2.0 * darcy_constant * np.array(
+            (perm_kji[0] * dxyz[0] * dxyz[1] / dxyz[2], ntg * perm_kji[1] * dxyz[0] * dxyz[2] / dxyz[1],
+             ntg * perm_kji[2] * dxyz[1] * dxyz[2] / dxyz[0]))
+        assert np.all(np.isclose(half_t, expected.reshape(1, 1, 1, 3)))
 
-   temp_epc = str(os.path.join(tmp_path, f"{bu.new_uuid()}.epc"))
-   model = rq.Model(temp_epc, new_epc = True, create_basics = True)
+    temp_epc = str(os.path.join(tmp_path, f"{bu.new_uuid()}.epc"))
+    model = rq.Model(temp_epc, new_epc = True, create_basics = True)
 
-   try_one_half_t_regular(model)
-   try_one_half_t_regular(model, extent_kji = (3, 4, 5))
-   try_one_half_t_regular(model, dxyz = (127.53, 21.05, 12.6452))
-   try_one_half_t_regular(model, perm_kji = (123.23, 512.4, 314.7))
-   try_one_half_t_regular(model, ntg = 0.7)
-   try_one_half_t_regular(model, darcy_constant = 0.001127)
-   try_one_half_t_regular(model,
-                          extent_kji = (5, 4, 3),
-                          dxyz = (84.23, 77.31, 15.823),
-                          perm_kji = (0.6732, 298.14, 384.2),
-                          ntg = 0.32,
-                          darcy_constant = 0.008527)
-   try_one_half_t_regular(model, rotate = 67.8)
+    try_one_half_t_regular(model)
+    try_one_half_t_regular(model, extent_kji = (3, 4, 5))
+    try_one_half_t_regular(model, dxyz = (127.53, 21.05, 12.6452))
+    try_one_half_t_regular(model, perm_kji = (123.23, 512.4, 314.7))
+    try_one_half_t_regular(model, ntg = 0.7)
+    try_one_half_t_regular(model, darcy_constant = 0.001127)
+    try_one_half_t_regular(model,
+                           extent_kji = (5, 4, 3),
+                           dxyz = (84.23, 77.31, 15.823),
+                           perm_kji = (0.6732, 298.14, 384.2),
+                           ntg = 0.32,
+                           darcy_constant = 0.008527)
+    try_one_half_t_regular(model, rotate = 67.8)
 
-   # should not have written anything, but try clean-up just in case
-   try:
-      os.remove(temp_epc)
-   except Exception:
-      pass
-   try:
-      os.remove(temp_epc[-4] + '.h5')
-   except Exception:
-      pass
+    # should not have written anything, but try clean-up just in case
+    try:
+        os.remove(temp_epc)
+    except Exception:
+        pass
+    try:
+        os.remove(temp_epc[-4] + '.h5')
+    except Exception:
+        pass
 
 
 def test_half_cell_t_2d_triangular_precursor_equilateral():
-   side = 123.45
-   height = side * maths.sin(vec.radians_from_degrees(60.0))
-   # create a pair of equilateral triangles
-   p = np.array([(0.0, 0.0), (side, 0.0), (side / 2.0, height), (side * 3.0 / 2.0, height)])
-   t = np.array([(0, 1, 2), (1, 2, 3)], dtype = int)
-   a, b = rqtr.half_cell_t_2d_triangular_precursor(p, t)
-   a_over_l = a / b
-   expected = side / (height / 3)
-   assert a_over_l.shape == (2, 3)
-   assert_array_almost_equal(a_over_l, expected)
+    side = 123.45
+    height = side * maths.sin(vec.radians_from_degrees(60.0))
+    # create a pair of equilateral triangles
+    p = np.array([(0.0, 0.0), (side, 0.0), (side / 2.0, height), (side * 3.0 / 2.0, height)])
+    t = np.array([(0, 1, 2), (1, 2, 3)], dtype = int)
+    a, b = rqtr.half_cell_t_2d_triangular_precursor(p, t)
+    a_over_l = a / b
+    expected = side / (height / 3)
+    assert a_over_l.shape == (2, 3)
+    assert_array_almost_equal(a_over_l, expected)

--- a/tests/test_triangulation.py
+++ b/tests/test_triangulation.py
@@ -14,99 +14,103 @@ from resqpy.olio.random_seed import seed
 
 def test_ccc():
 
-   def check_equidistant(c, p_list):
-      v = np.stack(tuple([c - p[:2] for p in p_list]))
-      r = vec.naive_2d_lengths(v)
-      assert_array_almost_equal(r[1:], r[0])
+    def check_equidistant(c, p_list):
+        v = np.stack(tuple([c - p[:2] for p in p_list]))
+        r = vec.naive_2d_lengths(v)
+        assert_array_almost_equal(r[1:], r[0])
 
-   # 3 points in orthogonal pattern
-   p1 = np.array((0.0, 0.0, 0.0))
-   p2 = np.array((20.0, 0.0, 0.0))
-   p3 = np.array((0.0, 10.0, 5.0))
-   assert_array_almost_equal(tri.ccc(p1, p2, p3), (10.0, 5.0))
-   # equilateral triangle
-   s = 23.57
-   p1 = np.array((10.0, 20.0, 30.0))
-   p2 = np.array((10.0, 20.0 + s, -45.0))
-   p3 = np.array((10.0 + s * maths.cos(maths.radians(30.0)), 20.0 + 0.5 * s, 12.13))
-   assert_array_almost_equal(tri.ccc(p1, p2, p3), np.mean(np.stack((p1, p2, p3)), axis = 0)[:2])
-   # asymmetric triangle
-   p1 = np.array((25.3, 12.1, 0.0))
-   p2 = np.array((23.6, 2.9, -1.0))
-   p3 = np.array((22.1, 87.3, 1.5))
-   c = np.array(tri.ccc(p1, p2, p3))
-   check_equidistant(c, (p1, p2, p3))
-   # highly asymmetric triangle
-   p1 = np.array((0.0, 0.0, 0.0))
-   p2 = np.array((100.0, 0.0, 0.0))
-   p3 = np.array((200.0, 1.0, 0.0))
-   c = np.array(tri.ccc(p1, p2, p3))
-   check_equidistant(c, (p1, p2, p3))
+    # 3 points in orthogonal pattern
+    p1 = np.array((0.0, 0.0, 0.0))
+    p2 = np.array((20.0, 0.0, 0.0))
+    p3 = np.array((0.0, 10.0, 5.0))
+    assert_array_almost_equal(tri.ccc(p1, p2, p3), (10.0, 5.0))
+    # equilateral triangle
+    s = 23.57
+    p1 = np.array((10.0, 20.0, 30.0))
+    p2 = np.array((10.0, 20.0 + s, -45.0))
+    p3 = np.array((10.0 + s * maths.cos(maths.radians(30.0)), 20.0 + 0.5 * s, 12.13))
+    assert_array_almost_equal(tri.ccc(p1, p2, p3), np.mean(np.stack((p1, p2, p3)), axis = 0)[:2])
+    # asymmetric triangle
+    p1 = np.array((25.3, 12.1, 0.0))
+    p2 = np.array((23.6, 2.9, -1.0))
+    p3 = np.array((22.1, 87.3, 1.5))
+    c = np.array(tri.ccc(p1, p2, p3))
+    check_equidistant(c, (p1, p2, p3))
+    # highly asymmetric triangle
+    p1 = np.array((0.0, 0.0, 0.0))
+    p2 = np.array((100.0, 0.0, 0.0))
+    p3 = np.array((200.0, 1.0, 0.0))
+    c = np.array(tri.ccc(p1, p2, p3))
+    check_equidistant(c, (p1, p2, p3))
 
 
 def test_voronoi():
-   seed_value = 3567
-   n_list = range(5, 50, 3)
-   model = rq.Model(create_basics = True)
-   crs = rqc.Crs(model)
-   crs.create_xml()
-   # setup unit square area of interest
-   aoi_xyz = np.zeros((4, 3))
-   aoi_xyz[1, 1] = 1.0
-   aoi_xyz[2, :2] = 1.0
-   aoi_xyz[3, 0] = 1.0
-   aoi = rql.Polyline(model, set_coord = aoi_xyz, set_bool = True, set_crs = crs.uuid, title = 'aoi')
-   # and an alternative area of interest
-   aoi_heptagon_xyz = np.zeros((7, 3))
-   aoi_heptagon_xyz[:, :2] = ((-0.5, -1.0), (-1.5, 0.5), (-1.0, 1.7), (0.5, 2.0), (2.0, 1.7), (2.5, 0.5), (1.5, -1.0))
-   aoi_heptagon = rql.Polyline(model,
-                               set_coord = aoi_heptagon_xyz,
-                               set_bool = True,
-                               set_crs = crs.uuid,
-                               title = 'heptagon')
-   aoi_heptagon_area = aoi_heptagon.area()
+    seed_value = 3567
+    n_list = range(5, 50, 3)
+    model = rq.Model(create_basics = True)
+    crs = rqc.Crs(model)
+    crs.create_xml()
+    # setup unit square area of interest
+    aoi_xyz = np.zeros((4, 3))
+    aoi_xyz[1, 1] = 1.0
+    aoi_xyz[2, :2] = 1.0
+    aoi_xyz[3, 0] = 1.0
+    aoi = rql.Polyline(model, set_coord = aoi_xyz, set_bool = True, set_crs = crs.uuid, title = 'aoi')
+    # and an alternative area of interest
+    aoi_heptagon_xyz = np.zeros((7, 3))
+    aoi_heptagon_xyz[:, :2] = ((-0.5, -1.0), (-1.5, 0.5), (-1.0, 1.7), (0.5, 2.0), (2.0, 1.7), (2.5, 0.5), (1.5, -1.0))
+    aoi_heptagon = rql.Polyline(model,
+                                set_coord = aoi_heptagon_xyz,
+                                set_bool = True,
+                                set_crs = crs.uuid,
+                                title = 'heptagon')
+    aoi_heptagon_area = aoi_heptagon.area()
 
-   for n in n_list:  # number of seed points (number of Voronoi cells)
-      seed(seed_value)
-      x = np.random.random(n)
-      y = np.random.random(n)
-      p = np.stack((x, y), axis = -1)
-      # compute the Delauney triangulation
-      t, b = tri.dt(p, plot_fn = None, progress_fn = None, return_hull = True)
-      # dt function can return triangulation with a slightly concave hull, which voronoi function cannot handle
-      hull = rql.Polyline(model, set_coord = p[b], set_bool = True, set_crs = crs.uuid, title = 'v cell')
-      if not hull.is_convex():
-         continue
-      # test the Voronoi diagram with the unit square area of interest
-      c, v = tri.voronoi(p, t, b, aoi)
-      assert len(v) == n
-      # check that the areas of the Voronoi cells sum to the area of interest
-      area = 0.0
-      for nodes in v:
-         v_cell = rql.Polyline(model, set_coord = c[nodes], set_bool = True, set_crs = crs.uuid, title = 'v cell')
-         area += v_cell.area()
-      assert maths.isclose(area, 1.0, rel_tol = 0.001)
-      # test the Voronoi diagram with the heptagonal area of interest
-      c_hept, v_hept = tri.voronoi(p, t, b, aoi_heptagon)
-      assert len(v_hept) == n
-      area = 0.0
-      for nodes in v_hept:
-         v_cell = rql.Polyline(model, set_coord = c_hept[nodes], set_bool = True, set_crs = crs.uuid, title = 'v cell')
-         area += v_cell.area()
-      assert maths.isclose(area, aoi_heptagon_area, rel_tol = 0.001)
-      # test re-triangulation of a Voronoi diagram, passing centre points
-      points, triangles = tri.triangulated_polygons(c_hept, v_hept, centres = p)
-      assert len(points) == len(c_hept) + n
-      assert len(triangles) == sum(len(vh) for vh in v_hept)
-      # test re-triangulation of a Voronoi diagram, computing centre points
-      points_2, triangles_2 = tri.triangulated_polygons(c_hept, v_hept)
-      assert len(points_2) == len(c_hept) + n
-      assert len(triangles_2) == sum(len(vh) for vh in v_hept)
-      assert np.all(triangles_2 == triangles)
-      for cell in range(n):
-         v_cell = rql.Polyline(model,
-                               set_coord = c_hept[v_hept[cell]],
-                               set_bool = True,
-                               set_crs = crs.uuid,
-                               title = 'v cell')
-         assert v_cell.point_is_inside_xy(points_2[len(c_hept) + cell])
+    for n in n_list:  # number of seed points (number of Voronoi cells)
+        seed(seed_value)
+        x = np.random.random(n)
+        y = np.random.random(n)
+        p = np.stack((x, y), axis = -1)
+        # compute the Delauney triangulation
+        t, b = tri.dt(p, plot_fn = None, progress_fn = None, return_hull = True)
+        # dt function can return triangulation with a slightly concave hull, which voronoi function cannot handle
+        hull = rql.Polyline(model, set_coord = p[b], set_bool = True, set_crs = crs.uuid, title = 'v cell')
+        if not hull.is_convex():
+            continue
+        # test the Voronoi diagram with the unit square area of interest
+        c, v = tri.voronoi(p, t, b, aoi)
+        assert len(v) == n
+        # check that the areas of the Voronoi cells sum to the area of interest
+        area = 0.0
+        for nodes in v:
+            v_cell = rql.Polyline(model, set_coord = c[nodes], set_bool = True, set_crs = crs.uuid, title = 'v cell')
+            area += v_cell.area()
+        assert maths.isclose(area, 1.0, rel_tol = 0.001)
+        # test the Voronoi diagram with the heptagonal area of interest
+        c_hept, v_hept = tri.voronoi(p, t, b, aoi_heptagon)
+        assert len(v_hept) == n
+        area = 0.0
+        for nodes in v_hept:
+            v_cell = rql.Polyline(model,
+                                  set_coord = c_hept[nodes],
+                                  set_bool = True,
+                                  set_crs = crs.uuid,
+                                  title = 'v cell')
+            area += v_cell.area()
+        assert maths.isclose(area, aoi_heptagon_area, rel_tol = 0.001)
+        # test re-triangulation of a Voronoi diagram, passing centre points
+        points, triangles = tri.triangulated_polygons(c_hept, v_hept, centres = p)
+        assert len(points) == len(c_hept) + n
+        assert len(triangles) == sum(len(vh) for vh in v_hept)
+        # test re-triangulation of a Voronoi diagram, computing centre points
+        points_2, triangles_2 = tri.triangulated_polygons(c_hept, v_hept)
+        assert len(points_2) == len(c_hept) + n
+        assert len(triangles_2) == sum(len(vh) for vh in v_hept)
+        assert np.all(triangles_2 == triangles)
+        for cell in range(n):
+            v_cell = rql.Polyline(model,
+                                  set_coord = c_hept[v_hept[cell]],
+                                  set_bool = True,
+                                  set_crs = crs.uuid,
+                                  title = 'v cell')
+            assert v_cell.point_is_inside_xy(points_2[len(c_hept) + cell])

--- a/tests/test_unstructured.py
+++ b/tests/test_unstructured.py
@@ -18,557 +18,557 @@ from resqpy.olio.random_seed import seed
 
 def test_hexa_grid_from_grid(example_model_with_properties):
 
-   model = example_model_with_properties
+    model = example_model_with_properties
 
-   ijk_grid_uuid = model.uuid(obj_type = 'IjkGridRepresentation')
-   assert ijk_grid_uuid is not None
+    ijk_grid_uuid = model.uuid(obj_type = 'IjkGridRepresentation')
+    assert ijk_grid_uuid is not None
 
-   # create an unstructured grid with hexahedral cells from an unsplit IJK grid (includes write_hdf5 and create_xml)
-   hexa = rug.HexaGrid.from_unsplit_grid(model, ijk_grid_uuid, inherit_properties = True, title = 'HEXA')
+    # create an unstructured grid with hexahedral cells from an unsplit IJK grid (includes write_hdf5 and create_xml)
+    hexa = rug.HexaGrid.from_unsplit_grid(model, ijk_grid_uuid, inherit_properties = True, title = 'HEXA')
 
-   hexa_uuid = hexa.uuid
+    hexa_uuid = hexa.uuid
 
-   epc = model.epc_file
-   assert epc
+    epc = model.epc_file
+    assert epc
 
-   model.store_epc()
+    model.store_epc()
 
-   # re-open model and check hexa grid
+    # re-open model and check hexa grid
 
-   model = rq.Model(epc)
+    model = rq.Model(epc)
 
-   unstructured_uuids = model.uuids(obj_type = 'UnstructuredGridRepresentation')
+    unstructured_uuids = model.uuids(obj_type = 'UnstructuredGridRepresentation')
 
-   assert unstructured_uuids is not None and len(unstructured_uuids) == 1
+    assert unstructured_uuids is not None and len(unstructured_uuids) == 1
 
-   hexa_grid = grr.any_grid(model, uuid = unstructured_uuids[0])
-   assert isinstance(hexa_grid, rug.HexaGrid)
+    hexa_grid = grr.any_grid(model, uuid = unstructured_uuids[0])
+    assert isinstance(hexa_grid, rug.HexaGrid)
 
-   assert hexa_grid.cell_shape == 'hexahedral'
+    assert hexa_grid.cell_shape == 'hexahedral'
 
-   hexa_grid.check_indices()
-   hexa_grid.check_hexahedral()
+    hexa_grid.check_indices()
+    hexa_grid.check_hexahedral()
 
-   # instantiate ijk grid and compare hexa grid with it
-   ijk_grid = grr.any_grid(model, uuid = ijk_grid_uuid)
-   assert ijk_grid is not None
-   assert not np.any(np.isnan(ijk_grid.points_ref()))
+    # instantiate ijk grid and compare hexa grid with it
+    ijk_grid = grr.any_grid(model, uuid = ijk_grid_uuid)
+    assert ijk_grid is not None
+    assert not np.any(np.isnan(ijk_grid.points_ref()))
 
-   assert hexa_grid.cell_count == ijk_grid.cell_count()
-   assert hexa_grid.active_cell_count() == hexa_grid.cell_count
-   assert hexa_grid.node_count == (ijk_grid.nk + 1) * (ijk_grid.nj + 1) * (ijk_grid.ni + 1)
-   assert hexa_grid.face_count == ((ijk_grid.nk + 1) * ijk_grid.nj * ijk_grid.ni + ijk_grid.nk *
-                                   (ijk_grid.nj + 1) * ijk_grid.ni + ijk_grid.nk * ijk_grid.nj * (ijk_grid.ni + 1))
+    assert hexa_grid.cell_count == ijk_grid.cell_count()
+    assert hexa_grid.active_cell_count() == hexa_grid.cell_count
+    assert hexa_grid.node_count == (ijk_grid.nk + 1) * (ijk_grid.nj + 1) * (ijk_grid.ni + 1)
+    assert hexa_grid.face_count == ((ijk_grid.nk + 1) * ijk_grid.nj * ijk_grid.ni + ijk_grid.nk *
+                                    (ijk_grid.nj + 1) * ijk_grid.ni + ijk_grid.nk * ijk_grid.nj * (ijk_grid.ni + 1))
 
-   assert bu.matching_uuids(hexa_grid.extract_crs_uuid(), ijk_grid.crs_uuid)
-   assert hexa_grid.crs_is_right_handed == rqc.Crs(model, uuid = ijk_grid.crs_uuid).is_right_handed_xyz()
+    assert bu.matching_uuids(hexa_grid.extract_crs_uuid(), ijk_grid.crs_uuid)
+    assert hexa_grid.crs_is_right_handed == rqc.Crs(model, uuid = ijk_grid.crs_uuid).is_right_handed_xyz()
 
-   # points arrays should be identical for the two grids
-   assert not np.any(np.isnan(hexa_grid.points_ref()))
-   assert_array_almost_equal(hexa_grid.points_ref(), ijk_grid.points_ref(masked = False).reshape((-1, 3)))
+    # points arrays should be identical for the two grids
+    assert not np.any(np.isnan(hexa_grid.points_ref()))
+    assert_array_almost_equal(hexa_grid.points_ref(), ijk_grid.points_ref(masked = False).reshape((-1, 3)))
 
-   # compare centre points of cells (not sure if these would be coincident for irregular shaped cells)
-   # note that the centre_point() method exercises several other methods
-   hexa_centres = hexa_grid.centre_point()
-   ijk_centres = ijk_grid.centre_point()
-   assert_array_almost_equal(hexa_centres, ijk_centres.reshape((-1, 3)), decimal = 3)
+    # compare centre points of cells (not sure if these would be coincident for irregular shaped cells)
+    # note that the centre_point() method exercises several other methods
+    hexa_centres = hexa_grid.centre_point()
+    ijk_centres = ijk_grid.centre_point()
+    assert_array_almost_equal(hexa_centres, ijk_centres.reshape((-1, 3)), decimal = 3)
 
-   # check that face and node indices are in range
-   hexa_grid.cache_all_geometry_arrays()
-   assert np.all(0 <= hexa_grid.faces_per_cell)
-   assert np.all(hexa_grid.faces_per_cell < hexa_grid.face_count)
-   assert np.all(0 <= hexa_grid.nodes_per_face)
-   assert np.all(hexa_grid.nodes_per_face < hexa_grid.node_count)
-   assert len(hexa_grid.faces_per_cell_cl) == hexa_grid.cell_count
-   assert len(hexa_grid.nodes_per_face_cl) == hexa_grid.face_count
+    # check that face and node indices are in range
+    hexa_grid.cache_all_geometry_arrays()
+    assert np.all(0 <= hexa_grid.faces_per_cell)
+    assert np.all(hexa_grid.faces_per_cell < hexa_grid.face_count)
+    assert np.all(0 <= hexa_grid.nodes_per_face)
+    assert np.all(hexa_grid.nodes_per_face < hexa_grid.node_count)
+    assert len(hexa_grid.faces_per_cell_cl) == hexa_grid.cell_count
+    assert len(hexa_grid.nodes_per_face_cl) == hexa_grid.face_count
 
-   # check distinct nodes for first cell
-   cell_nodes = hexa_grid.distinct_node_indices_for_cell(0)  # is sorted by node index
-   assert len(cell_nodes) == 8
-   ni1_nj1 = (ijk_grid.ni + 1) * (ijk_grid.nj + 1)
-   expected_nodes = np.array((0, 1, ijk_grid.ni + 1, ijk_grid.ni + 2, ni1_nj1, ni1_nj1 + 1, ni1_nj1 + ijk_grid.ni + 1,
-                              ni1_nj1 + ijk_grid.ni + 2),
-                             dtype = int)
-   assert np.all(cell_nodes == expected_nodes)
+    # check distinct nodes for first cell
+    cell_nodes = hexa_grid.distinct_node_indices_for_cell(0)  # is sorted by node index
+    assert len(cell_nodes) == 8
+    ni1_nj1 = (ijk_grid.ni + 1) * (ijk_grid.nj + 1)
+    expected_nodes = np.array((0, 1, ijk_grid.ni + 1, ijk_grid.ni + 2, ni1_nj1, ni1_nj1 + 1, ni1_nj1 + ijk_grid.ni + 1,
+                               ni1_nj1 + ijk_grid.ni + 2),
+                              dtype = int)
+    assert np.all(cell_nodes == expected_nodes)
 
-   # check that some simple convenience methods work okay
-   assert hexa_grid.face_count_for_cell(0) == 6
-   assert hexa_grid.max_face_count_for_any_cell() == 6
-   assert hexa_grid.max_node_count_for_any_face() == 4
+    # check that some simple convenience methods work okay
+    assert hexa_grid.face_count_for_cell(0) == 6
+    assert hexa_grid.max_face_count_for_any_cell() == 6
+    assert hexa_grid.max_node_count_for_any_face() == 4
 
-   # check that correct number of edges is found for a face
-   edges = hexa_grid.edges_for_face(hexa_grid.face_count // 2)  # arbitrary face in middle
-   assert edges.shape == (4, 2)
-   edges = hexa_grid.edges_for_face_with_node_indices_ordered_within_pairs(hexa_grid.face_count // 2)
-   assert edges.shape == (4, 2)
-   for a, b in edges:  # check node within pair ordering
-      assert a < b
+    # check that correct number of edges is found for a face
+    edges = hexa_grid.edges_for_face(hexa_grid.face_count // 2)  # arbitrary face in middle
+    assert edges.shape == (4, 2)
+    edges = hexa_grid.edges_for_face_with_node_indices_ordered_within_pairs(hexa_grid.face_count // 2)
+    assert edges.shape == (4, 2)
+    for a, b in edges:  # check node within pair ordering
+        assert a < b
 
-   # compare corner points for first cell with those for ijk grid cell
-   cp = hexa_grid.corner_points(0)
-   assert cp.shape == (8, 3)
-   assert_array_almost_equal(cp.reshape((2, 2, 2, 3)),
-                             ijk_grid.corner_points(cell_kji0 = (0, 0, 0), cache_resqml_array = False))
+    # compare corner points for first cell with those for ijk grid cell
+    cp = hexa_grid.corner_points(0)
+    assert cp.shape == (8, 3)
+    assert_array_almost_equal(cp.reshape((2, 2, 2, 3)),
+                              ijk_grid.corner_points(cell_kji0 = (0, 0, 0), cache_resqml_array = False))
 
-   # have a look at handedness of cell faces
-   assert len(hexa_grid.cell_face_is_right_handed) == 6 * hexa_grid.cell_count
-   # following assertion only applies to HexaGrid built from_unsplit_grid()
-   assert np.count_nonzero(hexa_grid.cell_face_is_right_handed) == 3 * hexa_grid.cell_count  # half are right handed
+    # have a look at handedness of cell faces
+    assert len(hexa_grid.cell_face_is_right_handed) == 6 * hexa_grid.cell_count
+    # following assertion only applies to HexaGrid built from_unsplit_grid()
+    assert np.count_nonzero(hexa_grid.cell_face_is_right_handed) == 3 * hexa_grid.cell_count  # half are right handed
 
-   # compare cell volumes for first cell
-   hexa_vol = hexa_grid.volume(0)
-   ijk_vol = ijk_grid.volume(cell_kji0 = 0, cache_resqml_array = False, cache_volume_array = False)
-   assert maths.isclose(hexa_vol, ijk_vol)
-   assert maths.isclose(hexa_vol, 1.0, rel_tol = 1.0e-3)
+    # compare cell volumes for first cell
+    hexa_vol = hexa_grid.volume(0)
+    ijk_vol = ijk_grid.volume(cell_kji0 = 0, cache_resqml_array = False, cache_volume_array = False)
+    assert maths.isclose(hexa_vol, ijk_vol)
+    assert maths.isclose(hexa_vol, 1.0, rel_tol = 1.0e-3)
 
-   # check face normal for first face (K- face of first cell)
-   assert_array_almost_equal(hexa_grid.face_normal(0), (0.0, 0.0, -1.0))
+    # check face normal for first face (K- face of first cell)
+    assert_array_almost_equal(hexa_grid.face_normal(0), (0.0, 0.0, -1.0))
 
-   # check that planar approximation of last face is about the same as the original
-   fi = hexa_grid.face_count - 1
-   assert_array_almost_equal(hexa_grid.planar_face_points(fi),
-                             hexa_grid.points_cached[hexa_grid.node_indices_for_face(fi)],
-                             decimal = 3)
+    # check that planar approximation of last face is about the same as the original
+    fi = hexa_grid.face_count - 1
+    assert_array_almost_equal(hexa_grid.planar_face_points(fi),
+                              hexa_grid.points_cached[hexa_grid.node_indices_for_face(fi)],
+                              decimal = 3)
 
-   # construct a Delauney triangulation of the last face
-   triangulated = hexa_grid.face_triangulation(fi, local_nodes = True)
-   assert triangulated.shape == (2, 3)
-   assert np.all(triangulated.flatten() < 4)
-   assert np.all(np.unique(triangulated) == (0, 1, 2, 3))
-   # also test the triangulation using the global node indices, for all the faces of the last cell
-   for face_index in hexa_grid.face_indices_for_cell(hexa_grid.cell_count - 1):
-      triangulated = hexa_grid.face_triangulation(face_index, local_nodes = False)
-      assert triangulated.shape == (2, 3)
+    # construct a Delauney triangulation of the last face
+    triangulated = hexa_grid.face_triangulation(fi, local_nodes = True)
+    assert triangulated.shape == (2, 3)
+    assert np.all(triangulated.flatten() < 4)
+    assert np.all(np.unique(triangulated) == (0, 1, 2, 3))
+    # also test the triangulation using the global node indices, for all the faces of the last cell
+    for face_index in hexa_grid.face_indices_for_cell(hexa_grid.cell_count - 1):
+        triangulated = hexa_grid.face_triangulation(face_index, local_nodes = False)
+        assert triangulated.shape == (2, 3)
 
-   # check the area of a middle face (the example model has unit area faces)
-   assert maths.isclose(hexa_grid.area_of_face(hexa_grid.face_count // 2), 1.0, rel_tol = 1.0e-3)
+    # check the area of a middle face (the example model has unit area faces)
+    assert maths.isclose(hexa_grid.area_of_face(hexa_grid.face_count // 2), 1.0, rel_tol = 1.0e-3)
 
-   # compare properties
-   ijk_pc = ijk_grid.extract_property_collection()
-   hexa_pc = hexa_grid.extract_property_collection()
-   assert ijk_pc is not None and hexa_pc is not None
-   assert ijk_pc.number_of_parts() <= hexa_pc.number_of_parts()  # hexa grid has extra active array in this test
-   for ijk_part in ijk_pc.parts():
-      p_title = ijk_pc.citation_title_for_part(ijk_part)
-      hexa_part = hexa_pc.singleton(citation_title = p_title)
-      assert hexa_part is not None
-      assert hexa_part != ijk_part  # properties are different objects with distinct uuids
-      assert hexa_pc.continuous_for_part(hexa_part) == ijk_pc.continuous_for_part(ijk_part)
-      ijk_array = ijk_pc.cached_part_array_ref(ijk_part)
-      hexa_array = hexa_pc.cached_part_array_ref(hexa_part)
-      assert ijk_array is not None and hexa_array is not None
-      if hexa_pc.continuous_for_part(hexa_part):
-         assert_array_almost_equal(hexa_array.flatten(), ijk_array.flatten())
-      else:
-         assert np.all(hexa_array.flatten() == ijk_array.flatten())
+    # compare properties
+    ijk_pc = ijk_grid.extract_property_collection()
+    hexa_pc = hexa_grid.extract_property_collection()
+    assert ijk_pc is not None and hexa_pc is not None
+    assert ijk_pc.number_of_parts() <= hexa_pc.number_of_parts()  # hexa grid has extra active array in this test
+    for ijk_part in ijk_pc.parts():
+        p_title = ijk_pc.citation_title_for_part(ijk_part)
+        hexa_part = hexa_pc.singleton(citation_title = p_title)
+        assert hexa_part is not None
+        assert hexa_part != ijk_part  # properties are different objects with distinct uuids
+        assert hexa_pc.continuous_for_part(hexa_part) == ijk_pc.continuous_for_part(ijk_part)
+        ijk_array = ijk_pc.cached_part_array_ref(ijk_part)
+        hexa_array = hexa_pc.cached_part_array_ref(hexa_part)
+        assert ijk_array is not None and hexa_array is not None
+        if hexa_pc.continuous_for_part(hexa_part):
+            assert_array_almost_equal(hexa_array.flatten(), ijk_array.flatten())
+        else:
+            assert np.all(hexa_array.flatten() == ijk_array.flatten())
 
-   # test TetraGrid.from_unstructured_cell is as expected for a hexahedral cell
-   tetra = rug.TetraGrid.from_unstructured_cell(hexa_grid, hexa_grid.cell_count // 2)
-   tetra.check_indices()
-   tetra.check_tetra()
-   assert tetra.cell_count == 12  # 2 tetrahedra per hexa face
-   assert tetra.node_count == 9  # 8 nodes of hexa cell plus centre point
-   assert tetra.face_count == 6 * 2 + 12 + 6
-   # check total volume of tetra grid version of cell
-   assert maths.isclose(tetra.grid_volume(), 1.0, rel_tol = 1.0e-3)
+    # test TetraGrid.from_unstructured_cell is as expected for a hexahedral cell
+    tetra = rug.TetraGrid.from_unstructured_cell(hexa_grid, hexa_grid.cell_count // 2)
+    tetra.check_indices()
+    tetra.check_tetra()
+    assert tetra.cell_count == 12  # 2 tetrahedra per hexa face
+    assert tetra.node_count == 9  # 8 nodes of hexa cell plus centre point
+    assert tetra.face_count == 6 * 2 + 12 + 6
+    # check total volume of tetra grid version of cell
+    assert maths.isclose(tetra.grid_volume(), 1.0, rel_tol = 1.0e-3)
 
 
 def test_tetra_grid(tmp_path):
 
-   epc = os.path.join(tmp_path, 'tetra_test.epc')
-   model = rq.new_model(epc)
-   crs = rqc.Crs(model)
-   crs.create_xml()
+    epc = os.path.join(tmp_path, 'tetra_test.epc')
+    model = rq.new_model(epc)
+    crs = rqc.Crs(model)
+    crs.create_xml()
 
-   # create an empty TetraGrid
-   tetra = rug.TetraGrid(model, title = 'star')
-   assert tetra.cell_shape == 'tetrahedral'
+    # create an empty TetraGrid
+    tetra = rug.TetraGrid(model, title = 'star')
+    assert tetra.cell_shape == 'tetrahedral'
 
-   # hand craft all attribute data
-   tetra.crs_uuid = model.uuid(obj_type = 'LocalDepth3dCrs')
-   assert tetra.crs_uuid is not None
-   assert bu.matching_uuids(tetra.crs_uuid, crs.uuid)
-   tetra.set_cell_count(5)
-   # faces
-   tetra.face_count = 16
-   tetra.faces_per_cell_cl = np.arange(4, 4 * 5 + 1, 4, dtype = int)
-   tetra.faces_per_cell = np.empty(20, dtype = int)
-   tetra.faces_per_cell[:4] = (0, 1, 2, 3)  # cell 0
-   tetra.faces_per_cell[4:8] = (0, 4, 5, 6)  # cell 1
-   tetra.faces_per_cell[8:12] = (1, 7, 8, 9)  # cell 2
-   tetra.faces_per_cell[12:16] = (2, 10, 11, 12)  # cell 3
-   tetra.faces_per_cell[16:] = (3, 13, 14, 15)  # cell 4
-   # nodes
-   tetra.node_count = 8
-   tetra.nodes_per_face_cl = np.arange(3, 3 * 16 + 1, 3, dtype = int)
-   tetra.nodes_per_face = np.empty(48, dtype = int)
-   # internal faces (cell 0)
-   tetra.nodes_per_face[:3] = (0, 1, 2)  # face 0
-   tetra.nodes_per_face[3:6] = (0, 3, 1)  # face 1
-   tetra.nodes_per_face[6:9] = (1, 3, 2)  # face 2
-   tetra.nodes_per_face[9:12] = (2, 3, 0)  # face 3
-   # external faces (cell 1)
-   tetra.nodes_per_face[12:15] = (0, 1, 4)  # face 4
-   tetra.nodes_per_face[15:18] = (1, 2, 4)  # face 5
-   tetra.nodes_per_face[18:21] = (2, 0, 4)  # face 6
-   # external faces (cell 2)
-   tetra.nodes_per_face[21:24] = (0, 3, 5)  # face 7
-   tetra.nodes_per_face[24:27] = (3, 1, 5)  # face 8
-   tetra.nodes_per_face[27:30] = (1, 0, 5)  # face 9
-   # external faces (cell 3)
-   tetra.nodes_per_face[30:33] = (1, 3, 6)  # face 10
-   tetra.nodes_per_face[33:36] = (3, 2, 6)  # face 11
-   tetra.nodes_per_face[36:39] = (2, 1, 6)  # face 12
-   # external faces (cell 4)
-   tetra.nodes_per_face[39:42] = (2, 3, 7)  # face 10
-   tetra.nodes_per_face[42:45] = (3, 0, 7)  # face 11
-   tetra.nodes_per_face[45:] = (0, 2, 7)  # face 12
-   # face handedness
-   tetra.cell_face_is_right_handed = np.zeros(20, dtype = bool)  # False for all faces for external cells (1 to 4)
-   tetra.cell_face_is_right_handed[:4] = True  # True for all faces of internal cell (0)
-   # points
-   tetra.points_cached = np.zeros((8, 3))
-   # internal cell (0) points
-   half_edge = 36.152
-   one_over_root_two = 1.0 / maths.sqrt(2.0)
-   tetra.points_cached[0] = (-half_edge, 0.0, -half_edge * one_over_root_two)
-   tetra.points_cached[1] = (half_edge, 0.0, -half_edge * one_over_root_two)
-   tetra.points_cached[2] = (0.0, half_edge, half_edge * one_over_root_two)
-   tetra.points_cached[3] = (0.0, -half_edge, half_edge * one_over_root_two)
-   # project remaining nodes outwards
-   for fi, o_node in enumerate((3, 2, 0, 1)):
-      fc = tetra.face_centre_point(fi)
-      tetra.points_cached[4 + fi] = fc - (tetra.points_cached[o_node] - fc)
+    # hand craft all attribute data
+    tetra.crs_uuid = model.uuid(obj_type = 'LocalDepth3dCrs')
+    assert tetra.crs_uuid is not None
+    assert bu.matching_uuids(tetra.crs_uuid, crs.uuid)
+    tetra.set_cell_count(5)
+    # faces
+    tetra.face_count = 16
+    tetra.faces_per_cell_cl = np.arange(4, 4 * 5 + 1, 4, dtype = int)
+    tetra.faces_per_cell = np.empty(20, dtype = int)
+    tetra.faces_per_cell[:4] = (0, 1, 2, 3)  # cell 0
+    tetra.faces_per_cell[4:8] = (0, 4, 5, 6)  # cell 1
+    tetra.faces_per_cell[8:12] = (1, 7, 8, 9)  # cell 2
+    tetra.faces_per_cell[12:16] = (2, 10, 11, 12)  # cell 3
+    tetra.faces_per_cell[16:] = (3, 13, 14, 15)  # cell 4
+    # nodes
+    tetra.node_count = 8
+    tetra.nodes_per_face_cl = np.arange(3, 3 * 16 + 1, 3, dtype = int)
+    tetra.nodes_per_face = np.empty(48, dtype = int)
+    # internal faces (cell 0)
+    tetra.nodes_per_face[:3] = (0, 1, 2)  # face 0
+    tetra.nodes_per_face[3:6] = (0, 3, 1)  # face 1
+    tetra.nodes_per_face[6:9] = (1, 3, 2)  # face 2
+    tetra.nodes_per_face[9:12] = (2, 3, 0)  # face 3
+    # external faces (cell 1)
+    tetra.nodes_per_face[12:15] = (0, 1, 4)  # face 4
+    tetra.nodes_per_face[15:18] = (1, 2, 4)  # face 5
+    tetra.nodes_per_face[18:21] = (2, 0, 4)  # face 6
+    # external faces (cell 2)
+    tetra.nodes_per_face[21:24] = (0, 3, 5)  # face 7
+    tetra.nodes_per_face[24:27] = (3, 1, 5)  # face 8
+    tetra.nodes_per_face[27:30] = (1, 0, 5)  # face 9
+    # external faces (cell 3)
+    tetra.nodes_per_face[30:33] = (1, 3, 6)  # face 10
+    tetra.nodes_per_face[33:36] = (3, 2, 6)  # face 11
+    tetra.nodes_per_face[36:39] = (2, 1, 6)  # face 12
+    # external faces (cell 4)
+    tetra.nodes_per_face[39:42] = (2, 3, 7)  # face 10
+    tetra.nodes_per_face[42:45] = (3, 0, 7)  # face 11
+    tetra.nodes_per_face[45:] = (0, 2, 7)  # face 12
+    # face handedness
+    tetra.cell_face_is_right_handed = np.zeros(20, dtype = bool)  # False for all faces for external cells (1 to 4)
+    tetra.cell_face_is_right_handed[:4] = True  # True for all faces of internal cell (0)
+    # points
+    tetra.points_cached = np.zeros((8, 3))
+    # internal cell (0) points
+    half_edge = 36.152
+    one_over_root_two = 1.0 / maths.sqrt(2.0)
+    tetra.points_cached[0] = (-half_edge, 0.0, -half_edge * one_over_root_two)
+    tetra.points_cached[1] = (half_edge, 0.0, -half_edge * one_over_root_two)
+    tetra.points_cached[2] = (0.0, half_edge, half_edge * one_over_root_two)
+    tetra.points_cached[3] = (0.0, -half_edge, half_edge * one_over_root_two)
+    # project remaining nodes outwards
+    for fi, o_node in enumerate((3, 2, 0, 1)):
+        fc = tetra.face_centre_point(fi)
+        tetra.points_cached[4 + fi] = fc - (tetra.points_cached[o_node] - fc)
 
-   # basic validity check
-   tetra.check_tetra()
+    # basic validity check
+    tetra.check_tetra()
 
-   # write arrays, create xml and store model
-   tetra.write_hdf5()
-   tetra.create_xml()
-   model.store_epc()
+    # write arrays, create xml and store model
+    tetra.write_hdf5()
+    tetra.create_xml()
+    model.store_epc()
 
-   # re-open model and establish grid
-   model = rq.Model(epc)
-   assert model is not None
-   tetra_uuid = model.uuid(obj_type = 'UnstructuredGridRepresentation', title = 'star')
-   assert tetra_uuid is not None
-   tetra = rug.TetraGrid(model, uuid = tetra_uuid)
-   assert tetra is not None
-   # perform basic checks
-   assert tetra.cell_count == 5
-   assert tetra.cell_shape == 'tetrahedral'
-   tetra.check_tetra()
+    # re-open model and establish grid
+    model = rq.Model(epc)
+    assert model is not None
+    tetra_uuid = model.uuid(obj_type = 'UnstructuredGridRepresentation', title = 'star')
+    assert tetra_uuid is not None
+    tetra = rug.TetraGrid(model, uuid = tetra_uuid)
+    assert tetra is not None
+    # perform basic checks
+    assert tetra.cell_count == 5
+    assert tetra.cell_shape == 'tetrahedral'
+    tetra.check_tetra()
 
-   # test volume calculation
-   expected_cell_volume = ((2.0 * half_edge)**3) / (6.0 * maths.sqrt(2.0))
-   for cell in range(tetra.cell_count):
-      assert maths.isclose(tetra.volume(cell), expected_cell_volume, rel_tol = 1.0e-3)
-   assert maths.isclose(tetra.grid_volume(), 5.0 * expected_cell_volume)
+    # test volume calculation
+    expected_cell_volume = ((2.0 * half_edge)**3) / (6.0 * maths.sqrt(2.0))
+    for cell in range(tetra.cell_count):
+        assert maths.isclose(tetra.volume(cell), expected_cell_volume, rel_tol = 1.0e-3)
+    assert maths.isclose(tetra.grid_volume(), 5.0 * expected_cell_volume)
 
-   # test face area
-   expected_area = maths.sqrt(3.0 * half_edge * (half_edge**3))
-   area = tetra.area_of_face(0)
-   assert maths.isclose(area, expected_area, rel_tol = 1.0e-3)
+    # test face area
+    expected_area = maths.sqrt(3.0 * half_edge * (half_edge**3))
+    area = tetra.area_of_face(0)
+    assert maths.isclose(area, expected_area, rel_tol = 1.0e-3)
 
-   # test internal / external face lists
-   assert np.all(tetra.external_face_indices() == np.arange(4, 16, dtype = int))
-   inactive_mask = np.zeros(5, dtype = bool)
-   assert np.all(tetra.external_face_indices_for_masked_cells(inactive_mask) == tetra.external_face_indices())
-   assert np.all(tetra.internal_face_indices_for_masked_cells(inactive_mask) == np.arange(4, dtype = int))
-   # mask out central cell
-   inactive_mask[0] = True
-   assert len(tetra.external_face_indices_for_masked_cells(inactive_mask)) == tetra.face_count
-   assert len(tetra.internal_face_indices_for_masked_cells(inactive_mask)) == 0
+    # test internal / external face lists
+    assert np.all(tetra.external_face_indices() == np.arange(4, 16, dtype = int))
+    inactive_mask = np.zeros(5, dtype = bool)
+    assert np.all(tetra.external_face_indices_for_masked_cells(inactive_mask) == tetra.external_face_indices())
+    assert np.all(tetra.internal_face_indices_for_masked_cells(inactive_mask) == np.arange(4, dtype = int))
+    # mask out central cell
+    inactive_mask[0] = True
+    assert len(tetra.external_face_indices_for_masked_cells(inactive_mask)) == tetra.face_count
+    assert len(tetra.internal_face_indices_for_masked_cells(inactive_mask)) == 0
 
 
 def test_vertical_prism_grid_from_surfaces(tmp_path):
 
-   epc = os.path.join(tmp_path, 'vertical_prism.epc')
-   model = rq.new_model(epc)
-   crs = rqc.Crs(model)
-   crs.create_xml()
+    epc = os.path.join(tmp_path, 'vertical_prism.epc')
+    model = rq.new_model(epc)
+    crs = rqc.Crs(model)
+    crs.create_xml()
 
-   # create a point set representing a pentagon with a centre node
-   pentagon_points = np.array([[-100.0, -200.0, 1050.0], [-200.0, 0.0, 1050.0], [0.0, 200.0, 1025.0],
-                               [200.0, 0.0, 975.0], [100.0, -200.0, 999.0], [0.0, 0.0, 1000.0]])
-   pentagon = rqs.PointSet(model, points_array = pentagon_points, crs_uuid = crs.uuid, title = 'pentagon')
-   pentagon.write_hdf5()
-   pentagon.create_xml()
+    # create a point set representing a pentagon with a centre node
+    pentagon_points = np.array([[-100.0, -200.0, 1050.0], [-200.0, 0.0, 1050.0], [0.0, 200.0, 1025.0],
+                                [200.0, 0.0, 975.0], [100.0, -200.0, 999.0], [0.0, 0.0, 1000.0]])
+    pentagon = rqs.PointSet(model, points_array = pentagon_points, crs_uuid = crs.uuid, title = 'pentagon')
+    pentagon.write_hdf5()
+    pentagon.create_xml()
 
-   # create a surface from the point set (will make a Delauney triangulation)
-   top_surf = rqs.Surface(model, point_set = pentagon, title = 'top surface')
-   top_surf.write_hdf5()
-   top_surf.create_xml()
-   surf_list = [top_surf]
+    # create a surface from the point set (will make a Delauney triangulation)
+    top_surf = rqs.Surface(model, point_set = pentagon, title = 'top surface')
+    top_surf.write_hdf5()
+    top_surf.create_xml()
+    surf_list = [top_surf]
 
-   # check the pentagon surface
-   pentagon_triangles, pentagon_points = top_surf.triangles_and_points()
-   assert pentagon_points.shape == (6, 3)
-   assert pentagon_triangles.shape == (5, 3)
+    # check the pentagon surface
+    pentagon_triangles, pentagon_points = top_surf.triangles_and_points()
+    assert pentagon_points.shape == (6, 3)
+    assert pentagon_triangles.shape == (5, 3)
 
-   # create a couple of horizontal surfaces at greater depths
-   boundary = np.array([[-300.0, -300.0, 0.0], [300.0, 300.0, 0.0]])
-   for depth in (1100.0, 1200.0):
-      base = rqs.Surface(model)
-      base.set_to_horizontal_plane(depth, boundary)
-      base.write_hdf5()
-      base.create_xml()
-      surf_list.append(base)
+    # create a couple of horizontal surfaces at greater depths
+    boundary = np.array([[-300.0, -300.0, 0.0], [300.0, 300.0, 0.0]])
+    for depth in (1100.0, 1200.0):
+        base = rqs.Surface(model)
+        base.set_to_horizontal_plane(depth, boundary)
+        base.write_hdf5()
+        base.create_xml()
+        surf_list.append(base)
 
-   # now build a vertical prism grid from the surfaces
-   grid = rug.VerticalPrismGrid.from_surfaces(model, surf_list, title = 'the pentagon')
-   grid.write_hdf5()
-   grid.create_xml()
+    # now build a vertical prism grid from the surfaces
+    grid = rug.VerticalPrismGrid.from_surfaces(model, surf_list, title = 'the pentagon')
+    grid.write_hdf5()
+    grid.create_xml()
 
-   model.store_epc()
+    model.store_epc()
 
-   # re-open model
+    # re-open model
 
-   model = rq.Model(epc)
-   assert model is not None
+    model = rq.Model(epc)
+    assert model is not None
 
-   # find grid by title
-   grid_uuid = model.uuid(obj_type = 'UnstructuredGridRepresentation', title = 'the pentagon')
-   assert grid_uuid is not None
+    # find grid by title
+    grid_uuid = model.uuid(obj_type = 'UnstructuredGridRepresentation', title = 'the pentagon')
+    assert grid_uuid is not None
 
-   # re-instantiate the grid
-   grid = rug.VerticalPrismGrid(model, uuid = grid_uuid)
-   assert grid is not None
-   assert grid.nk == 2
-   assert grid.cell_count == 10
-   assert grid.node_count == 18
-   assert grid.face_count == 35
+    # re-instantiate the grid
+    grid = rug.VerticalPrismGrid(model, uuid = grid_uuid)
+    assert grid is not None
+    assert grid.nk == 2
+    assert grid.cell_count == 10
+    assert grid.node_count == 18
+    assert grid.face_count == 35
 
-   # create a very similar grid using explicit triangulation arguments
+    # create a very similar grid using explicit triangulation arguments
 
-   # make the same Delauney triangulation
-   triangles = triangulation.dt(pentagon_points)
+    # make the same Delauney triangulation
+    triangles = triangulation.dt(pentagon_points)
 
-   # slightly shrink pentagon points to be within area of surfaces
-   for i in range(len(pentagon_points)):
-      if pentagon_points[i, 0] < 0.0:
-         pentagon_points[i, 0] += 1.0
-      elif pentagon_points[i, 0] > 0.0:
-         pentagon_points[i, 0] -= 1.0
-      if pentagon_points[i, 1] < 0.0:
-         pentagon_points[i, 1] += 1.0
-      elif pentagon_points[i, 1] > 0.0:
-         pentagon_points[i, 1] -= 1.0
+    # slightly shrink pentagon points to be within area of surfaces
+    for i in range(len(pentagon_points)):
+        if pentagon_points[i, 0] < 0.0:
+            pentagon_points[i, 0] += 1.0
+        elif pentagon_points[i, 0] > 0.0:
+            pentagon_points[i, 0] -= 1.0
+        if pentagon_points[i, 1] < 0.0:
+            pentagon_points[i, 1] += 1.0
+        elif pentagon_points[i, 1] > 0.0:
+            pentagon_points[i, 1] -= 1.0
 
-   # load the surfaces
-   surf_uuids = model.uuids(obj_type = 'TriangulatedSetRepresentation', sort_by = 'oldest')
-   surf_list = []
-   for surf_uuid in surf_uuids:
-      surf_list.append(rqs.Surface(model, uuid = surf_uuid))
+    # load the surfaces
+    surf_uuids = model.uuids(obj_type = 'TriangulatedSetRepresentation', sort_by = 'oldest')
+    surf_list = []
+    for surf_uuid in surf_uuids:
+        surf_list.append(rqs.Surface(model, uuid = surf_uuid))
 
-   # create a new vertical prism grid using the explicit triangulation arguments
-   similar = rug.VerticalPrismGrid.from_surfaces(model,
-                                                 surf_list,
-                                                 column_points = pentagon_points,
-                                                 column_triangles = triangles,
-                                                 title = 'similar pentagon')
+    # create a new vertical prism grid using the explicit triangulation arguments
+    similar = rug.VerticalPrismGrid.from_surfaces(model,
+                                                  surf_list,
+                                                  column_points = pentagon_points,
+                                                  column_triangles = triangles,
+                                                  title = 'similar pentagon')
 
-   # check similarity
-   for attr in ('cell_shape', 'nk', 'cell_count', 'node_count', 'face_count'):
-      assert getattr(grid, attr) == getattr(similar, attr)
-   for index_attr in ('nodes_per_face', 'nodes_per_face_cl', 'faces_per_cell', 'faces_per_cell_cl'):
-      assert np.all(getattr(grid, index_attr) == getattr(similar, index_attr))
-   assert_allclose(grid.points_ref(), similar.points_ref(), atol = 2.0)
+    # check similarity
+    for attr in ('cell_shape', 'nk', 'cell_count', 'node_count', 'face_count'):
+        assert getattr(grid, attr) == getattr(similar, attr)
+    for index_attr in ('nodes_per_face', 'nodes_per_face_cl', 'faces_per_cell', 'faces_per_cell_cl'):
+        assert np.all(getattr(grid, index_attr) == getattr(similar, index_attr))
+    assert_allclose(grid.points_ref(), similar.points_ref(), atol = 2.0)
 
-   # check that isotropic horizontal permeability is preserved
-   permeability = 250.0
-   primary_k = np.full((grid.cell_count,), permeability)
-   orthogonal_k = primary_k.copy()
-   triple_k = grid.triple_horizontal_permeability(primary_k, orthogonal_k, 37.0)
-   assert triple_k.shape == (grid.cell_count, 3)
-   assert_array_almost_equal(triple_k, permeability)
-   azimuth = np.linspace(0.0, 360.0, num = grid.cell_count)
-   triple_k = grid.triple_horizontal_permeability(primary_k, orthogonal_k, azimuth)
-   assert triple_k.shape == (grid.cell_count, 3)
-   assert_array_almost_equal(triple_k, permeability)
+    # check that isotropic horizontal permeability is preserved
+    permeability = 250.0
+    primary_k = np.full((grid.cell_count,), permeability)
+    orthogonal_k = primary_k.copy()
+    triple_k = grid.triple_horizontal_permeability(primary_k, orthogonal_k, 37.0)
+    assert triple_k.shape == (grid.cell_count, 3)
+    assert_array_almost_equal(triple_k, permeability)
+    azimuth = np.linspace(0.0, 360.0, num = grid.cell_count)
+    triple_k = grid.triple_horizontal_permeability(primary_k, orthogonal_k, azimuth)
+    assert triple_k.shape == (grid.cell_count, 3)
+    assert_array_almost_equal(triple_k, permeability)
 
-   # check that anisotropic horizontal permeability is correctly bounded
-   orthogonal_k *= 0.1
-   triple_k = grid.triple_horizontal_permeability(primary_k, orthogonal_k, azimuth)
-   assert triple_k.shape == (grid.cell_count, 3)
-   assert np.all(triple_k <= permeability)
-   assert np.all(triple_k >= permeability * 0.1)
-   assert np.min(triple_k) < permeability / 2.0
-   assert np.max(triple_k) > permeability / 2.0
+    # check that anisotropic horizontal permeability is correctly bounded
+    orthogonal_k *= 0.1
+    triple_k = grid.triple_horizontal_permeability(primary_k, orthogonal_k, azimuth)
+    assert triple_k.shape == (grid.cell_count, 3)
+    assert np.all(triple_k <= permeability)
+    assert np.all(triple_k >= permeability * 0.1)
+    assert np.min(triple_k) < permeability / 2.0
+    assert np.max(triple_k) > permeability / 2.0
 
-   # set up some properties
-   pc = grid.property_collection
-   assert pc is not None
-   pc.add_cached_array_to_imported_list(cached_array = None,
-                                        source_info = 'unit test',
-                                        keyword = 'NETGRS',
-                                        property_kind = 'net to gross ratio',
-                                        discrete = False,
-                                        uom = 'm3/m3',
-                                        indexable_element = 'cells',
-                                        const_value = 0.75)
-   pc.add_cached_array_to_imported_list(cached_array = None,
-                                        source_info = 'unit test',
-                                        keyword = 'PERMK',
-                                        property_kind = 'permeability rock',
-                                        facet_type = 'direction',
-                                        facet = 'K',
-                                        discrete = False,
-                                        uom = 'mD',
-                                        indexable_element = 'cells',
-                                        const_value = 10.0)
-   pc.add_cached_array_to_imported_list(cached_array = None,
-                                        source_info = 'unit test',
-                                        keyword = 'PERM',
-                                        property_kind = 'permeability rock',
-                                        facet_type = 'direction',
-                                        facet = 'primary',
-                                        discrete = False,
-                                        uom = 'mD',
-                                        indexable_element = 'cells',
-                                        const_value = 100.0)
-   pc.add_cached_array_to_imported_list(cached_array = None,
-                                        source_info = 'unit test',
-                                        keyword = 'PERM',
-                                        property_kind = 'permeability rock',
-                                        facet_type = 'direction',
-                                        facet = 'orthogonal',
-                                        discrete = False,
-                                        uom = 'mD',
-                                        indexable_element = 'cells',
-                                        const_value = 20.0)
-   x_min, x_max = grid.xyz_box()[:, 0]
-   relative_x = (grid.centre_point()[:, 0] - x_min) * (x_max - x_min)
-   azi = relative_x * 90.0 + 45.0
-   pc.add_cached_array_to_imported_list(cached_array = azi,
-                                        source_info = 'unit test',
-                                        keyword = 'primary permeability azimuth',
-                                        property_kind = 'plane angle',
-                                        facet_type = 'direction',
-                                        facet = 'primary',
-                                        discrete = False,
-                                        uom = 'dega',
-                                        indexable_element = 'cells')
-   pc.write_hdf5_for_imported_list()
-   pc.create_xml_for_imported_list_and_add_parts_to_model()
+    # set up some properties
+    pc = grid.property_collection
+    assert pc is not None
+    pc.add_cached_array_to_imported_list(cached_array = None,
+                                         source_info = 'unit test',
+                                         keyword = 'NETGRS',
+                                         property_kind = 'net to gross ratio',
+                                         discrete = False,
+                                         uom = 'm3/m3',
+                                         indexable_element = 'cells',
+                                         const_value = 0.75)
+    pc.add_cached_array_to_imported_list(cached_array = None,
+                                         source_info = 'unit test',
+                                         keyword = 'PERMK',
+                                         property_kind = 'permeability rock',
+                                         facet_type = 'direction',
+                                         facet = 'K',
+                                         discrete = False,
+                                         uom = 'mD',
+                                         indexable_element = 'cells',
+                                         const_value = 10.0)
+    pc.add_cached_array_to_imported_list(cached_array = None,
+                                         source_info = 'unit test',
+                                         keyword = 'PERM',
+                                         property_kind = 'permeability rock',
+                                         facet_type = 'direction',
+                                         facet = 'primary',
+                                         discrete = False,
+                                         uom = 'mD',
+                                         indexable_element = 'cells',
+                                         const_value = 100.0)
+    pc.add_cached_array_to_imported_list(cached_array = None,
+                                         source_info = 'unit test',
+                                         keyword = 'PERM',
+                                         property_kind = 'permeability rock',
+                                         facet_type = 'direction',
+                                         facet = 'orthogonal',
+                                         discrete = False,
+                                         uom = 'mD',
+                                         indexable_element = 'cells',
+                                         const_value = 20.0)
+    x_min, x_max = grid.xyz_box()[:, 0]
+    relative_x = (grid.centre_point()[:, 0] - x_min) * (x_max - x_min)
+    azi = relative_x * 90.0 + 45.0
+    pc.add_cached_array_to_imported_list(cached_array = azi,
+                                         source_info = 'unit test',
+                                         keyword = 'primary permeability azimuth',
+                                         property_kind = 'plane angle',
+                                         facet_type = 'direction',
+                                         facet = 'primary',
+                                         discrete = False,
+                                         uom = 'dega',
+                                         indexable_element = 'cells')
+    pc.write_hdf5_for_imported_list()
+    pc.create_xml_for_imported_list_and_add_parts_to_model()
 
-   model.store_epc()
+    model.store_epc()
 
-   # test that half cell transmissibilities can be computed
-   half_t = grid.half_cell_transmissibility()
-   assert np.all(half_t > 0.0)
+    # test that half cell transmissibilities can be computed
+    half_t = grid.half_cell_transmissibility()
+    assert np.all(half_t > 0.0)
 
-   # add the half cell transmissibility array as a property
-   pc.add_cached_array_to_imported_list(cached_array = half_t.flatten(),
-                                        source_info = 'unit test',
-                                        keyword = 'half transmissibility',
-                                        property_kind = 'transmissibility',
-                                        discrete = False,
-                                        count = 1,
-                                        indexable_element = 'faces per cell')
-   pc.write_hdf5_for_imported_list()
-   pc.create_xml_for_imported_list_and_add_parts_to_model(extra_metadata = {'uom': 'm3.cP/(d.kPa)'})
+    # add the half cell transmissibility array as a property
+    pc.add_cached_array_to_imported_list(cached_array = half_t.flatten(),
+                                         source_info = 'unit test',
+                                         keyword = 'half transmissibility',
+                                         property_kind = 'transmissibility',
+                                         discrete = False,
+                                         count = 1,
+                                         indexable_element = 'faces per cell')
+    pc.write_hdf5_for_imported_list()
+    pc.create_xml_for_imported_list_and_add_parts_to_model(extra_metadata = {'uom': 'm3.cP/(d.kPa)'})
 
-   model.store_epc()
+    model.store_epc()
 
 
 def test_vertical_prism_grid_from_seed_points_and_surfaces(tmp_path):
 
-   seed(23487656)  # to ensure test reproducibility
+    seed(23487656)  # to ensure test reproducibility
 
-   epc = os.path.join(tmp_path, 'voronoi_prism_grid.epc')
-   model = rq.new_model(epc)
-   crs = rqc.Crs(model)
-   crs.create_xml()
+    epc = os.path.join(tmp_path, 'voronoi_prism_grid.epc')
+    model = rq.new_model(epc)
+    crs = rqc.Crs(model)
+    crs.create_xml()
 
-   # define a boundary polyline:
-   b_count = 7
-   boundary_points = np.empty((b_count, 3))
-   radius = 1000.0
-   for i in range(b_count):
-      theta = -vec.radians_from_degrees(i * 360.0 / b_count)
-      boundary_points[i] = (2.0 * radius * maths.cos(theta), radius * maths.sin(theta), 0.0)
-   boundary = rql.Polyline(model,
-                           set_coord = boundary_points,
-                           set_bool = True,
-                           set_crs = crs.uuid,
-                           title = 'rough ellipse')
-   boundary.write_hdf5()
-   boundary.create_xml()
+    # define a boundary polyline:
+    b_count = 7
+    boundary_points = np.empty((b_count, 3))
+    radius = 1000.0
+    for i in range(b_count):
+        theta = -vec.radians_from_degrees(i * 360.0 / b_count)
+        boundary_points[i] = (2.0 * radius * maths.cos(theta), radius * maths.sin(theta), 0.0)
+    boundary = rql.Polyline(model,
+                            set_coord = boundary_points,
+                            set_bool = True,
+                            set_crs = crs.uuid,
+                            title = 'rough ellipse')
+    boundary.write_hdf5()
+    boundary.create_xml()
 
-   # derive a larger area of interest
-   aoi = rql.Polyline.from_scaled_polyline(boundary, 1.1, title = 'area of interest')
-   aoi.write_hdf5()
-   aoi.create_xml()
-   min_xy = np.min(aoi.coordinates[:, :2], axis = 0) - 50.0
-   max_xy = np.max(aoi.coordinates[:, :2], axis = 0) + 50.0
+    # derive a larger area of interest
+    aoi = rql.Polyline.from_scaled_polyline(boundary, 1.1, title = 'area of interest')
+    aoi.write_hdf5()
+    aoi.create_xml()
+    min_xy = np.min(aoi.coordinates[:, :2], axis = 0) - 50.0
+    max_xy = np.max(aoi.coordinates[:, :2], axis = 0) + 50.0
 
-   print(f'***** min max xy aoi+ : {min_xy} {max_xy}')  # debug
+    print(f'***** min max xy aoi+ : {min_xy} {max_xy}')  # debug
 
-   # create some seed points within boundary
-   seed_count = 5
-   seeds = rqs.PointSet(model,
-                        crs_uuid = crs.uuid,
-                        polyline = boundary,
-                        random_point_count = seed_count,
-                        title = 'seeds')
-   seeds.write_hdf5()
-   seeds.create_xml()
-   seeds_xy = seeds.single_patch_array_ref(0)
+    # create some seed points within boundary
+    seed_count = 5
+    seeds = rqs.PointSet(model,
+                         crs_uuid = crs.uuid,
+                         polyline = boundary,
+                         random_point_count = seed_count,
+                         title = 'seeds')
+    seeds.write_hdf5()
+    seeds.create_xml()
+    seeds_xy = seeds.single_patch_array_ref(0)
 
-   for seed_xy in seeds_xy:
-      assert aoi.point_is_inside_xy(seed_xy), f'seed point {seed_xy} outwith aoi'
+    for seed_xy in seeds_xy:
+        assert aoi.point_is_inside_xy(seed_xy), f'seed point {seed_xy} outwith aoi'
 
-   print(f'***** min max xy seeds : {np.min(seeds_xy, axis = 0)} {np.max(seeds_xy, axis = 0)}')  # debug
+    print(f'***** min max xy seeds : {np.min(seeds_xy, axis = 0)} {np.max(seeds_xy, axis = 0)}')  # debug
 
-   # create some horizon surfaces
-   ni, nj = 21, 11
-   lattice = rqs.Mesh(model,
-                      crs_uuid = crs.uuid,
-                      mesh_flavour = 'regular',
-                      ni = ni,
-                      nj = nj,
-                      origin = (min_xy[0], min_xy[1], 0.0),
-                      dxyz_dij = np.array([[(max_xy[0] - min_xy[0]) / (ni - 1), 0.0, 0.0],
-                                           [0.0, (max_xy[1] - min_xy[1]) / (nj - 1), 0.0]]))
-   lattice.write_hdf5()
-   lattice.create_xml()
-   horizons = []
-   for i in range(4):
-      horizon_depths = 1000.0 + 100.0 * i + 20.0 * (np.random.random((nj, ni)) - 0.5)
-      horizon_mesh = rqs.Mesh(model,
-                              crs_uuid = crs.uuid,
-                              mesh_flavour = 'ref&z',
-                              ni = ni,
-                              nj = nj,
-                              z_values = horizon_depths,
-                              z_supporting_mesh_uuid = lattice.uuid,
-                              title = 'h' + str(i))
-      horizon_mesh.write_hdf5()
-      horizon_mesh.create_xml()
-      horizon_surface = rqs.Surface(model,
-                                    crs_uuid = crs.uuid,
-                                    mesh = horizon_mesh,
-                                    quad_triangles = True,
-                                    title = horizon_mesh.title)
-      horizon_surface.write_hdf5()
-      horizon_surface.create_xml()
-      horizons.append(horizon_surface)
+    # create some horizon surfaces
+    ni, nj = 21, 11
+    lattice = rqs.Mesh(model,
+                       crs_uuid = crs.uuid,
+                       mesh_flavour = 'regular',
+                       ni = ni,
+                       nj = nj,
+                       origin = (min_xy[0], min_xy[1], 0.0),
+                       dxyz_dij = np.array([[(max_xy[0] - min_xy[0]) / (ni - 1), 0.0, 0.0],
+                                            [0.0, (max_xy[1] - min_xy[1]) / (nj - 1), 0.0]]))
+    lattice.write_hdf5()
+    lattice.create_xml()
+    horizons = []
+    for i in range(4):
+        horizon_depths = 1000.0 + 100.0 * i + 20.0 * (np.random.random((nj, ni)) - 0.5)
+        horizon_mesh = rqs.Mesh(model,
+                                crs_uuid = crs.uuid,
+                                mesh_flavour = 'ref&z',
+                                ni = ni,
+                                nj = nj,
+                                z_values = horizon_depths,
+                                z_supporting_mesh_uuid = lattice.uuid,
+                                title = 'h' + str(i))
+        horizon_mesh.write_hdf5()
+        horizon_mesh.create_xml()
+        horizon_surface = rqs.Surface(model,
+                                      crs_uuid = crs.uuid,
+                                      mesh = horizon_mesh,
+                                      quad_triangles = True,
+                                      title = horizon_mesh.title)
+        horizon_surface.write_hdf5()
+        horizon_surface.create_xml()
+        horizons.append(horizon_surface)
 
-   # create a re-triangulated Voronoi vertical prism grid
-   grid = rug.VerticalPrismGrid.from_seed_points_and_surfaces(model,
-                                                              seeds_xy,
-                                                              horizons,
-                                                              aoi,
-                                                              title = "giant's causeway")
-   assert grid is not None
-   grid.write_hdf5()
-   grid.create_xml()
+    # create a re-triangulated Voronoi vertical prism grid
+    grid = rug.VerticalPrismGrid.from_seed_points_and_surfaces(model,
+                                                               seeds_xy,
+                                                               horizons,
+                                                               aoi,
+                                                               title = "giant's causeway")
+    assert grid is not None
+    grid.write_hdf5()
+    grid.create_xml()
 
-   # check cell thicknesses are in expected range
-   thick = grid.thickness()
-   assert np.all(thick >= 80.0)
-   assert np.all(thick <= 120.0)
+    # check cell thicknesses are in expected range
+    thick = grid.thickness()
+    assert np.all(thick >= 80.0)
+    assert np.all(thick <= 120.0)
 
-   model.store_epc()
+    model.store_epc()

--- a/tests/test_vector_utilities.py
+++ b/tests/test_vector_utilities.py
@@ -8,79 +8,79 @@ import resqpy.olio.vector_utilities as vec
 
 
 def test_simple_functions():
-   assert_array_almost_equal(vec.zero_vector(), (0.0, 0.0, 0.0))
-   assert_array_almost_equal(vec.add((1.2, 3.4), (5.6, 7.8)), np.array([6.8, 11.2]))
-   assert_array_almost_equal(vec.subtract((5.6, 7.8, 10.0), (1.2, 3.4, -1.0)), np.array([4.4, 4.4, 11.0]))
-   assert_array_almost_equal(vec.elemental_multiply((1.2, 3.4), (5.6, 7.8)), (6.72, 26.52))
-   assert_array_almost_equal(vec.amplify((1.0, 2.0, 4.5), 2.5), (2.5, 5.0, 11.25))
-   assert_array_almost_equal(vec.v_3d((23.4, -98.7)), (23.4, -98.7, 0.0))
-   assert_array_almost_equal(vec.v_3d((23.4, 45.4, -98.7)), np.array((23.4, 45.4, -98.7)))
+    assert_array_almost_equal(vec.zero_vector(), (0.0, 0.0, 0.0))
+    assert_array_almost_equal(vec.add((1.2, 3.4), (5.6, 7.8)), np.array([6.8, 11.2]))
+    assert_array_almost_equal(vec.subtract((5.6, 7.8, 10.0), (1.2, 3.4, -1.0)), np.array([4.4, 4.4, 11.0]))
+    assert_array_almost_equal(vec.elemental_multiply((1.2, 3.4), (5.6, 7.8)), (6.72, 26.52))
+    assert_array_almost_equal(vec.amplify((1.0, 2.0, 4.5), 2.5), (2.5, 5.0, 11.25))
+    assert_array_almost_equal(vec.v_3d((23.4, -98.7)), (23.4, -98.7, 0.0))
+    assert_array_almost_equal(vec.v_3d((23.4, 45.4, -98.7)), np.array((23.4, 45.4, -98.7)))
 
 
 def test_unit_vectors():
-   v_set = np.array([(3.0, 4.0, 0.0), (3.7, -3.7, 3.7), (0.0, 0.0, 1.0), (0.0, 0.0, 0.0)])
-   one_over_root_three = 1.0 / maths.sqrt(3.0)
-   expected = np.array([(3.0 / 5.0, 4.0 / 5.0, 0.0), (one_over_root_three, -one_over_root_three, one_over_root_three),
-                        (0.0, 0.0, 1.0), (0.0, 0.0, 0.0)])
-   for v, e in zip(v_set, expected):
-      assert_array_almost_equal(vec.unit_vector(v), e)
-   assert_array_almost_equal(vec.unit_vectors(v_set), expected)
-   azi = [0.0, -90.0, 120.0, 180.0, 270.0, 360.0]
-   expected = np.array([(0.0, 1.0, 0.0), (-1.0, 0.0, 0.0), (maths.cos(maths.pi / 6), -0.5, 0.0), (0.0, -1.0, 0.0),
-                        (-1.0, 0.0, 0.0), (0.0, 1.0, 0.0)])
-   for a, e in zip(azi, expected):
-      assert_array_almost_equal(vec.unit_vector_from_azimuth(a), e)
+    v_set = np.array([(3.0, 4.0, 0.0), (3.7, -3.7, 3.7), (0.0, 0.0, 1.0), (0.0, 0.0, 0.0)])
+    one_over_root_three = 1.0 / maths.sqrt(3.0)
+    expected = np.array([(3.0 / 5.0, 4.0 / 5.0, 0.0), (one_over_root_three, -one_over_root_three, one_over_root_three),
+                         (0.0, 0.0, 1.0), (0.0, 0.0, 0.0)])
+    for v, e in zip(v_set, expected):
+        assert_array_almost_equal(vec.unit_vector(v), e)
+    assert_array_almost_equal(vec.unit_vectors(v_set), expected)
+    azi = [0.0, -90.0, 120.0, 180.0, 270.0, 360.0]
+    expected = np.array([(0.0, 1.0, 0.0), (-1.0, 0.0, 0.0), (maths.cos(maths.pi / 6), -0.5, 0.0), (0.0, -1.0, 0.0),
+                         (-1.0, 0.0, 0.0), (0.0, 1.0, 0.0)])
+    for a, e in zip(azi, expected):
+        assert_array_almost_equal(vec.unit_vector_from_azimuth(a), e)
 
 
 def test_angles():
-   pi_by_2 = maths.pi / 2.0
-   assert maths.isclose(vec.radians_from_degrees(90.0), pi_by_2)
-   assert_array_almost_equal(vec.radians_from_degrees((0.0, -90.0, 120.0, 270.0)),
-                             (0.0, -pi_by_2, maths.pi * 2 / 3, pi_by_2 * 3))
-   assert maths.isclose(vec.radians_from_degrees(vec.degrees_from_radians(1.2647)), 1.2647)
-   assert_array_almost_equal(vec.degrees_from_radians((0.0, -pi_by_2, maths.pi * 2 / 3, pi_by_2 * 3)),
-                             (0.0, -90.0, 120.0, 270.0))
-   assert maths.isclose(vec.degrees_from_radians(maths.pi), 180.0)
+    pi_by_2 = maths.pi / 2.0
+    assert maths.isclose(vec.radians_from_degrees(90.0), pi_by_2)
+    assert_array_almost_equal(vec.radians_from_degrees((0.0, -90.0, 120.0, 270.0)),
+                              (0.0, -pi_by_2, maths.pi * 2 / 3, pi_by_2 * 3))
+    assert maths.isclose(vec.radians_from_degrees(vec.degrees_from_radians(1.2647)), 1.2647)
+    assert_array_almost_equal(vec.degrees_from_radians((0.0, -pi_by_2, maths.pi * 2 / 3, pi_by_2 * 3)),
+                              (0.0, -90.0, 120.0, 270.0))
+    assert maths.isclose(vec.degrees_from_radians(maths.pi), 180.0)
 
 
 def test_azimuth():
-   vectors = np.array([
-      (0.0, 1.0, 0.0),  # north
-      (27.3, 0.0, 2341.0),  # east
-      (0.0, -4.5e6, -12000.0),  # south
-      (-0.001, 0.0, 23.2),  # west
-      (0.0, 0.0, 100.0),  # no bearing (expected to return 0.0 for azimuth(), NaN for azimuths())
-      (123.45, -123.45, 0.03),  # south east
-      (maths.cos(maths.radians(30.0)), 0.5, 0.0)  # bearing of 60 degrees
-   ])
-   expected = np.array((0.0, 90.0, 180.0, 270.0, 0.0, 135.0, 60.0))
-   for v, e in zip(vectors, expected):
-      assert maths.isclose(vec.azimuth(v), e)
-      assert maths.isclose(vec.azimuth(v[:2]), e)
-   expected[4] = np.NaN
-   assert_array_almost_equal(vec.azimuths(vectors), expected)
-   assert_array_almost_equal(vec.azimuths(vectors[:, :2]), expected)
+    vectors = np.array([
+        (0.0, 1.0, 0.0),  # north
+        (27.3, 0.0, 2341.0),  # east
+        (0.0, -4.5e6, -12000.0),  # south
+        (-0.001, 0.0, 23.2),  # west
+        (0.0, 0.0, 100.0),  # no bearing (expected to return 0.0 for azimuth(), NaN for azimuths())
+        (123.45, -123.45, 0.03),  # south east
+        (maths.cos(maths.radians(30.0)), 0.5, 0.0)  # bearing of 60 degrees
+    ])
+    expected = np.array((0.0, 90.0, 180.0, 270.0, 0.0, 135.0, 60.0))
+    for v, e in zip(vectors, expected):
+        assert maths.isclose(vec.azimuth(v), e)
+        assert maths.isclose(vec.azimuth(v[:2]), e)
+    expected[4] = np.NaN
+    assert_array_almost_equal(vec.azimuths(vectors), expected)
+    assert_array_almost_equal(vec.azimuths(vectors[:, :2]), expected)
 
 
 def test_inclination():
-   vectors = np.array([(0.0, 0.0, 1.0), (0.0, 0.0, -458.21), (0.0, 233.67, 233.67), (910.0, 0.0, 910.0),
-                       (0.0, 0.0, 0.0)])
-   expected = (0.0, 180.0, 45.0, 45.0, 90.0)  # last is an arbitrary value returned by the function for zero vector
-   for v, e in zip(vectors, expected):
-      assert maths.isclose(vec.inclination(v), e)
-   assert maths.isclose(vec.inclination((456.7, -456.7, 456.7)),
-                        90.0 - vec.degrees_from_radians(maths.acos(maths.sqrt(2) / maths.sqrt(3))))
+    vectors = np.array([(0.0, 0.0, 1.0), (0.0, 0.0, -458.21), (0.0, 233.67, 233.67), (910.0, 0.0, 910.0),
+                        (0.0, 0.0, 0.0)])
+    expected = (0.0, 180.0, 45.0, 45.0, 90.0)  # last is an arbitrary value returned by the function for zero vector
+    for v, e in zip(vectors, expected):
+        assert maths.isclose(vec.inclination(v), e)
+    assert maths.isclose(vec.inclination((456.7, -456.7, 456.7)),
+                         90.0 - vec.degrees_from_radians(maths.acos(maths.sqrt(2) / maths.sqrt(3))))
 
 
 def test_clockwise():
-   p1 = (4.4, 4.4)
-   p2 = (6.8, 6.8)
-   p3 = (-21.0, -21.0)
-   assert maths.isclose(vec.clockwise(p1, p2, p3), 0.0)
-   p1 = [1.0, 1.0, -45.0]
-   p2 = [2.0, 8.0, 23.1]
-   p3 = [5.0, 3.0, -11.0]
-   assert vec.clockwise(p1, p2, p3) > 0.0
-   p1, p2 = np.array(p2), np.array(p1)
-   p3 = np.array(p3)
-   assert vec.clockwise(p1, p2, p3) < 0.0
+    p1 = (4.4, 4.4)
+    p2 = (6.8, 6.8)
+    p3 = (-21.0, -21.0)
+    assert maths.isclose(vec.clockwise(p1, p2, p3), 0.0)
+    p1 = [1.0, 1.0, -45.0]
+    p2 = [2.0, 8.0, 23.1]
+    p3 = [5.0, 3.0, -11.0]
+    assert vec.clockwise(p1, p2, p3) > 0.0
+    p1, p2 = np.array(p2), np.array(p1)
+    p3 = np.array(p3)
+    assert vec.clockwise(p1, p2, p3) < 0.0

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -9,92 +9,93 @@ import resqpy.olio.volume as vol
 
 
 def unit_cube():
-   cp = np.zeros((2, 2, 2, 3))  # pagoda style corner point array for a single cell
-   # set to unit cube with xyz aligned with ijk respectively
-   cp[:, :, 1, 0] = 1.0
-   cp[:, 1, :, 1] = 1.0
-   cp[1, :, :, 2] = 1.0
-   return cp
+    cp = np.zeros((2, 2, 2, 3))  # pagoda style corner point array for a single cell
+    # set to unit cube with xyz aligned with ijk respectively
+    cp[:, :, 1, 0] = 1.0
+    cp[:, 1, :, 1] = 1.0
+    cp[1, :, :, 2] = 1.0
+    return cp
 
 
 def test_one_cell_volume():
-   cp = unit_cube().copy()
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 1.0), 'unit cube cell volume calculation fails'
-   # stretch in x (I)
-   cp[:, :, 1, 0] *= 2.5
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 2.5), 'square prism cell volume calculation fails'
-   # stretch in y & z (J & K)
-   cp[:, 1, :, 1] *= 2.0
-   cp[1, :, :, 2] *= 3.0
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False),
-                        15.0), 'regular cuboid cell volume calculation fails'
-   # apply a shear in x & y (should not change volume)
-   cp[1, :, :, :2] += 0.5
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False),
-                        15.0), 'parallelepiped cell volume calculation fails'
-   # translate into negative coordinate realm
-   cp[:] -= 3.827
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 15.0), 'translated cell volume calculation fails '
-   # invert one axis
-   cp[:, :, :, 1] *= -1.0
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = True), 15.0), 'off hand True cell volume calculation fails'
-   # collapse to plane
-   cp[:, :, :, 2] = 0.0
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 0.0), 'planar cell volume calculation fails'
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = True),
-                        0.0), 'off hand True planar cell volume calculation fails'
-   # test wedge
-   cp = unit_cube().copy()
-   cp[1, 1, :, 2] = 0.0
-   assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 0.5), 'triangular prism volume calculation fails'
+    cp = unit_cube().copy()
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 1.0), 'unit cube cell volume calculation fails'
+    # stretch in x (I)
+    cp[:, :, 1, 0] *= 2.5
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 2.5), 'square prism cell volume calculation fails'
+    # stretch in y & z (J & K)
+    cp[:, 1, :, 1] *= 2.0
+    cp[1, :, :, 2] *= 3.0
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False),
+                         15.0), 'regular cuboid cell volume calculation fails'
+    # apply a shear in x & y (should not change volume)
+    cp[1, :, :, :2] += 0.5
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False),
+                         15.0), 'parallelepiped cell volume calculation fails'
+    # translate into negative coordinate realm
+    cp[:] -= 3.827
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 15.0), 'translated cell volume calculation fails '
+    # invert one axis
+    cp[:, :, :, 1] *= -1.0
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = True),
+                         15.0), 'off hand True cell volume calculation fails'
+    # collapse to plane
+    cp[:, :, :, 2] = 0.0
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 0.0), 'planar cell volume calculation fails'
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = True),
+                         0.0), 'off hand True planar cell volume calculation fails'
+    # test wedge
+    cp = unit_cube().copy()
+    cp[1, 1, :, 2] = 0.0
+    assert maths.isclose(vol.tetra_cell_volume(cp, off_hand = False), 0.5), 'triangular prism volume calculation fails'
 
 
 def test_array_volume():
-   # note: the multiple cells generated here are all overlapping, which would not usually be the case
-   cp = np.zeros((5, 10, 15, 2, 2, 2, 3))  # pagoda style corner point array
-   cp[:] = unit_cube().reshape((1, 1, 1, 2, 2, 2, 3)) * 2.0
-   cp[:] += random(cp.size).reshape(cp.shape) - 0.5
-   # move whole cells by random translations
-   translate = (random(cp.size // 8) * 123.2356).reshape((cp.shape[0], cp.shape[1], cp.shape[2], 1, 1, 1, 3))
-   cp[:] += translate
-   # compute volumes using two different routines in the volume module and make sure they give the same answer
-   v1 = vol.tetra_volumes_slow(cp, off_hand = False)
-   v2 = vol.tetra_volumes(cp, off_hand = False)
-   # following is a stringent test requiring that exactly the same mathematical operations have been performed
-   assert_array_almost_equal(v1, v2)
+    # note: the multiple cells generated here are all overlapping, which would not usually be the case
+    cp = np.zeros((5, 10, 15, 2, 2, 2, 3))  # pagoda style corner point array
+    cp[:] = unit_cube().reshape((1, 1, 1, 2, 2, 2, 3)) * 2.0
+    cp[:] += random(cp.size).reshape(cp.shape) - 0.5
+    # move whole cells by random translations
+    translate = (random(cp.size // 8) * 123.2356).reshape((cp.shape[0], cp.shape[1], cp.shape[2], 1, 1, 1, 3))
+    cp[:] += translate
+    # compute volumes using two different routines in the volume module and make sure they give the same answer
+    v1 = vol.tetra_volumes_slow(cp, off_hand = False)
+    v2 = vol.tetra_volumes(cp, off_hand = False)
+    # following is a stringent test requiring that exactly the same mathematical operations have been performed
+    assert_array_almost_equal(v1, v2)
 
-   # the random changes to corner points should have left the volumes within a certain range
-   assert np.all(v1 >= 0.0), 'negative volume(s) returned by array function'
-   assert np.all(v1 <= 27.0), 'exaggerated volume(s) returned by array function'
-   # translate again and check that volumes are unchanged
-   translate = (random(cp.size // 8) * 3.23478).reshape((cp.shape[0], cp.shape[1], cp.shape[2], 1, 1, 1, 3))
-   cp[:] -= translate
-   v2 = vol.tetra_volumes(cp, off_hand = False)
-   assert_array_almost_equal(v1, v2)
+    # the random changes to corner points should have left the volumes within a certain range
+    assert np.all(v1 >= 0.0), 'negative volume(s) returned by array function'
+    assert np.all(v1 <= 27.0), 'exaggerated volume(s) returned by array function'
+    # translate again and check that volumes are unchanged
+    translate = (random(cp.size // 8) * 3.23478).reshape((cp.shape[0], cp.shape[1], cp.shape[2], 1, 1, 1, 3))
+    cp[:] -= translate
+    v2 = vol.tetra_volumes(cp, off_hand = False)
+    assert_array_almost_equal(v1, v2)
 
-   # test handedness inversion
-   cp[:, :, :, :, :, :, 0] *= -1.0
-   v1 = vol.tetra_volumes_slow(cp, off_hand = True)
-   v2 = vol.tetra_volumes(cp, off_hand = True)
-   assert_array_almost_equal(v1, v2)
-   assert np.all(v1 >= 0.0), 'negative volume(s) returned by array function'
-   assert np.all(v1 <= 27.0), 'exaggerated volume(s) returned by array function'
+    # test handedness inversion
+    cp[:, :, :, :, :, :, 0] *= -1.0
+    v1 = vol.tetra_volumes_slow(cp, off_hand = True)
+    v2 = vol.tetra_volumes(cp, off_hand = True)
+    assert_array_almost_equal(v1, v2)
+    assert np.all(v1 >= 0.0), 'negative volume(s) returned by array function'
+    assert np.all(v1 <= 27.0), 'exaggerated volume(s) returned by array function'
 
 
 def test_pyramid_volume():
-   apex = (1.0, 1.0, -3.0)
-   a = (0.0, 0.0, 0.0)
-   b = (0.0, 2.0, 0.0)
-   c = (2.0, 2.0, 0.0)
-   d = (2.0, 0.0, 0.0)
-   assert maths.isclose(vol.pyramid_volume(apex, a, b, c, d), 4.0)
-   assert maths.isclose(vol.pyramid_volume(apex, a, d, c, b, crs_is_right_handed = True), 4.0)
+    apex = (1.0, 1.0, -3.0)
+    a = (0.0, 0.0, 0.0)
+    b = (0.0, 2.0, 0.0)
+    c = (2.0, 2.0, 0.0)
+    d = (2.0, 0.0, 0.0)
+    assert maths.isclose(vol.pyramid_volume(apex, a, b, c, d), 4.0)
+    assert maths.isclose(vol.pyramid_volume(apex, a, d, c, b, crs_is_right_handed = True), 4.0)
 
 
 def test_tetrahedron_volume():
-   one_over_root_two = 1.0 / maths.sqrt(2.0)
-   a = (-1.0, 0.0, -one_over_root_two)
-   b = (1.0, 0.0, -one_over_root_two)
-   c = (0.0, -1.0, one_over_root_two)
-   d = (0.0, 1.0, one_over_root_two)
-   assert maths.isclose(vol.tetrahedron_volume(a, b, c, d), 4.0 / (3.0 * maths.sqrt(2.0)))
+    one_over_root_two = 1.0 / maths.sqrt(2.0)
+    a = (-1.0, 0.0, -one_over_root_two)
+    b = (1.0, 0.0, -one_over_root_two)
+    c = (0.0, -1.0, one_over_root_two)
+    d = (0.0, 1.0, one_over_root_two)
+    assert maths.isclose(vol.tetrahedron_volume(a, b, c, d), 4.0 / (3.0 * maths.sqrt(2.0)))

--- a/tests/test_weights_measures.py
+++ b/tests/test_weights_measures.py
@@ -12,44 +12,44 @@ from resqpy.olio.exceptions import InvalidUnitError, IncompatibleUnitsError
 
 def test_valid_uoms():
 
-   # Good units
-   assert "0.001 gal[US]/gal[US]" in wam.valid_uoms()
-   assert "Btu[IT]/min" in wam.valid_uoms()
-   assert "%" in wam.valid_uoms()
+    # Good units
+    assert "0.001 gal[US]/gal[US]" in wam.valid_uoms()
+    assert "Btu[IT]/min" in wam.valid_uoms()
+    assert "%" in wam.valid_uoms()
 
-   # Bad units
-   assert "foo barr" not in wam.valid_uoms()
-   assert "" not in wam.valid_uoms()
-   assert None not in wam.valid_uoms()
+    # Bad units
+    assert "foo barr" not in wam.valid_uoms()
+    assert "" not in wam.valid_uoms()
+    assert None not in wam.valid_uoms()
 
-   # With attributes, optionally with subset
-   for quantity in [None, "length"]:
-      uom_dict = wam.valid_uoms(quantity = quantity, return_attributes = True)
-      assert "m" in uom_dict.keys()
-      assert uom_dict["m"]["name"] == "metre"
-      assert uom_dict["m"]["dimension"] == "L"
+    # With attributes, optionally with subset
+    for quantity in [None, "length"]:
+        uom_dict = wam.valid_uoms(quantity = quantity, return_attributes = True)
+        assert "m" in uom_dict.keys()
+        assert uom_dict["m"]["name"] == "metre"
+        assert uom_dict["m"]["dimension"] == "L"
 
 
 def test_uom_aliases():
-   for uom, aliases in wam.UOM_ALIASES.items():
-      assert uom in wam.valid_uoms(), f"Bad uom {uom}"
-      for alias in aliases:
-         if alias != uom:
+    for uom, aliases in wam.UOM_ALIASES.items():
+        assert uom in wam.valid_uoms(), f"Bad uom {uom}"
+        for alias in aliases:
+            if alias != uom:
+                assert alias not in wam.valid_uoms(), f"Bad alias {alias}"
+
+    for alias, uom in wam.UOM_ALIAS_MAP.items():
+        assert uom in wam.valid_uoms(), f"Bad uom {uom}"
+        if alias != uom:
             assert alias not in wam.valid_uoms(), f"Bad alias {alias}"
 
-   for alias, uom in wam.UOM_ALIAS_MAP.items():
-      assert uom in wam.valid_uoms(), f"Bad uom {uom}"
-      if alias != uom:
-         assert alias not in wam.valid_uoms(), f"Bad alias {alias}"
-
-   for uom in wam.CASE_INSENSITIVE_UOMS:
-      assert uom in wam.valid_uoms(), f"Bad uom {uom}"
+    for uom in wam.CASE_INSENSITIVE_UOMS:
+        assert uom in wam.valid_uoms(), f"Bad uom {uom}"
 
 
 def test_aliases_are_unique():
-   n_aliases = sum(map(len, wam.UOM_ALIASES.values()))
-   all_aliases = set.union(*wam.UOM_ALIASES.values())
-   assert n_aliases == len(all_aliases)
+    n_aliases = sum(map(len, wam.UOM_ALIASES.values()))
+    all_aliases = set.union(*wam.UOM_ALIASES.values())
+    assert n_aliases == len(all_aliases)
 
 
 # ------- Test parsing uoms -------
@@ -63,14 +63,14 @@ def test_aliases_are_unique():
                                                      ('(MMSTB)', '1E6 bbl'), ('LB/(cu.ft.)', 'lbm/ft3'),
                                                      ('(KJ)            ', 'kJ')])
 def test_uom_from_string(input_uom, expected_uom):
-   validated_uom = wam.rq_uom(input_uom)
-   assert expected_uom == validated_uom
+    validated_uom = wam.rq_uom(input_uom)
+    assert expected_uom == validated_uom
 
 
 @pytest.mark.parametrize("input_uom", ["foobar", None, "", "qwertyuiol", "bifröst"])
 def test_bad_unit_raises_error(input_uom):
-   with pytest.raises(InvalidUnitError):
-      wam.rq_uom(input_uom)
+    with pytest.raises(InvalidUnitError):
+        wam.rq_uom(input_uom)
 
 
 # ----- Test quantities -------
@@ -78,160 +78,161 @@ def test_bad_unit_raises_error(input_uom):
 
 def test_quantities():
 
-   # Set of all quantities
-   quantities = wam.valid_quantities()
-   assert "length" in quantities
-   assert len(quantities) > 10
-   for q in quantities:
-      uoms = wam.valid_uoms(quantity = q)
-      assert len(uoms) > 0
-      for uom in uoms:
-         assert uom in wam.valid_uoms(), f"Bad uom {uom}"
+    # Set of all quantities
+    quantities = wam.valid_quantities()
+    assert "length" in quantities
+    assert len(quantities) > 10
+    for q in quantities:
+        uoms = wam.valid_uoms(quantity = q)
+        assert len(uoms) > 0
+        for uom in uoms:
+            assert uom in wam.valid_uoms(), f"Bad uom {uom}"
 
-   # With attributes
-   quantities_dict = wam.valid_quantities(return_attributes = True)
-   assert "length" in quantities_dict.keys()
-   assert quantities_dict["length"]["dimension"] == "L"
-   assert "m" in quantities_dict["length"]["members"]
+    # With attributes
+    quantities_dict = wam.valid_quantities(return_attributes = True)
+    assert "length" in quantities_dict.keys()
+    assert quantities_dict["length"]["dimension"] == "L"
+    assert "m" in quantities_dict["length"]["members"]
 
 
 # ---- Test unit conversions -------
 
 
 @pytest.mark.parametrize(
-   "unit_from, unit_to, value, expected",
-   [
-      # Straightforward conversions
-      ("m", "m", 1, 1),
-      ("m", "km", 1, 0.001),
-      ("ft", "m", 1, 0.3048),
-      ("ft", "ft[US]", 1, 0.999998),
+    "unit_from, unit_to, value, expected",
+    [
+        # Straightforward conversions
+        ("m", "m", 1, 1),
+        ("m", "km", 1, 0.001),
+        ("ft", "m", 1, 0.3048),
+        ("ft", "ft[US]", 1, 0.999998),
 
-      # Fractional units with aliases
-      ("bbl/d", "stb/day", 1, 1),
-      ("mmstb/day", "1E6 bbl/d", 1, 1),
-      ("mmscf/day", "1E6 ft3/d", 1, 1),
-      ("scf/stb", "ft3/bbl", 1, 1),
+        # Fractional units with aliases
+        ("bbl/d", "stb/day", 1, 1),
+        ("mmstb/day", "1E6 bbl/d", 1, 1),
+        ("mmscf/day", "1E6 ft3/d", 1, 1),
+        ("scf/stb", "ft3/bbl", 1, 1),
 
-      # Aliases of common units
-      ("metres", "m", 1, 1),
-      ("meters", "m", 1, 1),
-      ("pu", "%", 1, 1),
-      ("p.u.", "%", 1, 1),
+        # Aliases of common units
+        ("metres", "m", 1, 1),
+        ("meters", "m", 1, 1),
+        ("pu", "%", 1, 1),
+        ("p.u.", "%", 1, 1),
 
-      # Different base units!
-      ("%", "v/v", 1, 0.01),
-      ("pu", "v/v", 1, 0.01),
-      ("m3/m3", "%", 1, 100),
-      ("D", "ft2", 10, 1.062315e-10),
-   ])
+        # Different base units!
+        ("%", "v/v", 1, 0.01),
+        ("pu", "v/v", 1, 0.01),
+        ("m3/m3", "%", 1, 100),
+        ("D", "ft2", 10, 1.062315e-10),
+    ])
 @pytest.mark.filterwarnings("ignore:Assuming base units")
 def test_unit_conversion(unit_from, unit_to, value, expected):
-   result = wam.convert(value, unit_from, unit_to)
-   assert maths.isclose(result, expected, rel_tol = 1e-4)
+    result = wam.convert(value, unit_from, unit_to)
+    assert maths.isclose(result, expected, rel_tol = 1e-4)
 
 
 def test_convert_array():
-   # Duck typing should work
-   value = np.array([1, 2, 3])
-   expected = np.array([1000, 2000, 3000])
-   result = wam.convert(value, unit_from = "km", unit_to = "m")
-   assert_array_almost_equal(result, expected)
+    # Duck typing should work
+    value = np.array([1, 2, 3])
+    expected = np.array([1000, 2000, 3000])
+    result = wam.convert(value, unit_from = "km", unit_to = "m")
+    assert_array_almost_equal(result, expected)
 
 
 def test_conversion_factors_are_numeric():
-   for uom in wam.valid_uoms():
-      base_unit, dimension, factors = wam.get_conversion_factors(uom)
-      assert base_unit in wam.valid_uoms()
-      assert len(dimension) > 0
-      assert len(factors) == 4, f"Issue with {uom}"
-      assert all(isinstance(f, (int, float)) for f in factors), f"Issue with {uom}"
+    for uom in wam.valid_uoms():
+        base_unit, dimension, factors = wam.get_conversion_factors(uom)
+        assert base_unit in wam.valid_uoms()
+        assert len(dimension) > 0
+        assert len(factors) == 4, f"Issue with {uom}"
+        assert all(isinstance(f, (int, float)) for f in factors), f"Issue with {uom}"
 
 
 # Test incompatible units raise an Error
 
 
 @pytest.mark.parametrize("unit_from, unit_to", [
-   ("m", "gAPI"),
-   ("%", "bbl"),
-   ("%", "ft"),
-   ("m", "m3"),
+    ("m", "gAPI"),
+    ("%", "bbl"),
+    ("%", "ft"),
+    ("m", "m3"),
 ])
 def test_incompatible_units(unit_from, unit_to):
-   with pytest.raises(IncompatibleUnitsError):
-      wam.convert(1, unit_from, unit_to)
+    with pytest.raises(IncompatibleUnitsError):
+        wam.convert(1, unit_from, unit_to)
 
 
 def test_length_conversion():
-   assert maths.isclose(wam.convert_lengths(1.0, 'feet', 'metres'), 0.3048)
-   assert maths.isclose(wam.convert_lengths(10.0, 'ft', 'm'), 3.048)
-   a = np.random.random((4, 5))
-   a_m = 0.3048 * a
-   wam.convert_lengths(a, 'ft', 'm')
-   assert np.all(np.isclose(a_m, a))
-   a = np.random.random((4, 5))
-   a_ft = a / 0.3048
-   assert np.all(np.isclose(a_ft, wam.convert_lengths(a, 'm', 'ft')))
-   b = a.copy()
-   wam.convert_lengths(a, 'ft', 'm')
-   wam.convert_lengths(a, 'm', 'ft')
-   assert np.all(np.isclose(a, b))
+    assert maths.isclose(wam.convert_lengths(1.0, 'feet', 'metres'), 0.3048)
+    assert maths.isclose(wam.convert_lengths(10.0, 'ft', 'm'), 3.048)
+    a = np.random.random((4, 5))
+    a_m = 0.3048 * a
+    wam.convert_lengths(a, 'ft', 'm')
+    assert np.all(np.isclose(a_m, a))
+    a = np.random.random((4, 5))
+    a_ft = a / 0.3048
+    assert np.all(np.isclose(a_ft, wam.convert_lengths(a, 'm', 'ft')))
+    b = a.copy()
+    wam.convert_lengths(a, 'ft', 'm')
+    wam.convert_lengths(a, 'm', 'ft')
+    assert np.all(np.isclose(a, b))
 
 
 def test_time_conversion():
-   for period in (1.0, 0.0238, 67.824, 0.0):
-      assert maths.isclose(24 * period, wam.convert_times(period, 'days', 'hours'))
-      assert maths.isclose(24 * 60 * period, wam.convert_times(period, 'd', 'mins'))
-      assert maths.isclose(24 * 60 * 60 * period, wam.convert_times(period, 'day', 'sec'))
-      assert maths.isclose(24 * 60 * 60 * 1000 * period, wam.convert_times(period, 'day', 'ms'))
-      assert maths.isclose(60 * period, wam.convert_times(period, 'hr', 'min'))
-      assert maths.isclose(60 * period, wam.convert_times(period, 'min', 's'))
-      assert maths.isclose(period / 24, wam.convert_times(period, 'days', 'hours', invert = True))
-      assert maths.isclose(period / (24 * 60), wam.convert_times(period, 'd', 'mins', invert = True))
-      assert maths.isclose(period / (24 * 60 * 60), wam.convert_times(period, 'day', 'sec', invert = True))
-      assert maths.isclose(period / (24 * 60 * 60 * 1000), wam.convert_times(period, 'day', 'ms', invert = True))
-      assert maths.isclose(period / 60, wam.convert_times(period, 'hr', 'min', invert = True))
-      assert maths.isclose(period / 60, wam.convert_times(period, 'min', 's', invert = True))
-      assert maths.isclose(period / 24, wam.convert_times(period, 'hours', 'days'))
-      assert maths.isclose(period / (24 * 60), wam.convert_times(period, 'mins', 'd'))
-      assert maths.isclose(period / (24 * 60 * 60), wam.convert_times(period, 'sec', 'day'))
-      assert maths.isclose(period / (24 * 60 * 60 * 1000), wam.convert_times(period, 'ms', 'day'))
-      assert maths.isclose(period / 60, wam.convert_times(period, 'min', 'hr'))
-      assert maths.isclose(period / 60, wam.convert_times(period, 's', 'min'))
-   a = np.random.random((2, 3, 4))
-   b = a.copy()
-   wam.convert_times(a, 'd', 's')
-   assert np.all(np.isclose(a, 24.0 * 60.0 * 60.0 * b))
-   wam.convert_times(a, 'd', 's', invert = True)
-   assert np.all(np.isclose(a, b))
+    for period in (1.0, 0.0238, 67.824, 0.0):
+        assert maths.isclose(24 * period, wam.convert_times(period, 'days', 'hours'))
+        assert maths.isclose(24 * 60 * period, wam.convert_times(period, 'd', 'mins'))
+        assert maths.isclose(24 * 60 * 60 * period, wam.convert_times(period, 'day', 'sec'))
+        assert maths.isclose(24 * 60 * 60 * 1000 * period, wam.convert_times(period, 'day', 'ms'))
+        assert maths.isclose(60 * period, wam.convert_times(period, 'hr', 'min'))
+        assert maths.isclose(60 * period, wam.convert_times(period, 'min', 's'))
+        assert maths.isclose(period / 24, wam.convert_times(period, 'days', 'hours', invert = True))
+        assert maths.isclose(period / (24 * 60), wam.convert_times(period, 'd', 'mins', invert = True))
+        assert maths.isclose(period / (24 * 60 * 60), wam.convert_times(period, 'day', 'sec', invert = True))
+        assert maths.isclose(period / (24 * 60 * 60 * 1000), wam.convert_times(period, 'day', 'ms', invert = True))
+        assert maths.isclose(period / 60, wam.convert_times(period, 'hr', 'min', invert = True))
+        assert maths.isclose(period / 60, wam.convert_times(period, 'min', 's', invert = True))
+        assert maths.isclose(period / 24, wam.convert_times(period, 'hours', 'days'))
+        assert maths.isclose(period / (24 * 60), wam.convert_times(period, 'mins', 'd'))
+        assert maths.isclose(period / (24 * 60 * 60), wam.convert_times(period, 'sec', 'day'))
+        assert maths.isclose(period / (24 * 60 * 60 * 1000), wam.convert_times(period, 'ms', 'day'))
+        assert maths.isclose(period / 60, wam.convert_times(period, 'min', 'hr'))
+        assert maths.isclose(period / 60, wam.convert_times(period, 's', 'min'))
+    a = np.random.random((2, 3, 4))
+    b = a.copy()
+    wam.convert_times(a, 'd', 's')
+    assert np.all(np.isclose(a, 24.0 * 60.0 * 60.0 * b))
+    wam.convert_times(a, 'd', 's', invert = True)
+    assert np.all(np.isclose(a, b))
 
 
 def test_pressure_conversion():
-   assert maths.isclose(20684.28, wam.convert_pressures(3000.0, 'psi', 'kPa'), rel_tol = 1.0e-4)
-   a = np.random.random(10)
-   b = a.copy()
-   assert np.all(np.isclose(100.0 * b, wam.convert_pressures(a, 'bar', 'kPa')))
-   wam.convert_pressures(a, 'kPa', 'bar')
-   assert np.all(np.isclose(b, a))
+    assert maths.isclose(20684.28, wam.convert_pressures(3000.0, 'psi', 'kPa'), rel_tol = 1.0e-4)
+    a = np.random.random(10)
+    b = a.copy()
+    assert np.all(np.isclose(100.0 * b, wam.convert_pressures(a, 'bar', 'kPa')))
+    wam.convert_pressures(a, 'kPa', 'bar')
+    assert np.all(np.isclose(b, a))
 
 
 def test_volume_conversion():
-   assert maths.isclose(wam.convert_volumes(1.0, 'm3', 'ft3'), 35.3147, rel_tol = 1.0e-4)
-   assert maths.isclose(wam.convert_volumes(1000.0, 'stb', 'm3'), 158.987, rel_tol = 1.0e-4)
-   units = ('m3', 'ft3', 'bbl')
-   for rate in (2100.0, 0.0, -312.45):
-      for from_units in units:
-         for to_units in units:
-            assert maths.isclose(
-               rate, wam.convert_volumes(wam.convert_volumes(rate, from_units, to_units), to_units, from_units))
+    assert maths.isclose(wam.convert_volumes(1.0, 'm3', 'ft3'), 35.3147, rel_tol = 1.0e-4)
+    assert maths.isclose(wam.convert_volumes(1000.0, 'stb', 'm3'), 158.987, rel_tol = 1.0e-4)
+    units = ('m3', 'ft3', 'bbl')
+    for rate in (2100.0, 0.0, -312.45):
+        for from_units in units:
+            for to_units in units:
+                assert maths.isclose(
+                    rate, wam.convert_volumes(wam.convert_volumes(rate, from_units, to_units), to_units, from_units))
 
 
 def test_flow_rate_conversion():
-   assert maths.isclose(wam.convert_flow_rates(1000.0, 'm3/d', 'ft3/d'), 35314.6667, rel_tol = 1.0e-5)
-   assert maths.isclose(wam.convert_flow_rates(1000.0, 'm3/d', 'bbl/d'), 1000.0 / 0.158987, rel_tol = 1.0e-4)
-   units = ('m3/d', 'ft3/s', 'bbl/d', 'stb/hr', '1000 bbl/d', '1E6 ft3/d')
-   for rate in (2100.0, 0.0, -312.45):
-      for from_units in units:
-         for to_units in units:
-            assert maths.isclose(
-               rate, wam.convert_flow_rates(wam.convert_flow_rates(rate, from_units, to_units), to_units, from_units))
+    assert maths.isclose(wam.convert_flow_rates(1000.0, 'm3/d', 'ft3/d'), 35314.6667, rel_tol = 1.0e-5)
+    assert maths.isclose(wam.convert_flow_rates(1000.0, 'm3/d', 'bbl/d'), 1000.0 / 0.158987, rel_tol = 1.0e-4)
+    units = ('m3/d', 'ft3/s', 'bbl/d', 'stb/hr', '1000 bbl/d', '1E6 ft3/d')
+    for rate in (2100.0, 0.0, -312.45):
+        for from_units in units:
+            for to_units in units:
+                assert maths.isclose(
+                    rate,
+                    wam.convert_flow_rates(wam.convert_flow_rates(rate, from_units, to_units), to_units, from_units))

--- a/tests/test_well.py
+++ b/tests/test_well.py
@@ -18,111 +18,111 @@ import resqpy.olio.uuid as bu
 
 def test_MdDatum(example_model_and_crs):
 
-   # Set up a new datum
-   model, crs = example_model_and_crs
-   epc = model.epc_file
-   data = dict(
-      location = (0, -99999, 3.14),
-      md_reference = 'mean low water',
-   )
-   datum = resqpy.well.MdDatum(parent_model = model, crs_uuid = crs.uuid, **data)
-   uuid = datum.uuid
+    # Set up a new datum
+    model, crs = example_model_and_crs
+    epc = model.epc_file
+    data = dict(
+        location = (0, -99999, 3.14),
+        md_reference = 'mean low water',
+    )
+    datum = resqpy.well.MdDatum(parent_model = model, crs_uuid = crs.uuid, **data)
+    uuid = datum.uuid
 
-   # Save to disk and reload
-   datum.create_part()
-   model.store_epc()
+    # Save to disk and reload
+    datum.create_part()
+    model.store_epc()
 
-   del model, crs, datum
-   model2 = Model(epc_file = epc)
-   datum2 = resqpy.well.MdDatum(parent_model = model2, uuid = uuid)
+    del model, crs, datum
+    model2 = Model(epc_file = epc)
+    datum2 = resqpy.well.MdDatum(parent_model = model2, uuid = uuid)
 
-   for key, expected_value in data.items():
-      assert getattr(datum2, key) == expected_value, f"Issue with {key}"
+    for key, expected_value in data.items():
+        assert getattr(datum2, key) == expected_value, f"Issue with {key}"
 
-   identical = resqpy.well.MdDatum(parent_model = model2, crs_uuid = datum2.crs_uuid, **data)
-   data['md_reference'] = 'kelly bushing'
-   different = resqpy.well.MdDatum(parent_model = model2, crs_uuid = datum2.crs_uuid, **data)
-   assert identical == datum2
-   assert different != datum2
+    identical = resqpy.well.MdDatum(parent_model = model2, crs_uuid = datum2.crs_uuid, **data)
+    data['md_reference'] = 'kelly bushing'
+    different = resqpy.well.MdDatum(parent_model = model2, crs_uuid = datum2.crs_uuid, **data)
+    assert identical == datum2
+    assert different != datum2
 
 
 def test_trajectory_iterators(example_model_with_well):
-   # Test that trajectories can be found via iterators
+    # Test that trajectories can be found via iterators
 
-   model, well_interp, datum, traj = example_model_with_well
+    model, well_interp, datum, traj = example_model_with_well
 
-   # Iterate via wells
-   uuids_1 = []
-   for well in model.iter_wellbore_interpretations():
-      for traj in well.iter_trajectories():
-         uuids_1.append(traj.uuid)
+    # Iterate via wells
+    uuids_1 = []
+    for well in model.iter_wellbore_interpretations():
+        for traj in well.iter_trajectories():
+            uuids_1.append(traj.uuid)
 
-   # Iterate directly
-   uuids_2 = []
-   for traj in model.iter_trajectories():
-      uuids_2.append(traj.uuid)
+    # Iterate directly
+    uuids_2 = []
+    for traj in model.iter_trajectories():
+        uuids_2.append(traj.uuid)
 
-   # Two sets of trajectories should match, assuming all trajectories have a parent well
-   assert len(uuids_1) > 0
-   assert sorted(uuids_1) == sorted(uuids_2)
+    # Two sets of trajectories should match, assuming all trajectories have a parent well
+    assert len(uuids_1) > 0
+    assert sorted(uuids_1) == sorted(uuids_2)
 
 
 def test_logs(example_model_with_logs):
 
-   model, well_interp, datum, traj, frame, log_collection = example_model_with_logs
+    model, well_interp, datum, traj, frame, log_collection = example_model_with_logs
 
-   # Check logs can be extracted from resqml dataset
+    # Check logs can be extracted from resqml dataset
 
-   # Check exactly one wellbore frame exists in the model
-   discovered_frames = 0
-   for trajectory in model.iter_trajectories():
-      for frame in trajectory.iter_wellbore_frames():
-         discovered_frames += 1
-   assert discovered_frames == 1
+    # Check exactly one wellbore frame exists in the model
+    discovered_frames = 0
+    for trajectory in model.iter_trajectories():
+        for frame in trajectory.iter_wellbore_frames():
+            discovered_frames += 1
+    assert discovered_frames == 1
 
-   # Check MDs
-   mds = frame.node_mds
-   assert isinstance(mds, np.ndarray)
-   assert_array_almost_equal(mds, [1, 2, 3, 4])
+    # Check MDs
+    mds = frame.node_mds
+    assert isinstance(mds, np.ndarray)
+    assert_array_almost_equal(mds, [1, 2, 3, 4])
 
-   # Check logs
-   log_list = list(log_collection.iter_logs())
-   assert len(log_list) == 2
+    # Check logs
+    log_list = list(log_collection.iter_logs())
+    assert len(log_list) == 2
 
-   # TODO: would be nice to write: log_collection.get_curve("GR")
-   gr = log_list[0]
-   assert gr.title == "GR"
-   assert gr.uom == "gAPI"
-   assert_array_almost_equal(gr.values(), [1, 2, 1, 2])
+    # TODO: would be nice to write: log_collection.get_curve("GR")
+    gr = log_list[0]
+    assert gr.title == "GR"
+    assert gr.uom == "gAPI"
+    assert_array_almost_equal(gr.values(), [1, 2, 1, 2])
 
-   nphi = log_list[1]
-   assert nphi.title == 'NPHI'
+    nphi = log_list[1]
+    assert nphi.title == 'NPHI'
 
-   # TODO: get more units working
-   # assert nphi.uom == "v/v"
-   assert_array_almost_equal(nphi.values(), [0.1, 0.1, np.NaN, np.NaN])
+    # TODO: get more units working
+    # assert nphi.uom == "v/v"
+    assert_array_almost_equal(nphi.values(), [0.1, 0.1, np.NaN, np.NaN])
 
 
 def test_logs_conversion(example_model_with_logs):
 
-   model, well_interp, datum, traj, frame, log_collection = example_model_with_logs
+    model, well_interp, datum, traj, frame, log_collection = example_model_with_logs
 
-   # Pandas
-   df = log_collection.to_df()
-   df_expected = pd.DataFrame(data = {"GR": [1, 2, 1, 2], "NPHI": [0.1, 0.1, np.NaN, np.NaN]}, index = [1, 2, 3, 4])
-   assert_frame_equal(df_expected, df, check_dtype = False)
+    # Pandas
+    df = log_collection.to_df()
+    df_expected = pd.DataFrame(data = {"GR": [1, 2, 1, 2], "NPHI": [0.1, 0.1, np.NaN, np.NaN]}, index = [1, 2, 3, 4])
+    assert_frame_equal(df_expected, df, check_dtype = False)
 
-   # LAS
-   las = log_collection.to_las()
-   assert las.well.WELL.value == 'well A'
+    # LAS
+    las = log_collection.to_las()
+    assert las.well.WELL.value == 'well A'
 
-   gr = las.get_curve("GR")
-   assert gr.unit.casefold() == "GAPI".casefold()
-   assert_array_almost_equal(gr.data, [1, 2, 1, 2])
+    gr = las.get_curve("GR")
+    assert gr.unit.casefold() == "GAPI".casefold()
+    assert_array_almost_equal(gr.data, [1, 2, 1, 2])
 
-   nphi = las.get_curve("NPHI")
-   # assert nphi.unit == "GAPI"
-   assert_array_almost_equal(nphi.data, [0.1, 0.1, np.NaN, np.NaN])
+    nphi = las.get_curve("NPHI")
+    # assert nphi.unit == "GAPI"
+    assert_array_almost_equal(nphi.data, [0.1, 0.1, np.NaN, np.NaN])
 
 
 # Trajectory
@@ -130,180 +130,180 @@ def test_logs_conversion(example_model_with_logs):
 
 def test_Trajectory_add_well_feature_and_interp(example_model_and_crs):
 
-   # Prepare an example Trajectory without a well feature
-   wellname = "Hullabaloo"
-   model, crs = example_model_and_crs
-   datum = resqpy.well.MdDatum(parent_model = model,
-                               crs_uuid = crs.uuid,
-                               location = (0, 0, -100),
-                               md_reference = 'kelly bushing')
-   datum.create_xml()
-   traj = resqpy.well.Trajectory(parent_model = model, md_datum = datum, well_name = wellname)
+    # Prepare an example Trajectory without a well feature
+    wellname = "Hullabaloo"
+    model, crs = example_model_and_crs
+    datum = resqpy.well.MdDatum(parent_model = model,
+                                crs_uuid = crs.uuid,
+                                location = (0, 0, -100),
+                                md_reference = 'kelly bushing')
+    datum.create_xml()
+    traj = resqpy.well.Trajectory(parent_model = model, md_datum = datum, well_name = wellname)
 
-   # Add the well interp
-   assert traj.wellbore_feature is None
-   assert traj.wellbore_interpretation is None
-   traj.create_feature_and_interpretation()
+    # Add the well interp
+    assert traj.wellbore_feature is None
+    assert traj.wellbore_interpretation is None
+    traj.create_feature_and_interpretation()
 
-   # Check well is present
-   assert traj.wellbore_feature is not None
-   assert traj.wellbore_feature.feature_name == wellname
+    # Check well is present
+    assert traj.wellbore_feature is not None
+    assert traj.wellbore_feature.feature_name == wellname
 
 
 # Deviation Survey tests
 
 
 def test_DeviationSurvey(example_model_with_well, tmp_path):
-   # Test that all attrbutes are correctly saved and loaded from disk
+    # Test that all attrbutes are correctly saved and loaded from disk
 
-   # --------- Arrange ----------
-   # Create a Deviation Survey object in memory
+    # --------- Arrange ----------
+    # Create a Deviation Survey object in memory
 
-   # Load example model from a fixture
-   model, well_interp, datum, traj = example_model_with_well
-   epc_path = model.epc_file
+    # Load example model from a fixture
+    model, well_interp, datum, traj = example_model_with_well
+    epc_path = model.epc_file
 
-   # Create 3 copies of the survey, using different initialisers
-   data = dict(
-      title = 'Majestic Umlaut ö',
-      originator = 'Thor, god of sparkles',
-      md_uom = 'ft',
-      angle_uom = 'rad',
-      is_final = True,
-   )
-   array_data = dict(
-      measured_depths = np.array([1, 2, 3], dtype = float) + 1000.0,
-      azimuths = np.array([4, 5, 6], dtype = float),
-      inclinations = np.array([7, 8, 9], dtype = float),
-      first_station = np.array([0, -1, 999], dtype = float),
-   )
+    # Create 3 copies of the survey, using different initialisers
+    data = dict(
+        title = 'Majestic Umlaut ö',
+        originator = 'Thor, god of sparkles',
+        md_uom = 'ft',
+        angle_uom = 'rad',
+        is_final = True,
+    )
+    array_data = dict(
+        measured_depths = np.array([1, 2, 3], dtype = float) + 1000.0,
+        azimuths = np.array([4, 5, 6], dtype = float),
+        inclinations = np.array([7, 8, 9], dtype = float),
+        first_station = np.array([0, -1, 999], dtype = float),
+    )
 
-   survey = resqpy.well.DeviationSurvey(
-      parent_model = model,
-      represented_interp = well_interp,
-      md_datum = datum,
-      **data,
-      **array_data,
-   )
-   survey_uuid = survey.uuid
+    survey = resqpy.well.DeviationSurvey(
+        parent_model = model,
+        represented_interp = well_interp,
+        md_datum = datum,
+        **data,
+        **array_data,
+    )
+    survey_uuid = survey.uuid
 
-   df = pd.DataFrame(columns = ['MD', 'AZIM_GN', 'INCL', 'X', 'Y', 'Z'])
-   for col, key in zip(('MD', 'AZIM_GN', 'INCL'), ('measured_depths', 'azimuths', 'inclinations')):
-      df[col] = array_data[key]
-   for axis, col in enumerate(('X', 'Y', 'Z')):
-      df[col] = np.NaN
-      df.loc[0, col] = array_data['first_station'][axis]
+    df = pd.DataFrame(columns = ['MD', 'AZIM_GN', 'INCL', 'X', 'Y', 'Z'])
+    for col, key in zip(('MD', 'AZIM_GN', 'INCL'), ('measured_depths', 'azimuths', 'inclinations')):
+        df[col] = array_data[key]
+    for axis, col in enumerate(('X', 'Y', 'Z')):
+        df[col] = np.NaN
+        df.loc[0, col] = array_data['first_station'][axis]
 
-   survey_b = resqpy.well.DeviationSurvey.from_data_frame(parent_model = model,
-                                                          data_frame = df,
-                                                          md_datum = datum,
-                                                          md_uom = data['md_uom'],
-                                                          angle_uom = data['angle_uom'])
-   survey_b_uuid = survey_b.uuid
+    survey_b = resqpy.well.DeviationSurvey.from_data_frame(parent_model = model,
+                                                           data_frame = df,
+                                                           md_datum = datum,
+                                                           md_uom = data['md_uom'],
+                                                           angle_uom = data['angle_uom'])
+    survey_b_uuid = survey_b.uuid
 
-   csv_file = os.path.join(tmp_path, 'survey_c.csv')
-   df.to_csv(csv_file)
+    csv_file = os.path.join(tmp_path, 'survey_c.csv')
+    df.to_csv(csv_file)
 
-   survey_c = resqpy.well.DeviationSurvey.from_ascii_file(parent_model = model,
-                                                          deviation_survey_file = csv_file,
-                                                          md_datum = datum,
-                                                          md_uom = data['md_uom'],
-                                                          angle_uom = data['angle_uom'])
-   survey_c_uuid = survey_c.uuid
+    survey_c = resqpy.well.DeviationSurvey.from_ascii_file(parent_model = model,
+                                                           deviation_survey_file = csv_file,
+                                                           md_datum = datum,
+                                                           md_uom = data['md_uom'],
+                                                           angle_uom = data['angle_uom'])
+    survey_c_uuid = survey_c.uuid
 
-   # ----------- Act ---------
+    # ----------- Act ---------
 
-   # Save to disk
-   for s in (survey, survey_b, survey_c):
-      s.write_hdf5()
-      s.create_xml()
-   model.store_epc()
-   model.h5_release()
+    # Save to disk
+    for s in (survey, survey_b, survey_c):
+        s.write_hdf5()
+        s.create_xml()
+    model.store_epc()
+    model.h5_release()
 
-   # import shutil
-   # shutil.copy(epc_path, r'C:\Temp')
-   # shutil.copy(epc_path.replace('.epc', '.h5'), r'C:\Temp')
+    # import shutil
+    # shutil.copy(epc_path, r'C:\Temp')
+    # shutil.copy(epc_path.replace('.epc', '.h5'), r'C:\Temp')
 
-   # Clear memory
-   del model, well_interp, datum, traj, survey, survey_b, survey_c
+    # Clear memory
+    del model, well_interp, datum, traj, survey, survey_b, survey_c
 
-   # Reload from disk
-   model2 = Model(epc_file = epc_path)
-   survey2 = resqpy.well.DeviationSurvey(model2, uuid = survey_uuid)
-   survey_b2 = resqpy.well.DeviationSurvey(model2, uuid = survey_b_uuid)
-   survey_c2 = resqpy.well.DeviationSurvey(model2, uuid = survey_c_uuid)
+    # Reload from disk
+    model2 = Model(epc_file = epc_path)
+    survey2 = resqpy.well.DeviationSurvey(model2, uuid = survey_uuid)
+    survey_b2 = resqpy.well.DeviationSurvey(model2, uuid = survey_b_uuid)
+    survey_c2 = resqpy.well.DeviationSurvey(model2, uuid = survey_c_uuid)
 
-   # --------- Assert --------------
-   # Check all attributes were loaded from disk correctly
+    # --------- Assert --------------
+    # Check all attributes were loaded from disk correctly
 
-   for key, expected_value in data.items():
-      assert getattr(survey2, key) == expected_value, f"Error for {key}"
-      if 'uom' in key:
-         for s in (survey_b2, survey_c2):
-            assert getattr(s, key) == expected_value, f"Error for {key}"
+    for key, expected_value in data.items():
+        assert getattr(survey2, key) == expected_value, f"Error for {key}"
+        if 'uom' in key:
+            for s in (survey_b2, survey_c2):
+                assert getattr(s, key) == expected_value, f"Error for {key}"
 
-   for s in (survey2, survey_b2, survey_c2):
-      for key, expected_value in array_data.items():
-         assert_array_almost_equal(getattr(s, key), expected_value, err_msg = f"Error for {key}")
-      assert s.station_count == len(array_data['azimuths'])
+    for s in (survey2, survey_b2, survey_c2):
+        for key, expected_value in array_data.items():
+            assert_array_almost_equal(getattr(s, key), expected_value, err_msg = f"Error for {key}")
+        assert s.station_count == len(array_data['azimuths'])
 
 
 # BlockedWell
 
 
 def test_wellspec_properties(example_model_and_crs):
-   model, crs = example_model_and_crs
-   grid = RegularGrid(model,
-                      extent_kji = (3, 4, 3),
-                      dxyz = (50.0, -50.0, 50.0),
-                      origin = (0.0, 0.0, 100.0),
-                      crs_uuid = crs.uuid,
-                      set_points_cached = True)
-   grid.write_hdf5()
-   grid.create_xml(write_geometry = True)
-   wellspec_file = os.path.join(model.epc_directory, 'wellspec.dat')
-   well_name = 'DOGLEG'
-   source_df = pd.DataFrame([[2, 2, 1, 0.0, 0.0, 0.0, 0.25], [2, 2, 2, 0.45, -90.0, 2.5, 0.25],
-                             [2, 3, 2, 0.45, -90.0, 1.0, 0.20], [2, 3, 3, 0.0, 0.0, -0.5, 0.20]],
-                            columns = ['IW', 'JW', 'L', 'ANGLV', 'ANGLA', 'SKIN', 'RADW'])
-   with open(wellspec_file, 'w') as fp:
-      fp.write(F'WELLSPEC {well_name}\n')
-      for col in source_df.columns:
-         fp.write(f' {col:>6s}')
-      fp.write('\n')
-      for row_index in range(len(source_df)):
-         row = source_df.iloc[row_index]
-         for col in source_df.columns:
-            if col in ['IW', 'JW', 'L']:
-               fp.write(f' {int(row[col]):6d}')
-            else:
-               fp.write(f' {row[col]:6.2f}')
-         fp.write('\n')
-   bw = resqpy.well.BlockedWell(model,
-                                wellspec_file = wellspec_file,
-                                well_name = well_name,
-                                use_face_centres = True,
-                                add_wellspec_properties = True)
-   assert bw is not None
-   bw_uuid = bw.uuid
-   skin_uuid = model.uuid(title = 'SKIN', related_uuid = bw.uuid)
-   assert skin_uuid is not None
-   skin_prop = Property(model, uuid = skin_uuid)
-   assert skin_prop is not None
-   assert_array_almost_equal(skin_prop.array_ref(), [0.0, 2.5, 1.0, -0.5])
-   model.store_epc()
-   # re-open model from persistent storage
-   model = Model(model.epc_file)
-   bw2_uuid = model.uuid(obj_type = 'BlockedWellboreRepresentation', title = 'DOGLEG')
-   assert bw2_uuid is not None
-   bw2 = resqpy.well.BlockedWell(model, uuid = bw2_uuid)
-   assert bu.matching_uuids(bw_uuid, bw2_uuid)
-   df2 = bw.dataframe(extra_columns_list = ['ANGLV', 'ANGLA', 'LENGTH', 'SKIN', 'RADW'], use_properties = True)
-   assert df2 is not None
-   assert len(df2.columns) == 8
-   for col in ['ANGLV', 'ANGLA', 'SKIN', 'RADW']:
-      assert_array_almost_equal(np.array(source_df[col]), np.array(df2[col]))
-   df3 = bw.dataframe(extra_columns_list = ['ANGLV', 'ANGLA', 'LENGTH', 'SKIN', 'RADW'],
-                      use_properties = ['SKIN', 'RADW'])
-   for col in ['SKIN', 'RADW']:
-      assert_array_almost_equal(np.array(source_df[col]), np.array(df3[col]))
+    model, crs = example_model_and_crs
+    grid = RegularGrid(model,
+                       extent_kji = (3, 4, 3),
+                       dxyz = (50.0, -50.0, 50.0),
+                       origin = (0.0, 0.0, 100.0),
+                       crs_uuid = crs.uuid,
+                       set_points_cached = True)
+    grid.write_hdf5()
+    grid.create_xml(write_geometry = True)
+    wellspec_file = os.path.join(model.epc_directory, 'wellspec.dat')
+    well_name = 'DOGLEG'
+    source_df = pd.DataFrame([[2, 2, 1, 0.0, 0.0, 0.0, 0.25], [2, 2, 2, 0.45, -90.0, 2.5, 0.25],
+                              [2, 3, 2, 0.45, -90.0, 1.0, 0.20], [2, 3, 3, 0.0, 0.0, -0.5, 0.20]],
+                             columns = ['IW', 'JW', 'L', 'ANGLV', 'ANGLA', 'SKIN', 'RADW'])
+    with open(wellspec_file, 'w') as fp:
+        fp.write(F'WELLSPEC {well_name}\n')
+        for col in source_df.columns:
+            fp.write(f' {col:>6s}')
+        fp.write('\n')
+        for row_index in range(len(source_df)):
+            row = source_df.iloc[row_index]
+            for col in source_df.columns:
+                if col in ['IW', 'JW', 'L']:
+                    fp.write(f' {int(row[col]):6d}')
+                else:
+                    fp.write(f' {row[col]:6.2f}')
+            fp.write('\n')
+    bw = resqpy.well.BlockedWell(model,
+                                 wellspec_file = wellspec_file,
+                                 well_name = well_name,
+                                 use_face_centres = True,
+                                 add_wellspec_properties = True)
+    assert bw is not None
+    bw_uuid = bw.uuid
+    skin_uuid = model.uuid(title = 'SKIN', related_uuid = bw.uuid)
+    assert skin_uuid is not None
+    skin_prop = Property(model, uuid = skin_uuid)
+    assert skin_prop is not None
+    assert_array_almost_equal(skin_prop.array_ref(), [0.0, 2.5, 1.0, -0.5])
+    model.store_epc()
+    # re-open model from persistent storage
+    model = Model(model.epc_file)
+    bw2_uuid = model.uuid(obj_type = 'BlockedWellboreRepresentation', title = 'DOGLEG')
+    assert bw2_uuid is not None
+    bw2 = resqpy.well.BlockedWell(model, uuid = bw2_uuid)
+    assert bu.matching_uuids(bw_uuid, bw2_uuid)
+    df2 = bw.dataframe(extra_columns_list = ['ANGLV', 'ANGLA', 'LENGTH', 'SKIN', 'RADW'], use_properties = True)
+    assert df2 is not None
+    assert len(df2.columns) == 8
+    for col in ['ANGLV', 'ANGLA', 'SKIN', 'RADW']:
+        assert_array_almost_equal(np.array(source_df[col]), np.array(df2[col]))
+    df3 = bw.dataframe(extra_columns_list = ['ANGLV', 'ANGLA', 'LENGTH', 'SKIN', 'RADW'],
+                       use_properties = ['SKIN', 'RADW'])
+    for col in ['SKIN', 'RADW']:
+        assert_array_almost_equal(np.array(source_df[col]), np.array(df3[col]))


### PR DESCRIPTION
As I am he only person in the known universe who finds 3 space indentation infinitely more beautiful than 4 space, I am finally yielding to requests from beleaguered colleagues to abandon the holy trinity.  This change modifies the yapf indentation to 4 space.  A sad day for individual creative expression in the world of programming.

As PEP8 also includes the totally unreadable lack of spaces around=in argument lists, this change does not include a move to a different auto formatter, which I will continue to argue against.