### PR TITLE
Bulk fix docstrings with docformatter

### DIFF
--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -1,4 +1,4 @@
-""" RESQML manipulation library
+"""RESQML manipulation library.
 
 .. autosummary::
     :toctree: _autosummary
@@ -23,7 +23,6 @@
     weights_and_measures
     well
     olio
-
 """
 
 try:

--- a/resqpy/crs.py
+++ b/resqpy/crs.py
@@ -27,7 +27,7 @@ PointType = Union[Tuple[float, float, float], List[float], np.ndarray]
 
 
 class Crs(BaseResqpy):
-    """ Coordinate reference system object """
+    """Coordinate reference system object."""
 
     @property
     def resqml_type(self):
@@ -56,43 +56,43 @@ class Crs(BaseResqpy):
             extra_metadata: Optional[Dict[str, str]] = None):
         """Create a new coordinate reference system object.
 
-      arguments:
-         parent_model (model.Model): the model to which the new Crs object will belong
-         crs_root (xml root node): DEPRECATED – use uuid instead; the xml root node for an existing RESQML crs object
-         crs_uuid (uuid.UUID): the uuid of an existing RESQML crs object in model, from which to instantiate the
-            resqpy Crs object; if present, all the remaining arguments are ignored
-         x_offset, y_offset, z_offset (floats, default zero): the local origin within an implicit parent crs
-         rotation (float, default zero): a projected view rotation (in the xy plane), in radians, relative to an
-            implicit parent crs
-         xy_units (str, default 'm'): the units applicable to x & y values; must be one of the RESQML length uom strings
-         z_units (str, default 'm'): the units applicable to z depth values; must be one of the RESQML length uom strings
-         z_inc_down (boolean, default True): if True, increasing z values indicate greater depth (ie. in direction of
-            gravity); if False, increasing z values indicate greater elevation
-         axis_order (str, default 'easting northing'): the compass directions of the positive x and y axes respectively
-         time_units (str, optional): if present, the time units of the z values (for seismic datasets), in which case the
-            z_units argument is irrelevant
-         epsg_code (str, optional): if present, the EPSG code of the implicit parent crs
-         title (str, optional): the citation title to use for a new crs;
-            ignored if uuid or crs_root is not None
-         originator (str, optional): the name of the person creating the crs, defaults to login id;
-            ignored if uuid or crs_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the crs;
-            ignored if uuid or crs_root is not None
+        arguments:
+            parent_model (model.Model): the model to which the new Crs object will belong
+            crs_root (xml root node): DEPRECATED – use uuid instead; the xml root node for an existing RESQML crs object
+            crs_uuid (uuid.UUID): the uuid of an existing RESQML crs object in model, from which to instantiate the
+                resqpy Crs object; if present, all the remaining arguments are ignored
+            x_offset, y_offset, z_offset (floats, default zero): the local origin within an implicit parent crs
+            rotation (float, default zero): a projected view rotation (in the xy plane), in radians, relative to an
+                implicit parent crs
+            xy_units (str, default 'm'): the units applicable to x & y values; must be one of the RESQML length uom strings
+            z_units (str, default 'm'): the units applicable to z depth values; must be one of the RESQML length uom strings
+            z_inc_down (boolean, default True): if True, increasing z values indicate greater depth (ie. in direction of
+                gravity); if False, increasing z values indicate greater elevation
+            axis_order (str, default 'easting northing'): the compass directions of the positive x and y axes respectively
+            time_units (str, optional): if present, the time units of the z values (for seismic datasets), in which case the
+                z_units argument is irrelevant
+            epsg_code (str, optional): if present, the EPSG code of the implicit parent crs
+            title (str, optional): the citation title to use for a new crs;
+                ignored if uuid or crs_root is not None
+            originator (str, optional): the name of the person creating the crs, defaults to login id;
+                ignored if uuid or crs_root is not None
+            extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the crs;
+                ignored if uuid or crs_root is not None
 
-      returns:
-         a new resqpy Crs object
+        returns:
+            a new resqpy Crs object
 
-      notes:
-         although resqpy does not have full support for identifying a parent crs, the modifiers such as a local origin
-         may be used on the assumption that all crs objects refer to the same implicit parent crs;
-         there are two equivalent RESQML classes and which one is generated depends on whether the time_units argument
-         is used, when instantiating from values;
-         it is strongly encourage to call the create_xml() method immediately after instantiation (unless the resqpy
-         crs is a temporary object) as the uuid may be modified at that point to re-use any existing equivalent RESQML
-         crs object in the model
+        notes:
+            although resqpy does not have full support for identifying a parent crs, the modifiers such as a local origin
+            may be used on the assumption that all crs objects refer to the same implicit parent crs;
+            there are two equivalent RESQML classes and which one is generated depends on whether the time_units argument
+            is used, when instantiating from values;
+            it is strongly encourage to call the create_xml() method immediately after instantiation (unless the resqpy
+            crs is a temporary object) as the uuid may be modified at that point to re-use any existing equivalent RESQML
+            crs object in the model
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         self.xy_units = xy_units
         self.z_units = z_units
@@ -257,8 +257,8 @@ class Crs(BaseResqpy):
     def convert_to(self, other_crs: 'Crs', xyz: PointType) -> Tuple[float, float, float]:
         """Converts a single xyz point from this coordinate reference system to the other.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self is other_crs:
             return _as_xyz_tuple(xyz)
@@ -273,8 +273,8 @@ class Crs(BaseResqpy):
     def convert_array_to(self, other_crs: 'Crs', xyz: np.ndarray):
         """Converts in situ a numpy array of xyz points from this coordinate reference system to the other.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.is_equivalent(other_crs):
             return
@@ -291,8 +291,8 @@ class Crs(BaseResqpy):
     def convert_from(self, other_crs: 'Crs', xyz: PointType) -> Tuple[float, float, float]:
         """Converts a single xyz point from the other coordinate reference system to this one.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self is other_crs:
             return _as_xyz_tuple(xyz)
@@ -307,8 +307,8 @@ class Crs(BaseResqpy):
     def convert_array_from(self, other_crs: 'Crs', xyz: np.ndarray):
         """Converts in situ a numpy array of xyz points from the other coordinate reference system to this one.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.is_equivalent(other_crs):
             return
@@ -332,30 +332,30 @@ class Crs(BaseResqpy):
             reuse: bool = True):
         """Creates a Coordinate Reference System xml node and optionally adds as a part in the parent model.
 
-      arguments:
-         title (string, optional): used as the Title text in the citation node
-         originator (string, optional): the name of the human being who created the crs object;
-            default is to use the login name
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the crs
-         add_as_part (boolean, default True): if True the newly created crs node is added to the model
-            as a part
-         root (optional, usually None): DEPRECATED; if not None, the newly created crs node is appended
-            as a child of this node (rarely used)
-         reuse (boolean, default True): if True and an equivalent crs already exists in the model then
-            the uuid for this Crs is modified to match that of the existing object and the existing
-            xml node is returned without anything new being added
+        arguments:
+            title (string, optional): used as the Title text in the citation node
+            originator (string, optional): the name of the human being who created the crs object;
+                default is to use the login name
+            extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the crs
+            add_as_part (boolean, default True): if True the newly created crs node is added to the model
+                as a part
+            root (optional, usually None): DEPRECATED; if not None, the newly created crs node is appended
+                as a child of this node (rarely used)
+            reuse (boolean, default True): if True and an equivalent crs already exists in the model then
+                the uuid for this Crs is modified to match that of the existing object and the existing
+                xml node is returned without anything new being added
 
-      returns:
-         newly created (or reused) coordinate reference system xml node
+        returns:
+            newly created (or reused) coordinate reference system xml node
 
-      notes:
-         if the reuse argument is True, it is strongly recommended to call this method immediately after
-         a new Crs has been instantiated from explicit values, as the uuid may be modified here;
-         if reuse is True, the title is not regarded as important and a match with an existing object
-         may occur even if the titles differ
+        notes:
+            if the reuse argument is True, it is strongly recommended to call this method immediately after
+            a new Crs has been instantiated from explicit values, as the uuid may be modified here;
+            if reuse is True, the title is not regarded as important and a match with an existing object
+            may occur even if the titles differ
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if reuse and self.try_reuse():
             return self.root  # check for reusable (equivalent) object
@@ -440,12 +440,12 @@ class Crs(BaseResqpy):
 
     @property
     def crs_root(self):
-        """DEPRECATED. Alias for root"""
+        """DEPRECATED alias for root."""
         warnings.warn("Attribute 'crs_root' is deprecated. Use 'root'", DeprecationWarning)
         return self.root
 
 
 def _as_xyz_tuple(xyz):
-    """Coerce into 3-tuple of floats"""
+    """Coerce into 3-tuple of floats."""
 
     return tuple(float(xyz[0]), float(xyz[1]), float(xyz[2]))

--- a/resqpy/derived_model.py
+++ b/resqpy/derived_model.py
@@ -60,25 +60,25 @@ def _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_r
 def zone_layer_ranges_from_array(zone_array, min_k0 = 0, max_k0 = None, use_dominant_zone = False):
     """Returns a list of (zone_min_k0, zone_max_k0, zone_index) derived from zone_array.
 
-   arguments:
-      zone_array (3D numpy int array or masked array): array holding zone index value per cell
-      min_k0 (int, default 0): the minimum layer number (0 based) to be included in the ranges
-      max_k0 (int, default None): the maximum layer number (0 based) to be included in the ranges;
-         note that this layer is included (unlike in python ranges); if None, the maximum layer
-         number in zone_array is used
-      use_dominant_zone (boolean, default False): if True, the most common zone value in each layer is used for the whole
-         layer; if False, then variation of zone values in active cells in a layer will raise an assertion error
+    arguments:
+       zone_array (3D numpy int array or masked array): array holding zone index value per cell
+       min_k0 (int, default 0): the minimum layer number (0 based) to be included in the ranges
+       max_k0 (int, default None): the maximum layer number (0 based) to be included in the ranges;
+          note that this layer is included (unlike in python ranges); if None, the maximum layer
+          number in zone_array is used
+       use_dominant_zone (boolean, default False): if True, the most common zone value in each layer is used for the whole
+          layer; if False, then variation of zone values in active cells in a layer will raise an assertion error
 
-   returns:
-      a list of (int, int, int) being (zone_min_k0, zone_max_k0, zone_index) for each zone index value present
+    returns:
+       a list of (int, int, int) being (zone_min_k0, zone_max_k0, zone_index) for each zone index value present
 
-   notes:
-      the function requires zone indices (for active cells, if zone_array is masked) within a layer
-      to be consistent: an assertion error is raised otherwise; the returned list is sorted by layer
-      ranges rather than zone index; if use_dominant_zone is True then a side effect of the function is
-      to modify the values in zone_array to be consistent across each layer, effectively reassigning some
-      cells to a different zone!
-   """
+    notes:
+       the function requires zone indices (for active cells, if zone_array is masked) within a layer
+       to be consistent: an assertion error is raised otherwise; the returned list is sorted by layer
+       ranges rather than zone index; if use_dominant_zone is True then a side effect of the function is
+       to modify the values in zone_array to be consistent across each layer, effectively reassigning some
+       cells to a different zone!
+    """
 
     def dominant_zone(zone_array):
         # modifies data in zone_array such that each layer has a single (most common) value
@@ -148,30 +148,30 @@ def add_zone_by_layer_property(epc_file,
                                extra_metadata = {}):
     """Adds a discrete zone property (and local property kind) with indexable element of layers.
 
-   arguments:
-      epc_file (string): file name to load resqml model from and to update with the zonal property
-      grid_uuid (uuid.UUID or str, optional): required unless the model has only one grid, or one named ROOT
-      zone_by_layer_vector (nk integers, optional): either this or zone_by_cell_property_uuid must be given;
-         a 1D numpy array, tuple or list of ints, being the zone number to which each layer belongs
-      zone_by_cell_property_uuid (uuid.UUID or str, optional): either this or zone_by_layer_vector must be given;
-         the uuid of a discrete property with grid as supporting representation and cells as indexable elements,
-         holidng the zone to which the cell belongs
-      use_dominant_zone (boolean, default False): if True and more than one zone is represented within the cells
-         of a layer, then the whole layer is assigned to the zone with the biggest count of cells in the layer;
-         if False, an exception is raised if more than one zone is represented by the cells of a layer; ignored
-         if zone_by_cell_property_uuid is None
-      use_local_property_kind (boolean, default True): if True, the new zone by layer property is given a
-         local property kind titled 'zone'; if False, the property kind will be set to 'discrete'
-      null_value (int, default -1): the value to use if a layer does not belong to any zone (rarely used)
-      title (str, default 'ZONE'): the citation title of the new zone by layer property
-      realization (int, optional): if present the new zone by layer property is marked as belonging to this
-         realization
-      extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
-         property
+    arguments:
+       epc_file (string): file name to load resqml model from and to update with the zonal property
+       grid_uuid (uuid.UUID or str, optional): required unless the model has only one grid, or one named ROOT
+       zone_by_layer_vector (nk integers, optional): either this or zone_by_cell_property_uuid must be given;
+          a 1D numpy array, tuple or list of ints, being the zone number to which each layer belongs
+       zone_by_cell_property_uuid (uuid.UUID or str, optional): either this or zone_by_layer_vector must be given;
+          the uuid of a discrete property with grid as supporting representation and cells as indexable elements,
+          holidng the zone to which the cell belongs
+       use_dominant_zone (boolean, default False): if True and more than one zone is represented within the cells
+          of a layer, then the whole layer is assigned to the zone with the biggest count of cells in the layer;
+          if False, an exception is raised if more than one zone is represented by the cells of a layer; ignored
+          if zone_by_cell_property_uuid is None
+       use_local_property_kind (boolean, default True): if True, the new zone by layer property is given a
+          local property kind titled 'zone'; if False, the property kind will be set to 'discrete'
+       null_value (int, default -1): the value to use if a layer does not belong to any zone (rarely used)
+       title (str, default 'ZONE'): the citation title of the new zone by layer property
+       realization (int, optional): if present the new zone by layer property is marked as belonging to this
+          realization
+       extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
+          property
 
-   returns:
-      numpy vector of zone numbers (by layer), uuid of newly created property
-   """
+    returns:
+       numpy vector of zone numbers (by layer), uuid of newly created property
+    """
 
     assert zone_by_layer_vector is not None or zone_by_cell_property_uuid is not None
     assert zone_by_layer_vector is None or zone_by_cell_property_uuid is None
@@ -259,43 +259,43 @@ def add_one_grid_property_array(epc_file,
                                 new_epc_file = None):
     """Adds a grid property from a numpy array to an existing resqml dataset.
 
-   arguments:
-      epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
-      a (3D numpy array): the property array to be added to the model; for a constant array set this None
-         and use the const_value argument, otherwise this array is required
-      property_kind (string): the resqml property kind
-      grid_uuid (uuid object or string, optional): the uuid of the grid to which the property relates;
-         if None, the property is attached to the 'main' grid
-      source_info (string): typically the name of a file from which the array has been read but can be any
-         information regarding the source of the data
-      title (string): this will be used as the citation title when a part is generated for the array; for simulation
-         models it is desirable to use the simulation keyword when appropriate
-      discrete (boolean, default False): if True, the array should contain integer (or boolean) data; if False, float
-      uom (string, default None): the resqml units of measure for the data; not relevant to discrete data
-      time_index (integer, default None): if not None, the time index to be used when creating a part for the array
-      time_series_uuid (uuid object or string, default None): required if time_index is not None
-      string_lookup_uuid (uuid object or string, optional): required if the array is to be stored as a categorical
-         property; set to None for non-categorical discrete data; only relevant if discrete is True
-      null_value (int, default None): if present, this is used in the metadata to indicate that this value
-         is to be interpreted as a null value wherever it appears in the data (use for discrete data only)
-      indexable_element (string, default 'cells'): the indexable element in the supporting representation (the grid)
-      facet_type (string): resqml facet type, or None
-      facet (string): resqml facet, or None
-      realization (int): realization number, or None
-      local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
-      count_per_element (int, default 1): the number of values per indexable element; if greater than one then this
-         must be the fastest cycling axis in the cached array, ie last index
-      const_value (float or int, optional): if present, a constant array is added 'filled' with this value, in which
-         case argument a should be None
-      points (bool, default False): if True, this is a points property with an extra dimension of extent 3
-      extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
-         property
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
-         a new epc file (& associated h5 file) is created to contain a copy of the grid and the new property
+    arguments:
+       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
+       a (3D numpy array): the property array to be added to the model; for a constant array set this None
+          and use the const_value argument, otherwise this array is required
+       property_kind (string): the resqml property kind
+       grid_uuid (uuid object or string, optional): the uuid of the grid to which the property relates;
+          if None, the property is attached to the 'main' grid
+       source_info (string): typically the name of a file from which the array has been read but can be any
+          information regarding the source of the data
+       title (string): this will be used as the citation title when a part is generated for the array; for simulation
+          models it is desirable to use the simulation keyword when appropriate
+       discrete (boolean, default False): if True, the array should contain integer (or boolean) data; if False, float
+       uom (string, default None): the resqml units of measure for the data; not relevant to discrete data
+       time_index (integer, default None): if not None, the time index to be used when creating a part for the array
+       time_series_uuid (uuid object or string, default None): required if time_index is not None
+       string_lookup_uuid (uuid object or string, optional): required if the array is to be stored as a categorical
+          property; set to None for non-categorical discrete data; only relevant if discrete is True
+       null_value (int, default None): if present, this is used in the metadata to indicate that this value
+          is to be interpreted as a null value wherever it appears in the data (use for discrete data only)
+       indexable_element (string, default 'cells'): the indexable element in the supporting representation (the grid)
+       facet_type (string): resqml facet type, or None
+       facet (string): resqml facet, or None
+       realization (int): realization number, or None
+       local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
+       count_per_element (int, default 1): the number of values per indexable element; if greater than one then this
+          must be the fastest cycling axis in the cached array, ie last index
+       const_value (float or int, optional): if present, a constant array is added 'filled' with this value, in which
+          case argument a should be None
+       points (bool, default False): if True, this is a points property with an extra dimension of extent 3
+       extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
+          property
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
+          a new epc file (& associated h5 file) is created to contain a copy of the grid and the new property
 
-   returns:
-      uuid.UUID of newly created property object
-   """
+    returns:
+       uuid.UUID of newly created property object
+    """
 
     if new_epc_file and epc_file and (
         (new_epc_file == epc_file) or
@@ -387,40 +387,40 @@ def add_one_blocked_well_property(epc_file,
                                   new_epc_file = None):
     """Adds a blocked well property from a numpy array to an existing resqml dataset.
 
-   arguments:
-      epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
-      a (1D numpy array): the blocked well property array to be added to the model
-      property_kind (string): the resqml property kind
-      blocked_well_uuid (uuid object or string): the uuid of the blocked well to which the property relates
-      source_info (string): typically the name of a file from which the array has been read but can be any
-         information regarding the source of the data
-      title (string): this will be used as the citation title when a part is generated for the array
-      discrete (boolean, default False): if True, the array should contain integer (or boolean) data; if False, float
-      uom (string, default None): the resqml units of measure for the data; not relevant to discrete data
-      time_index (integer, default None): if not None, the time index to be used when creating a part for the array
-      time_series_uuid (uuid object or string, default None): required if time_index is not None
-      string_lookup_uuid (uuid object or string, optional): required if the array is to be stored as a categorical
-         property; set to None for non-categorical discrete data; only relevant if discrete is True
-      null_value (int, default None): if present, this is used in the metadata to indicate that this value
-         is to be interpreted as a null value wherever it appears in the data (use for discrete data only)
-      indexable_element (string, default 'cells'): the indexable element in the supporting representation (the blocked well);
-         valid values are 'cells', 'intervals' (which includes unblocked intervals), or 'nodes'
-      facet_type (string): resqml facet type, or None
-      facet (string): resqml facet, or None
-      realization (int): realization number, or None
-      local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
-      count_per_element (int, default 1): the number of values per indexable element; if greater than one then this
-         must be the fastest cycling axis in the cached array, ie last index; if greater than 1 then a must be a 2D array
-      points (bool, default False): if True, this is a points property with an extra dimension of extent 3
-      extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
-         property
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
-         a new epc file (& associated h5 file) is created to contain a copy of the blocked well (and dependencies) and
-         the new property
+    arguments:
+       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
+       a (1D numpy array): the blocked well property array to be added to the model
+       property_kind (string): the resqml property kind
+       blocked_well_uuid (uuid object or string): the uuid of the blocked well to which the property relates
+       source_info (string): typically the name of a file from which the array has been read but can be any
+          information regarding the source of the data
+       title (string): this will be used as the citation title when a part is generated for the array
+       discrete (boolean, default False): if True, the array should contain integer (or boolean) data; if False, float
+       uom (string, default None): the resqml units of measure for the data; not relevant to discrete data
+       time_index (integer, default None): if not None, the time index to be used when creating a part for the array
+       time_series_uuid (uuid object or string, default None): required if time_index is not None
+       string_lookup_uuid (uuid object or string, optional): required if the array is to be stored as a categorical
+          property; set to None for non-categorical discrete data; only relevant if discrete is True
+       null_value (int, default None): if present, this is used in the metadata to indicate that this value
+          is to be interpreted as a null value wherever it appears in the data (use for discrete data only)
+       indexable_element (string, default 'cells'): the indexable element in the supporting representation (the blocked well);
+          valid values are 'cells', 'intervals' (which includes unblocked intervals), or 'nodes'
+       facet_type (string): resqml facet type, or None
+       facet (string): resqml facet, or None
+       realization (int): realization number, or None
+       local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
+       count_per_element (int, default 1): the number of values per indexable element; if greater than one then this
+          must be the fastest cycling axis in the cached array, ie last index; if greater than 1 then a must be a 2D array
+       points (bool, default False): if True, this is a points property with an extra dimension of extent 3
+       extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
+          property
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
+          a new epc file (& associated h5 file) is created to contain a copy of the blocked well (and dependencies) and
+          the new property
 
-   returns:
-      uuid.UUID of newly created property object
-   """
+    returns:
+       uuid.UUID of newly created property object
+    """
 
     if new_epc_file and epc_file and (
         (new_epc_file == epc_file) or
@@ -481,38 +481,38 @@ def add_wells_from_ascii_file(epc_file,
                               new_epc_file = None):
     """Adds new md datum, trajectory, interpretation and feature objects for each well in a tabular ascii file..
 
-   arguments:
-      epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
-      crs_uuid (uuid.UUID): the unique identifier of the coordinate reference system applicable to the x,y,z data;
-         if None, a default crs will be created, making use of the length_uom and z_inc_down arguments
-      trajectory_file (string): the path of the ascii file holding the well trajectory data to be loaded
-      comment_character (string, default '#'): character deemed to introduce a comment in the trajectory file
-      space_separated_instead_of_csv (boolean, default False): if True, the columns in the trajectory file are space
-         separated; if False, comma separated
-      well_col (string, default 'WELL'): the heading for the column containing well names
-      md_col (string, default 'MD'): the heading for the column containing measured depths
-      x_col (string, default 'X'): the heading for the column containing X (usually easting) data
-      y_col (string, default 'Y'): the heading for the column containing Y (usually northing) data
-      z_col (string, default 'Z'): the heading for the column containing Z (depth or elevation) data
-      length_uom (string, default 'm'): the units of measure for the measured depths; should be 'm' or 'ft'
-      md_domain (string, optional): the source of the original deviation data; may be 'logger' or 'driller'
-      drilled (boolean, default False): True should be used for wells that have been drilled; False otherwise (planned,
-         proposed, or a location being studied)
-      z_inc_down (boolean, default True): indicates whether z values increase with depth; only used in the creation
-         of a default coordinate reference system; ignored if crs_uuid is not None
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
-         a new epc file (& associated h5 file) is created to contain a copy of the grid and the new property
+    arguments:
+       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
+       crs_uuid (uuid.UUID): the unique identifier of the coordinate reference system applicable to the x,y,z data;
+          if None, a default crs will be created, making use of the length_uom and z_inc_down arguments
+       trajectory_file (string): the path of the ascii file holding the well trajectory data to be loaded
+       comment_character (string, default '#'): character deemed to introduce a comment in the trajectory file
+       space_separated_instead_of_csv (boolean, default False): if True, the columns in the trajectory file are space
+          separated; if False, comma separated
+       well_col (string, default 'WELL'): the heading for the column containing well names
+       md_col (string, default 'MD'): the heading for the column containing measured depths
+       x_col (string, default 'X'): the heading for the column containing X (usually easting) data
+       y_col (string, default 'Y'): the heading for the column containing Y (usually northing) data
+       z_col (string, default 'Z'): the heading for the column containing Z (depth or elevation) data
+       length_uom (string, default 'm'): the units of measure for the measured depths; should be 'm' or 'ft'
+       md_domain (string, optional): the source of the original deviation data; may be 'logger' or 'driller'
+       drilled (boolean, default False): True should be used for wells that have been drilled; False otherwise (planned,
+          proposed, or a location being studied)
+       z_inc_down (boolean, default True): indicates whether z values increase with depth; only used in the creation
+          of a default coordinate reference system; ignored if crs_uuid is not None
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
+          a new epc file (& associated h5 file) is created to contain a copy of the grid and the new property
 
-   returns:
-      int: the number of wells added
+    returns:
+       int: the number of wells added
 
-   notes:
-      ascii file must be table with first line being column headers, with columns for WELL, MD, X, Y & Z;
-      actual column names can be set with optional arguments;
-      all the objects are added to the model, with array data being written to the hdf5 file for the trajectories;
-      the md_domain and drilled values are stored in the RESQML metadata but are only for human information and do not
-      generally affect computations
-   """
+    notes:
+       ascii file must be table with first line being column headers, with columns for WELL, MD, X, Y & Z;
+       actual column names can be set with optional arguments;
+       all the objects are added to the model, with array data being written to the hdf5 file for the trajectories;
+       the md_domain and drilled values are stored in the RESQML metadata but are only for human information and do not
+       generally affect computations
+    """
 
     assert trajectory_file and os.path.exists(trajectory_file)
     if md_domain:
@@ -570,34 +570,34 @@ def zonal_grid(epc_file,
                new_epc_file = None):
     """Extends an existing model with a new version of the source grid converted to a single, thick, layer per zone.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): a multi-layer RESQML grid object; if None, the epc_file is loaded
-         and it should contain one ijk grid object (or one 'ROOT' grid) which is used as the source grid
-      zone_title (string): if not None, a discrete property with this as the citation title is used as the zone property
-      zone_uuid (string or uuid): if not None, a discrete property with this uuid is used as the zone property (see notes)
-      zone_layer_range_list (list of (int, int, int)): each entry being (min_k0, max_k0, zone_index); alternative to
-         working from a zone array
-      k0_min (int, optional): the minimum layer number in the source grid (zero based) to include in the zonal version;
-         default is zero (ie. top layer in source grid)
-      k0_max (int, optional): the maximum layer number in the source grid (zero based) to include in the zonal version;
-         default is nk - 1 (ie. bottom layer in source grid)
-      use_dominant_zone (boolean, default False): if True, the most common zone value in each layer is used for the whole
-         layer; if False, then variation of zone values in active cells in a layer will raise an assertion error
-      inactive_laissez_faire (boolean, optional): if True, a cell in the zonal grid will be set active if any of the
-         corresponding cells in the source grid are active; otherwise all corresponding cells in the source grid
-         must be active for the zonal cell to be active; default is True
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the zonal grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): a multi-layer RESQML grid object; if None, the epc_file is loaded
+          and it should contain one ijk grid object (or one 'ROOT' grid) which is used as the source grid
+       zone_title (string): if not None, a discrete property with this as the citation title is used as the zone property
+       zone_uuid (string or uuid): if not None, a discrete property with this uuid is used as the zone property (see notes)
+       zone_layer_range_list (list of (int, int, int)): each entry being (min_k0, max_k0, zone_index); alternative to
+          working from a zone array
+       k0_min (int, optional): the minimum layer number in the source grid (zero based) to include in the zonal version;
+          default is zero (ie. top layer in source grid)
+       k0_max (int, optional): the maximum layer number in the source grid (zero based) to include in the zonal version;
+          default is nk - 1 (ie. bottom layer in source grid)
+       use_dominant_zone (boolean, default False): if True, the most common zone value in each layer is used for the whole
+          layer; if False, then variation of zone values in active cells in a layer will raise an assertion error
+       inactive_laissez_faire (boolean, optional): if True, a cell in the zonal grid will be set active if any of the
+          corresponding cells in the source grid are active; otherwise all corresponding cells in the source grid
+          must be active for the zonal cell to be active; default is True
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the zonal grid (& crs)
 
-   returns:
-      new grid object (grid.Grid) with one layer per zone of the source grid
+    returns:
+       new grid object (grid.Grid) with one layer per zone of the source grid
 
-   notes:
-      usually one of zone_title or zone_uuid or zone_layer_range_list should be passed, if none are passed then a
-      single layer grid is generated; zone_layer_range_list will take precendence if present
-   """
+    notes:
+       usually one of zone_title or zone_uuid or zone_layer_range_list should be passed, if none are passed then a
+       single layer grid is generated; zone_layer_range_list will take precendence if present
+    """
 
     def fetch_zone_array(grid, zone_title = None, zone_uuid = None, masked = True):
         properties = grid.extract_property_collection()
@@ -830,24 +830,24 @@ def single_layer_grid(epc_file,
                       new_epc_file = None):
     """Extends an existing model with a new version of the source grid converted to a single, thick, layer.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): a multi-layer RESQML grid object; if None, the epc_file is loaded
-         and it should contain one ijk grid object (or one 'ROOT' grid) which is used as the source grid
-      k0_min (int, optional): the minimum layer number in the source grid (zero based) to include in the single layer version;
-         default is zero (ie. top layer in source grid)
-      k0_max (int, optional): the maximum layer number in the source grid (zero based) to include in the single layer version;
-         default is nk - 1 (ie. bottom layer in source grid)
-      inactive_laissez_faire (boolean, optional): if True, a cell in the single layer grid will be set active if any of the
-         corresponding cells in the source grid are active; otherwise all corresponding cells in the source grid
-         must be active for the single layer cell to be active; default is True
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the single layer grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): a multi-layer RESQML grid object; if None, the epc_file is loaded
+          and it should contain one ijk grid object (or one 'ROOT' grid) which is used as the source grid
+       k0_min (int, optional): the minimum layer number in the source grid (zero based) to include in the single layer version;
+          default is zero (ie. top layer in source grid)
+       k0_max (int, optional): the maximum layer number in the source grid (zero based) to include in the single layer version;
+          default is nk - 1 (ie. bottom layer in source grid)
+       inactive_laissez_faire (boolean, optional): if True, a cell in the single layer grid will be set active if any of the
+          corresponding cells in the source grid are active; otherwise all corresponding cells in the source grid
+          must be active for the single layer cell to be active; default is True
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the single layer grid (& crs)
 
-   returns:
-      new grid object (grid.Grid) with a single layer representation of the source grid
-   """
+    returns:
+       new grid object (grid.Grid) with a single layer representation of the source grid
+    """
 
     return zonal_grid(epc_file,
                       source_grid = source_grid,
@@ -870,33 +870,33 @@ def interpolated_grid(epc_file,
                       new_epc_file = None):
     """Extends an existing model with a new grid geometry linearly interpolated between the two source_grids.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to
-      grid_a, grid_b (grid.Grid objects): a pair of RESQML grid objects representing the end cases, between
-         which the new grid will be interpolated
-      a_to_b_0_to_1 (float, default 0.5): the interpolation factor in the range zero to one; a value of 0.0 will yield
-         a copy of grid a, a value of 1.0 will yield a copy of grid b, intermediate values will yield a grid with all
-         points interpolated
-      split_tolerance (float, default 0.01): maximum offset of corner points for shared point to be generated; units
-         are same as those in grid crs; only relevant if working from corner points, ignored otherwise
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with grid_a
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the interpolated grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to
+       grid_a, grid_b (grid.Grid objects): a pair of RESQML grid objects representing the end cases, between
+          which the new grid will be interpolated
+       a_to_b_0_to_1 (float, default 0.5): the interpolation factor in the range zero to one; a value of 0.0 will yield
+          a copy of grid a, a value of 1.0 will yield a copy of grid b, intermediate values will yield a grid with all
+          points interpolated
+       split_tolerance (float, default 0.01): maximum offset of corner points for shared point to be generated; units
+          are same as those in grid crs; only relevant if working from corner points, ignored otherwise
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with grid_a
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the interpolated grid (& crs)
 
-   returns:
-      new grid object (grid.Grid) with geometry interpolated between grid a and grid b
+    returns:
+       new grid object (grid.Grid) with geometry interpolated between grid a and grid b
 
-   notes:
-      the hdf5 file used by the grid_a model is appended to, so it is recommended that the grid_a model's epc is specified
-      as the first argument (unless a new epc file is required, sharing the hdf5 file)
-   """
+    notes:
+       the hdf5 file used by the grid_a model is appended to, so it is recommended that the grid_a model's epc is specified
+       as the first argument (unless a new epc file is required, sharing the hdf5 file)
+    """
 
     assert epc_file or new_epc_file, 'epc file name not specified'
     if new_epc_file and epc_file and (
@@ -1162,34 +1162,34 @@ def extract_box(epc_file = None,
                 new_epc_file = None):
     """Extends an existing model with a new grid extracted as a logical IJK box from the source grid.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      box (numpy int array of shape (2, 3)): the minimum and maximum kji0 indices in the source grid (zero based) to include
-         in the extracted grid; note that cells with index equal to maximum value are included (unlike with python ranges)
-      box_inactive (numpy bool array, optional): if present, shape must match box and values will be or'ed in with the
-         inactive mask inherited from the source grid; if None, inactive mask will be as inherited from source grid
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid, with values taken from the specified box
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      set_parent_window (boolean, optional): if True, the extracted grid has its parent window attribute set; if False,
-         the parent window is not set; if None, the default will be True if new_epc_file is None or False otherwise
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the extracted grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       box (numpy int array of shape (2, 3)): the minimum and maximum kji0 indices in the source grid (zero based) to include
+          in the extracted grid; note that cells with index equal to maximum value are included (unlike with python ranges)
+       box_inactive (numpy bool array, optional): if present, shape must match box and values will be or'ed in with the
+          inactive mask inherited from the source grid; if None, inactive mask will be as inherited from source grid
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid, with values taken from the specified box
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       set_parent_window (boolean, optional): if True, the extracted grid has its parent window attribute set; if False,
+          the parent window is not set; if None, the default will be True if new_epc_file is None or False otherwise
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the extracted grid (& crs)
 
-   returns:
-      new grid object with extent as implied by the box argument
+    returns:
+       new grid object with extent as implied by the box argument
 
-   note:
-      the epc file and associated hdf5 file are appended to (extended) with the new grid, unless a new_epc_file is specified,
-      in which case the grid and inherited properties are written there instead
-   """
+    note:
+       the epc file and associated hdf5 file are appended to (extended) with the new grid, unless a new_epc_file is specified,
+       in which case the grid and inherited properties are written there instead
+    """
 
     def array_box(a, box):
         return a[box[0, 0]:box[1, 0] + 1, box[0, 1]:box[1, 1] + 1, box[0, 2]:box[1, 2] + 1].copy()
@@ -1471,61 +1471,61 @@ def extract_box_for_well(epc_file = None,
                          new_epc_file = None):
     """Extends an existing model with a new grid extracted as an IJK box around a well trajectory in the source grid.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      min_k0, max_k0 (integers, optional): layer range to include; default is full vertical range of source grid
-      trajectory_epc (string, optional): the source file for the trajectory or blocked well, if different to that for
-         the source grid
-      trajectory_uuid (uuid.UUID): the uuid of the trajectory object for the well, if working from a trajectory
-      blocked_well_uuid (uuid.UUID): the uuid of the blocked well object, an alternative to working from a trajectory;
-         must include blocking against source_grid
-      column_ji0 (integer pair, optional): an alternative to providing a trajectory: the column indices of a 'vertical' well
-      column_xy (float pair, optional): an alternative to column_ji0: the x, y location used to determine the column
-      well_name (string, optional): name to use for column well, ignored if trajectory_uuid is not None
-      radius (float, optional): the radius around the wellbore to include in the box; units are those of grid xy values;
-         radial distances are applied horizontally regardless of well inclination; if not present, only cells penetrated
-         by the trajectory are included
-      outer_radius (float, optional): an outer radius around the wellbore, beyond which an inactive cell mask for the
-         source_grid will be set to True (inactive); units are those of grid xy values
-      active_cells_shape (string, default 'tube'): the logical shape of cells marked as active in the extracted box;
-         'tube' results in an active shape with circular cross section in IJ planes, that follows the trajectory; 'prism'
-         activates all cells in IJ columns where any cell is within the tube; 'box' leaves the entire IJK cuboid active
-      quad_triangles (boolean, default True): if True, cell K faces are treated as 4 triangles (with a common face
-         centre point) when computing the intersection of the trajectory with layer interfaces (horizons); if False,
-         the K faces are treated as 2 triangles
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid, with values taken from the extracted box
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      inherit_well (boolean, default False): if True, the new model will have a copy of the well trajectory, its crs (if
-         different from that of the grid), and any related wellbore interpretation and feature
-      set_parent_window (boolean, optional): if True, the extracted grid has its parent window attribute set; if False,
-         the parent window is not set; if None, the default will be True if new_epc_file is None or False otherwise
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the extracted grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       min_k0, max_k0 (integers, optional): layer range to include; default is full vertical range of source grid
+       trajectory_epc (string, optional): the source file for the trajectory or blocked well, if different to that for
+          the source grid
+       trajectory_uuid (uuid.UUID): the uuid of the trajectory object for the well, if working from a trajectory
+       blocked_well_uuid (uuid.UUID): the uuid of the blocked well object, an alternative to working from a trajectory;
+          must include blocking against source_grid
+       column_ji0 (integer pair, optional): an alternative to providing a trajectory: the column indices of a 'vertical' well
+       column_xy (float pair, optional): an alternative to column_ji0: the x, y location used to determine the column
+       well_name (string, optional): name to use for column well, ignored if trajectory_uuid is not None
+       radius (float, optional): the radius around the wellbore to include in the box; units are those of grid xy values;
+          radial distances are applied horizontally regardless of well inclination; if not present, only cells penetrated
+          by the trajectory are included
+       outer_radius (float, optional): an outer radius around the wellbore, beyond which an inactive cell mask for the
+          source_grid will be set to True (inactive); units are those of grid xy values
+       active_cells_shape (string, default 'tube'): the logical shape of cells marked as active in the extracted box;
+          'tube' results in an active shape with circular cross section in IJ planes, that follows the trajectory; 'prism'
+          activates all cells in IJ columns where any cell is within the tube; 'box' leaves the entire IJK cuboid active
+       quad_triangles (boolean, default True): if True, cell K faces are treated as 4 triangles (with a common face
+          centre point) when computing the intersection of the trajectory with layer interfaces (horizons); if False,
+          the K faces are treated as 2 triangles
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid, with values taken from the extracted box
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       inherit_well (boolean, default False): if True, the new model will have a copy of the well trajectory, its crs (if
+          different from that of the grid), and any related wellbore interpretation and feature
+       set_parent_window (boolean, optional): if True, the extracted grid has its parent window attribute set; if False,
+          the parent window is not set; if None, the default will be True if new_epc_file is None or False otherwise
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the extracted grid (& crs)
 
-   returns:
-      (grid, box) where: grid is the new Grid object with extent as determined by source grid geometry, trajectory and
-      radius arguments; and box is a numpy int array of shape (2, 3) with first axis covering min, max and second axis
-      covering k,j,i; the box array holds the minimum and maximum indices (zero based) in the source grid that have
-      been included in the extraction (nb. maximum indices are included, unlike the usual python protocol)
+    returns:
+       (grid, box) where: grid is the new Grid object with extent as determined by source grid geometry, trajectory and
+       radius arguments; and box is a numpy int array of shape (2, 3) with first axis covering min, max and second axis
+       covering k,j,i; the box array holds the minimum and maximum indices (zero based) in the source grid that have
+       been included in the extraction (nb. maximum indices are included, unlike the usual python protocol)
 
-   notes:
-      this function is designed to work fully for vertical and deviated wells; for horizontal wells use blocked well mode;
-      the extracted box includes all layers between the specified min and max horizons, even if the trajectory terminates
-      above the deeper horizon or does not intersect horizon(s) for other reasons;
-      when specifying a column well by providing x,y the IJ column with the centre of the topmost k face closest to the
-      given point is selected;
-      if an outer_radius is given, a boolean property will be created for the source grid with values set True where the
-      centres of the cells are beyond this distance from the well, measured horizontally; if outer_radius and new_epc_file
-      are both given, the source grid will be copied to the new epc
-   """
+    notes:
+       this function is designed to work fully for vertical and deviated wells; for horizontal wells use blocked well mode;
+       the extracted box includes all layers between the specified min and max horizons, even if the trajectory terminates
+       above the deeper horizon or does not intersect horizon(s) for other reasons;
+       when specifying a column well by providing x,y the IJ column with the centre of the topmost k face closest to the
+       given point is selected;
+       if an outer_radius is given, a boolean property will be created for the source grid with values set True where the
+       centres of the cells are beyond this distance from the well, measured horizontally; if outer_radius and new_epc_file
+       are both given, the source grid will be copied to the new epc
+    """
 
     assert epc_file or new_epc_file, 'epc file name not specified'
     if new_epc_file and epc_file and (
@@ -1785,41 +1785,41 @@ def refined_grid(epc_file,
                  new_epc_file = None):
     """Generates a refined version of the source grid, optionally inheriting properties.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid unless source_grid_uuid is specified to identify the grid
-      fine_coarse (resqpy.olio.fine_coarse.FineCoarse object): the mapping between cells in the fine (output) and
-         coarse (source) grids
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid, with values resampled in the simplest way onto the finer grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      source_grid_uuid (uuid.UUID, optional): the uuid of the source grid – an alternative to the source_grid argument
-         as a way of identifying the grid
-      set_parent_window (boolean or str, optional): if True or 'parent', the refined grid has its parent window attribute
-         set; if False, the parent window is not set; if None, the default will be True if new_epc_file is None or False
-         otherwise; if 'grandparent' then an intervening parent window with no refinement or coarsening will be skipped
-         and its box used in the parent window for the new grid, relating directly to the original grid
-      infill_missing_geometry (boolean, default True): if True, an attempt is made to generate grid geometry in the
-         source grid wherever it is undefined; if False, any undefined geometry will result in an assertion failure
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the refined grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid unless source_grid_uuid is specified to identify the grid
+       fine_coarse (resqpy.olio.fine_coarse.FineCoarse object): the mapping between cells in the fine (output) and
+          coarse (source) grids
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid, with values resampled in the simplest way onto the finer grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       source_grid_uuid (uuid.UUID, optional): the uuid of the source grid – an alternative to the source_grid argument
+          as a way of identifying the grid
+       set_parent_window (boolean or str, optional): if True or 'parent', the refined grid has its parent window attribute
+          set; if False, the parent window is not set; if None, the default will be True if new_epc_file is None or False
+          otherwise; if 'grandparent' then an intervening parent window with no refinement or coarsening will be skipped
+          and its box used in the parent window for the new grid, relating directly to the original grid
+       infill_missing_geometry (boolean, default True): if True, an attempt is made to generate grid geometry in the
+          source grid wherever it is undefined; if False, any undefined geometry will result in an assertion failure
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the refined grid (& crs)
 
-   returns:
-      new grid object being the refined grid; the epc and hdf5 files are written to as an intentional side effect
+    returns:
+       new grid object being the refined grid; the epc and hdf5 files are written to as an intentional side effect
 
-   notes:
-      this function refines an entire grid; to refine a local area of a grid, first use the extract_box function
-      and then use this function on the extracted grid; in such a case, using a value of 'grandparent' for the
-      set_parent_window argument will relate the refined grid back to the original;
-      if geometry infilling takes place, cached geometry and mask arrays within the source grid object will be
-      modified as a side-effect of the function (but not written to hdf5 or changed in xml)
-   """
+    notes:
+       this function refines an entire grid; to refine a local area of a grid, first use the extract_box function
+       and then use this function on the extracted grid; in such a case, using a value of 'grandparent' for the
+       set_parent_window argument will relate the refined grid back to the original;
+       if geometry infilling takes place, cached geometry and mask arrays within the source grid object will be
+       modified as a side-effect of the function (but not written to hdf5 or changed in xml)
+    """
 
     assert epc_file or source_grid is not None, 'neither epc file name nor source grid supplied'
     if not epc_file:
@@ -2124,37 +2124,37 @@ def coarsened_grid(epc_file,
                    new_epc_file = None):
     """Generates a coarsened version of an unsplit source grid, todo: optionally inheriting properties.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      fine_coarse (resqpy.olio.fine_coarse.FineCoarse object): the mapping between cells in the fine (source) and
-         coarse (output) grids
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid, with values upscaled or sampled
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      set_parent_window (boolean or str, optional): if True or 'parent', the coarsened grid has its parent window attribute
-         set; if False, the parent window is not set; if None, the default will be True if new_epc_file is None or False
-         otherwise; if 'grandparent' then an intervening parent window with no refinement or coarsening will be skipped
-         and its box used in the parent window for the new grid, relating directly to the original grid
-      infill_missing_geometry (boolean, default True): if True, an attempt is made to generate grid geometry in the
-         source grid wherever it is undefined; if False, any undefined geometry will result in an assertion failure
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the refined grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       fine_coarse (resqpy.olio.fine_coarse.FineCoarse object): the mapping between cells in the fine (source) and
+          coarse (output) grids
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid, with values upscaled or sampled
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       set_parent_window (boolean or str, optional): if True or 'parent', the coarsened grid has its parent window attribute
+          set; if False, the parent window is not set; if None, the default will be True if new_epc_file is None or False
+          otherwise; if 'grandparent' then an intervening parent window with no refinement or coarsening will be skipped
+          and its box used in the parent window for the new grid, relating directly to the original grid
+       infill_missing_geometry (boolean, default True): if True, an attempt is made to generate grid geometry in the
+          source grid wherever it is undefined; if False, any undefined geometry will result in an assertion failure
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the refined grid (& crs)
 
-   returns:
-      new grid object being the coarsened grid; the epc and hdf5 files are written to as an intentional side effect
+    returns:
+       new grid object being the coarsened grid; the epc and hdf5 files are written to as an intentional side effect
 
-   note:
-      this function coarsens an entire grid; to coarsen a local area of a grid, first use the extract_box function
-      and then use this function on the extracted grid; in such a case, using a value of 'grandparent' for the
-      set_parent_window argument will relate the coarsened grid back to the original
-   """
+    note:
+       this function coarsens an entire grid; to coarsen a local area of a grid, first use the extract_box function
+       and then use this function on the extracted grid; in such a case, using a value of 'grandparent' for the
+       set_parent_window argument will relate the coarsened grid back to the original
+    """
 
     assert epc_file or new_epc_file, 'epc file name not specified'
     if new_epc_file and epc_file and (
@@ -2311,37 +2311,37 @@ def local_depth_adjustment(epc_file,
                            new_epc_file = None):
     """Applies a local depth adjustment to the grid, adding as a new grid part in the model.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): a multi-layer RESQML grid object; if None, the epc_file is loaded
-         and it should contain one ijk grid object (or one 'ROOT' grid) which is used as the source grid
-      centre_x, centre_y (floats): the centre of the depth adjustment, corresponding to the location of maximum change
-         in depth; crs is implicitly that of the grid but see also use_local_coords argument
-      radius (float): the radius of adjustment of depths; units are implicitly xy (projected) units of grid crs
-      centre_shift (float): the maximum vertical depth adjustment; units are implicily z (vertical) units of grid crs;
-         use positive value to increase depth, negative to make shallower
-      use_local_coords (boolean): if True, centre_x & centre_y are taken to be in the local coordinates of the grid's
-         crs; otherwise the global coordinates
-      decay_shape (string): 'linear' yields a cone shaped change in depth values; 'quadratic' (the default) yields a
-         bell shaped change
-      ref_k0 (integer, default 0): the layer in the grid to use as reference for determining the distance of a pillar
-         from the centre of the depth adjustment; the corners of the top face of the reference layer are used
-      store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
-         displacement of cells' centres brought about by the local depth shift
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the adjusted grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): a multi-layer RESQML grid object; if None, the epc_file is loaded
+          and it should contain one ijk grid object (or one 'ROOT' grid) which is used as the source grid
+       centre_x, centre_y (floats): the centre of the depth adjustment, corresponding to the location of maximum change
+          in depth; crs is implicitly that of the grid but see also use_local_coords argument
+       radius (float): the radius of adjustment of depths; units are implicitly xy (projected) units of grid crs
+       centre_shift (float): the maximum vertical depth adjustment; units are implicily z (vertical) units of grid crs;
+          use positive value to increase depth, negative to make shallower
+       use_local_coords (boolean): if True, centre_x & centre_y are taken to be in the local coordinates of the grid's
+          crs; otherwise the global coordinates
+       decay_shape (string): 'linear' yields a cone shaped change in depth values; 'quadratic' (the default) yields a
+          bell shaped change
+       ref_k0 (integer, default 0): the layer in the grid to use as reference for determining the distance of a pillar
+          from the centre of the depth adjustment; the corners of the top face of the reference layer are used
+       store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
+          displacement of cells' centres brought about by the local depth shift
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the adjusted grid (& crs)
 
-   returns:
-      new grid object which is a copy of the source grid with the local depth adjustment applied
-   """
+    returns:
+       new grid object which is a copy of the source grid with the local depth adjustment applied
+    """
 
     def decayed_shift(centre_shift, distance, radius, decay_shape):
         norm_dist = min(distance / radius, 1.0)  # 0..1
@@ -2497,29 +2497,29 @@ def tilted_grid(epc_file,
                 new_epc_file = None):
     """Extends epc file with a new grid which is a version of the source grid tilted.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      pivot_xyz (triple float): a point in 3D space on the pivot axis, which is horizontal and orthogonal to azimuth
-      azimuth: the direction of tilt (orthogonal to tilt axis), as a compass bearing in degrees
-      dip: the angle to tilt the grid by, in degrees; a positive value tilts points in direction azimuth downwards (needs checking!)
-      store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
-         displacement of cells' centres brought about by the tilting
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the tilted grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       pivot_xyz (triple float): a point in 3D space on the pivot axis, which is horizontal and orthogonal to azimuth
+       azimuth: the direction of tilt (orthogonal to tilt axis), as a compass bearing in degrees
+       dip: the angle to tilt the grid by, in degrees; a positive value tilts points in direction azimuth downwards (needs checking!)
+       store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
+          displacement of cells' centres brought about by the tilting
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the tilted grid (& crs)
 
-   returns:
-      a new grid (grid.Grid object) which is a copy of the source grid tilted in 3D space
-   """
+    returns:
+       a new grid (grid.Grid object) which is a copy of the source grid tilted in 3D space
+    """
 
     assert epc_file or new_epc_file, 'epc file name not specified'
     if new_epc_file and epc_file and (
@@ -2588,28 +2588,28 @@ def unsplit_grid(epc_file,
                  new_epc_file = None):
     """Extends epc file with a new grid which is a version of the source grid with all faults healed.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the unsplit grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the unsplit grid (& crs)
 
-   returns:
-      a new grid (grid.Grid object) which is an unfaulted copy of the source grid
+    returns:
+       a new grid (grid.Grid object) which is an unfaulted copy of the source grid
 
-   notes:
-      the faults are healed by shifting the thrown sides up and down to the midpoint, only along the line of the fault;
-      to smooth the adjustments away from the line of the fault, use the global_fault_throw_scaling() function first
-   """
+    notes:
+       the faults are healed by shifting the thrown sides up and down to the midpoint, only along the line of the fault;
+       to smooth the adjustments away from the line of the fault, use the global_fault_throw_scaling() function first
+    """
 
     assert epc_file or new_epc_file, 'epc file name not specified'
     if new_epc_file and epc_file and (
@@ -2684,49 +2684,49 @@ def add_faults(epc_file,
                new_epc_file = None):
     """Extends epc file with a new grid which is a version of the source grid with new curtain fault(s) added.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      polylines (lines.PolylineSet or list of lines.Polyline, optional): list of poly lines for which curtain faults
-         are to be added; either this or lines_file_list or full_pillar_list_dict must be present
-      lines_file_list (list of str, optional): a list of file paths, each containing one or more poly lines in simple
-         ascii format§; see notes; either this or polylines or full_pillar_list_dicr must be present
-      lines_crs_uuid (uuid, optional): if present, the uuid of a coordinate reference system with which to interpret
-         the contents of the lines files; if None, the crs used by the grid will be assumed
-      full_pillar_list_dict (dict mapping str to list of pairs of ints, optional): dictionary mapping from a fault name
-         to a list of pairs of ints being the ordered neigbouring primary pillar (j0, i0) defining the curtain fault;
-         either this or polylines or lines_file_list must be present
-      left_right_throw_dict (dict mapping str to pair of floats, optional): dictionary mapping from a fault name to a
-         pair of floats being the semi-throw adjustment on the left and the right of the fault (see notes); semi-throw
-         values default to (+0.5, -0.5)
-      create_gcs (boolean, default True): if True, and faults are being defined by lines, a grid connection set is
-         created with one feature per new fault and associated organisational objects are also created; ignored if
-         lines_file_list is None
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the unsplit grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       polylines (lines.PolylineSet or list of lines.Polyline, optional): list of poly lines for which curtain faults
+          are to be added; either this or lines_file_list or full_pillar_list_dict must be present
+       lines_file_list (list of str, optional): a list of file paths, each containing one or more poly lines in simple
+          ascii format§; see notes; either this or polylines or full_pillar_list_dicr must be present
+       lines_crs_uuid (uuid, optional): if present, the uuid of a coordinate reference system with which to interpret
+          the contents of the lines files; if None, the crs used by the grid will be assumed
+       full_pillar_list_dict (dict mapping str to list of pairs of ints, optional): dictionary mapping from a fault name
+          to a list of pairs of ints being the ordered neigbouring primary pillar (j0, i0) defining the curtain fault;
+          either this or polylines or lines_file_list must be present
+       left_right_throw_dict (dict mapping str to pair of floats, optional): dictionary mapping from a fault name to a
+          pair of floats being the semi-throw adjustment on the left and the right of the fault (see notes); semi-throw
+          values default to (+0.5, -0.5)
+       create_gcs (boolean, default True): if True, and faults are being defined by lines, a grid connection set is
+          created with one feature per new fault and associated organisational objects are also created; ignored if
+          lines_file_list is None
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the unsplit grid (& crs)
 
-   returns:
-      a new grid (grid.Grid object) which is a copy of the source grid with the structure modified to incorporate
-      the new faults
+    returns:
+       a new grid (grid.Grid object) which is a copy of the source grid with the structure modified to incorporate
+       the new faults
 
-   notes:
-      full_pillar_list_dict is typically generated by Grid.make_face_sets_from_pillar_lists();
-      pillars will be split as needed to model the new faults, though existing splits will be used as appropriate, so
-      this function may also be used to add a constant to the throw of existing faults;
-      the left_right_throw_dict contains a pair of floats for each fault name (as found in keys of full_pillar_list_dict);
-      these throw values are lengths in the uom of the crs used by the grid (which must have the same xy units as z units);
+    notes:
+       full_pillar_list_dict is typically generated by Grid.make_face_sets_from_pillar_lists();
+       pillars will be split as needed to model the new faults, though existing splits will be used as appropriate, so
+       this function may also be used to add a constant to the throw of existing faults;
+       the left_right_throw_dict contains a pair of floats for each fault name (as found in keys of full_pillar_list_dict);
+       these throw values are lengths in the uom of the crs used by the grid (which must have the same xy units as z units);
 
-      this function does not add a GridConnectionSet to the model – calling code may wish to do that
-   """
+       this function does not add a GridConnectionSet to the model – calling code may wish to do that
+    """
 
     def make_face_sets_for_new_lines(new_lines, face_set_id, grid, full_pillar_list_dict, composite_face_set_dict):
         """Adds entries to full_pillar_list_dict & composite_face_set_dict for new lines."""
@@ -2740,17 +2740,17 @@ def add_faults(epc_file,
     def fault_from_pillar_list(grid, full_pillar_list, delta_throw_left, delta_throw_right):
         """Creates and/or adjusts throw on a single fault defined by a full pillar list, in memory.
 
-      arguments:
-         grid (grid.Grid): the grid object to be adjusted in memory (should have originally been copied
-            without the hdf5 arrays having been written yet, nor xml created)
-         full_pillar_list (list of pairs of ints (j0, i0)): the full list of primary pillars defining
-            the fault; neighbouring pairs must differ by exactly one in either j0 or i0 but not both
-         delta_throw_left (float): the amount to add to the 'depth' of points to the left of the line
-            when viewed from above, looking along the line in the direction of the pillar list entries;
-            units are implicitly the length units of the crs used by the grid; see notes about 'depth'
-         delta_throw_right (float): as for delta_throw_left but applied to points to the right of the
-            line
-      """
+        arguments:
+           grid (grid.Grid): the grid object to be adjusted in memory (should have originally been copied
+              without the hdf5 arrays having been written yet, nor xml created)
+           full_pillar_list (list of pairs of ints (j0, i0)): the full list of primary pillars defining
+              the fault; neighbouring pairs must differ by exactly one in either j0 or i0 but not both
+           delta_throw_left (float): the amount to add to the 'depth' of points to the left of the line
+              when viewed from above, looking along the line in the direction of the pillar list entries;
+              units are implicitly the length units of the crs used by the grid; see notes about 'depth'
+           delta_throw_right (float): as for delta_throw_left but applied to points to the right of the
+              line
+        """
 
         def pillar_vector(grid, p_index):
             # return a unit vector for direction of pillar, in direction of increasing k
@@ -3014,48 +3014,48 @@ def fault_throw_scaling(epc_file,
                         new_epc_file = None):
     """Extends epc with a new grid with fault throws multiplied by scaling factors.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      scaling_factor (float, optional): if present, the default scaling factor to apply to split pillars which do not
-         appear in any of the faults in the scaling dictionary; if None, such pillars are left unchanged
-      connection_set (fault.GridConnectionSet object): the connection set with associated fault feature list, used to
-         identify which faces (and hence pillars) belong to which named fault
-      scaling_dict (dictionary mapping string to float): the scaling factor to apply to each named fault; any faults not
-         included in the dictionary will be left unadjusted (unless a default scaling factor is given as scaling_factor arg)
-      ref_k0 (integer, default 0): the reference layer (zero based) to use when determining the pre-existing throws
-      ref_k_faces (string, default 'top'): 'top' or 'base' identifying which bounding interface to use as the reference
-      cell_range (integer, default 0): the number of cells away from faults which will have depths adjusted to spatially
-         smooth the effect of the throw scaling (ie. reduce sudden changes in gradient due to the scaling)
-      offset_decay (float, default 0.5): DEPRECATED; ignored
-      store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
-         displacement of cells' centres brought about by the fault throw scaling
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      inherit_gcs (boolean, default True): if True, any grid connection set objects related to the source grid will be
-         inherited by the modified grid
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the derived grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       scaling_factor (float, optional): if present, the default scaling factor to apply to split pillars which do not
+          appear in any of the faults in the scaling dictionary; if None, such pillars are left unchanged
+       connection_set (fault.GridConnectionSet object): the connection set with associated fault feature list, used to
+          identify which faces (and hence pillars) belong to which named fault
+       scaling_dict (dictionary mapping string to float): the scaling factor to apply to each named fault; any faults not
+          included in the dictionary will be left unadjusted (unless a default scaling factor is given as scaling_factor arg)
+       ref_k0 (integer, default 0): the reference layer (zero based) to use when determining the pre-existing throws
+       ref_k_faces (string, default 'top'): 'top' or 'base' identifying which bounding interface to use as the reference
+       cell_range (integer, default 0): the number of cells away from faults which will have depths adjusted to spatially
+          smooth the effect of the throw scaling (ie. reduce sudden changes in gradient due to the scaling)
+       offset_decay (float, default 0.5): DEPRECATED; ignored
+       store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
+          displacement of cells' centres brought about by the fault throw scaling
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       inherit_gcs (boolean, default True): if True, any grid connection set objects related to the source grid will be
+          inherited by the modified grid
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the derived grid (& crs)
 
-   returns:
-      new grid (grid.Grid object), with fault throws scaled according to values in the scaling dictionary
+    returns:
+       new grid (grid.Grid object), with fault throws scaled according to values in the scaling dictionary
 
-   notes:
-      grid points are moved along pillar lines;
-      stretch is towards or away from mid-point of throw;
-      same shift is applied to all layers along pillar;
-      pillar lines assumed to be straight;
-      the offset decay argument might be changed in a future version to give improved smoothing;
-      if a large fault is represented by a series of parallel minor faults 'stepping' down, each minor fault will have the
-      scaling factor applied independently, leading to some unrealistic results
-   """
+    notes:
+       grid points are moved along pillar lines;
+       stretch is towards or away from mid-point of throw;
+       same shift is applied to all layers along pillar;
+       pillar lines assumed to be straight;
+       the offset decay argument might be changed in a future version to give improved smoothing;
+       if a large fault is represented by a series of parallel minor faults 'stepping' down, each minor fault will have the
+       scaling factor applied independently, leading to some unrealistic results
+    """
 
     assert epc_file or new_epc_file, 'epc file name not specified'
     if new_epc_file and epc_file and (
@@ -3295,38 +3295,38 @@ def global_fault_throw_scaling(epc_file,
                                new_epc_file = None):
     """Rewrites epc with a new grid with all the fault throws multiplied by the same scaling factor.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      scaling_factor (float): the scaling factor to apply to the throw across all split pillars
-      ref_k0 (integer, default 0): the reference layer (zero based) to use when determining the pre-existing throws
-      ref_k_faces (string, default 'top'): 'top' or 'base' identifying which bounding interface to use as the reference
-      cell_range (integer, default 0): the number of cells away from faults which will have depths adjusted to spatially
-         smooth the effect of the throw scaling (ie. reduce sudden changes in gradient due to the scaling)
-      offset_decay (float, default 0.5): DEPRECATED; ignored
-      store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
-         displacement of cells' centres brought about by the fault throw scaling
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      inherit_gcs (boolean, default True): if True, any grid connection set objects related to the source grid will be
-         inherited by the modified grid
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the derived grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       scaling_factor (float): the scaling factor to apply to the throw across all split pillars
+       ref_k0 (integer, default 0): the reference layer (zero based) to use when determining the pre-existing throws
+       ref_k_faces (string, default 'top'): 'top' or 'base' identifying which bounding interface to use as the reference
+       cell_range (integer, default 0): the number of cells away from faults which will have depths adjusted to spatially
+          smooth the effect of the throw scaling (ie. reduce sudden changes in gradient due to the scaling)
+       offset_decay (float, default 0.5): DEPRECATED; ignored
+       store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
+          displacement of cells' centres brought about by the fault throw scaling
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       inherit_gcs (boolean, default True): if True, any grid connection set objects related to the source grid will be
+          inherited by the modified grid
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the derived grid (& crs)
 
-   returns:
-      new grid (grid.Grid object), with all fault throws scaled by the scaling factor
+    returns:
+       new grid (grid.Grid object), with all fault throws scaled by the scaling factor
 
-   notes:
-      a scaling factor of 1 implies no change;
-      calls fault_throw_scaling(), see also documentation for that function
-   """
+    notes:
+       a scaling factor of 1 implies no change;
+       calls fault_throw_scaling(), see also documentation for that function
+    """
 
     return fault_throw_scaling(epc_file,
                                source_grid = source_grid,
@@ -3359,51 +3359,52 @@ def drape_to_surface(epc_file,
                      inherit_all_realizations = False,
                      new_grid_title = None,
                      new_epc_file = None):
-    """Extends a resqml model with a new grid where the reference layer boundary of the source grid has been re-draped to a surface.
+    """Extends a resqml model with a new grid where the reference layer boundary of the source grid has been re-draped
+    to a surface.
 
-   arguments:
-      epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
-      source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
-         (or one 'ROOT' grid) which is used as the source grid
-      surface (surface.Surface object, optional): the surface to drape the grid to; if None, a surface is generated from
-         the reference layer boundary (which can then be scaled with the scaling_factor)
-      scaling_factor (float, optional): if not None, prior to draping, the surface is stretched vertically by this factor,
-         away from a horizontal plane located at the surface's shallowest depth
-      ref_k0 (integer, default 0): the reference layer (zero based) to drape to the surface
-      ref_k_faces (string, default 'top'): 'top' or 'base' identifying which bounding interface to use as the reference
-      quad_triangles (boolean, default True): if True and surface is None, each cell face in the reference boundary layer
-         is represented by 4 triangles (with a common vertex at the face centre) in the generated surface; if False,
-         only 2 trianges are used for each cell face (which gives a non-unique solution)
-      cell_range (integer, default 0): the number of cells away from faults which will have depths adjusted to spatially
-         smooth the effect of the throw scaling (ie. reduce sudden changes in gradient due to the scaling)
-      offset_decay (float, default 0.5): the factor to reduce depth shifts by with each cell step away from faults (used
-         in conjunction with cell_range)
-      store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
-         displacement of cells' centres brought about by the local depth shift
-      inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
-         with the source grid
-      inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
-         inherit_properties is False
-      inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
-         realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
-         inherit_properties is False or inherit_realization is not None
-      new_grid_title (string): used as the citation title text for the new grid object
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
-         a new epc file (& associated h5 file) is created to contain the draped grid (& crs)
+    arguments:
+       epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file
+       source_grid (grid.Grid object, optional): if None, the epc_file is loaded and it should contain one ijk grid object
+          (or one 'ROOT' grid) which is used as the source grid
+       surface (surface.Surface object, optional): the surface to drape the grid to; if None, a surface is generated from
+          the reference layer boundary (which can then be scaled with the scaling_factor)
+       scaling_factor (float, optional): if not None, prior to draping, the surface is stretched vertically by this factor,
+          away from a horizontal plane located at the surface's shallowest depth
+       ref_k0 (integer, default 0): the reference layer (zero based) to drape to the surface
+       ref_k_faces (string, default 'top'): 'top' or 'base' identifying which bounding interface to use as the reference
+       quad_triangles (boolean, default True): if True and surface is None, each cell face in the reference boundary layer
+          is represented by 4 triangles (with a common vertex at the face centre) in the generated surface; if False,
+          only 2 trianges are used for each cell face (which gives a non-unique solution)
+       cell_range (integer, default 0): the number of cells away from faults which will have depths adjusted to spatially
+          smooth the effect of the throw scaling (ie. reduce sudden changes in gradient due to the scaling)
+       offset_decay (float, default 0.5): the factor to reduce depth shifts by with each cell step away from faults (used
+          in conjunction with cell_range)
+       store_displacement (boolean, default False): if True, 3 grid property parts are created, one each for x, y, & z
+          displacement of cells' centres brought about by the local depth shift
+       inherit_properties (boolean, default False): if True, the new grid will have a copy of any properties associated
+          with the source grid
+       inherit_realization (int, optional): realization number for which properties will be inherited; ignored if
+          inherit_properties is False
+       inherit_all_realizations (boolean, default False): if True (and inherit_realization is None), properties for all
+          realizations will be inherited; if False, only properties with a realization of None are inherited; ignored if
+          inherit_properties is False or inherit_realization is not None
+       new_grid_title (string): used as the citation title text for the new grid object
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new grid object; if present,
+          a new epc file (& associated h5 file) is created to contain the draped grid (& crs)
 
-   returns:
-      new grid (grid.Grid object), with geometry draped to surface
+    returns:
+       new grid (grid.Grid object), with geometry draped to surface
 
-   notes:
-      at least one of a surface or a scaling factor must be given;
-      if no surface is given, one is created from the fault-healed grid points for the reference layer interface;
-      if a scaling factor other than 1.0 is given, the surface is flexed vertically, relative to its shallowest point;
-      layer thicknesses measured along pillars are maintained; cell volumes may change;
-      the coordinate reference systems for the surface and the grid are assumed to be the same;
-      this function currently uses an exhaustive, computationally and memory intensive algorithm;
-      setting quad_triangles argument to False should give a factor of 2 speed up and reduction in memory requirement;
-      the epc file and associated hdf5 file are appended to (extended) with the new grid, as a side effect of this function
-   """
+    notes:
+       at least one of a surface or a scaling factor must be given;
+       if no surface is given, one is created from the fault-healed grid points for the reference layer interface;
+       if a scaling factor other than 1.0 is given, the surface is flexed vertically, relative to its shallowest point;
+       layer thicknesses measured along pillars are maintained; cell volumes may change;
+       the coordinate reference systems for the surface and the grid are assumed to be the same;
+       this function currently uses an exhaustive, computationally and memory intensive algorithm;
+       setting quad_triangles argument to False should give a factor of 2 speed up and reduction in memory requirement;
+       the epc file and associated hdf5 file are appended to (extended) with the new grid, as a side effect of this function
+    """
 
     log.info('draping grid to surface')
 
@@ -3535,7 +3536,8 @@ def drape_to_surface(epc_file,
 
 
 def add_single_cell_grid(points, new_grid_title = None, new_epc_file = None):
-    """Creates a model with a single cell IJK Grid, with a cuboid cell aligned with x,y,z axes, enclosing the range of points."""
+    """Creates a model with a single cell IJK Grid, with a cuboid cell aligned with x,y,z axes, enclosing the range of
+    points."""
 
     # determine range of points
     min_xyz = np.nanmin(points.reshape((-1, 3)), axis = 0)
@@ -3578,11 +3580,11 @@ def add_single_cell_grid(points, new_grid_title = None, new_epc_file = None):
 def copy_grid(source_grid, target_model = None, copy_crs = True):
     """Creates a copy of the IJK grid object in the target model (usually prior to modifying points in situ).
 
-   note:
-      this function is not usually called directly by application code; it does not write to the hdf5
-      file nor create xml for the copied grid;
-      the copy will be a resqpy Grid even if the source grid is a RegularGrid
-   """
+    note:
+       this function is not usually called directly by application code; it does not write to the hdf5
+       file nor create xml for the copied grid;
+       the copy will be a resqpy Grid even if the source grid is a RegularGrid
+    """
 
     assert source_grid.grid_representation in ['IjkGrid', 'IjkBlockGrid']
 
@@ -3649,9 +3651,9 @@ def copy_grid(source_grid, target_model = None, copy_crs = True):
 def displacement_properties(new_grid, old_grid):
     """Computes cell centre differences in x, y, & z, between old & new grids, and returns a collection of 3 properties.
 
-   note:
-      this function is not usually called directly by application code
-   """
+    note:
+       this function is not usually called directly by application code
+    """
 
     displacement_collection = rqp.GridPropertyCollection()
     displacement_collection.set_grid(new_grid)
@@ -3697,33 +3699,33 @@ def write_grid(epc_file,
                extra_metadata = {}):
     """Append to or create epc and h5 files, with grid and optionally property collection.
 
-   arguments:
-      epc_file (string): name of existing epc file (if appending) or new epc file to be created (if writing)
-      grid (grid.Grid object): the grid object to be written to the epc & h5 files
-      ext_uuid (uuid.UUID object, optional): if present and the mode is 'a', the arrays are appended to
-         the hdf5 file that has this uuid; if None or mode is 'w', the hdf5 file is determined automatically
-      property_collection (property.GridPropertyCollection object, optional): if present, a collection of
-         grid properties to write and relate to the grid
-      grid_title (string): used as the citation title for the grid object
-      mode (string, default 'a'): 'a' or 'w'; if 'a', epc_file should be an existing file which is extended
-         (appended to) with the new grid and properties; if 'w', epc_file is created along with an h5 file
-         and will be populated with the grid, crs and properties
-      geometry (boolean, default True): if True, the grid object is included in the write; if False, only the
-         property collection is written, in which case grid must be fully established with xml in place
-      time_series_uuid (uuid.UUID, optional): the uuid of a time series object; required if property_collection
-         contains any recurrent properties in its import list
-      string_lookup_uuid (optional): if present, the uuid of the string table lookup which any non-continuous
-         properties relate to (ie. they are all taken to be categorical); leave as None if discrete property
-         objects are required rather than categorical
-      extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to any new
-         properties
+    arguments:
+       epc_file (string): name of existing epc file (if appending) or new epc file to be created (if writing)
+       grid (grid.Grid object): the grid object to be written to the epc & h5 files
+       ext_uuid (uuid.UUID object, optional): if present and the mode is 'a', the arrays are appended to
+          the hdf5 file that has this uuid; if None or mode is 'w', the hdf5 file is determined automatically
+       property_collection (property.GridPropertyCollection object, optional): if present, a collection of
+          grid properties to write and relate to the grid
+       grid_title (string): used as the citation title for the grid object
+       mode (string, default 'a'): 'a' or 'w'; if 'a', epc_file should be an existing file which is extended
+          (appended to) with the new grid and properties; if 'w', epc_file is created along with an h5 file
+          and will be populated with the grid, crs and properties
+       geometry (boolean, default True): if True, the grid object is included in the write; if False, only the
+          property collection is written, in which case grid must be fully established with xml in place
+       time_series_uuid (uuid.UUID, optional): the uuid of a time series object; required if property_collection
+          contains any recurrent properties in its import list
+       string_lookup_uuid (optional): if present, the uuid of the string table lookup which any non-continuous
+          properties relate to (ie. they are all taken to be categorical); leave as None if discrete property
+          objects are required rather than categorical
+       extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to any new
+          properties
 
-   returns:
-      list of uuid.UUID, being the uuids of property parts added from the property_collection, if any
+    returns:
+       list of uuid.UUID, being the uuids of property parts added from the property_collection, if any
 
-   note:
-      this function is not usually called directly by application code
-   """
+    note:
+       this function is not usually called directly by application code
+    """
 
     log.debug('write_grid(): epc_file: ' + str(epc_file) + '; mode: ' + str(mode) + '; grid extent: ' +
               str(grid.extent_kji))
@@ -3827,44 +3829,44 @@ def add_edges_per_column_property_array(epc_file,
                                         new_epc_file = None):
     """Adds an edges per column grid property from a numpy array to an existing resqml dataset.
 
-   arguments:
-      epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
-      a (3D numpy array): the property array to be added to the model; expected shape (nj,ni,2,2) or (nj,ni,4)
-      property_kind (string): the resqml property kind
-      grid_uuid (uuid object or string, optional): the uuid of the grid to which the property relates;
-         if None, the property is attached to the 'main' grid
-      source_info (string): typically the name of a file from which the array has been read but can be any
-         information regarding the source of the data
-      title (string): this will be used as the citation title when a part is generated for the array; for simulation
-         models it is desirable to use the simulation keyword when appropriate
-      discrete (boolean, default False): if True, the array should contain integer (or boolean) data; if False, float
-      uom (string, default None): the resqml units of measure for the data; not relevant to discrete data
-      time_index (integer, default None): if not None, the time index to be used when creating a part for the array
-      time_series_uuid (uuid object or string, default None): required if time_index is not None
-      string_lookup_uuid (uuid object or string, optional): required if the array is to be stored as a categorical
-         property; set to None for non-categorical discrete data; only relevant if discrete is True
-      null_value (int, default None): if present, this is used in the metadata to indicate that this value
-         is to be interpreted as a null value wherever it appears in the data (use for discrete data only)
-      facet_type (string): resqml facet type, or None
-      facet (string): resqml facet, or None
-      realization (int): realization number, or None
-      local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
-      extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
-         property
-      new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
-         a new epc file (& associated h5 file) is created to contain a copy of the grid and the new property
+    arguments:
+       epc_file (string): file name to load model resqml model from (and rewrite to if new_epc_file is None)
+       a (3D numpy array): the property array to be added to the model; expected shape (nj,ni,2,2) or (nj,ni,4)
+       property_kind (string): the resqml property kind
+       grid_uuid (uuid object or string, optional): the uuid of the grid to which the property relates;
+          if None, the property is attached to the 'main' grid
+       source_info (string): typically the name of a file from which the array has been read but can be any
+          information regarding the source of the data
+       title (string): this will be used as the citation title when a part is generated for the array; for simulation
+          models it is desirable to use the simulation keyword when appropriate
+       discrete (boolean, default False): if True, the array should contain integer (or boolean) data; if False, float
+       uom (string, default None): the resqml units of measure for the data; not relevant to discrete data
+       time_index (integer, default None): if not None, the time index to be used when creating a part for the array
+       time_series_uuid (uuid object or string, default None): required if time_index is not None
+       string_lookup_uuid (uuid object or string, optional): required if the array is to be stored as a categorical
+          property; set to None for non-categorical discrete data; only relevant if discrete is True
+       null_value (int, default None): if present, this is used in the metadata to indicate that this value
+          is to be interpreted as a null value wherever it appears in the data (use for discrete data only)
+       facet_type (string): resqml facet type, or None
+       facet (string): resqml facet, or None
+       realization (int): realization number, or None
+       local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
+       extra_metadata (dict, optional): any items in this dictionary are added as extra metadata to the new
+          property
+       new_epc_file (string, optional): if None, the source epc_file is extended with the new property object; if present,
+          a new epc file (& associated h5 file) is created to contain a copy of the grid and the new property
 
-   returns:
-      uuid.UUID - the uuid of the newly created property
+    returns:
+       uuid.UUID - the uuid of the newly created property
 
-   notes:
-      the RESQML protocol for saving edges per column properties uses a clockwise ordering of the 4 edges
-      of a column; the resqpy protocol uses 2 dimensions of extent 2, being the axis (J, I) and face (-, +);
-      this function assumes the array is in RESQML protocol if it has shape (nj, ni, 4) and resqpy protocol
-      if it has shape (nj, ni, 2, 2); when reloading the property it will be presented in RESQML protocol;
-      calling code can use property module functions reformat_column_edges_from_resqml_format() and
-      reformat_column_edges_to_resqml_format() to convert between the protocols if needed
-   """
+    notes:
+       the RESQML protocol for saving edges per column properties uses a clockwise ordering of the 4 edges
+       of a column; the resqpy protocol uses 2 dimensions of extent 2, being the axis (J, I) and face (-, +);
+       this function assumes the array is in RESQML protocol if it has shape (nj, ni, 4) and resqpy protocol
+       if it has shape (nj, ni, 2, 2); when reloading the property it will be presented in RESQML protocol;
+       calling code can use property module functions reformat_column_edges_from_resqml_format() and
+       reformat_column_edges_to_resqml_format() to convert between the protocols if needed
+    """
 
     assert a.ndim in [3, 4]
     if a.ndim == 4:  # resqpy protocol
@@ -3905,25 +3907,25 @@ def gather_ensemble(case_epc_list,
                     create_epc_lookup = True):
     """Creates a composite resqml dataset by merging all parts from all models in list, assigning realization numbers.
 
-   arguments:
-      case_epc_list (list of strings): paths of individual realization epc files
-      new_epc_file (string): path of new composite epc to be created (with paired hdf5 file)
-      consolidate (boolean, default True): if True, simple parts are tested for equivalence and where similar enough
-         a single shared object is established in the composite dataset
-      shared_grids (boolean, default True): if True and consolidate is True, then grids are also consolidated
-         with equivalence based on extent of grids (and citation titles if grid extents within the first case
-         are not distinct); ignored if consolidate is False
-      shared_time_series (boolean, default False): if True and consolidate is True, then time series are consolidated
-         with equivalence based on title, without checking that timestamp lists are the same
-      create_epc_lookup (boolean, default True): if True, a StringLookupTable is created to map from realization
-         number to case epc path
+    arguments:
+       case_epc_list (list of strings): paths of individual realization epc files
+       new_epc_file (string): path of new composite epc to be created (with paired hdf5 file)
+       consolidate (boolean, default True): if True, simple parts are tested for equivalence and where similar enough
+          a single shared object is established in the composite dataset
+       shared_grids (boolean, default True): if True and consolidate is True, then grids are also consolidated
+          with equivalence based on extent of grids (and citation titles if grid extents within the first case
+          are not distinct); ignored if consolidate is False
+       shared_time_series (boolean, default False): if True and consolidate is True, then time series are consolidated
+          with equivalence based on title, without checking that timestamp lists are the same
+       create_epc_lookup (boolean, default True): if True, a StringLookupTable is created to map from realization
+          number to case epc path
 
-   notes:
-      property objects will have an integer realization number assigned, which matches the corresponding index into
-      the case_epc_list;
-      if consolidating with shared grids, then only properties will be gathered from realisations after the first and
-      an exception will be raised if the grids are not matched between realisations
-   """
+    notes:
+       property objects will have an integer realization number assigned, which matches the corresponding index into
+       the case_epc_list;
+       if consolidating with shared grids, then only properties will be gathered from realisations after the first and
+       an exception will be raised if the grids are not matched between realisations
+    """
 
     if not consolidate:
         shared_grids = False

--- a/resqpy/fault.py
+++ b/resqpy/fault.py
@@ -51,59 +51,60 @@ class GridConnectionSet(BaseResqpy):
                  title = None,
                  originator = None,
                  extra_metadata = None):
-        """Initializes a new GridConnectionSet and optionally loads it from xml or a list of simulator format ascii files.
+        """Initializes a new GridConnectionSet and optionally loads it from xml or a list of simulator format ascii
+        files.
 
-      arguments:
-         parent_model (model.Model object): the resqml model that this grid connection set will be part of
-         uuid (uuid.UUID, optional): the uuid of an existing RESQML GridConnectionSetRepresentation from which
-               this resqpy object is populated
-         connection_set_root (DEPRECATED): use uuid instead; the root node of the xml tree for the
-               obj_GridConnectionSet part; ignored if uuid is present
-         find_properties (boolean, default True): if True and uuid is present, the property collection
-               relating to the grid connection set is prepared
-         grid (grid.Grid object, optional): If present, the grid object that this connection set relates to;
-               if absent, the main grid for the parent model is assumed; only used if connection set root is
-               None; see also notes
-         ascii_load_format (string, optional): If present, must be 'nexus'; ignored if loading from xml;
-               otherwise required if ascii_file is present
-         ascii_file (string, optional): the full path of an ascii file holding fault definition data in
-               nexus keyword format; ignored if loading from xml; otherwise, if present, ascii_load_format
-               must also be set
-         k_faces, j_faces, i_faces (boolean arrays, optional): if present, these arrays are used to identify
-               which faces between logically neighbouring cells to include in the new grid connection set
-         create_organizing_objects_where_needed (boolean, default False): if True when loading from ascii or
-               face masks, a fault interpretation object and tectonic boundary feature object will be created
-               for any named fault for which such objects do not exist; if False, missing organizational objects
-               will cause an error to be logged; ignored when loading from xml
-         create_transmissibility_multiplier_property (boolean, default True): if True when loading from ascii,
-               a transmissibility multiplier property is created for the connection set
-         fault_tmult_dict (dict of str: float): optional dictionary mapping fault name to a transmissibility
-               multiplier; only used if initialising from ascii and creating a multiplier property
-         title (str, optional): the citation title to use for a new grid connection set;
-            ignored if uuid or connection_set_root is not None
-         originator (str, optional): the name of the person creating the new grid connection set, defaults to login id;
-            ignored if uuid or connection_set_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the grid connection set
-            ignored if uuid or connection_set_root is not None
+        arguments:
+           parent_model (model.Model object): the resqml model that this grid connection set will be part of
+           uuid (uuid.UUID, optional): the uuid of an existing RESQML GridConnectionSetRepresentation from which
+                 this resqpy object is populated
+           connection_set_root (DEPRECATED): use uuid instead; the root node of the xml tree for the
+                 obj_GridConnectionSet part; ignored if uuid is present
+           find_properties (boolean, default True): if True and uuid is present, the property collection
+                 relating to the grid connection set is prepared
+           grid (grid.Grid object, optional): If present, the grid object that this connection set relates to;
+                 if absent, the main grid for the parent model is assumed; only used if connection set root is
+                 None; see also notes
+           ascii_load_format (string, optional): If present, must be 'nexus'; ignored if loading from xml;
+                 otherwise required if ascii_file is present
+           ascii_file (string, optional): the full path of an ascii file holding fault definition data in
+                 nexus keyword format; ignored if loading from xml; otherwise, if present, ascii_load_format
+                 must also be set
+           k_faces, j_faces, i_faces (boolean arrays, optional): if present, these arrays are used to identify
+                 which faces between logically neighbouring cells to include in the new grid connection set
+           create_organizing_objects_where_needed (boolean, default False): if True when loading from ascii or
+                 face masks, a fault interpretation object and tectonic boundary feature object will be created
+                 for any named fault for which such objects do not exist; if False, missing organizational objects
+                 will cause an error to be logged; ignored when loading from xml
+           create_transmissibility_multiplier_property (boolean, default True): if True when loading from ascii,
+                 a transmissibility multiplier property is created for the connection set
+           fault_tmult_dict (dict of str: float): optional dictionary mapping fault name to a transmissibility
+                 multiplier; only used if initialising from ascii and creating a multiplier property
+           title (str, optional): the citation title to use for a new grid connection set;
+              ignored if uuid or connection_set_root is not None
+           originator (str, optional): the name of the person creating the new grid connection set, defaults to login id;
+              ignored if uuid or connection_set_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the grid connection set
+              ignored if uuid or connection_set_root is not None
 
-      returns:
-         a new GridConnectionSet object, initialised from xml or ascii file, or left empty
+        returns:
+           a new GridConnectionSet object, initialised from xml or ascii file, or left empty
 
-      notes:
-         in the resqml standard, a grid connection set can be used to identify connections between different
-         grids (eg. parent grid to LGR); however, many of the methods in this code currently only handle
-         connections within a single grid;
-         when loading from an ascii file, cell faces are paired on a simplistic logical neighbour basis (as if
-         there is no throw on the fault); this is because the simulator input does not include the full
-         juxtaposition information; the simple mode is adequate for identifying which faces are involved in a
-         fault but not for matters of juxtaposition or absolute transmissibility calculations;
-         if uuid is None and connection_set_root is None and ascii_file is None and k_faces, j_faces & i_faces are None,
-         then an empty connection set is returned;
-         if a transmissibility multiplier property is generated, it will only appear in the property collection
-         for the grid connection set after the create_xml() method has been called
+        notes:
+           in the resqml standard, a grid connection set can be used to identify connections between different
+           grids (eg. parent grid to LGR); however, many of the methods in this code currently only handle
+           connections within a single grid;
+           when loading from an ascii file, cell faces are paired on a simplistic logical neighbour basis (as if
+           there is no throw on the fault); this is because the simulator input does not include the full
+           juxtaposition information; the simple mode is adequate for identifying which faces are involved in a
+           fault but not for matters of juxtaposition or absolute transmissibility calculations;
+           if uuid is None and connection_set_root is None and ascii_file is None and k_faces, j_faces & i_faces are None,
+           then an empty connection set is returned;
+           if a transmissibility multiplier property is generated, it will only appear in the property collection
+           for the grid connection set after the create_xml() method has been called
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         log.debug('initialising grid connection set')
         self.count = None  #: number of face-juxtaposition pairs in this connection set
@@ -230,7 +231,8 @@ class GridConnectionSet(BaseResqpy):
         return self.property_collection
 
     def set_pairs_from_kelp(self, kelp_0, kelp_1, feature_name, create_organizing_objects_where_needed, axis = 'K'):
-        """Sets cell_index_pairs and face_index_pairs based on j and i face kelp strands, using simple no throw pairing."""
+        """Sets cell_index_pairs and face_index_pairs based on j and i face kelp strands, using simple no throw
+        pairing."""
 
         # note: this method has been reworked to allow 'kelp' to be 'horizontal' strands when working in cross section
 
@@ -395,20 +397,20 @@ class GridConnectionSet(BaseResqpy):
                                 one_based_indexing = True):
         """Sets cell_index_pairs and face_index_pairs based on pandas dataframe, using simple no throw pairing.
 
-      arguments:
-         faces (pandas.DataFrame): dataframe with columns 'name', 'face', 'i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult'
-         create_organizing_objects_where_needed (bool, default False): if True, FaultInterpretation and
-            TectonicBoundaryFeature objects are created (including xml creation) where needed
-         create_mult_prop (bool, default True): if True, a transmissibility multiplier property is added to the
-            collection for this grid connection set
-         fault_tmult_dict (dict of str: float): optional dictionary mapping fault name to a transmissibility
-               multiplier; if present, is combined with multiplier values from the dataframe
-         one_based_indexing (bool, default True): if True, the i, j & k values in the dataframe are taken to be
-            in simulator protocol and 1 is subtracted to yield the RESQML cell indices
+        arguments:
+           faces (pandas.DataFrame): dataframe with columns 'name', 'face', 'i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult'
+           create_organizing_objects_where_needed (bool, default False): if True, FaultInterpretation and
+              TectonicBoundaryFeature objects are created (including xml creation) where needed
+           create_mult_prop (bool, default True): if True, a transmissibility multiplier property is added to the
+              collection for this grid connection set
+           fault_tmult_dict (dict of str: float): optional dictionary mapping fault name to a transmissibility
+                 multiplier; if present, is combined with multiplier values from the dataframe
+           one_based_indexing (bool, default True): if True, the i, j & k values in the dataframe are taken to be
+              in simulator protocol and 1 is subtracted to yield the RESQML cell indices
 
-      note:
-         as a side effect, this method will set the cell indices in faces to be zero based
-      """
+        note:
+           as a side effect, this method will set the cell indices in faces to be zero based
+        """
 
         if len(self.grid_list) > 1:
             log.warning('setting grid connection set pairs from dataframe for first grid in list only')
@@ -525,9 +527,9 @@ class GridConnectionSet(BaseResqpy):
     def write_hdf5_and_create_xml_for_new_properties(self):
         """Wites any new property arrays to hdf5, creates xml for the properties and adds them to model.
 
-      note:
-         this method is usually called by the create_xml() method for the grid connection set
-      """
+        note:
+           this method is usually called by the create_xml() method for the grid connection set
+        """
 
         if self.property_collection is not None:
             self.property_collection.write_hdf5_for_imported_list()
@@ -562,12 +564,12 @@ class GridConnectionSet(BaseResqpy):
     def single_feature(self, feature_index = None, feature_name = None):
         """Returns a new GridConnectionSet object containing the single feature copied from this set.
 
-      note:
-         the single feature connection set is established in memory but this method does not write
-         to the hdf5 nor create xml or add as a part to the model
+        note:
+           the single feature connection set is established in memory but this method does not write
+           to the hdf5 nor create xml or add as a part to the model
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert feature_index is not None or feature_name is not None
 
@@ -588,25 +590,25 @@ class GridConnectionSet(BaseResqpy):
     def filtered_by_layer_range(self, min_k0 = None, max_k0 = None, pare_down = True, return_indices = False):
         """Returns a new GridConnectionSet, being a copy with cell faces whittled down to a layer range.
 
-      arguments:
-         min_k0 (int, optional): if present, the minimum layer number to be included (zero based)
-         max_k0 (int, optional): if present, the maximum layer number to be included (zero based)
-         pare_down (bool, default True): if True, any unused features in the new grid connection set will be removed
-            and the feature indices adjusted appropriately; if False, unused features will be left in the list for
-            the new connection set, meaning that the feature indices will be compatible with those for self
-         return_indices (bool, default False): if True, a numpy list of the selected indices is also returned (see notes)
+        arguments:
+           min_k0 (int, optional): if present, the minimum layer number to be included (zero based)
+           max_k0 (int, optional): if present, the maximum layer number to be included (zero based)
+           pare_down (bool, default True): if True, any unused features in the new grid connection set will be removed
+              and the feature indices adjusted appropriately; if False, unused features will be left in the list for
+              the new connection set, meaning that the feature indices will be compatible with those for self
+           return_indices (bool, default False): if True, a numpy list of the selected indices is also returned (see notes)
 
-      returns:
-         a new GridConnectionSet or (GridConnectionSet, numpy int array of shape (N,)) depending on return_indices argument,
-         where the array is a list of selected indices (see notes)
+        returns:
+           a new GridConnectionSet or (GridConnectionSet, numpy int array of shape (N,)) depending on return_indices argument,
+           where the array is a list of selected indices (see notes)
 
-      notes:
-         cells in layer max_k0 are included in the filtered set (not pythonesque);
-         currently only works for single grid connection sets;
-         if return_indices is True, a second item is returned which is a 1D numpy int array holding the indices of
-         cell face pairs that have been selected from the original grid connection set; these values can be used to
-         select equivalent entries from associated properties
-      """
+        notes:
+           cells in layer max_k0 are included in the filtered set (not pythonesque);
+           currently only works for single grid connection sets;
+           if return_indices is True, a second item is returned which is a 1D numpy int array holding the indices of
+           cell face pairs that have been selected from the original grid connection set; these values can be used to
+           select equivalent entries from associated properties
+        """
 
         self.cache_arrays()
         assert len(self.grid_list) == 1, 'attempt to filter multi-grid connection set by layer range'
@@ -631,25 +633,25 @@ class GridConnectionSet(BaseResqpy):
     def filtered_by_cell_mask(self, mask, both_cells_required = True, pare_down = True, return_indices = False):
         """Returns a new GridConnectionSet, being a copy with cell faces whittled down by a boolean mask array.
 
-      arguments:
-         mask (numpy bool array of shape grid.extent_kji): connections will be kept for cells where this mask is True
-         both_cells_required (bool, default True): if True, both cells involved in a connection must have a mask value
-            of True to be included; if False, any connection where either cell has a True mask value will be included
-         pare_down (bool, default True): if True, any unused features in the new grid connection set will be removed
-            and the feature indices adjusted appropriately; if False, unused features will be left in the list for
-            the new connection set, meaning that the feature indices will be compatible with those for self
-         return_indices (bool, default False): if True, a numpy list of the selected indices is also returned (see notes)
+        arguments:
+           mask (numpy bool array of shape grid.extent_kji): connections will be kept for cells where this mask is True
+           both_cells_required (bool, default True): if True, both cells involved in a connection must have a mask value
+              of True to be included; if False, any connection where either cell has a True mask value will be included
+           pare_down (bool, default True): if True, any unused features in the new grid connection set will be removed
+              and the feature indices adjusted appropriately; if False, unused features will be left in the list for
+              the new connection set, meaning that the feature indices will be compatible with those for self
+           return_indices (bool, default False): if True, a numpy list of the selected indices is also returned (see notes)
 
-      returns:
-         a new GridConnectionSet or (GridConnectionSet, numpy int array of shape (N,)) depending on return_indices argument,
-         where the array is a list of selected indices (see notes)
+        returns:
+           a new GridConnectionSet or (GridConnectionSet, numpy int array of shape (N,)) depending on return_indices argument,
+           where the array is a list of selected indices (see notes)
 
-      note:
-         currently only works for single grid connection sets;
-         if return_indices is True, a second item is returned which is a 1D numpy int array holding the indices of
-         cell face pairs that have been selected from the original grid connection set; these values can be used to
-         select equivalent entries from associated properties
-      """
+        note:
+           currently only works for single grid connection sets;
+           if return_indices is True, a second item is returned which is a 1D numpy int array holding the indices of
+           cell face pairs that have been selected from the original grid connection set; these values can be used to
+           select equivalent entries from associated properties
+        """
 
         assert len(self.grid_list) == 1, 'attempt to filter multi-grid connection set by cell mask'
         grid = self.grid_list[0]
@@ -692,8 +694,8 @@ class GridConnectionSet(BaseResqpy):
     def cache_arrays(self):
         """Checks that the connection set array data is loaded and loads from hdf5 if not.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.cell_index_pairs is None or self.face_index_pairs is None or (self.feature_list is not None and
                                                                               self.feature_indices is None):
@@ -767,8 +769,8 @@ class GridConnectionSet(BaseResqpy):
     def number_of_grids(self):
         """Returns the number of grids involved in the connection set.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return len(self.grid_list)
 
@@ -781,8 +783,8 @@ class GridConnectionSet(BaseResqpy):
     def number_of_features(self):
         """Returns the number of features (faults) in the connection set.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.feature_list is None:
             return 0
@@ -791,8 +793,8 @@ class GridConnectionSet(BaseResqpy):
     def list_of_feature_names(self, strip = True):
         """Returns a list of the feature (fault) names for which the connection set has cell face data.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.feature_list is None:
             return None
@@ -812,15 +814,15 @@ class GridConnectionSet(BaseResqpy):
     def feature_index_and_uuid_for_fault_name(self, fault_name):
         """Returns the index into the feature (fault) list for the named fault.
 
-      arguments:
-         fault_name (string): the name of the fault of interest
+        arguments:
+           fault_name (string): the name of the fault of interest
 
-      returns:
-         (index, uuid) where index is an integer which can be used to index the feature_list and is compatible
-            with the elements of feature_indices (connection interpretations elements in xml);
-            uuid is the uuid.UUID of the feature interpretation for the fault;
-            (None, None) is returned if the named fault is not found in the feature list
-      """
+        returns:
+           (index, uuid) where index is an integer which can be used to index the feature_list and is compatible
+              with the elements of feature_indices (connection interpretations elements in xml);
+              uuid is the uuid.UUID of the feature interpretation for the fault;
+              (None, None) is returned if the named fault is not found in the feature list
+        """
 
         if self.feature_list is None:
             return (None, None)
@@ -835,16 +837,16 @@ class GridConnectionSet(BaseResqpy):
     def feature_name_for_feature_index(self, feature_index, strip = True):
         """Returns the fault name corresponding to the given index into the feature (fault) list.
 
-      arguments:
-         feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
-         strip (boolean, default True): if True, the citation title for the feature interpretation is split
-            and the first word is returned (stripped of leading and trailing whitespace); if False, the
-            citation title is returned unaltered
+        arguments:
+           feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
+           strip (boolean, default True): if True, the citation title for the feature interpretation is split
+              and the first word is returned (stripped of leading and trailing whitespace); if False, the
+              citation title is returned unaltered
 
-      returns:
-         string being the citation title of the indexed fault interpretation part, optionally stripped
-         down to the first word; by convention this is the name of the fault
-      """
+        returns:
+           string being the citation title of the indexed fault interpretation part, optionally stripped
+           down to the first word; by convention this is the name of the fault
+        """
 
         if self.feature_list is None:
             return None
@@ -860,10 +862,10 @@ class GridConnectionSet(BaseResqpy):
     def feature_index_for_cell_face(self, cell_kji0, axis, p01):
         """Returns the index into the feature (fault) list for the given face of the given cell, or None.
 
-      note:
-         where the cell face appears in more than one feature, the result will arbitrarily be the first
-         occurrence in the cell_index_pair ordering of the grid connection set
-      """
+        note:
+           where the cell face appears in more than one feature, the result will arbitrarily be the first
+           occurrence in the cell_index_pair ordering of the grid connection set
+        """
 
         self.cache_arrays()
         if self.feature_indices is None:
@@ -888,16 +890,16 @@ class GridConnectionSet(BaseResqpy):
     def raw_list_of_cell_face_pairs_for_feature_index(self, feature_index):
         """Returns list of cell face pairs contributing to feature (fault) with given index, in raw form.
 
-      arguments:
-         feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
+        arguments:
+           feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
 
-      returns:
-         (cell_index_pairs, face_index_pairs) or (cell_index_pairs, face_index_pairs, grid_index_pairs)
-         where each is an integer numpy array of shape (N, 2);
-         if the connection set is for a single grid, the returned value is a pair, otherwise a triplet;
-         the returned data is in raw form: normalized cell indices (for flattened array) and face indices
-         in range 0..5; grid indices can be used to index the grid_list attribute for relevant Grid object
-      """
+        returns:
+           (cell_index_pairs, face_index_pairs) or (cell_index_pairs, face_index_pairs, grid_index_pairs)
+           where each is an integer numpy array of shape (N, 2);
+           if the connection set is for a single grid, the returned value is a pair, otherwise a triplet;
+           the returned data is in raw form: normalized cell indices (for flattened array) and face indices
+           in range 0..5; grid indices can be used to index the grid_list attribute for relevant Grid object
+        """
 
         matches = self.indices_for_feature_index(feature_index)
         if matches is None:
@@ -910,26 +912,26 @@ class GridConnectionSet(BaseResqpy):
     def inherit_properties_for_selected_indices(self, other, selected_indices):
         """Adds to imported property list by sampling the properties for another grid connection set.
 
-      arguments:
-         other (GridConnectionSet): the source grid connection set whose properties will be sampled
-         selected_indices (1D numpy int array): the indices, into the main arrays of other, of the
-            cell face pairs for which data is to be inherited
+        arguments:
+           other (GridConnectionSet): the source grid connection set whose properties will be sampled
+           selected_indices (1D numpy int array): the indices, into the main arrays of other, of the
+              cell face pairs for which data is to be inherited
 
-      notes:
-         this method is typically called after creating a subset grid connection set using methods
-         such as: filtered_by_layer_range(), filtered_by_cell_mask() or single_feature(); for the
-         first two of those, set the return_indices argument True to acquire the array to pass as
-         selected_indices here; when working with a single_feature() connection set, the indices
-         can be acquired by calling indices_for_feature_index() for the source connection set;
-         this method only adds the inherited property data to the imported list of the property
-         collection for this grid connection set (self); it does not write the data to hdf5 or
-         create the xml; those actions will happen when calling create_xml() with the
-         write_new_properties argument set True; they can also be triggered by calling the
-         write_hdf5_and_create_xml_for_new_properties() method directly;
-         the property collection for the other grid connection set must be established before
-         calling this method, for example by setting find_properties to True when instantiating
-         other
-      """
+        notes:
+           this method is typically called after creating a subset grid connection set using methods
+           such as: filtered_by_layer_range(), filtered_by_cell_mask() or single_feature(); for the
+           first two of those, set the return_indices argument True to acquire the array to pass as
+           selected_indices here; when working with a single_feature() connection set, the indices
+           can be acquired by calling indices_for_feature_index() for the source connection set;
+           this method only adds the inherited property data to the imported list of the property
+           collection for this grid connection set (self); it does not write the data to hdf5 or
+           create the xml; those actions will happen when calling create_xml() with the
+           write_new_properties argument set True; they can also be triggered by calling the
+           write_hdf5_and_create_xml_for_new_properties() method directly;
+           the property collection for the other grid connection set must be established before
+           calling this method, for example by setting find_properties to True when instantiating
+           other
+        """
 
         if other.property_collection is None or other.property_collection.number_of_parts() == 0:
             return
@@ -942,19 +944,19 @@ class GridConnectionSet(BaseResqpy):
     def list_of_cell_face_pairs_for_feature_index(self, feature_index):
         """Returns list of cell face pairs contributing to feature (fault) with given index.
 
-      arguments:
-         feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
+        arguments:
+           feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
 
-      returns:
-         (cell_index_pairs, face_index_pairs) or (cell_index_pairs, face_index_pairs, grid_index_pairs)
-         where cell_index_pairs is a numpy int array of shape (N, 2, 3) being the paired kji0 cell indices;
-         and face_index_pairs is a numpy int array of shape (N, 2, 2) being the paired face indices with the
-         final axis of extent 2 indexed by 0 to give the facial axis (0 = K, 1 = J, 2 = I), and indexed by 1
-         to give the facial polarity (0 = minus face, 1 = plus face);
-         and grid_index_pairs is a numpy int array of shape (N, 2) the values of which can be used to index
-         the grid_list attribute to access relevant Grid objects;
-         if the connection set is for a single grid, the return value is a pair; otherwise a triplet
-      """
+        returns:
+           (cell_index_pairs, face_index_pairs) or (cell_index_pairs, face_index_pairs, grid_index_pairs)
+           where cell_index_pairs is a numpy int array of shape (N, 2, 3) being the paired kji0 cell indices;
+           and face_index_pairs is a numpy int array of shape (N, 2, 2) being the paired face indices with the
+           final axis of extent 2 indexed by 0 to give the facial axis (0 = K, 1 = J, 2 = I), and indexed by 1
+           to give the facial polarity (0 = minus face, 1 = plus face);
+           and grid_index_pairs is a numpy int array of shape (N, 2) the values of which can be used to index
+           the grid_list attribute to access relevant Grid objects;
+           if the connection set is for a single grid, the return value is a pair; otherwise a triplet
+        """
 
         self.cache_arrays()
         if self.feature_indices is None:
@@ -976,18 +978,18 @@ class GridConnectionSet(BaseResqpy):
     def simplified_sets_of_kelp_for_feature_index(self, feature_index):
         """Returns a pair of sets of column indices, one for J+ faces, one for I+ faces, contributing to feature.
 
-      arguments:
-         feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
+        arguments:
+           feature_index (non-negative integer): the index into the ordered feature list (fault interpretation list)
 
-      returns:
-         (set of numpy pair of integers, set of numpy pair of integers) the first set is those columns where
-         the J+ faces are contributing to the connection (or the J- faces of the neighbouring column); the second
-         set is where the the I+ faces are contributing to the connection (or the I- faces of the neighbouring column)
+        returns:
+           (set of numpy pair of integers, set of numpy pair of integers) the first set is those columns where
+           the J+ faces are contributing to the connection (or the J- faces of the neighbouring column); the second
+           set is where the the I+ faces are contributing to the connection (or the I- faces of the neighbouring column)
 
-      notes:
-         K faces are ignored;
-         this is compatible with the resqml baffle functionality elsewhere
-      """
+        notes:
+           K faces are ignored;
+           this is compatible with the resqml baffle functionality elsewhere
+        """
 
         cell_pairs, face_pairs = self.list_of_cell_face_pairs_for_feature_index(feature_index)
         simple_j_set = set(
@@ -1014,13 +1016,13 @@ class GridConnectionSet(BaseResqpy):
     def rework_face_pairs(self):
         """Overwrites the in-memory array of face pairs to reflect neighbouring I or J columns.
 
-      note:
-         the indexing of faces within a cell is not clearly documented in the RESQML guides;
-         the constant self.face_index_map and its inverse is the best guess at what this mapping is;
-         this function overwrites the faces within cell data where a connected pair are in neighbouring
-         I or J columns, using the face within cell values that fit with the neighbourly relationship;
-         for some implausibly extreme gridding, this might not give the correct result
-      """
+        note:
+           the indexing of faces within a cell is not clearly documented in the RESQML guides;
+           the constant self.face_index_map and its inverse is the best guess at what this mapping is;
+           this function overwrites the faces within cell data where a connected pair are in neighbouring
+           I or J columns, using the face within cell values that fit with the neighbourly relationship;
+           for some implausibly extreme gridding, this might not give the correct result
+        """
 
         self.cache_arrays()
         if self.feature_indices is None:
@@ -1052,8 +1054,8 @@ class GridConnectionSet(BaseResqpy):
     def write_hdf5(self, file_name = None, mode = 'a'):
         """Create or append to an hdf5 file, writing datasets for the connection set after caching arrays.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # NB: cell pairs, face pairs, and feature indices arrays must be ready, in memory
         # note: grid pairs not yet supported
@@ -1093,10 +1095,11 @@ class GridConnectionSet(BaseResqpy):
                    write_new_properties = True,
                    title = None,
                    originator = None):
-        """Creates a Grid Connection Set (fault faces) xml node and optionally adds as child of root and/or to parts forest.
+        """Creates a Grid Connection Set (fault faces) xml node and optionally adds as child of root and/or to parts
+        forest.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # NB: only one grid handled for now
         # xml for grid(s) must be created before calling this method
@@ -1327,16 +1330,16 @@ class GridConnectionSet(BaseResqpy):
                         write_row(self, fp, feature_name, i, j, k, k2, axis, polarity)
 
     def get_column_edge_list_for_feature(self, feature, gridindex = 0, min_k = 0, max_k = 0):
-        """Extracts a list of cell faces for a given feature index, over a given range of layers in the grid
+        """Extracts a list of cell faces for a given feature index, over a given range of layers in the grid.
 
-      Args:
-         feature - feature index
-         gridindex - index of grid to be used in grid connection set gridlist, default 0
-         min_k - minimum k layer, default 0
-         max_k - maximum k layer, default 0
-      Returns:
-         list of cell faces for the feature (j_col, i_col, face_axis, face_polarity)
-      """
+        Args:
+           feature - feature index
+           gridindex - index of grid to be used in grid connection set gridlist, default 0
+           min_k - minimum k layer, default 0
+           max_k - maximum k layer, default 0
+        Returns:
+           list of cell faces for the feature (j_col, i_col, face_axis, face_polarity)
+        """
         subgcs = self.filtered_by_layer_range(min_k0 = min_k, max_k0 = max_k, pare_down = False)
         if subgcs is None:
             return None
@@ -1366,22 +1369,22 @@ class GridConnectionSet(BaseResqpy):
         return ij_faces_np
 
     def get_column_edge_bool_array_for_feature(self, feature, gridindex = 0, min_k = 0, max_k = 0):
-        """Generate a boolean aray defining which column edges are present for a given feature and k-layer range
+        """Generate a boolean aray defining which column edges are present for a given feature and k-layer range.
 
-      Args:
-         feature - feature index
-         gridindex - index of grid to be used in grid connection set gridlist, default 0
-         min_k - minimum k layer
-         max_k - maximum k layer
-      Returns:
-         boolean fault_by_column_edge_mask array (shape nj,ni,2,2)
+        Args:
+           feature - feature index
+           gridindex - index of grid to be used in grid connection set gridlist, default 0
+           min_k - minimum k layer
+           max_k - maximum k layer
+        Returns:
+           boolean fault_by_column_edge_mask array (shape nj,ni,2,2)
 
-      Note: the indices for the final two axes define the edges:
-         the first defines j or i (0 or 1)
-         the second negative or positive face (0 or 1)
+        Note: the indices for the final two axes define the edges:
+           the first defines j or i (0 or 1)
+           the second negative or positive face (0 or 1)
 
-         so [[True,False],[False,True]] indicates the -j and +i edges of the column are present
-      """
+           so [[True,False],[False,True]] indicates the -j and +i edges of the column are present
+        """
         cell_face_list = self.get_column_edge_list_for_feature(feature, gridindex, min_k, max_k)
 
         fault_by_column_edge_mask = np.zeros((self.grid_list[gridindex].nj, self.grid_list[gridindex].ni, 2, 2),
@@ -1397,19 +1400,19 @@ class GridConnectionSet(BaseResqpy):
                                            property_name = 'Transmissibility multiplier'):
         """Returns a list of property values by feature based on extra metadata items.
 
-      arguments:
-         feature_index_list (list of int, optional): if present, the feature indices for which property values will be included
-            in the resulting list; if None, values will be included for each feature in the feature_list for this connection set
-         property_name (string, default 'Transmissibility multiplier'): the property name of interest, as used in the features'
-            extra metadata as a key (this not a property collection citation title)
+        arguments:
+           feature_index_list (list of int, optional): if present, the feature indices for which property values will be included
+              in the resulting list; if None, values will be included for each feature in the feature_list for this connection set
+           property_name (string, default 'Transmissibility multiplier'): the property name of interest, as used in the features'
+              extra metadata as a key (this not a property collection citation title)
 
-      returns:
-         list of float being the list of property values for the list of features, in corresponding order
+        returns:
+           list of float being the list of property values for the list of features, in corresponding order
 
-      note:
-         this method does not refer to property collection arrays, it simply looks for a constant extra metadata item
-         for each feature; where no such item is found, a NaN is added to the return list
-      """
+        note:
+           this method does not refer to property collection arrays, it simply looks for a constant extra metadata item
+           for each feature; where no such item is found, a NaN is added to the return list
+        """
 
         if feature_index_list is None:
             feature_index_list = range(len(self.feature_list))
@@ -1432,29 +1435,30 @@ class GridConnectionSet(BaseResqpy):
                                                 property_name = 'Transmissibility multiplier',
                                                 gridindex = 0,
                                                 ref_k = None):
-        """Generate a float value aray defining the property values for different column edges present for a given feature
+        """Generate a float value aray defining the property values for different column edges present for a given
+        feature.
 
-      Args:
-         feature - feature index
-         fault_by_column_edge_mask - fault_by_column_edge_mask with True on edges where feature is present
-         property_name - name of property, should be present within the FaultInterpreation feature metadata;
-            lowercase version is also used as property kind when searching for a property array
-         gridindex - index of grid for which column edge data is required
-         ref_k - reference k_layer to use where property has variable value for a feature;
-            if None, no property array will be used and None will be returned for variable properties
+        Args:
+           feature - feature index
+           fault_by_column_edge_mask - fault_by_column_edge_mask with True on edges where feature is present
+           property_name - name of property, should be present within the FaultInterpreation feature metadata;
+              lowercase version is also used as property kind when searching for a property array
+           gridindex - index of grid for which column edge data is required
+           ref_k - reference k_layer to use where property has variable value for a feature;
+              if None, no property array will be used and None will be returned for variable properties
 
-      Returns:
-         float property_value_by_column_edge array (shape nj,ni,2,2) based on extra metadata
+        Returns:
+           float property_value_by_column_edge array (shape nj,ni,2,2) based on extra metadata
 
-      Note: the indices for the final two axes define the edges:
-         the first defines j or i (0 or 1)
-         the second negative or positive face (0 or 1)
+        Note: the indices for the final two axes define the edges:
+           the first defines j or i (0 or 1)
+           the second negative or positive face (0 or 1)
 
-         so [[1,np.nan],[np.nan,np.nan]] indicates the -j edge of the column are present with a value of 1
+           so [[1,np.nan],[np.nan,np.nan]] indicates the -j edge of the column are present with a value of 1
 
-         this method preferentially uses a constant extra metadata item for the feature, with the property
-         collection being used when the extra metadata is absent
-      """
+           this method preferentially uses a constant extra metadata item for the feature, with the property
+           collection being used when the extra metadata is absent
+        """
 
         single_grid = (self.number_of_grids() == 1)
         if single_grid:
@@ -1514,22 +1518,23 @@ class GridConnectionSet(BaseResqpy):
                                                    property_name = 'Transmissibility multiplier',
                                                    feature_list = None,
                                                    ref_k = None):
-        """Generate a combined mask, index and value arrays for all column edges across a k-layer range, for a defined feature_list
+        """Generate a combined mask, index and value arrays for all column edges across a k-layer range, for a defined
+        feature_list.
 
-      Args:
-         gridindex - index of grid to be used in grid connection set gridlist, default 0
-         min_k - minimum k_layer
-         max_k - maximum k_layer
-         property_name - name of property, should be present within the FaultInterpreation feature metadata;
-            lowercase version is used as property kind when searching for a property array
-         feature_list - list of feature index numbers to run for, default to all features
-         ref_k - reference k_layer to use where property has variable value for a feature;
-            if None defaults to min_k
-      Returns:
-         bool array mask showing all column edges within features (shape nj,ni,2,2)
-         int array showing the feature index for all column edges within features (shape nj,ni,2,2)
-         float array showing the property value for all column edges within features (shape nj,ni,2,2)
-      """
+        Args:
+           gridindex - index of grid to be used in grid connection set gridlist, default 0
+           min_k - minimum k_layer
+           max_k - maximum k_layer
+           property_name - name of property, should be present within the FaultInterpreation feature metadata;
+              lowercase version is used as property kind when searching for a property array
+           feature_list - list of feature index numbers to run for, default to all features
+           ref_k - reference k_layer to use where property has variable value for a feature;
+              if None defaults to min_k
+        Returns:
+           bool array mask showing all column edges within features (shape nj,ni,2,2)
+           int array showing the feature index for all column edges within features (shape nj,ni,2,2)
+           float array showing the property value for all column edges within features (shape nj,ni,2,2)
+        """
         self.cache_arrays()
         #     if feature_list is None: feature_list = np.unique(self.feature_indices)
         if feature_list is None:
@@ -1576,28 +1581,28 @@ class GridConnectionSet(BaseResqpy):
     def tr_property_array(self, fa = None, tol_fa = 0.0001, tol_half_t = 1.0e-5, apply_multipliers = False):
         """Return a transmissibility array with one value per pair in the connection set.
 
-      argument:
-         fa (numpy float array of shape (count, 2), optional): if present, the fractional area for each pair connection,
-            from perspective of each side of connection; if None, a fractional area of one is assumed
-         tol_fa (float, default 0.0001): fractional area tolerance – if the fractional area on either side of a
-            juxtaposition is less than this, then the corresponding transmissibility is set to zero
-         tol_half_t (float, default 1.0e-5): if the half cell transmissibility either side of a juxtaposition is
-            less than this, the corresponding transmissibility is set to zero; units are as for returned values (see
-            notes)
-         apply_multipliers (boolean, default False): if True, a transmissibility multiplier array is fetched from the
-            property collection for the connection set, and failing that a multiplier for each feature is
-            extracted from the feature extra metadata, and applied to the transmissibility calculation
+        argument:
+           fa (numpy float array of shape (count, 2), optional): if present, the fractional area for each pair connection,
+              from perspective of each side of connection; if None, a fractional area of one is assumed
+           tol_fa (float, default 0.0001): fractional area tolerance – if the fractional area on either side of a
+              juxtaposition is less than this, then the corresponding transmissibility is set to zero
+           tol_half_t (float, default 1.0e-5): if the half cell transmissibility either side of a juxtaposition is
+              less than this, the corresponding transmissibility is set to zero; units are as for returned values (see
+              notes)
+           apply_multipliers (boolean, default False): if True, a transmissibility multiplier array is fetched from the
+              property collection for the connection set, and failing that a multiplier for each feature is
+              extracted from the feature extra metadata, and applied to the transmissibility calculation
 
-      returns:
-         numpy float array of shape (count,) being the absolute transmissibilities across the connected cell face pairs;
-         see notes regarding units
+        returns:
+           numpy float array of shape (count,) being the absolute transmissibilities across the connected cell face pairs;
+           see notes regarding units
 
-      notes:
-         implicit units of measure of returned values will be m3.cP/(kPa.d) if grids' crs length units are metres,
-         bbl.cP/(psi.d) if length units are feet; the computation is compatible with the Nexus NEWTRAN formulation;
-         multiple grids are assumed to be in the same units and z units must be the same as xy units; this method
-         does not add the transmissibility array as a property
-      """
+        notes:
+           implicit units of measure of returned values will be m3.cP/(kPa.d) if grids' crs length units are metres,
+           bbl.cP/(psi.d) if length units are feet; the computation is compatible with the Nexus NEWTRAN formulation;
+           multiple grids are assumed to be in the same units and z units must be the same as xy units; this method
+           does not add the transmissibility array as a property
+        """
 
         feature_mult_list = None
         mult_array = None
@@ -1650,17 +1655,17 @@ class GridConnectionSet(BaseResqpy):
     def inherit_features(self, featured):
         """Inherit features from another connection set, reassigning feature indices for matching faces.
 
-      arguments:
-         featured (GridConnectionSet): the other connection set which holds features to be inherited
+        arguments:
+           featured (GridConnectionSet): the other connection set which holds features to be inherited
 
-      notes:
-         the list of cell face pairs in this set remains unchanged; the corresponding feature indices
-         are updated based on individual cell faces that are found in the featured connection set;
-         the feature list is extended with inherited features as required; this method is typically
-         used to populate a fault connection set built from grid geometry with named fault features
-         from a simplistic connection set, thus combining full geometric juxtaposition information
-         with named features; currently restricted to single grid connection sets
-      """
+        notes:
+           the list of cell face pairs in this set remains unchanged; the corresponding feature indices
+           are updated based on individual cell faces that are found in the featured connection set;
+           the feature list is extended with inherited features as required; this method is typically
+           used to populate a fault connection set built from grid geometry with named fault features
+           from a simplistic connection set, thus combining full geometric juxtaposition information
+           with named features; currently restricted to single grid connection sets
+        """
 
         def sorted_paired_cell_face_index_position(cell_face_index, a_or_b):
             # pair one side (a_or_b) of cell_face_index with its position, then sort
@@ -1762,16 +1767,16 @@ class GridConnectionSet(BaseResqpy):
 def pinchout_connection_set(grid, skip_inactive = True, feature_name = 'pinchout'):
     """Returns a new GridConnectionSet representing non-standard K face connections across pinchouts.
 
-   arguments:
-      grid (grid.Grid): the grid for which a pinchout connection set is required
-      skip_inactive (boolean, default True): if True, connections are not included where there is an inactive cell
-         above or below the pinchout; if False, such connections are included
-      feature_name (string, default 'pinchout'): the name to use as citation title in the feature and interpretation
+    arguments:
+       grid (grid.Grid): the grid for which a pinchout connection set is required
+       skip_inactive (boolean, default True): if True, connections are not included where there is an inactive cell
+          above or below the pinchout; if False, such connections are included
+       feature_name (string, default 'pinchout'): the name to use as citation title in the feature and interpretation
 
-   notes:
-      this function does not write to hdf5, nor create xml for the new grid connection set;
-      however, it does create one feature and a corresponding interpretation and creates xml for those
-   """
+    notes:
+       this function does not write to hdf5, nor create xml for the new grid connection set;
+       however, it does create one feature and a corresponding interpretation and creates xml for those
+    """
 
     assert grid is not None
 
@@ -1816,20 +1821,20 @@ def pinchout_connection_set(grid, skip_inactive = True, feature_name = 'pinchout
 def k_gap_connection_set(grid, skip_inactive = True, feature_name = 'k gap connection', tolerance = 0.001):
     """Returns a new GridConnectionSet representing K face connections where a K gap is zero thickness.
 
-   arguments:
-      grid (grid.Grid): the grid for which a K gap connection set is required
-      skip_inactive (boolean, default True): if True, connections are not included where there is an inactive cell
-         above or below the pinchout; if False, such connections are included
-      feature_name (string, default 'pinchout'): the name to use as citation title in the feature and interpretation
-      tolerance (float, default 0.001): the minimum vertical distance below which a K gap is deemed to be zero
-         thickness; units are implicitly the z units of the coordinate reference system used by grid
+    arguments:
+       grid (grid.Grid): the grid for which a K gap connection set is required
+       skip_inactive (boolean, default True): if True, connections are not included where there is an inactive cell
+          above or below the pinchout; if False, such connections are included
+       feature_name (string, default 'pinchout'): the name to use as citation title in the feature and interpretation
+       tolerance (float, default 0.001): the minimum vertical distance below which a K gap is deemed to be zero
+          thickness; units are implicitly the z units of the coordinate reference system used by grid
 
-   notes:
-      this function does not write to hdf5, nor create xml for the new grid connection set;
-      however, it does create one feature and a corresponding interpretation and creates xml for those;
-      note that the entries in the connection set will be for logically K-neighbouring pairs of cells – such pairs
-      are omitted from the standard transmissibilities due to the presence of the K gap layer
-   """
+    notes:
+       this function does not write to hdf5, nor create xml for the new grid connection set;
+       however, it does create one feature and a corresponding interpretation and creates xml for those;
+       note that the entries in the connection set will be for logically K-neighbouring pairs of cells – such pairs
+       are omitted from the standard transmissibilities due to the presence of the K gap layer
+    """
 
     assert grid is not None
     if not grid.k_gaps:
@@ -1870,16 +1875,16 @@ def k_gap_connection_set(grid, skip_inactive = True, feature_name = 'k gap conne
 def add_connection_set_and_tmults(model, fault_incl, tmult_dict = None):
     """Add a grid connection set to a resqml model, based on a fault include file and a dictionary of fault:tmult pairs.
 
-   Grid connection set added to resqml model, with extra_metadata on the fault interpretation containing the MULTFL values
+    Grid connection set added to resqml model, with extra_metadata on the fault interpretation containing the MULTFL values
 
-   Args:
-      model: resqml model object
-      fault_incl: fullpath to fault include file or list of fullpaths to fault include files
-      tmult_dict: dictionary of fault name/transmissibility multiplier pairs (must align with faults in include file).
-         Optional, if blank values in the fault.include file will be used instead
-   Returns:
-      grid connection set uuid
-   """
+    Args:
+       model: resqml model object
+       fault_incl: fullpath to fault include file or list of fullpaths to fault include files
+       tmult_dict: dictionary of fault name/transmissibility multiplier pairs (must align with faults in include file).
+          Optional, if blank values in the fault.include file will be used instead
+    Returns:
+       grid connection set uuid
+    """
 
     if isinstance(fault_incl, list):
         if len(fault_incl) > 1:

--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -90,29 +90,29 @@ class Grid(BaseResqpy):
                  extra_metadata = {}):
         """Create a Grid object and optionally populate from xml tree.
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
-         grid_root (DEPRECATED): use uuid instead; the root of the xml tree for the grid part
-         find_properties (boolean, default True): if True and uuid (or grid_root) is present, a
-            grid property collection is instantiated as an attribute, holding properties for which
-            this grid is the supporting representation
-         geometry_required (boolean, default True): if True and no geometry node exists in the xml,
-            an assertion error is raised; ignored if uuid is None (and grid_root is None)
-         title (str, optional): citation title for new grid; ignored if loading from xml
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if loading from xml
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if loading from xml
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
+           grid_root (DEPRECATED): use uuid instead; the root of the xml tree for the grid part
+           find_properties (boolean, default True): if True and uuid (or grid_root) is present, a
+              grid property collection is instantiated as an attribute, holding properties for which
+              this grid is the supporting representation
+           geometry_required (boolean, default True): if True and no geometry node exists in the xml,
+              an assertion error is raised; ignored if uuid is None (and grid_root is None)
+           title (str, optional): citation title for new grid; ignored if loading from xml
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if loading from xml
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if loading from xml
 
-      returns:
-         a newly created Grid object
+        returns:
+           a newly created Grid object
 
-      notes:
-         only IJK grids are handled at the moment (the resqml standard also defines 5 other varieties)
+        notes:
+           only IJK grids are handled at the moment (the resqml standard also defines 5 other varieties)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # note: currently only handles IJK grids
         # todo: check grid_root, if passed, is for an IJK grid
@@ -203,31 +203,31 @@ class Grid(BaseResqpy):
 
     @property
     def grid_root(self):
-        """Alias for root"""
+        """Alias for root."""
         return self.root
 
     def set_modified(self, update_xml = False, update_hdf5 = False):
         """Assigns a new uuid to this grid; also calls set_modified() for parent model.
 
-      arguments:
-         update_xml (boolean, default False): if True, the uuid is modified in the xml tree
-            for the grid part
-         update_hdf5: (boolean, default False): if True, the uuid in the hdf5 internal path names
-            for the datasets (arrays) for the grid are updated
+        arguments:
+           update_xml (boolean, default False): if True, the uuid is modified in the xml tree
+              for the grid part
+           update_hdf5: (boolean, default False): if True, the uuid in the hdf5 internal path names
+              for the datasets (arrays) for the grid are updated
 
-      returns:
-         the new uuid for this grid object
+        returns:
+           the new uuid for this grid object
 
-      notes:
-         a resqml object should be thought of as immutable; therefore when modifying an object,
-         it is preferable to assign it a new unique identifer which this method does for a grid;
-         the hdf5 internal path names held in xml are only updated if both update_xml and update_hdf5
-         are True;
-         if the grid object has been created using the Model.copy_part() method, it is not
-         necessary to call this function as a new uuid will already have been assigned;
-         NB: relationships are not updated by this function, including the relationship to the
-         hdf5 external part
-      """
+        notes:
+           a resqml object should be thought of as immutable; therefore when modifying an object,
+           it is preferable to assign it a new unique identifer which this method does for a grid;
+           the hdf5 internal path names held in xml are only updated if both update_xml and update_hdf5
+           are True;
+           if the grid object has been created using the Model.copy_part() method, it is not
+           necessary to call this function as a new uuid will already have been assigned;
+           NB: relationships are not updated by this function, including the relationship to the
+           hdf5 external part
+        """
 
         old_uuid = self.uuid
         self.uuid = bu.new_uuid()
@@ -252,11 +252,11 @@ class Grid(BaseResqpy):
     def extract_extent_kji(self):
         """Returns the grid extent; for IJK grids this is a 3 integer numpy array, order is Nk, Nj, Ni.
 
-      returns:
-         numpy int array of shape (3,) being number of cells in k, j & i axes respectively;
-         the return value is cached in attribute extent_kji, which can alternatively be referenced
-         directly by calling code as the value is set from xml on initialisation
-      """
+        returns:
+           numpy int array of shape (3,) being number of cells in k, j & i axes respectively;
+           the return value is cached in attribute extent_kji, which can alternatively be referenced
+           directly by calling code as the value is set from xml on initialisation
+        """
 
         if self.extent_kji is not None:
             return self.extent_kji
@@ -269,16 +269,16 @@ class Grid(BaseResqpy):
     def cell_count(self, active_only = False, non_pinched_out_only = False, geometry_defined_only = False):
         """Returns number of cells in grid; optionally limited by active, non-pinched-out, or having geometry.
 
-      arguments:
-         active_only (boolean, default False): if True, the count of active cells is returned
-         non_pinched_out_only (boolean, default False): if True, the count of cells with vertical
-            thickness greater than 0.001 (units are crs vertical units) is returned
-         geometry_defined_only (boolean, default False): if True, the count of cells which have a
-            defined geometry is returned (a zero thickness cell may still have a defined geometry)
+        arguments:
+           active_only (boolean, default False): if True, the count of active cells is returned
+           non_pinched_out_only (boolean, default False): if True, the count of cells with vertical
+              thickness greater than 0.001 (units are crs vertical units) is returned
+           geometry_defined_only (boolean, default False): if True, the count of cells which have a
+              defined geometry is returned (a zero thickness cell may still have a defined geometry)
 
-      returns:
-         integer being the number of cells in the grid
-      """
+        returns:
+           integer being the number of cells in the grid
+        """
 
         # todo: elsewhere: setting of active array from boolean array or zero pore volume
         if not (active_only or non_pinched_out_only or geometry_defined_only):
@@ -307,12 +307,12 @@ class Grid(BaseResqpy):
     def natural_cell_indices(self, cell_kji0s):
         """Returns a numpy integer array with a value for each of the cells, being the index into a flattened array.
 
-      argument:
-         cell_kji0s: numpy integer array of shape (..., 3) being a list of cell indices in kji0 protocol
+        argument:
+           cell_kji0s: numpy integer array of shape (..., 3) being a list of cell indices in kji0 protocol
 
-      returns:
-         numpy integer array of shape (...,) being the equivalent natural cell indices (for a flattened array of cells)
-      """
+        returns:
+           numpy integer array of shape (...,) being the equivalent natural cell indices (for a flattened array of cells)
+        """
 
         return (cell_kji0s[..., 0] * self.nj + cell_kji0s[..., 1]) * self.ni + cell_kji0s[..., 2]
 
@@ -324,14 +324,15 @@ class Grid(BaseResqpy):
         return (k0, j0, i0)
 
     def denaturalized_cell_indices(self, c0s):
-        """Returns an integer numpy array of shape (..., 3) holding kji0 indices for the cells with given natural indices.
+        """Returns an integer numpy array of shape (..., 3) holding kji0 indices for the cells with given natural
+        indices.
 
-      argument:
-         c0s: numpy integer array of shape (...,) being natural cell indices (for a flattened array)
+        argument:
+           c0s: numpy integer array of shape (...,) being natural cell indices (for a flattened array)
 
-      returns:
-         numpy integer array of shape (..., 3) being the equivalent kji0 protocol cell indices
-      """
+        returns:
+           numpy integer array of shape (..., 3) being the equivalent kji0 protocol cell indices
+        """
 
         k0s, ji0s = divmod(c0s, self.nj * self.ni)
         j0s, i0s = divmod(ji0s, self.ni)
@@ -340,17 +341,17 @@ class Grid(BaseResqpy):
     def resolve_geometry_child(self, tag, child_node = None):
         """If xml child node is None, looks for tag amongst children of geometry root.
 
-      arguments:
-         tag (string): the tag of the geometry child node of interest
-         child_node (optional): the already resolved xml root of the child, or None
+        arguments:
+           tag (string): the tag of the geometry child node of interest
+           child_node (optional): the already resolved xml root of the child, or None
 
-      returns:
-         xml node of child of geometry node for this grid, which matches tag
+        returns:
+           xml node of child of geometry node for this grid, which matches tag
 
-      note:
-         if child_node argument is not None, it is simply returned;
-         if child_node is None, the geometry node for this grid is scanned for a child with matching tag
-      """
+        note:
+           if child_node argument is not None, it is simply returned;
+           if child_node is None, the geometry node for this grid is scanned for a child with matching tag
+        """
 
         if child_node is not None:
             return child_node
@@ -359,9 +360,9 @@ class Grid(BaseResqpy):
     def extract_crs_uuid(self):
         """Returns uuid for coordinate reference system, as stored in geometry xml tree.
 
-      returns:
-         uuid.UUID object
-      """
+        returns:
+           uuid.UUID object
+        """
 
         if self.crs_uuid is not None:
             return self.crs_uuid
@@ -374,14 +375,14 @@ class Grid(BaseResqpy):
     def extract_crs_root(self):
         """Returns root in parent model xml parts forest of coordinate reference system used by this grid geomwtry.
 
-      returns:
-         root node in xml tree for coordinate reference system
+        returns:
+           root node in xml tree for coordinate reference system
 
-      note:
-         resqml allows a part to refer to another part that is not actually present in the same epc package;
-         in practice, the crs is a tiny part and has always been included in datasets encountered so far;
-         if the crs is not present, this method will return None (I think)
-      """
+        note:
+           resqml allows a part to refer to another part that is not actually present in the same epc package;
+           in practice, the crs is a tiny part and has always been included in datasets encountered so far;
+           if the crs is not present, this method will return None (I think)
+        """
 
         if self.crs_root is not None:
             return self.crs_root
@@ -394,16 +395,16 @@ class Grid(BaseResqpy):
     def extract_grid_is_right_handed(self):
         """Returns boolean indicating whether grid IJK axes are right handed, as stored in xml.
 
-      returns:
-         boolean: True if grid is right handed; False if left handed
+        returns:
+           boolean: True if grid is right handed; False if left handed
 
-      notes:
-         this is the actual handedness of the IJK indexing of grid cells;
-         the coordinate reference system has its own implicit handedness for xyz axes;
-         Nexus requires the IJK space to be righthanded so if it is not, the handedness of the xyz space is
-         falsified when exporting for Nexus (as Nexus allows xyz to be right or lefthanded and it is the
-         handedness of the IJK space with respect to the xyz space that matters)
-      """
+        notes:
+           this is the actual handedness of the IJK indexing of grid cells;
+           the coordinate reference system has its own implicit handedness for xyz axes;
+           Nexus requires the IJK space to be righthanded so if it is not, the handedness of the xyz space is
+           falsified when exporting for Nexus (as Nexus allows xyz to be right or lefthanded and it is the
+           handedness of the IJK space with respect to the xyz space that matters)
+        """
 
         if self.grid_is_right_handed is not None:
             return self.grid_is_right_handed
@@ -416,16 +417,16 @@ class Grid(BaseResqpy):
     def extract_k_direction_is_down(self):
         """Returns boolean indicating whether increasing K indices are generally for deeper cells, as stored in xml.
 
-      returns:
-         boolean: True if increasing K generally indicates increasing depth
+        returns:
+           boolean: True if increasing K generally indicates increasing depth
 
-      notes:
-         resqml allows layers to fold back over themselves, so the relationship between k and depth might not
-         be monotonic;
-         higher level code sometimes requires k to increase with depth;
-         independently of this, z values may increase upwards or downwards in a coordinate reference system;
-         this method does not modify the grid_is_righthanded indicator
-      """
+        notes:
+           resqml allows layers to fold back over themselves, so the relationship between k and depth might not
+           be monotonic;
+           higher level code sometimes requires k to increase with depth;
+           independently of this, z values may increase upwards or downwards in a coordinate reference system;
+           this method does not modify the grid_is_righthanded indicator
+        """
 
         if self.k_direction_is_down is not None:
             return self.k_direction_is_down
@@ -438,10 +439,10 @@ class Grid(BaseResqpy):
     def extract_geometry_time_index(self):
         """Returns integer time index, or None, for the grid geometry, as stored in xml for dynamic geometries.
 
-      notes:
-         if the value is not None, it represents the time index as stored in the xml, or the time index as
-         updated when setting the node points from a points property
-      """
+        notes:
+           if the value is not None, it represents the time index as stored in the xml, or the time index as
+           updated when setting the node points from a points property
+        """
         if self.time_index is not None and self.time_series_uuid is not None:
             return self.time_index
         self.time_index = None
@@ -456,9 +457,9 @@ class Grid(BaseResqpy):
     def set_k_direction_from_points(self):
         """Sets the K direction indicator based on z direction and mean z values for top and base.
 
-      note:
-         this method does not modify the grid_is_righthanded indicator
-      """
+        note:
+           this method does not modify the grid_is_righthanded indicator
+        """
 
         p = self.points_ref(masked = False)
         self.k_direction_is_down = True  # arbitrary default
@@ -471,13 +472,13 @@ class Grid(BaseResqpy):
     def extract_pillar_shape(self):
         """Returns string indicating whether whether pillars are curved, straight, or vertical as stored in xml.
 
-      returns:
-         string: either 'curved', 'straight' or 'vertical'
+        returns:
+           string: either 'curved', 'straight' or 'vertical'
 
-      note:
-         resqml datasets often have 'curved', even when the pillars are actually 'vertical' or 'straight';
-         use actual_pillar_shape() method to determine the shape from the actual xyz points data
-      """
+        note:
+           resqml datasets often have 'curved', even when the pillars are actually 'vertical' or 'straight';
+           use actual_pillar_shape() method to determine the shape from the actual xyz points data
+        """
 
         if self.pillar_shape is not None:
             return self.pillar_shape
@@ -490,16 +491,16 @@ class Grid(BaseResqpy):
     def extract_has_split_coordinate_lines(self):
         """Returns boolean indicating whether grid geometry has any split coordinate lines (split pillars, ie. faults).
 
-      returns:
-         boolean: True if the grid has one or more split pillars; False if all pillars are unsplit
+        returns:
+           boolean: True if the grid has one or more split pillars; False if all pillars are unsplit
 
-      notes:
-         the return value is based on the array elements present in the xml tree, unless it has already been
-         determined;
-         resqml ijk grids with split coordinate lines have extra arrays compared to unfaulted grids, and the main
-         Points array is indexed differently: [k', pillar_index, xyz] instead of [k', j', i', xyz] (where k', j', i'
-         range of nk+k_gaps+1, nj+1, ni+1 respectively)
-      """
+        notes:
+           the return value is based on the array elements present in the xml tree, unless it has already been
+           determined;
+           resqml ijk grids with split coordinate lines have extra arrays compared to unfaulted grids, and the main
+           Points array is indexed differently: [k', pillar_index, xyz] instead of [k', j', i', xyz] (where k', j', i'
+           range of nk+k_gaps+1, nj+1, ni+1 respectively)
+        """
 
         if self.has_split_coordinate_lines is not None:
             return self.has_split_coordinate_lines
@@ -512,18 +513,18 @@ class Grid(BaseResqpy):
     def extract_k_gaps(self):
         """Returns information about gaps (voids) between layers in the grid.
 
-      returns:
-         (int, numpy bool array, numpy int array) being the number of gaps between layers;
-         a 1D bool array of extent nk-1 set True where there is a gap below the layer; and
-         a 1D int array being the k index to actually use in the points data for each layer k0
+        returns:
+           (int, numpy bool array, numpy int array) being the number of gaps between layers;
+           a 1D bool array of extent nk-1 set True where there is a gap below the layer; and
+           a 1D int array being the k index to actually use in the points data for each layer k0
 
-      notes:
-         all returned elements are stored as attributes in the grid object; int and bool array elements
-         will be None if there are no k gaps; each k gap implies an extra element in the points data for
-         each pillar; when wanting to index k interfaces (horizons) rather than layers, the last of the
-         returned values can be used to index the k axis of the points data to yield the top face of the
-         layer and the successor in k will always index the basal face of the same layer
-      """
+        notes:
+           all returned elements are stored as attributes in the grid object; int and bool array elements
+           will be None if there are no k gaps; each k gap implies an extra element in the points data for
+           each pillar; when wanting to index k interfaces (horizons) rather than layers, the last of the
+           returned values can be used to index the k axis of the points data to yield the top face of the
+           layer and the successor in k will always index the basal face of the same layer
+        """
 
         if self.k_gaps is not None:
             return self.k_gaps, self.k_gap_after_array, self.k_raw_index_array
@@ -778,13 +779,13 @@ class Grid(BaseResqpy):
     def set_parent(self, parent_grid_uuid, self_is_refinement, parent_window):
         """Set relationship with respect to a parent grid.
 
-      arguments:
-         parent_grid_uuid (uuid.UUID): the uuid of the parent grid
-         self_is_refinement (boolean): if True, this grid is a refinement of the subset of the parent grid;
-            if False, this grid is a coarsening
-         parent_window: (olio.fine_coarse.FineCoarse object): slice mapping information in K, j & I axes; note
-            that self_is_refinement determines which of the 2 grids is fine and which is coarse
-      """
+        arguments:
+           parent_grid_uuid (uuid.UUID): the uuid of the parent grid
+           self_is_refinement (boolean): if True, this grid is a refinement of the subset of the parent grid;
+              if False, this grid is a coarsening
+           parent_window: (olio.fine_coarse.FineCoarse object): slice mapping information in K, j & I axes; note
+              that self_is_refinement determines which of the 2 grids is fine and which is coarse
+        """
 
         if self.parent_grid_uuid is not None:
             log.warning('overwriting parent grid information')
@@ -816,14 +817,14 @@ class Grid(BaseResqpy):
     def extract_property_collection(self):
         """Load grid property collection object holding lists of all properties in model that relate to this grid.
 
-      returns:
-         resqml_property.GridPropertyCollection object
+        returns:
+           resqml_property.GridPropertyCollection object
 
-      note:
-         a reference to the grid property collection is cached in this grid object; if the properties change,
-         for example by generating some new properties, the property_collection attribute of the grid object
-         would need to be reset to None elsewhere before calling this method again
-      """
+        note:
+           a reference to the grid property collection is cached in this grid object; if the properties change,
+           for example by generating some new properties, the property_collection attribute of the grid object
+           would need to be reset to None elsewhere before calling this method again
+        """
 
         if self.property_collection is not None:
             return self.property_collection
@@ -833,14 +834,14 @@ class Grid(BaseResqpy):
     def extract_inactive_mask(self, check_pinchout = False):
         """Returns boolean numpy array indicating which cells are inactive, if (in)active property found in this grid.
 
-      returns:
-         numpy array of booleans, of shape (nk, nj, ni) being True for cells which are inactive; False for active
+        returns:
+           numpy array of booleans, of shape (nk, nj, ni) being True for cells which are inactive; False for active
 
-      note:
-         RESQML does not have a built-in concept of inactive (dead) cells, though the usage guide advises to use a
-         discrete property with a local property kind of 'active'; this resqpy code can maintain an 'inactive'
-         attribute for the grid object, which is a boolean numpy array indicating which cells are inactive
-      """
+        note:
+           RESQML does not have a built-in concept of inactive (dead) cells, though the usage guide advises to use a
+           discrete property with a local property kind of 'active'; this resqpy code can maintain an 'inactive'
+           attribute for the grid object, which is a boolean numpy array indicating which cells are inactive
+        """
 
         if self.inactive is not None and not check_pinchout:
             return self.inactive
@@ -899,20 +900,21 @@ class Grid(BaseResqpy):
         return self.inactive
 
     def cell_geometry_is_defined(self, cell_kji0 = None, cell_geometry_is_defined_root = None, cache_array = True):
-        """Returns True if the geometry of the specified cell is defined; can also be used to cache (load) the boolean array.
+        """Returns True if the geometry of the specified cell is defined; can also be used to cache (load) the boolean
+        array.
 
-      arguments:
-         cell_kji0 (triplet of integer, optional): if present, the index of the cell of interest, in kji0 protocol;
-            if False, None is returned but the boolean array can still be cached
-         cell_geometry_is_defined_root (optional): if present, the root of the 'cell geometry is defined' xml tree for
-            this grid; this optional argument is to allow for speed optimisation, to save searching for the node
-         cache_array (boolean, default True): if True, the 'cell geometry is defined' array is cached in memory, unless
-            the xml tree indicates that geometry is defined for all cells, in which case that is noted
+        arguments:
+           cell_kji0 (triplet of integer, optional): if present, the index of the cell of interest, in kji0 protocol;
+              if False, None is returned but the boolean array can still be cached
+           cell_geometry_is_defined_root (optional): if present, the root of the 'cell geometry is defined' xml tree for
+              this grid; this optional argument is to allow for speed optimisation, to save searching for the node
+           cache_array (boolean, default True): if True, the 'cell geometry is defined' array is cached in memory, unless
+              the xml tree indicates that geometry is defined for all cells, in which case that is noted
 
-      returns:
-         if cell_kji0 is not None, a boolean is returned indicating whether geometry is defined for that cell;
-         if cell_kji0 is None, None is returned (but the array caching logic will have been applied)
-      """
+        returns:
+           if cell_kji0 is not None, a boolean is returned indicating whether geometry is defined for that cell;
+           if cell_kji0 is None, None is returned (but the array caching logic will have been applied)
+        """
 
         if self.geometry_defined_for_all_cells_cached:
             return True
@@ -956,20 +958,21 @@ class Grid(BaseResqpy):
             return result
 
     def pillar_geometry_is_defined(self, pillar_ji0 = None, pillar_geometry_is_defined_root = None, cache_array = True):
-        """Returns True if the geometry of the specified pillar is defined; False otherwise; can also be used to cache (load) the boolean array.
+        """Returns True if the geometry of the specified pillar is defined; False otherwise; can also be used to cache
+        (load) the boolean array.
 
-      arguments:
-         pillar_ji0 (pair of integers, optional): if present, the index of the pillar of interest, in ji0 protocol;
-            if False, None is returned but the boolean array can still be cached
-         pillar_geometry_is_defined_root (optional): if present, the root of the 'pillar geometry is defined' xml tree for
-            this grid; this optional argument is to allow for speed optimisation, to save searching for the node
-         cache_array (boolean, default True): if True, the 'pillar geometry is defined' array is cached in memory, unless
-            the xml tree indicates that geometry is defined for all pillars, in which case that is noted
+        arguments:
+           pillar_ji0 (pair of integers, optional): if present, the index of the pillar of interest, in ji0 protocol;
+              if False, None is returned but the boolean array can still be cached
+           pillar_geometry_is_defined_root (optional): if present, the root of the 'pillar geometry is defined' xml tree for
+              this grid; this optional argument is to allow for speed optimisation, to save searching for the node
+           cache_array (boolean, default True): if True, the 'pillar geometry is defined' array is cached in memory, unless
+              the xml tree indicates that geometry is defined for all pillars, in which case that is noted
 
-      returns:
-         if pillar_ji0 is not None, a boolean is returned indicating whether geometry is defined for that pillar;
-         if pillar_ji0 is None, None is returned unless geometry is defined for all pillars in which case True is returned
-      """
+        returns:
+           if pillar_ji0 is not None, a boolean is returned indicating whether geometry is defined for that pillar;
+           if pillar_ji0 is None, None is returned unless geometry is defined for all pillars in which case True is returned
+        """
 
         if self.geometry_defined_for_all_pillars_cached:
             return True
@@ -1008,13 +1011,13 @@ class Grid(BaseResqpy):
     def geometry_defined_for_all_cells(self, cache_array = True):
         """Returns True if geometry is defined for all cells; False otherwise.
 
-      argument:
-         cache_array (boolean, default True): if True, the 'cell geometry is defined' array is cached in memory,
-            unless the xml indicates that geometry is defined for all cells, in which case that is noted
+        argument:
+           cache_array (boolean, default True): if True, the 'cell geometry is defined' array is cached in memory,
+              unless the xml indicates that geometry is defined for all cells, in which case that is noted
 
-      returns:
-         boolean: True if geometry is defined for all cells; False otherwise
-      """
+        returns:
+           boolean: True if geometry is defined for all cells; False otherwise
+        """
 
         if self.geometry_defined_for_all_cells_cached is not None:
             return self.geometry_defined_for_all_cells_cached
@@ -1038,15 +1041,15 @@ class Grid(BaseResqpy):
     def geometry_defined_for_all_pillars(self, cache_array = True, pillar_geometry_is_defined_root = None):
         """Returns True if geometry is defined for all pillars; False otherwise.
 
-      arguments:
-         cache_array (boolean, default True): if True, the 'pillar geometry is defined' array is cached in memory,
-            unless the xml indicates that geometry is defined for all pillars, in which case that is noted
-         pillar_geometry_is_defined_root (optional): if present, the root of the 'pillar geometry is defined' xml tree for
-            this grid; this optional argument is to allow for speed optimisation, to save searching for the node
+        arguments:
+           cache_array (boolean, default True): if True, the 'pillar geometry is defined' array is cached in memory,
+              unless the xml indicates that geometry is defined for all pillars, in which case that is noted
+           pillar_geometry_is_defined_root (optional): if present, the root of the 'pillar geometry is defined' xml tree for
+              this grid; this optional argument is to allow for speed optimisation, to save searching for the node
 
-      returns:
-         boolean: True if the geometry is defined for all pillars; False otherwise
-      """
+        returns:
+           boolean: True if the geometry is defined for all pillars; False otherwise
+        """
 
         if self.geometry_defined_for_all_pillars_cached is not None:
             return self.geometry_defined_for_all_pillars_cached
@@ -1070,14 +1073,14 @@ class Grid(BaseResqpy):
     def cell_geometry_is_defined_ref(self):
         """Returns an in-memory numpy array containing the boolean data indicating which cells have geometry defined.
 
-      returns:
-         numpy array of booleans of shape (nk, nj, ni); True value indicates cell has geometry defined; False
-         indicates that the cell's geometry (points xyz values) cannot be used
+        returns:
+           numpy array of booleans of shape (nk, nj, ni); True value indicates cell has geometry defined; False
+           indicates that the cell's geometry (points xyz values) cannot be used
 
-      note:
-         if geometry is flagged in the xml as being defined for all cells, then this function returns None;
-         geometry_defined_for_all_cells() can be used to test for that situation
-      """
+        note:
+           if geometry is flagged in the xml as being defined for all cells, then this function returns None;
+           geometry_defined_for_all_cells() can be used to test for that situation
+        """
 
         # todo: treat this array like any other property?; handle constant array seamlessly?
         self.cell_geometry_is_defined(cache_array = True)
@@ -1088,15 +1091,15 @@ class Grid(BaseResqpy):
     def pillar_geometry_is_defined_ref(self):
         """Returns an in-memory numpy array containing the boolean data indicating which pillars have geometry defined.
 
-      returns:
-         numpy array of booleans of shape (nj + 1, ni + 1); True value indicates pillar has geometry defined (at
-         least for some points); False indicates that the pillar's geometry (points xyz values) cannot be used;
-         the resulting array only covers primary pillars; extra pillars for split pillars always have geometry
-         defined
+        returns:
+           numpy array of booleans of shape (nj + 1, ni + 1); True value indicates pillar has geometry defined (at
+           least for some points); False indicates that the pillar's geometry (points xyz values) cannot be used;
+           the resulting array only covers primary pillars; extra pillars for split pillars always have geometry
+           defined
 
-      note:
-         if geometry is flagged in the xml as being defined for all pillars, then this function returns None
-      """
+        note:
+           if geometry is flagged in the xml as being defined for all pillars, then this function returns None
+        """
 
         # todo: double-check behaviour in presence of split pillars
         # todo: treat this array like any other property?; handle constant array seamlessly?
@@ -1111,31 +1114,32 @@ class Grid(BaseResqpy):
                                 complete_partial_pillars = False,
                                 nullify_partial_pillars = False,
                                 complete_all = False):
-        """Sets cached flags and/or arrays indicating which primary pillars have any points defined and which cells all points.
+        """Sets cached flags and/or arrays indicating which primary pillars have any points defined and which cells all
+        points.
 
-      arguments:
-         treat_as_nan (float, optional): if present, any point with this value as x, y or z is changed
-            to hold NaN values, which is the correct RESQML representation of undefined values
-         treat_dots_as_nan (boolean, default False): if True, the points around any inactive cell which has zero length along
-            all its I and J edges will be set to NaN (which can intentionally invalidate the geometry of neighbouring cells)
-         complete_partial_pillars (boolean, default False): if True, pillars which have some but not all points defined will
-            have values generated for the undefined (NaN) points
-         nullify_partial_pillars (boolean, default False): if True, pillars which have some undefined (NaN) points will be
-            treated as if all the points on the pillar are undefined
-         complete_all (boolean, default False): if True, values will be generated for all undefined points (includes
-            completion of partial pillars if both partial pillar arguments are False)
+        arguments:
+           treat_as_nan (float, optional): if present, any point with this value as x, y or z is changed
+              to hold NaN values, which is the correct RESQML representation of undefined values
+           treat_dots_as_nan (boolean, default False): if True, the points around any inactive cell which has zero length along
+              all its I and J edges will be set to NaN (which can intentionally invalidate the geometry of neighbouring cells)
+           complete_partial_pillars (boolean, default False): if True, pillars which have some but not all points defined will
+              have values generated for the undefined (NaN) points
+           nullify_partial_pillars (boolean, default False): if True, pillars which have some undefined (NaN) points will be
+              treated as if all the points on the pillar are undefined
+           complete_all (boolean, default False): if True, values will be generated for all undefined points (includes
+              completion of partial pillars if both partial pillar arguments are False)
 
-      notes:
-         this method discards any previous information about which pillars and cells have geometry defined; the new settings
-         are based solely on where points data is NaN (or has the value supplied as treat_as_nan etc.);
-         the inactive attribute is also updated by this method, though any cells previously flagged as inactive will still be
-         inactive;
-         if points are generated due to either complete... argument being set True, the inactive mask is set prior to
-         generating points, so all cells making use of generated points will be inactive; however, the geometry will show
-         as defined where points have been generated;
-         at most one of complete_partial_pillars and nullify_partial_pillars may be True;
-         although the method modifies the cached (attribute) copies of various arrays, they are not written to hdf5 here
-      """
+        notes:
+           this method discards any previous information about which pillars and cells have geometry defined; the new settings
+           are based solely on where points data is NaN (or has the value supplied as treat_as_nan etc.);
+           the inactive attribute is also updated by this method, though any cells previously flagged as inactive will still be
+           inactive;
+           if points are generated due to either complete... argument being set True, the inactive mask is set prior to
+           generating points, so all cells making use of generated points will be inactive; however, the geometry will show
+           as defined where points have been generated;
+           at most one of complete_partial_pillars and nullify_partial_pillars may be True;
+           although the method modifies the cached (attribute) copies of various arrays, they are not written to hdf5 here
+        """
 
         def infill_partial_pillar(grid, pillar_index):
             points = grid.points_ref(masked = False).reshape((grid.nk_plus_k_gaps + 1, -1, 3))
@@ -1494,18 +1498,18 @@ class Grid(BaseResqpy):
     def actual_pillar_shape(self, patch_metadata = False, tolerance = 0.001):
         """Returns actual shape of pillars.
 
-      arguments:
-         patch_metadata (boolean, default False): if True, the actual shape replaces whatever was in the metadata
-         tolerance (float, default 0.001): a length value (in units of grid xy units) used as a Manhattan distance
-            limit in the xy plane when considering whether a point lies 'on' a straight line
+        arguments:
+           patch_metadata (boolean, default False): if True, the actual shape replaces whatever was in the metadata
+           tolerance (float, default 0.001): a length value (in units of grid xy units) used as a Manhattan distance
+              limit in the xy plane when considering whether a point lies 'on' a straight line
 
-      returns:
-         string: 'vertical', 'straight' or 'curved'
+        returns:
+           string: 'vertical', 'straight' or 'curved'
 
-      note:
-         setting patch_metadata True will affect the attribute in this Grid object; however, it will not be
-         preserved unless the create_xml() method is called, followed at some point with model.store_epc()
-      """
+        note:
+           setting patch_metadata True will affect the attribute in this Grid object; however, it will not be
+           preserved unless the create_xml() method is called, followed at some point with model.store_epc()
+        """
 
         pillar_shape = gf.actual_pillar_shape(self.points_ref(masked = False), tolerance = tolerance)
         if patch_metadata:
@@ -1515,27 +1519,27 @@ class Grid(BaseResqpy):
     def cache_all_geometry_arrays(self):
         """Loads from hdf5 into memory all the arrays defining the grid geometry.
 
-      returns:
-         None
+        returns:
+           None
 
-      notes:
-         call this method if much grid geometry processing is coming up, to save having to worry about
-         individual caching arguments to many other methods;
-         this method does not create a column to pillar mapping which will often also be needed;
-         the arrays are cached as direct attributes to this grid object;
-         the names, shapes and types of the attributes are:
-            array_cell_geometry_is_defined   (nk, nj, ni)  bool
-            array_pillar_geometry_is_defined (nj + 1, ni + 1)  bool
-            points_cached  (nk + 1, nj + 1, ni + 1, 3) or (nk + 1, np, 3)  float  (np = number of primary pillars)
-            split_pillar_indices_cached  (nps)  int  (nps = number of primary pillars that are split)
-            cols_for_split_pillars  (npxc)  int  (npxc = number of column corners using extra pillars due to splitting)
-            cols_for_split_pillars_cl  (npx)  int  (npx = number of extra pillars due to splitting)
-         the last 3 are only present when the grid has one or more split pillars;
-         the split pillar data includes the use of a 'jagged' array (effectively an array of lists represented as
-         a linear array and a 'cumulative length' index array)
+        notes:
+           call this method if much grid geometry processing is coming up, to save having to worry about
+           individual caching arguments to many other methods;
+           this method does not create a column to pillar mapping which will often also be needed;
+           the arrays are cached as direct attributes to this grid object;
+           the names, shapes and types of the attributes are:
+              array_cell_geometry_is_defined   (nk, nj, ni)  bool
+              array_pillar_geometry_is_defined (nj + 1, ni + 1)  bool
+              points_cached  (nk + 1, nj + 1, ni + 1, 3) or (nk + 1, np, 3)  float  (np = number of primary pillars)
+              split_pillar_indices_cached  (nps)  int  (nps = number of primary pillars that are split)
+              cols_for_split_pillars  (npxc)  int  (npxc = number of column corners using extra pillars due to splitting)
+              cols_for_split_pillars_cl  (npx)  int  (npx = number of extra pillars due to splitting)
+           the last 3 are only present when the grid has one or more split pillars;
+           the split pillar data includes the use of a 'jagged' array (effectively an array of lists represented as
+           a linear array and a 'cumulative length' index array)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # todo: recheck the description of split pillar arrays given in the doc string
         self.cell_geometry_is_defined(cache_array = True)
@@ -1586,44 +1590,44 @@ class Grid(BaseResqpy):
                                         active_collection = None):
         """Modifies the cached points (geometry), setting the values from a points property.
 
-      arguments:
-         points_property_uuid (uuid, optional): the uuid of the points property; if present the
-            remaining arguments are ignored except for inactive & active arguments
-         property_collection (PropertyCollection, optional): defaults to property collection
-            for the grid; should only contain one set of points properties (but may also contain
-            other non-points properties)
-         realization (int, optional): if present, the property in the collection with this
-            realization number is used
-         time_index (int, optional): if present, the property in the collection with this
-            time index is used
-         set_grid_time_index (bool, default True): if True, the grid's time index will be set
-            to the time_index argument and the grid's time series uuid will be set to that
-            referred to by the points property; if False, the grid's time index will not be
-            modified
-         set_inactive (bool, default True): if True, the grid's inactive mask will be set
-            based on an active cell property
-         active_property_uuid (uuid, optional): if present, the uuid of an active cell property
-            to base the inactive mask on; ignored if set_inactive is False
-         active_collection (uuid, optional): default's to property_collection if present, or
-            the grid's property collection otherwise; only used if set_inactive is True and
-            active_property_uuid is None
+        arguments:
+           points_property_uuid (uuid, optional): the uuid of the points property; if present the
+              remaining arguments are ignored except for inactive & active arguments
+           property_collection (PropertyCollection, optional): defaults to property collection
+              for the grid; should only contain one set of points properties (but may also contain
+              other non-points properties)
+           realization (int, optional): if present, the property in the collection with this
+              realization number is used
+           time_index (int, optional): if present, the property in the collection with this
+              time index is used
+           set_grid_time_index (bool, default True): if True, the grid's time index will be set
+              to the time_index argument and the grid's time series uuid will be set to that
+              referred to by the points property; if False, the grid's time index will not be
+              modified
+           set_inactive (bool, default True): if True, the grid's inactive mask will be set
+              based on an active cell property
+           active_property_uuid (uuid, optional): if present, the uuid of an active cell property
+              to base the inactive mask on; ignored if set_inactive is False
+           active_collection (uuid, optional): default's to property_collection if present, or
+              the grid's property collection otherwise; only used if set_inactive is True and
+              active_property_uuid is None
 
-      notes:
-         the points property must have indexable element 'nodes' and be the same shape as the
-         official points array for the grid;
-         note that the shape of the points array is quite different between grids with split
-         pillars and those without;
-         the uom of the points property must be a length uom and match that used by the grid's crs;
-         the inactive mask of the grid will only be updated if the set_inactive argument is True;
-         if points_property_uuid has been provided, and set_inactive is True, the active property
-         must be identified with the active_property_uuid argument;
-         if set_inactive is True and active_property_uuid is None and points_property_uuid is None and
-         realization and/or time_index is in use, the active property collection must contain one
-         series of active properties with the same variants (realizations and time indices) as the
-         points property series;
-         the active cell properties should be discrete and have a local property kind titled 'active';
-         various cached data are invalidated and cleared by this method
-      """
+        notes:
+           the points property must have indexable element 'nodes' and be the same shape as the
+           official points array for the grid;
+           note that the shape of the points array is quite different between grids with split
+           pillars and those without;
+           the uom of the points property must be a length uom and match that used by the grid's crs;
+           the inactive mask of the grid will only be updated if the set_inactive argument is True;
+           if points_property_uuid has been provided, and set_inactive is True, the active property
+           must be identified with the active_property_uuid argument;
+           if set_inactive is True and active_property_uuid is None and points_property_uuid is None and
+           realization and/or time_index is in use, the active property collection must contain one
+           series of active properties with the same variants (realizations and time indices) as the
+           points property series;
+           the active cell properties should be discrete and have a local property kind titled 'active';
+           various cached data are invalidated and cleared by this method
+        """
 
         if points_property_uuid is None:
             if property_collection is None:
@@ -1692,12 +1696,12 @@ class Grid(BaseResqpy):
     def column_is_inactive(self, col_ji0):
         """Returns True if all the cells in the specified column are inactive.
 
-      arguments:
-         col_ji0 (int pair): the (j0, i0) column indices
+        arguments:
+           col_ji0 (int pair): the (j0, i0) column indices
 
-      returns:
-         boolean: True if all the cells in the column are inactive; False if at least one cell is active
-      """
+        returns:
+           boolean: True if all the cells in the column are inactive; False if at least one cell is active
+        """
 
         self.extract_inactive_mask()
         if self.inactive is None:
@@ -1707,23 +1711,23 @@ class Grid(BaseResqpy):
     def create_column_pillar_mapping(self):
         """Creates an array attribute holding set of 4 pillar indices for each I, J column of cells.
 
-      returns:
-         numpy integer array of shape (nj, ni, 2, 2) where the last two indices are jp, ip;
-         the array contains the pillar index for each of the 4 corners of each column of cells
+        returns:
+           numpy integer array of shape (nj, ni, 2, 2) where the last two indices are jp, ip;
+           the array contains the pillar index for each of the 4 corners of each column of cells
 
-      notes:
-         the array is also cached as an attribute of the grid object: self.pillars_for_column
-         for grids with split coordinates lines (faults), this array allows for fast access to
-         the correct pillar data for the corner of a column of cells;
-         here and elsewhere, ip & jp (& kp) refer to a 0 or 1 index which determines the side
-         of a cell, ip & jp together select one of the four corners of a column;
-         the pillar index is a single integer, which is used as the second index into the points
-         array for a grid geometry with split pillars;
-         for unsplit grid geometries, such a pillar index must be converted back into a j', i'
-         pair of indices (or the points array must be reshaped to combine the two indices into one)
+        notes:
+           the array is also cached as an attribute of the grid object: self.pillars_for_column
+           for grids with split coordinates lines (faults), this array allows for fast access to
+           the correct pillar data for the corner of a column of cells;
+           here and elsewhere, ip & jp (& kp) refer to a 0 or 1 index which determines the side
+           of a cell, ip & jp together select one of the four corners of a column;
+           the pillar index is a single integer, which is used as the second index into the points
+           array for a grid geometry with split pillars;
+           for unsplit grid geometries, such a pillar index must be converted back into a j', i'
+           pair of indices (or the points array must be reshaped to combine the two indices into one)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if hasattr(self, 'pillars_for_column') and self.pillars_for_column is not None:
             return self.pillars_for_column
@@ -1761,19 +1765,20 @@ class Grid(BaseResqpy):
         return self.pillars_for_column
 
     def pillar_foursome(self, ji0, none_if_unsplit = False):
-        """Returns a numpy int array of shape (2, 2) being the natural pillar indices applicable to each column around primary.
+        """Returns a numpy int array of shape (2, 2) being the natural pillar indices applicable to each column around
+        primary.
 
-      arguments:
-         ji0 (pair of ints): the pillar indices (j0, i0) of the primary pillar of interest
-         none_if_unsplit (boolean, default False): if True and the primary pillar is unsplit, None is returned; if False,
-            a foursome is returned full of the natural index of the primary pillar
+        arguments:
+           ji0 (pair of ints): the pillar indices (j0, i0) of the primary pillar of interest
+           none_if_unsplit (boolean, default False): if True and the primary pillar is unsplit, None is returned; if False,
+              a foursome is returned full of the natural index of the primary pillar
 
-      returns:
-         numpy int array of shape (2, 2) being the natural pillar indices (second axis index in raw points array)
-         applicable to each of the four columns around the primary pillar; axes of foursome are (jp, ip); if the
-         primary pillar is unsplit, None is returned if none_if_unsplit is set to True, otherwise the foursome as
-         usual
-      """
+        returns:
+           numpy int array of shape (2, 2) being the natural pillar indices (second axis index in raw points array)
+           applicable to each of the four columns around the primary pillar; axes of foursome are (jp, ip); if the
+           primary pillar is unsplit, None is returned if none_if_unsplit is set to True, otherwise the foursome as
+           usual
+        """
 
         j0, i0 = ji0
 
@@ -1874,10 +1879,10 @@ class Grid(BaseResqpy):
     def find_faults(self, set_face_sets = False, create_organizing_objects_where_needed = False):
         """Searches for column-faces that are faulted and assigns fault ids; creates list of column-faces per fault id.
 
-      note:
-         this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
-         GridConnectionSet class
-      """
+        note:
+           this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
+           GridConnectionSet class
+        """
 
         # note:the logic to group kelp into distinct fault ids is simplistic and won't always give the right grouping
 
@@ -1966,10 +1971,10 @@ class Grid(BaseResqpy):
     def fault_throws(self):
         """Finds mean throw of each J and I face; adds throw arrays as attributes to this grid and returns them.
 
-      note:
-         this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
-         GridConnectionSet class
-      """
+        note:
+           this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
+           GridConnectionSet class
+        """
 
         if hasattr(self, 'fault_throw_j') and self.fault_throw_j is not None and hasattr(
                 self, 'fault_throw_i') and self.fault_throw_i is not None:
@@ -1994,34 +1999,35 @@ class Grid(BaseResqpy):
         return (self.fault_throw_j, self.fault_throw_i)
 
     def fault_throws_per_edge_per_column(self, mode = 'maximum', simple_z = False, axis_polarity_mode = True):
-        """Returns numpy array of shape (nj, ni, 2, 2) or (nj, ni, 4) holding max, mean or min throw based on split node separations.
+        """Returns numpy array of shape (nj, ni, 2, 2) or (nj, ni, 4) holding max, mean or min throw based on split node
+        separations.
 
-      arguments:
-         mode (string, default 'maximum'): one of 'minimum', 'mean', 'maximum'; determines how to resolve variation in throw for
-            each column edge
-         simple_z (boolean, default False): if True, the returned throw values are vertical offsets; if False, the displacement
-            in xyz space between split points is the basis of the returned values and may include a lateral offset component as
-            well as xy displacement due to sloping pillars
-         axis_polarity (boolean, default True): determines shape and ordering of returned array; if True, the returned array has
-            shape (nj, ni, 2, 2); if False the shape is (nj, ni, 4); see return value notes for more information
+        arguments:
+           mode (string, default 'maximum'): one of 'minimum', 'mean', 'maximum'; determines how to resolve variation in throw for
+              each column edge
+           simple_z (boolean, default False): if True, the returned throw values are vertical offsets; if False, the displacement
+              in xyz space between split points is the basis of the returned values and may include a lateral offset component as
+              well as xy displacement due to sloping pillars
+           axis_polarity (boolean, default True): determines shape and ordering of returned array; if True, the returned array has
+              shape (nj, ni, 2, 2); if False the shape is (nj, ni, 4); see return value notes for more information
 
-      returns:
-         numpy float array of shape (nj, ni, 2, 2) or (nj, ni, 4) holding fault throw values for each column edge; units are
-            z units of crs for this grid; if simple_z is False, xy units and z units must be the same; positive values indicate
-            greater depth if z is increasing downwards (or shallower if z is increasing upwards); negative values indicate the
-            opposite; the shape and ordering of the returned array is determined by axis_polarity_mode; if axis_polarity_mode is
-            True, the returned array has shape (nj, ni, 2, 2) with the third index being axis (0 = J, 1 = I) and the final index
-            being polarity (0 = minus face edge, 1 = plus face edge); if axis_polarity_mode is False, the shape is (nj, ni, 4)
-            and the face edges are ordered I-, J+, I+, J-, as required by the resqml standard for a property with indexable
-            element 'edges per column'
+        returns:
+           numpy float array of shape (nj, ni, 2, 2) or (nj, ni, 4) holding fault throw values for each column edge; units are
+              z units of crs for this grid; if simple_z is False, xy units and z units must be the same; positive values indicate
+              greater depth if z is increasing downwards (or shallower if z is increasing upwards); negative values indicate the
+              opposite; the shape and ordering of the returned array is determined by axis_polarity_mode; if axis_polarity_mode is
+              True, the returned array has shape (nj, ni, 2, 2) with the third index being axis (0 = J, 1 = I) and the final index
+              being polarity (0 = minus face edge, 1 = plus face edge); if axis_polarity_mode is False, the shape is (nj, ni, 4)
+              and the face edges are ordered I-, J+, I+, J-, as required by the resqml standard for a property with indexable
+              element 'edges per column'
 
-      notes:
-         the throws calculated by this method are based merely on grid geometry and do not refer to grid connection sets;
-         NB: the same absolute value is returned, with opposite sign, for the edges on opposing sides of a fault; either one of
-         these alone indicates the full throw;
-         the property module contains a pair of reformatting functions for moving an array between the two axis polarity modes;
-         minimum and maximum modes work on the absolute throws
-      """
+        notes:
+           the throws calculated by this method are based merely on grid geometry and do not refer to grid connection sets;
+           NB: the same absolute value is returned, with opposite sign, for the edges on opposing sides of a fault; either one of
+           these alone indicates the full throw;
+           the property module contains a pair of reformatting functions for moving an array between the two axis polarity modes;
+           minimum and maximum modes work on the absolute throws
+        """
 
         assert mode in ['maximum', 'mean', 'minimum']
         if not simple_z:
@@ -2109,10 +2115,10 @@ class Grid(BaseResqpy):
     def make_face_set_from_dataframe(self, df):
         """Creates a curtain face set for each named fault in dataframe.
 
-      note:
-         this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
-         GridConnectionSet class
-      """
+        note:
+           this method is deprecated, or due for overhaul to make compatible with resqml_fault module and the
+           GridConnectionSet class
+        """
 
         # df columns: name, i1, i2, j1, j2, k1, k2, face
         self.clear_face_sets()
@@ -2175,12 +2181,12 @@ class Grid(BaseResqpy):
                                          projection = 'xy'):
         """Creates a curtain face set for each pillar (or rod) list.
 
-      returns:
-         (face_set_dict, full_pillar_list_dict)
+        returns:
+           (face_set_dict, full_pillar_list_dict)
 
-      note:
-         'xz' and 'yz' projections currently only supported for unsplit grids
-      """
+        note:
+           'xz' and 'yz' projections currently only supported for unsplit grids
+        """
 
         # NB. this code was originally written for axis K and projection xy, working with horizon points
         # it has since been reworked for the cross sectional cases, so variables named 'pillar...' may refer to rods
@@ -2300,15 +2306,15 @@ class Grid(BaseResqpy):
         return local_face_set_dict, full_pillar_list_dict
 
     def check_top_and_base_cell_edge_directions(self):
-        """checks grid top face I & J edge vectors (in x,y) against basal equivalents: max 90 degree angle tolerated
+        """checks grid top face I & J edge vectors (in x,y) against basal equivalents: max 90 degree angle tolerated.
 
-      returns: boolean: True if all checks pass; False if one or more checks fail
+        returns: boolean: True if all checks pass; False if one or more checks fail
 
-      notes:
-         similarly checks cell edge directions in neighbouring cells in top (and separately in base)
-         currently requires geometry to be defined for all pillars
-         logs a warning if a check is not passed
-      """
+        notes:
+           similarly checks cell edge directions in neighbouring cells in top (and separately in base)
+           currently requires geometry to be defined for all pillars
+           logs a warning if a check is not passed
+        """
 
         log.debug('deriving cell edge vectors at top and base (for checking)')
         self.point(cache_array = True)
@@ -2376,22 +2382,22 @@ class Grid(BaseResqpy):
     def point_raw(self, index = None, points_root = None, cache_array = True):
         """Returns element from points data, indexed as in the hdf5 file; can optionally be used to cache points data.
 
-      arguments:
-         index (2 or 3 integers, optional): if not None, the index into the raw points data for the point of interest
-         points_root (optional): the xml node holding the points data
-         cache_array (boolean, default True): if True, the raw points data is cached in memory as a side effect
+        arguments:
+           index (2 or 3 integers, optional): if not None, the index into the raw points data for the point of interest
+           points_root (optional): the xml node holding the points data
+           cache_array (boolean, default True): if True, the raw points data is cached in memory as a side effect
 
-      returns:
-         (x, y, z) of selected point as a 3 element numpy vector, or None if index is None
+        returns:
+           (x, y, z) of selected point as a 3 element numpy vector, or None if index is None
 
-      notes:
-         this function is typically called either to cache the points data in memory, or to fetch the coordinates of
-         a single point; the details of the indexing depend upon whether the grid has split coordinate lines: if not,
-         the index should be a triple kji0 with axes ranging over the shared corners nk+k_gaps+1, nj+1, ni+1; if there
-         are split pillars, index should be a pair, being the k0 in range nk+k_gaps+1 and a pillar index; note that if
-         index is passed, the k0 element must already have been mapped to the raw index value taking into consideration
-         any k gaps; if the grid object does not include geometry then None is returned
-      """
+        notes:
+           this function is typically called either to cache the points data in memory, or to fetch the coordinates of
+           a single point; the details of the indexing depend upon whether the grid has split coordinate lines: if not,
+           the index should be a triple kji0 with axes ranging over the shared corners nk+k_gaps+1, nj+1, ni+1; if there
+           are split pillars, index should be a pair, being the k0 in range nk+k_gaps+1 and a pillar index; note that if
+           index is passed, the k0 element must already have been mapped to the raw index value taking into consideration
+           any k gaps; if the grid object does not include geometry then None is returned
+        """
 
         # NB: shape of index depends on whether grid has split pillars
         if index is not None and not self.geometry_defined_for_all_pillars(cache_array = cache_array):
@@ -2438,19 +2444,19 @@ class Grid(BaseResqpy):
               cache_array = True):
         """Return a cell corner point xyz; can optionally be used to cache points data.
 
-      arguments:
-         cell_kji0 (3 integers, optional): if not None, the index of the cell for the point of interest, in kji0 protocol
-         corner_index (3 integers, default zeros): the kp, jp, ip corner-within-cell indices (each 0 or 1)
-         points_root (optional): the xml node holding the points data
-         cache_array (boolean, default True): if True, the raw points data is cached in memory as a side effect
+        arguments:
+           cell_kji0 (3 integers, optional): if not None, the index of the cell for the point of interest, in kji0 protocol
+           corner_index (3 integers, default zeros): the kp, jp, ip corner-within-cell indices (each 0 or 1)
+           points_root (optional): the xml node holding the points data
+           cache_array (boolean, default True): if True, the raw points data is cached in memory as a side effect
 
-      returns:
-         (x, y, z) of selected point as a 3 element numpy vector, or None if cell_kji0 is None
+        returns:
+           (x, y, z) of selected point as a 3 element numpy vector, or None if cell_kji0 is None
 
-      note:
-         if cell_kji0 is passed, the k0 value should be the layer index before adjustment for k_gaps, which this
-         method will apply
-      """
+        note:
+           if cell_kji0 is passed, the k0 value should be the layer index before adjustment for k_gaps, which this
+           method will apply
+        """
 
         if cache_array and self.points_cached is None:
             self.point_raw(points_root = points_root, cache_array = True)
@@ -2479,23 +2485,23 @@ class Grid(BaseResqpy):
     def points_ref(self, masked = True):
         """Returns an in-memory numpy array containing the xyz data for points used in the grid geometry.
 
-      argument:
-         masked (boolean, default True): if True, a masked array is returned with NaN points masked out;
-            if False, a simple (unmasked) numpy array is returned
+        argument:
+           masked (boolean, default True): if True, a masked array is returned with NaN points masked out;
+              if False, a simple (unmasked) numpy array is returned
 
-      returns:
-         numpy array or masked array of float, of shape (nk + k_gaps + 1, nj + 1, ni + 1, 3) or (nk + k_gaps + 1, np, 3)
-         where np is the total number of pillars (primary pillars + extras for split pillars)
+        returns:
+           numpy array or masked array of float, of shape (nk + k_gaps + 1, nj + 1, ni + 1, 3) or (nk + k_gaps + 1, np, 3)
+           where np is the total number of pillars (primary pillars + extras for split pillars)
 
-      notes:
-         this is the usual way to get at the actual grid geometry points data in the native resqml layout;
-         the has_split_coordinate_lines boolean attribute can be used to determine which shape to expect;
-         the shape is (nk + k_gaps + 1, nj + 1, ni + 1, 3) if there are no split coordinate lines (unfaulted);
-         otherwise it is (nk + k_gaps + 1, np, 3), where np > (nj + 1) * (ni + 1), due to extra pillar data for
-         the split pillars
+        notes:
+           this is the usual way to get at the actual grid geometry points data in the native resqml layout;
+           the has_split_coordinate_lines boolean attribute can be used to determine which shape to expect;
+           the shape is (nk + k_gaps + 1, nj + 1, ni + 1, 3) if there are no split coordinate lines (unfaulted);
+           otherwise it is (nk + k_gaps + 1, np, 3), where np > (nj + 1) * (ni + 1), due to extra pillar data for
+           the split pillars
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.points_cached is None:
             self.point_raw(cache_array = True)
@@ -2508,10 +2514,10 @@ class Grid(BaseResqpy):
     def uncache_points(self):
         """Frees up memory by removing the cached copy of the grid's points data.
 
-      note:
-         the memory will only actually become free when any other references to it pass out of scope
-         or are deleted
-      """
+        note:
+           the memory will only actually become free when any other references to it pass out of scope
+           or are deleted
+        """
 
         if self.points_cached is not None:
             del self.points_cached
@@ -2520,20 +2526,20 @@ class Grid(BaseResqpy):
     def unsplit_points_ref(self, cache_array = False, masked = False):
         """Returns a copy of the points array that has split pillars merged back into an unsplit configuration.
 
-      arguments:
-         cache_array (boolean, default False): if True, a copy of the unsplit points array is added as
-            attribute array_unsplit_points to this grid object
-         masked (boolean, default False): if True, a masked array is returned with NaN points masked out;
-            if False, a simple (unmasked) numpy array is returned
+        arguments:
+           cache_array (boolean, default False): if True, a copy of the unsplit points array is added as
+              attribute array_unsplit_points to this grid object
+           masked (boolean, default False): if True, a masked array is returned with NaN points masked out;
+              if False, a simple (unmasked) numpy array is returned
 
-      returns:
-         numpy array of float of shape (nk + k_gaps + 1, nj + 1, ni + 1, 3)
+        returns:
+           numpy array of float of shape (nk + k_gaps + 1, nj + 1, ni + 1, 3)
 
-      note:
-         for grids without split pillars, this function simply returns the points array in its native form;
-         for grids with split pillars, an unsplit equivalent points array is calculated as the average of
-         contributions to each pillar from the surrounding cell columns
-      """
+        note:
+           for grids without split pillars, this function simply returns the points array in its native form;
+           for grids with split pillars, an unsplit equivalent points array is calculated as the average of
+           contributions to each pillar from the surrounding cell columns
+        """
 
         if hasattr(self, 'array_unsplit_points'):
             return self.array_unsplit_points
@@ -2582,22 +2588,22 @@ class Grid(BaseResqpy):
     def xyz_box(self, points_root = None, lazy = True, local = False):
         """Returns the minimum and maximum xyz for the grid geometry.
 
-      arguments:
-         points_root (optional): if not None, the xml root node for the points data (speed optimization)
-         lazy (boolean, default True): if True, only the 8 outermost logical corners of the grid are used
-            to determine the ranges of xyz; if False, all the points in the entire grid are scanned to
-            determine the xyz ranges in an exhaustive manner
-         local (boolean, default False): if True, the xyz ranges that are returned are in the local
-            coordinate space, otherwise the global (crs parent) coordinate space
+        arguments:
+           points_root (optional): if not None, the xml root node for the points data (speed optimization)
+           lazy (boolean, default True): if True, only the 8 outermost logical corners of the grid are used
+              to determine the ranges of xyz; if False, all the points in the entire grid are scanned to
+              determine the xyz ranges in an exhaustive manner
+           local (boolean, default False): if True, the xyz ranges that are returned are in the local
+              coordinate space, otherwise the global (crs parent) coordinate space
 
-      returns:
-         numpy array of float of shape (2, 3); the first axis is minimum, maximum; the second axis is x, y, z
+        returns:
+           numpy array of float of shape (2, 3); the first axis is minimum, maximum; the second axis is x, y, z
 
-      note:
-         if the lazy argument is True, the results are likely to under-report the ranges, especially for z
+        note:
+           if the lazy argument is True, the results are likely to under-report the ranges, especially for z
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.xyz_box_cached is None or (not lazy and not self.xyz_box_cached_thoroughly):
             self.xyz_box_cached = np.zeros((2, 3))
@@ -2633,49 +2639,49 @@ class Grid(BaseResqpy):
     def xyz_box_centre(self, points_root = None, lazy = False, local = False):
         """Returns the (x,y,z) point (as 3 element numpy) at the centre of the xyz box for the grid.
 
-      arguments:
-         points_root (optional): if not None, the xml root node for the points data (speed optimization)
-         lazy (boolean, default True): if True, only the 8 outermost logical corners of the grid are used
-            to determine the ranges of xyz and hence the centre; if False, all the points in the entire
-            grid are scanned to determine the xyz ranges in an exhaustive manner
-         local (boolean, default False): if True, the xyz values that are returned are in the local
-            coordinate space, otherwise the global (crs parent) coordinate space
+        arguments:
+           points_root (optional): if not None, the xml root node for the points data (speed optimization)
+           lazy (boolean, default True): if True, only the 8 outermost logical corners of the grid are used
+              to determine the ranges of xyz and hence the centre; if False, all the points in the entire
+              grid are scanned to determine the xyz ranges in an exhaustive manner
+           local (boolean, default False): if True, the xyz values that are returned are in the local
+              coordinate space, otherwise the global (crs parent) coordinate space
 
-      returns:
-         numpy array of float of shape (3,) being the x, y, z coordinates of the centre of the grid
+        returns:
+           numpy array of float of shape (3,) being the x, y, z coordinates of the centre of the grid
 
-      note:
-         the centre point returned is simply the midpoint of the x, y & z ranges of the grid
-      """
+        note:
+           the centre point returned is simply the midpoint of the x, y & z ranges of the grid
+        """
 
         return np.nanmean(self.xyz_box(points_root = points_root, lazy = lazy, local = local), axis = 0)
 
     def horizon_points(self, ref_k0 = 0, heal_faults = False, kp = 0):
         """Returns reference to a points layer array of shape ((nj + 1), (ni + 1), 3) based on primary pillars.
 
-      arguments:
-         ref_k0 (integer): the horizon layer number, in the range 0 to nk (or layer number in range 0..nk-1
-            in the case of grids with k gaps)
-         heal_faults (boolean, default False): if True and the grid has split coordinate lines, an unsplit
-            equivalent of the grid points is generated first and the returned points are based on that data;
-            otherwise, the primary pillar data is used, which effectively gives a point from one side or
-            another of any faults, rather than an averaged point
-         kp (integer, default 0): set to 1 to specify the base of layer ref_k0, in case of grids with k gaps
+        arguments:
+           ref_k0 (integer): the horizon layer number, in the range 0 to nk (or layer number in range 0..nk-1
+              in the case of grids with k gaps)
+           heal_faults (boolean, default False): if True and the grid has split coordinate lines, an unsplit
+              equivalent of the grid points is generated first and the returned points are based on that data;
+              otherwise, the primary pillar data is used, which effectively gives a point from one side or
+              another of any faults, rather than an averaged point
+           kp (integer, default 0): set to 1 to specify the base of layer ref_k0, in case of grids with k gaps
 
-      returns:
-         a numpy array of floats of shape ((nj + 1), (ni + 1), 3) being the (shared) cell corner point
-         locations for the plane of points, based on the primary pillars or unsplit equivalent pillars
+        returns:
+           a numpy array of floats of shape ((nj + 1), (ni + 1), 3) being the (shared) cell corner point
+           locations for the plane of points, based on the primary pillars or unsplit equivalent pillars
 
-      notes:
-         the primary pillars are the 'first' set of points for a pillar; a split pillar will have one to
-         three other sets of point data but those are ignored by this function unless heal_faults is True,
-         in which case an averaged point will be used for the split pillars;
-         to get full unhealed representation of split horizon points, use split_horizon_points() function
-         instead;
-         for grids without k gaps, ref_k0 can be used alone, in the range 0..nk, to identify the horizon;
-         alternatively, or for grids with k gaps, the ref_k0 can specify the layer in the range 0..nk-1,
-         with kp being passed the value 0 (default) for the top of the layer, or 1 for the base of the layer
-      """
+        notes:
+           the primary pillars are the 'first' set of points for a pillar; a split pillar will have one to
+           three other sets of point data but those are ignored by this function unless heal_faults is True,
+           in which case an averaged point will be used for the split pillars;
+           to get full unhealed representation of split horizon points, use split_horizon_points() function
+           instead;
+           for grids without k gaps, ref_k0 can be used alone, in the range 0..nk, to identify the horizon;
+           alternatively, or for grids with k gaps, the ref_k0 can specify the layer in the range 0..nk-1,
+           with kp being passed the value 0 (default) for the top of the layer, or 1 for the base of the layer
+        """
 
         # note: if heal_faults is False, primary pillars only are used
         pe_j = self.nj + 1
@@ -2697,23 +2703,23 @@ class Grid(BaseResqpy):
     def split_horizon_points(self, ref_k0 = 0, masked = False, kp = 0):
         """Returns reference to a corner points for a horizon, of shape (nj, ni, 2, 2, 3).
 
-      arguments:
-         ref_k0 (integer): the horizon layer number, in the range 0 to nk (or layer number in range 0..nk-1
-            in the case of grids with k gaps)
-         masked (boolean, default False): if True, a masked array is returned with NaN points masked out;
-            if False, a simple (unmasked) numpy array is returned
-         kp (integer, default 0): set to 1 to specify the base of layer ref_k0, in case of grids with k gaps
+        arguments:
+           ref_k0 (integer): the horizon layer number, in the range 0 to nk (or layer number in range 0..nk-1
+              in the case of grids with k gaps)
+           masked (boolean, default False): if True, a masked array is returned with NaN points masked out;
+              if False, a simple (unmasked) numpy array is returned
+           kp (integer, default 0): set to 1 to specify the base of layer ref_k0, in case of grids with k gaps
 
-      returns:
-         numpy array of shape (nj, ni, 2, 2, 3) being corner point x,y,z values for cell corners (j, i, jp, ip)
+        returns:
+           numpy array of shape (nj, ni, 2, 2, 3) being corner point x,y,z values for cell corners (j, i, jp, ip)
 
-      notes:
-         if split points are needed for a range of horizons, it is more efficient to call split_horizons_points()
-         than repeatedly call this function;
-         for grids without k gaps, ref_k0 can be used alone, in the range 0..nk, to identify the horizon;
-         alternatively, or for grids with k gaps, the ref_k0 can specify the layer in the range 0..nk-1,
-         with kp being passed the value 0 (default) for the top of the layer, or 1 for the base of the layer
-      """
+        notes:
+           if split points are needed for a range of horizons, it is more efficient to call split_horizons_points()
+           than repeatedly call this function;
+           for grids without k gaps, ref_k0 can be used alone, in the range 0..nk, to identify the horizon;
+           alternatively, or for grids with k gaps, the ref_k0 can specify the layer in the range 0..nk-1,
+           with kp being passed the value 0 (default) for the top of the layer, or 1 for the base of the layer
+        """
 
         if self.k_gaps:
             ref_k0 = self.k_raw_index_array[ref_k0]
@@ -2742,20 +2748,20 @@ class Grid(BaseResqpy):
     def split_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
         """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid.
 
-      arguments:
-         axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
-         ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
-         plus_face (boolean, default False): if False, negative face is used; if True, positive
-         masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
+        arguments:
+           axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
+           ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
+           plus_face (boolean, default False): if False, negative face is used; if True, positive
+           masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
 
-      returns:
-         a numpy array of shape (nk + 1, nj, 2, 3) or (nk + 1, ni, 2, 3) being the xyz points of the cell corners
-         on the interfacial cross section; 3rd axis is jp or ip; final axis is xyz
+        returns:
+           a numpy array of shape (nk + 1, nj, 2, 3) or (nk + 1, ni, 2, 3) being the xyz points of the cell corners
+           on the interfacial cross section; 3rd axis is jp or ip; final axis is xyz
 
-      note:
-         this function will only work for grids with no k gaps; it is intended for split grids though will also
-         function for unsplit grids; use split_gap_x_section_points() if k gaps are present
-      """
+        note:
+           this function will only work for grids with no k gaps; it is intended for split grids though will also
+           function for unsplit grids; use split_gap_x_section_points() if k gaps are present
+        """
 
         log.debug(f'x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
         assert axis.upper() in ['I', 'J']
@@ -2772,22 +2778,23 @@ class Grid(BaseResqpy):
             return points[:, cpm[ref_slice0, :, ij_p, :], :]
 
     def split_gap_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
-        """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid with k gaps.
+        """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid with k
+        gaps.
 
-      arguments:
-         axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
-         ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
-         plus_face (boolean, default False): if False, negative face is used; if True, positive
-         masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
+        arguments:
+           axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
+           ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
+           plus_face (boolean, default False): if False, negative face is used; if True, positive
+           masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
 
-      returns:
-         a numpy array of shape (nk, nj, 2, 2, 3) or (nk, ni, 2, 2, 3) being the xyz points of the cell corners
-         on the interfacial cross section; 3rd axis is kp; 4th axis is jp or ip; final axis is xyz
+        returns:
+           a numpy array of shape (nk, nj, 2, 2, 3) or (nk, ni, 2, 2, 3) being the xyz points of the cell corners
+           on the interfacial cross section; 3rd axis is kp; 4th axis is jp or ip; final axis is xyz
 
-      note:
-         this function is intended for split grids with k gaps though will also function for split grids
-         without k gaps
-      """
+        note:
+           this function is intended for split grids with k gaps though will also function for split grids
+           without k gaps
+        """
 
         log.debug(f'k gap x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
         assert axis.upper() in ['I', 'J']
@@ -2818,21 +2825,21 @@ class Grid(BaseResqpy):
     def unsplit_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
         """Returns a 2D (+1 for xyz) array of points representing cell corners from an I or J interface slice.
 
-      arguments:
-         axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
-         ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
-         plus_face (boolean, default False): if False, negative face is used; if True, positive
-         masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
+        arguments:
+           axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
+           ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
+           plus_face (boolean, default False): if False, negative face is used; if True, positive
+           masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
 
-      returns:
-         a 2+1D numpy array being the xyz points of the cell corners on the interfacial cross section;
-         the 2D axes are K,J or K,I - whichever does not involve axis; shape is (nk + 1, nj + 1, 3) or
-         (nk + 1, ni + 1, 3)
+        returns:
+           a 2+1D numpy array being the xyz points of the cell corners on the interfacial cross section;
+           the 2D axes are K,J or K,I - whichever does not involve axis; shape is (nk + 1, nj + 1, 3) or
+           (nk + 1, ni + 1, 3)
 
-      note:
-         restricted to unsplit grids with no k gaps; use split_x_section_points() for split grids with no k gaps
-         or split_gap_x_section_points() for split grids with k gaps or x_section_corner_points() for any grid
-      """
+        note:
+           restricted to unsplit grids with no k gaps; use split_x_section_points() for split grids with no k gaps
+           or split_gap_x_section_points() for split grids with k gaps or x_section_corner_points() for any grid
+        """
 
         log.debug(f'x-sect: axis {axis}; ref_slice0 {ref_slice0}; plus_face {plus_face}; masked {masked}')
         assert axis.upper() in ['I', 'J']
@@ -2863,27 +2870,27 @@ class Grid(BaseResqpy):
                                 azimuth = None):
         """Returns a fully expanded array of points representing cell corners from an I or J interface slice.
 
-      arguments:
-         axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
-         ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
-         plus_face (boolean, default False): if False, negative face is used; if True, positive
-         masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
-         rotate (boolean, default False): if True, the cross section points are rotated around the z axis so that
-            an azimuthal direction is mapped onto the positive x axis
-         aximuth (float, optional): the compass bearing in degrees to map onto the positive x axis if rotating;
-            if None, the mean direction of the cross sectional points, along axis, is used; ignored if rotate
-            is False
+        arguments:
+           axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
+           ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
+           plus_face (boolean, default False): if False, negative face is used; if True, positive
+           masked (boolean, default False): if True, a masked numpy array is returned with NaN values masked out
+           rotate (boolean, default False): if True, the cross section points are rotated around the z axis so that
+              an azimuthal direction is mapped onto the positive x axis
+           aximuth (float, optional): the compass bearing in degrees to map onto the positive x axis if rotating;
+              if None, the mean direction of the cross sectional points, along axis, is used; ignored if rotate
+              is False
 
-      returns:
-         a numpy float array of shape (nk, nj, 2, 2, 3) or (nk, ni, 2, 2, 3) being the xyz points of the cell
-         corners on the interfacial cross section; the 3rd index (1st 2) is kp, the 4th index is jp or ip
+        returns:
+           a numpy float array of shape (nk, nj, 2, 2, 3) or (nk, ni, 2, 2, 3) being the xyz points of the cell
+           corners on the interfacial cross section; the 3rd index (1st 2) is kp, the 4th index is jp or ip
 
-      note:
-         this method will work for unsplit or split grids, with or without k gaps; use rotate argument to yield
-         points with predominant variation in xz, suitable for plotting cross sections; if rotate is True then
-         the absolute values of x & y will not be very meaningful though the units will still be the grid's xy
-         units for relative purposes
-      """
+        note:
+           this method will work for unsplit or split grids, with or without k gaps; use rotate argument to yield
+           points with predominant variation in xz, suitable for plotting cross sections; if rotate is True then
+           the absolute values of x & y will not be very meaningful though the units will still be the grid's xy
+           units for relative purposes
+        """
 
         assert axis.upper() in ['I', 'J']
         nj_or_ni = self.nj if axis.upper() == 'I' else self.ni
@@ -2927,19 +2934,19 @@ class Grid(BaseResqpy):
     def pixel_map_for_split_horizon_points(self, horizon_points, origin, width, height, dx, dy = None):
         """Makes a mapping from pixels to cell j, i indices, based on split horizon points for a single horizon.
 
-      args:
-         horizon_points (numpy array of shape (nj, ni, 2, 2, 2+)): corner point x,y,z values for cell
-            corners (j, i, jp, ip); as returned by split_horizon_points()
-         origin (float pair): x, y of south west corner of area covered by pixel rectangle, in local crs
-         width (int): the width of the pixel rectangle (number of pixels)
-         height (int): the height of the pixel rectangle (number of pixels)
-         dx (float): the size (west to east) of a pixel, in locel crs
-         dx (float, optional): the size (south to north) of a pixel, in locel crs; defaults to dx
+        args:
+           horizon_points (numpy array of shape (nj, ni, 2, 2, 2+)): corner point x,y,z values for cell
+              corners (j, i, jp, ip); as returned by split_horizon_points()
+           origin (float pair): x, y of south west corner of area covered by pixel rectangle, in local crs
+           width (int): the width of the pixel rectangle (number of pixels)
+           height (int): the height of the pixel rectangle (number of pixels)
+           dx (float): the size (west to east) of a pixel, in locel crs
+           dx (float, optional): the size (south to north) of a pixel, in locel crs; defaults to dx
 
-      returns:
-         numpy int array of shape (height, width, 2), being the j, i indices of cells that the pixel centres lie within;
-         values of -1 are used as null (ie. pixel not within any cell)
-      """
+        returns:
+           numpy int array of shape (height, width, 2), being the j, i indices of cells that the pixel centres lie within;
+           values of -1 are used as null (ie. pixel not within any cell)
+        """
 
         if dy is None:
             dy = dx
@@ -2989,20 +2996,20 @@ class Grid(BaseResqpy):
     def pixel_maps(self, origin, width, height, dx, dy = None, k0 = None, vertical_ref = 'top'):
         """Makes a mapping from pixels to cell j, i indices, based on split horizon points for a single horizon.
 
-      args:
-         origin (float pair): x, y of south west corner of area covered by pixel rectangle, in local crs
-         width (int): the width of the pixel rectangle (number of pixels)
-         height (int): the height of the pixel rectangle (number of pixels)
-         dx (float): the size (west to east) of a pixel, in locel crs
-         dy (float, optional): the size (south to north) of a pixel, in locel crs; defaults to dx
-         k0 (int, default None): if present, the single layer to create a 2D pixel map for; if None, a 3D map
-            is created with one layer per layer of the grid
-         vertical_ref (string, default 'top'): 'top' or 'base'
+        args:
+           origin (float pair): x, y of south west corner of area covered by pixel rectangle, in local crs
+           width (int): the width of the pixel rectangle (number of pixels)
+           height (int): the height of the pixel rectangle (number of pixels)
+           dx (float): the size (west to east) of a pixel, in locel crs
+           dy (float, optional): the size (south to north) of a pixel, in locel crs; defaults to dx
+           k0 (int, default None): if present, the single layer to create a 2D pixel map for; if None, a 3D map
+              is created with one layer per layer of the grid
+           vertical_ref (string, default 'top'): 'top' or 'base'
 
-      returns:
-         numpy int array of shape (height, width, 2), or (nk, height, width, 2), being the j, i indices of cells
-         that the pixel centres lie within; values of -1 are used as null (ie. pixel not within any cell)
-      """
+        returns:
+           numpy int array of shape (height, width, 2), or (nk, height, width, 2), being the j, i indices of cells
+           that the pixel centres lie within; values of -1 are used as null (ie. pixel not within any cell)
+        """
 
         if len(origin) == 3:
             origin = tuple(origin[0:2])
@@ -3031,23 +3038,23 @@ class Grid(BaseResqpy):
     def split_horizons_points(self, min_k0 = None, max_k0 = None, masked = False):
         """Returns reference to a corner points layer of shape (nh, nj, ni, 2, 2, 3) where nh is number of horizons.
 
-      arguments:
-         min_k0 (integer): the lowest horizon layer number to be included, in the range 0 to nk + k_gaps; defaults to zero
-         max_k0 (integer): the highest horizon layer number to be included, in the range 0 to nk + k_gaps; defaults to nk + k_gaps
-         masked (boolean, default False): if True, a masked array is returned with NaN points masked out;
-            if False, a simple (unmasked) numpy array is returned
+        arguments:
+           min_k0 (integer): the lowest horizon layer number to be included, in the range 0 to nk + k_gaps; defaults to zero
+           max_k0 (integer): the highest horizon layer number to be included, in the range 0 to nk + k_gaps; defaults to nk + k_gaps
+           masked (boolean, default False): if True, a masked array is returned with NaN points masked out;
+              if False, a simple (unmasked) numpy array is returned
 
-      returns:
-         numpy array of shape (nh, nj, ni, 2, 2, 3) where nh = max_k0 - min_k0 + 1, being corner point x,y,z values
-         for horizon corners (h, j, i, jp, ip) where h is the horizon (layer interface) index in the range
-         0 .. max_k0 - min_k0
+        returns:
+           numpy array of shape (nh, nj, ni, 2, 2, 3) where nh = max_k0 - min_k0 + 1, being corner point x,y,z values
+           for horizon corners (h, j, i, jp, ip) where h is the horizon (layer interface) index in the range
+           0 .. max_k0 - min_k0
 
-      notes:
-         data for horizon max_k0 is included in the result (unlike with python ranges);
-         in the case of a grid with k gaps, the horizons points returned will follow the k indexing of the points data
-         and calling code will need to keep track of the min_k0 offset when using k_raw_index_array to select a slice
-         of the horizons points array
-      """
+        notes:
+           data for horizon max_k0 is included in the result (unlike with python ranges);
+           in the case of a grid with k gaps, the horizons points returned will follow the k indexing of the points data
+           and calling code will need to keep track of the min_k0 offset when using k_raw_index_array to select a slice
+           of the horizons points array
+        """
 
         if min_k0 is None:
             min_k0 = 0
@@ -3078,12 +3085,12 @@ class Grid(BaseResqpy):
     def pillar_distances_sqr(self, xy, ref_k0 = 0, kp = 0, horizon_points = None):
         """Returns array of the square of the distances of primary pillars in x,y plane to point xy.
 
-      arguments:
-         xy (float pair): the xy coordinate to compute the pillar distances to
-         ref_k0 (int, default 0): the horizon layer number to use
-         horizon_points (numpy array, optional): if present, should be array as returned by
-            horizon_points() method; pass for efficiency in case of multiple calls
-      """
+        arguments:
+           xy (float pair): the xy coordinate to compute the pillar distances to
+           ref_k0 (int, default 0): the horizon layer number to use
+           horizon_points (numpy array, optional): if present, should be array as returned by
+              horizon_points() method; pass for efficiency in case of multiple calls
+        """
 
         # note: currently works with unmasked data and using primary pillars only
         pe_j = self.extent_kji[1] + 1
@@ -3108,9 +3115,9 @@ class Grid(BaseResqpy):
     def nearest_rod(self, xyz, projection, axis, ref_slice0 = 0, plus_face = False):
         """Returns the (k0, j0) or (k0 ,i0) indices of the closest point(s) to xyz(s); projection is 'xy', 'xz' or 'yz'.
 
-      note:
-         currently only for unsplit grids
-      """
+        note:
+           currently only for unsplit grids
+        """
 
         x_sect = self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face)
         if type(xyz) is np.ndarray and xyz.ndim > 1:
@@ -3127,9 +3134,9 @@ class Grid(BaseResqpy):
     def coordinate_line_end_points(self):
         """Returns xyz of top and bottom of each primary pillar.
 
-      returns:
-         numpy float array of shape (nj + 1, ni + 1, 2, 3)
-      """
+        returns:
+           numpy float array of shape (nj + 1, ni + 1, 2, 3)
+        """
 
         points = self.points_ref(masked = False).reshape((self.nk + 1, -1, 3))
         primary_pillar_count = (self.nj + 1) * (self.ni + 1)
@@ -3141,16 +3148,16 @@ class Grid(BaseResqpy):
     def z_corner_point_depths(self, order = 'cellular'):
         """Returns the z (depth) values of each corner of each cell.
 
-      arguments:
-         order (string, default 'cellular'): either 'cellular' or 'linear'; if 'cellular' the resulting array has
-            shape (nk, nj, ni, 2, 2, 2); if 'linear', the shape is (nk, 2, nj, 2, ni, 2)
+        arguments:
+           order (string, default 'cellular'): either 'cellular' or 'linear'; if 'cellular' the resulting array has
+              shape (nk, nj, ni, 2, 2, 2); if 'linear', the shape is (nk, 2, nj, 2, ni, 2)
 
-      returns:
-         numpy array of shape (nk, nj, ni, 2, 2, 2) or (nk, 2, nj, 2, ni, 2); for the cellular ordering, the
-         result can be indexed with [k, j, i, kp, jp, ip] (where kp, for example, is 0 for the K- face and 1 for K+);
-         for the linear ordering, the equivalent indexing is [k, kp, j, jp, i, ip], as used by some common simulator
-         keyword formats
-      """
+        returns:
+           numpy array of shape (nk, nj, ni, 2, 2, 2) or (nk, 2, nj, 2, ni, 2); for the cellular ordering, the
+           result can be indexed with [k, j, i, kp, jp, ip] (where kp, for example, is 0 for the K- face and 1 for K+);
+           for the linear ordering, the equivalent indexing is [k, kp, j, jp, i, ip], as used by some common simulator
+           keyword formats
+        """
 
         assert order in ['cellular', 'linear']
 
@@ -3212,17 +3219,17 @@ class Grid(BaseResqpy):
     def corner_points(self, cell_kji0 = None, points_root = None, cache_resqml_array = True, cache_cp_array = False):
         """Returns a numpy array of corner points for a single cell or the whole grid.
 
-      notes:
-         if cell_kji0 is not None, a 4D array of shape (2, 2, 2, 3) holding single cell corner points in logical order
-         [kp, jp, ip, xyz] is returned; if cell_kji0 is None, a pagoda style 7D array [k, j, i, kp, jp, ip, xyz] is
-         cached and returned;
-         the ordering of the corner points is in the logical order, which is not the same as that used by Nexus CORP data;
-         olio.grid_functions.resequence_nexus_corp() can be used to switch back and forth between this pagoda ordering
-         and Nexus corp ordering;
-         this is the usual way to access full corner points for cells where working with native resqml data is undesirable
+        notes:
+           if cell_kji0 is not None, a 4D array of shape (2, 2, 2, 3) holding single cell corner points in logical order
+           [kp, jp, ip, xyz] is returned; if cell_kji0 is None, a pagoda style 7D array [k, j, i, kp, jp, ip, xyz] is
+           cached and returned;
+           the ordering of the corner points is in the logical order, which is not the same as that used by Nexus CORP data;
+           olio.grid_functions.resequence_nexus_corp() can be used to switch back and forth between this pagoda ordering
+           and Nexus corp ordering;
+           this is the usual way to access full corner points for cells where working with native resqml data is undesirable
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # note: this function returns a derived object rather than a native resqml object
 
@@ -3340,29 +3347,31 @@ class Grid(BaseResqpy):
         return cp
 
     def invalidate_corner_points(self):
-        """Deletes cached copy of corner points, if present; use if any pillar geometry changes, or to reclaim memory."""
+        """Deletes cached copy of corner points, if present; use if any pillar geometry changes, or to reclaim
+        memory."""
 
         if hasattr(self, 'array_corner_points'):
             delattr(self, 'array_corner_points')
 
     def centre_point(self, cell_kji0 = None, cache_centre_array = False):
-        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all cells.
+        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all
+        cells.
 
-      arguments:
-         cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
-            centre point is required; zero based indexing
-         cache_centre_array (boolean, default False): If True, or cell_kji0 is None, an array of centre points
-            is generated and added as an attribute of the grid, with attribute name array_centre_point
+        arguments:
+           cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
+              centre point is required; zero based indexing
+           cache_centre_array (boolean, default False): If True, or cell_kji0 is None, an array of centre points
+              is generated and added as an attribute of the grid, with attribute name array_centre_point
 
-      returns:
-         (x, y, z) 3 element numpy array of floats holding centre point of cell;
-         or numpy 3+1D array if cell_kji0 is None
+        returns:
+           (x, y, z) 3 element numpy array of floats holding centre point of cell;
+           or numpy 3+1D array if cell_kji0 is None
 
-      note:
-         resulting coordinates are in the same (local) crs as the grid points
+        note:
+           resulting coordinates are in the same (local) crs as the grid points
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if cell_kji0 is None:
             cache_centre_array = True
@@ -3434,16 +3443,16 @@ class Grid(BaseResqpy):
     def centre_point_list(self, cell_kji0s):
         """Returns centre points for a list of cells; caches centre points for all cells.
 
-      arguments:
-         cell_kji0s (numpy int array of shape (N, 3)): the (k, j, i) indices of the individual cells for which the
-            centre points are required; zero based indexing
+        arguments:
+           cell_kji0s (numpy int array of shape (N, 3)): the (k, j, i) indices of the individual cells for which the
+              centre points are required; zero based indexing
 
-      returns:
-         numpy float array of shape (N, 3) being the (x, y, z) centre points of the cells
+        returns:
+           numpy float array of shape (N, 3) being the (x, y, z) centre points of the cells
 
-      note:
-         resulting coordinates are in the same (local) crs as the grid points
-      """
+        note:
+           resulting coordinates are in the same (local) crs as the grid points
+        """
 
         assert cell_kji0s.ndim == 2 and cell_kji0s.shape[1] == 3
         centres_list = np.empty(cell_kji0s.shape)
@@ -3460,34 +3469,34 @@ class Grid(BaseResqpy):
                   property_collection = None):
         """Returns vertical (z) thickness of cell and/or caches thicknesses for all cells.
 
-      arguments:
-         cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
-                               thickness is required; zero based indexing
-         cache_resqml_array (boolean, default True): If True, the raw points array from the hdf5 file
-                               is cached in memory, but only if it is needed to generate the thickness
-         cache_cp_array (boolean, default True): If True, an array of corner points is generated and
-                               added as an attribute of the grid, with attribute name corner_points, but only
-                               if it is needed in order to generate the thickness
-         cache_thickness_array (boolean, default False): if True, thicknesses are generated for all cells in
-                               the grid and added as an attribute named array_thickness
-         property_collection (property:GridPropertyCollection, optional): If not None, this collection
-                               is probed for a suitable thickness or cell length property which is used
-                               preferentially to calculating thickness; if no suitable property is found,
-                               the calculation is made as if the collection were None
+        arguments:
+           cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
+                                 thickness is required; zero based indexing
+           cache_resqml_array (boolean, default True): If True, the raw points array from the hdf5 file
+                                 is cached in memory, but only if it is needed to generate the thickness
+           cache_cp_array (boolean, default True): If True, an array of corner points is generated and
+                                 added as an attribute of the grid, with attribute name corner_points, but only
+                                 if it is needed in order to generate the thickness
+           cache_thickness_array (boolean, default False): if True, thicknesses are generated for all cells in
+                                 the grid and added as an attribute named array_thickness
+           property_collection (property:GridPropertyCollection, optional): If not None, this collection
+                                 is probed for a suitable thickness or cell length property which is used
+                                 preferentially to calculating thickness; if no suitable property is found,
+                                 the calculation is made as if the collection were None
 
-      returns:
-         float, being the thickness of cell identified by cell_kji0; or numpy float array if cell_kji0 is None
+        returns:
+           float, being the thickness of cell identified by cell_kji0; or numpy float array if cell_kji0 is None
 
-      notes:
-         the function can be used to find the thickness of a single cell, or cache thickness for all cells, or both;
-         if property_collection is not None, a suitable thickness or cell length property will be used if present;
-         if calculated, thickness is defined as z difference between centre points of top and base faces (TVT);
-         at present, assumes K increases with same polarity as z; if not, negative thickness will be calculated;
-         units of result are implicitly those of z coordinates in grid's coordinate reference system, or units of
-         measure of property array if the result is based on a suitable property
+        notes:
+           the function can be used to find the thickness of a single cell, or cache thickness for all cells, or both;
+           if property_collection is not None, a suitable thickness or cell length property will be used if present;
+           if calculated, thickness is defined as z difference between centre points of top and base faces (TVT);
+           at present, assumes K increases with same polarity as z; if not, negative thickness will be calculated;
+           units of result are implicitly those of z coordinates in grid's coordinate reference system, or units of
+           measure of property array if the result is based on a suitable property
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         def load_from_property(collection):
             if collection is None:
@@ -3570,11 +3579,12 @@ class Grid(BaseResqpy):
         return abs(np.mean(cp[1, :, :, 2]) - np.mean(cp[0, :, :, 2]))
 
     def point_areally(self, tolerance = 0.001):
-        """Returns a numpy boolean array of shape extent_kji indicating which cells are reduced to a point in both I & J axes.
+        """Returns a numpy boolean array of shape extent_kji indicating which cells are reduced to a point in both I & J
+        axes.
 
-      Note:
-         Any NaN point values will yield True for a cell
-      """
+        Note:
+           Any NaN point values will yield True for a cell
+        """
 
         points = self.points_ref(masked = False)
         # todo: turn off NaN warning for numpy > ?
@@ -3616,35 +3626,35 @@ class Grid(BaseResqpy):
                property_collection = None):
         """Returns bulk rock volume of cell or numpy array of bulk rock volumes for all cells.
 
-      arguments:
-         cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
-                               volume is required; zero based indexing
-         cache_resqml_array (boolean, default True): If True, the raw points array from the hdf5 file
-                               is cached in memory, but only if it is needed to generate the volume
-         cache_cp_array (boolean, default False): If True, an array of corner points is generated and
-                               added as an attribute of the grid, with attribute name corner_points, but only
-                               if it is needed in order to generate the volume
-         cache_volume_array (boolean, default False): if True, volumes are generated for all cells in
-                               the grid and added as an attribute named array_volume
-         property_collection (property:GridPropertyCollection, optional): If not None, this collection
-                               is probed for a suitable volume property which is used preferentially
-                               to calculating volume; if no suitable property is found,
-                               the calculation is made as if the collection were None
+        arguments:
+           cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
+                                 volume is required; zero based indexing
+           cache_resqml_array (boolean, default True): If True, the raw points array from the hdf5 file
+                                 is cached in memory, but only if it is needed to generate the volume
+           cache_cp_array (boolean, default False): If True, an array of corner points is generated and
+                                 added as an attribute of the grid, with attribute name corner_points, but only
+                                 if it is needed in order to generate the volume
+           cache_volume_array (boolean, default False): if True, volumes are generated for all cells in
+                                 the grid and added as an attribute named array_volume
+           property_collection (property:GridPropertyCollection, optional): If not None, this collection
+                                 is probed for a suitable volume property which is used preferentially
+                                 to calculating volume; if no suitable property is found,
+                                 the calculation is made as if the collection were None
 
-      returns:
-         float, being the volume of cell identified by cell_kji0;
-         or numpy float array of shape (nk, nj, ni) if cell_kji0 is None
+        returns:
+           float, being the volume of cell identified by cell_kji0;
+           or numpy float array of shape (nk, nj, ni) if cell_kji0 is None
 
-      notes:
-         the function can be used to find the volume of a single cell, or cache volumes for all cells, or both;
-         if property_collection is not None, a suitable volume property will be used if present;
-         if calculated, volume is computed using 6 tetras each with a non-planar bilinear base face;
-         at present, grid's coordinate reference system must use same units in z as xy (projected);
-         units of result are implicitly those of coordinates in grid's coordinate reference system, or units of
-         measure of property array if the result is based on a suitable property
+        notes:
+           the function can be used to find the volume of a single cell, or cache volumes for all cells, or both;
+           if property_collection is not None, a suitable volume property will be used if present;
+           if calculated, volume is computed using 6 tetras each with a non-planar bilinear base face;
+           at present, grid's coordinate reference system must use same units in z as xy (projected);
+           units of result are implicitly those of coordinates in grid's coordinate reference system, or units of
+           measure of property array if the result is based on a suitable property
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         def load_from_property(collection):
             if collection is None:
@@ -3715,10 +3725,11 @@ class Grid(BaseResqpy):
                     cache_cp_array = False,
                     cache_thickness_array = False,
                     cache_pinchout_array = None):
-        """Returns boolean or boolean array indicating whether cell is pinched out; ie. has a thickness less than tolerance.
+        """Returns boolean or boolean array indicating whether cell is pinched out; ie. has a thickness less than
+        tolerance.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # note: this function returns a derived object rather than a native resqml object
         # note: returns True for cells without geometry
@@ -3754,26 +3765,26 @@ class Grid(BaseResqpy):
     def half_cell_transmissibility(self, use_property = True, realization = None, tolerance = 1.0e-6):
         """Returns (and caches if realization is None) half cell transmissibilities for this grid.
 
-      arguments:
-         use_property (boolean, default True): if True, the grid's property collection is inspected for
-            a possible half cell transmissibility array and if found, it is used instead of calculation
-         realization (int, optional) if present, only a property with this realization number will be used
-         tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
-            will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
-            units are implicitly those of the grid's crs length units
+        arguments:
+           use_property (boolean, default True): if True, the grid's property collection is inspected for
+              a possible half cell transmissibility array and if found, it is used instead of calculation
+           realization (int, optional) if present, only a property with this realization number will be used
+           tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
+              will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
+              units are implicitly those of the grid's crs length units
 
-      returns:
-         numpy float array of shape (nk, nj, ni, 3, 2) where the 3 covers K,J,I and the 2 covers the
-            face polarity: - (0) and + (1); units will depend on the length units of the coordinate reference
-            system for the grid; the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m
-            and ft respectively
+        returns:
+           numpy float array of shape (nk, nj, ni, 3, 2) where the 3 covers K,J,I and the 2 covers the
+              face polarity: - (0) and + (1); units will depend on the length units of the coordinate reference
+              system for the grid; the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m
+              and ft respectively
 
-      notes:
-         the returned array is in the logical resqpy arrangement; it must be discombobulated before being
-         added as a property; this method does not write to hdf5, nor create a new property or xml;
-         if realization is None, a grid attribute cached array will be used; tolerance will only be
-         used if the half cell transmissibilities are actually computed
-      """
+        notes:
+           the returned array is in the logical resqpy arrangement; it must be discombobulated before being
+           added as a property; this method does not write to hdf5, nor create a new property or xml;
+           if realization is None, a grid attribute cached array will be used; tolerance will only be
+           used if the half cell transmissibilities are actually computed
+        """
 
         # todo: allow passing of property uuids for ntg, k_k, j, i
 
@@ -3805,49 +3816,49 @@ class Grid(BaseResqpy):
     def transmissibility(self, tolerance = 1.0e-6, use_tr_properties = True, realization = None, modifier_mode = None):
         """Returns transmissibilities for standard (IJK neighbouring) connections within this grid.
 
-      arguments:
-         tolerance (float, default 1.0e-6): the minimum half cell transmissibility below which zero inter-cell
-            transmissibility will be set; units are as for returned values (see notes)
-         use_tr_properties (boolean, default True): if True, the grid's property collection is inspected for
-            possible transmissibility arrays and if found, they are used instead of calculation; note that
-            when this argument is False, the property collection is still used for the feed arrays to the
-            calculation
-         realization (int, optional) if present, only properties with this realization number will be used;
-            applies to pre-computed transmissibility properties or permeability and net to gross ratio
-            properties when computing
-         modifier_mode (string, optional): if None, no transmissibility modifiers are applied; other
-            options are: 'faces multiplier', for which directional transmissibility properties with indexable
-            element of 'faces' will be used; 'faces per cell multiplier', in which case a transmissibility
-            property with 'faces per cell' as the indexable element will be used to modify the half cell
-            transmissibilities prior to combination; or 'absolute' in which case directional properties
-            of local property kind 'fault transmissibility' (or 'mat transmissibility') and indexable
-            element of 'faces' will be used as a third transmissibility term along with the two half
-            cell transmissibilities at each face; see also the notes below
+        arguments:
+           tolerance (float, default 1.0e-6): the minimum half cell transmissibility below which zero inter-cell
+              transmissibility will be set; units are as for returned values (see notes)
+           use_tr_properties (boolean, default True): if True, the grid's property collection is inspected for
+              possible transmissibility arrays and if found, they are used instead of calculation; note that
+              when this argument is False, the property collection is still used for the feed arrays to the
+              calculation
+           realization (int, optional) if present, only properties with this realization number will be used;
+              applies to pre-computed transmissibility properties or permeability and net to gross ratio
+              properties when computing
+           modifier_mode (string, optional): if None, no transmissibility modifiers are applied; other
+              options are: 'faces multiplier', for which directional transmissibility properties with indexable
+              element of 'faces' will be used; 'faces per cell multiplier', in which case a transmissibility
+              property with 'faces per cell' as the indexable element will be used to modify the half cell
+              transmissibilities prior to combination; or 'absolute' in which case directional properties
+              of local property kind 'fault transmissibility' (or 'mat transmissibility') and indexable
+              element of 'faces' will be used as a third transmissibility term along with the two half
+              cell transmissibilities at each face; see also the notes below
 
-      returns:
-         3 numpy float arrays of shape (nk + 1, nj, ni), (nk, nj + 1, ni), (nk, nj, ni + 1) being the
-         neighbourly transmissibilities in K, J & I axes respectively
+        returns:
+           3 numpy float arrays of shape (nk + 1, nj, ni), (nk, nj + 1, ni), (nk, nj, ni + 1) being the
+           neighbourly transmissibilities in K, J & I axes respectively
 
-      notes:
-         the 3 permeability arrays (and net to gross ratio if in use) must be identifiable in the property
-         collection as they are used for the calculation;
-         implicit units of measure of returned values will be m3.cP/(kPa.d) if grid crs length units are metres,
-         bbl.cP/(psi.d) if length units are feet; the computation is compatible with the Nexus NEWTRAN formulation;
-         values will be zero at pinchouts, and at column edges where there is a split pillar, even if there is
-         juxtapostion of faces; the same is true of K gap faces (even where the gap is zero); NaNs in any of
-         the feed properties also result in transmissibility values of zero;
-         outer facing values will always be zero (included to be in accordance with RESQML faces properties);
-         array caching in the grid object will only be used if realization is None; if a modifier mode of
-         'faces multiplier' or 'faces per cell multiplier' is specified, properties will be searched for with
-         local property kind 'transmissibility multiplier' and the appropriate indexable element (and direction
-         facet in the case of 'faces multiplier'); the modifier mode of 'absolute' can be used to model the
-         effect of faults and thin shales, tar mats etc. in a way which is independent of cell size;
-         for 'aboslute' directional properties with indexable element of 'faces' and local property kind
-         'fault transmissibility' (or 'mat transmissibility') will be used; such absolute faces transmissibilities
-         should have a value of np.inf or np.nan where no modification is required; note that this method is only
-         dealing with logically neighbouring cells and will not compute values for faces with a split pillar,
-         which should be handled elsewhere
-      """
+        notes:
+           the 3 permeability arrays (and net to gross ratio if in use) must be identifiable in the property
+           collection as they are used for the calculation;
+           implicit units of measure of returned values will be m3.cP/(kPa.d) if grid crs length units are metres,
+           bbl.cP/(psi.d) if length units are feet; the computation is compatible with the Nexus NEWTRAN formulation;
+           values will be zero at pinchouts, and at column edges where there is a split pillar, even if there is
+           juxtapostion of faces; the same is true of K gap faces (even where the gap is zero); NaNs in any of
+           the feed properties also result in transmissibility values of zero;
+           outer facing values will always be zero (included to be in accordance with RESQML faces properties);
+           array caching in the grid object will only be used if realization is None; if a modifier mode of
+           'faces multiplier' or 'faces per cell multiplier' is specified, properties will be searched for with
+           local property kind 'transmissibility multiplier' and the appropriate indexable element (and direction
+           facet in the case of 'faces multiplier'); the modifier mode of 'absolute' can be used to model the
+           effect of faults and thin shales, tar mats etc. in a way which is independent of cell size;
+           for 'aboslute' directional properties with indexable element of 'faces' and local property kind
+           'fault transmissibility' (or 'mat transmissibility') will be used; such absolute faces transmissibilities
+           should have a value of np.inf or np.nan where no modification is required; note that this method is only
+           dealing with logically neighbouring cells and will not compute values for faces with a split pillar,
+           which should be handled elsewhere
+        """
 
         # todo: improve handling of units: check uom for half cell transmissibility property and for absolute modifiers
 
@@ -4085,25 +4096,25 @@ class Grid(BaseResqpy):
                              title = 'fault juxtaposition set'):
         """Returns (and caches) a GridConnectionSet representing juxtaposition across faces with split pillars.
 
-      arguments:
-         skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
-            be omitted from the results
-         compute_transmissibilities (boolean, default False): if True, then transmissibilities will be computed
-            for the cell face pairs (unless already existing as a cached attribute of the grid)
-         add_to_model (boolean, default False): if True, the connection set is written to hdf5 and xml is created;
-            if compute_transmissibilty is True then the transmissibility property is also added
-         realization (int, optional): if present, is used as the realization number when adding transmissibility
-            property to model; ignored if compute_transmissibility is False
-         inherit_features_from (GridConnectionSet, optional): if present, the features (named faults) are
-            inherited from this grid connection set based on a match of either cell face in a juxtaposed pair
-         title (string, default 'fault juxtaposition set'): the citation title to use if adding to model
+        arguments:
+           skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
+              be omitted from the results
+           compute_transmissibilities (boolean, default False): if True, then transmissibilities will be computed
+              for the cell face pairs (unless already existing as a cached attribute of the grid)
+           add_to_model (boolean, default False): if True, the connection set is written to hdf5 and xml is created;
+              if compute_transmissibilty is True then the transmissibility property is also added
+           realization (int, optional): if present, is used as the realization number when adding transmissibility
+              property to model; ignored if compute_transmissibility is False
+           inherit_features_from (GridConnectionSet, optional): if present, the features (named faults) are
+              inherited from this grid connection set based on a match of either cell face in a juxtaposed pair
+           title (string, default 'fault juxtaposition set'): the citation title to use if adding to model
 
-      returns:
-         GridConnectionSet, numpy float array of shape (count,) transmissibilities (or None), where count is the
-         number of cell face pairs in the grid connection set, which contains entries for all juxtaposed faces
-         with a split pillar as an edge; if the grid does not have split pillars (ie. is unfaulted) or there
-         are no qualifying connections, (None, None) is returned
-      """
+        returns:
+           GridConnectionSet, numpy float array of shape (count,) transmissibilities (or None), where count is the
+           number of cell face pairs in the grid connection set, which contains entries for all juxtaposed faces
+           with a split pillar as an edge; if the grid does not have split pillars (ie. is unfaulted) or there
+           are no qualifying connections, (None, None) is returned
+        """
 
         if not hasattr(self, 'fgcs') or self.fgcs_skip_inactive != skip_inactive:
             self.fgcs, self.fgcs_fractional_area = rqtr.fault_connection_set(self, skip_inactive = skip_inactive)
@@ -4151,22 +4162,22 @@ class Grid(BaseResqpy):
                                 realization = None):
         """Returns (and caches) a GridConnectionSet representing juxtaposition across pinched out cells.
 
-      arguments:
-         skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
-            be omitted from the results
-         compute_transmissibilities (boolean, default False): if True, then transmissibilities will be computed
-            for the cell face pairs (unless already existing as a cached attribute of the grid)
-         add_to_model (boolean, default False): if True, the connection set is written to hdf5 and xml is created;
-            if compute_transmissibilty is True then the transmissibility property is also added
-         realization (int, optional): if present, is used as the realization number when adding transmissibility
-            property to model; ignored if compute_transmissibility is False
+        arguments:
+           skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
+              be omitted from the results
+           compute_transmissibilities (boolean, default False): if True, then transmissibilities will be computed
+              for the cell face pairs (unless already existing as a cached attribute of the grid)
+           add_to_model (boolean, default False): if True, the connection set is written to hdf5 and xml is created;
+              if compute_transmissibilty is True then the transmissibility property is also added
+           realization (int, optional): if present, is used as the realization number when adding transmissibility
+              property to model; ignored if compute_transmissibility is False
 
-      returns:
-         GridConnectionSet, numpy float array of shape (count,) transmissibilities (or None), where count is the
-         number of cell face pairs in the grid connection set, which contains entries for all juxtaposed K faces
-         separated logically by pinched out (zero thickness) cells; if there are no pinchouts (or no qualifying
-         connections) then (None, None) will be returned
-      """
+        returns:
+           GridConnectionSet, numpy float array of shape (count,) transmissibilities (or None), where count is the
+           number of cell face pairs in the grid connection set, which contains entries for all juxtaposed K faces
+           separated logically by pinched out (zero thickness) cells; if there are no pinchouts (or no qualifying
+           connections) then (None, None) will be returned
+        """
 
         if not hasattr(self, 'pgcs') or self.pgcs_skip_inactive != skip_inactive:
             self.pgcs = rqf.pinchout_connection_set(self, skip_inactive = skip_inactive)
@@ -4212,27 +4223,27 @@ class Grid(BaseResqpy):
                              tolerance = 0.001):
         """Returns (and caches) a GridConnectionSet representing juxtaposition across zero thickness K gaps.
 
-      arguments:
-         skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
-            be omitted from the results
-         compute_transmissibilities (boolean, default False): if True, then transmissibilities will be computed
-            for the cell face pairs (unless already existing as a cached attribute of the grid)
-         add_to_model (boolean, default False): if True, the connection set is written to hdf5 and xml is created;
-            if compute_transmissibilty is True then the transmissibility property is also added
-         realization (int, optional): if present, is used as the realization number when adding transmissibility
-            property to model; ignored if compute_transmissibility is False
-         tolerance (float, default 0.001): the maximum K gap thickness that will be 'bridged' by a connection;
-            units are implicitly those of the z units in the grid's coordinate reference system
+        arguments:
+           skip_inactive (boolean, default True): if True, then cell face pairs involving an inactive cell will
+              be omitted from the results
+           compute_transmissibilities (boolean, default False): if True, then transmissibilities will be computed
+              for the cell face pairs (unless already existing as a cached attribute of the grid)
+           add_to_model (boolean, default False): if True, the connection set is written to hdf5 and xml is created;
+              if compute_transmissibilty is True then the transmissibility property is also added
+           realization (int, optional): if present, is used as the realization number when adding transmissibility
+              property to model; ignored if compute_transmissibility is False
+           tolerance (float, default 0.001): the maximum K gap thickness that will be 'bridged' by a connection;
+              units are implicitly those of the z units in the grid's coordinate reference system
 
-      returns:
-         GridConnectionSet, numpy float array of shape (count,) transmissibilities (or None), where count is the
-         number of cell face pairs in the grid connection set, which contains entries for all juxtaposed K faces
-         separated logically by pinched out (zero thickness) cells; if there are no pinchouts (or no qualifying
-         connections) then (None, None) will be returned
+        returns:
+           GridConnectionSet, numpy float array of shape (count,) transmissibilities (or None), where count is the
+           number of cell face pairs in the grid connection set, which contains entries for all juxtaposed K faces
+           separated logically by pinched out (zero thickness) cells; if there are no pinchouts (or no qualifying
+           connections) then (None, None) will be returned
 
-      note:
-         if cached values are found they are returned regardless of the specified tolerance
-      """
+        note:
+           if cached values are found they are returned regardless of the specified tolerance
+        """
 
         if not hasattr(self, 'kgcs') or self.kgcs_skip_inactive != skip_inactive:
             self.kgcs = rqf.k_gap_connection_set(self, skip_inactive = skip_inactive, tolerance = tolerance)
@@ -4308,7 +4319,8 @@ class Grid(BaseResqpy):
                            points_root = None,
                            cache_resqml_array = True,
                            cache_cp_array = False):
-        """Returns xyz point interpolated from corners of cell depending on 3 interpolation fractions in range 0 to 1."""
+        """Returns xyz point interpolated from corners of cell depending on 3 interpolation fractions in range 0 to
+        1."""
 
         # todo: think about best ordering of axes operations given high aspect ratio of cells (for best accuracy)
         fp = np.empty(3)
@@ -4335,25 +4347,26 @@ class Grid(BaseResqpy):
                             points_root = None,
                             cache_resqml_array = True,
                             cache_cp_array = False):
-        """Returns xyz points interpolated from corners of cell depending on 3 interpolation fraction numpy vectors, each value in range 0 to 1.
+        """Returns xyz points interpolated from corners of cell depending on 3 interpolation fraction numpy vectors,
+        each value in range 0 to 1.
 
-      arguments:
-         cell_kji0 (triple int): indices of individual cell whose corner points are to be interpolated
-         interpolation_fractions (list of three numpy vectors of floats): k, j & i interpolation fraction vectors, each element in range 0 to 1
-         points_root (xml node, optional): for efficiency when making multiple calls, this can be set to the xml node of the points data
-         cache_resqml_array (boolean, default True): if True, the resqml points data will be cached as an attribute of this grid object
-         cache_cp_array (boolean, default False): if True a fully expanded 7D corner points array will be established for this grid and
-            cached as an attribute (recommended if looping over many or all the cells and if memory space allows)
+        arguments:
+           cell_kji0 (triple int): indices of individual cell whose corner points are to be interpolated
+           interpolation_fractions (list of three numpy vectors of floats): k, j & i interpolation fraction vectors, each element in range 0 to 1
+           points_root (xml node, optional): for efficiency when making multiple calls, this can be set to the xml node of the points data
+           cache_resqml_array (boolean, default True): if True, the resqml points data will be cached as an attribute of this grid object
+           cache_cp_array (boolean, default False): if True a fully expanded 7D corner points array will be established for this grid and
+              cached as an attribute (recommended if looping over many or all the cells and if memory space allows)
 
-      returns:
-         4D numpy float array of shape (nik, nij, nii, 3) being the interpolated points; nik is the number of elements in the first of the
-         interpolation fraction lists (ie. for k); similarly for nij and nii; the final axis covers xyz
+        returns:
+           4D numpy float array of shape (nik, nij, nii, 3) being the interpolated points; nik is the number of elements in the first of the
+           interpolation fraction lists (ie. for k); similarly for nij and nii; the final axis covers xyz
 
-      notea:
-         this method returns a lattice of trilinear interpolations of the corner point of the host cell; the returned points are in 'shared'
-         arrangement (like resqml points data for an IjkGrid without split pillars or k gaps), not a fully expanded 7D array; calling code
-         must redistribute to corner points of individual fine cells if that is the intention
-      """
+        notea:
+           this method returns a lattice of trilinear interpolations of the corner point of the host cell; the returned points are in 'shared'
+           arrangement (like resqml points data for an IjkGrid without split pillars or k gaps), not a fully expanded 7D array; calling code
+           must redistribute to corner points of individual fine cells if that is the intention
+        """
 
         assert len(interpolation_fractions) == 3
         fp = interpolation_fractions
@@ -4440,9 +4453,9 @@ class Grid(BaseResqpy):
     def interface_length(self, cell_kji0, axis, points_root = None, cache_resqml_array = True, cache_cp_array = False):
         """Returns the length between centres of an opposite pair of faces of the cell.
 
-      note:
-         assumes that x,y and z units are the same
-      """
+        note:
+           assumes that x,y and z units are the same
+        """
 
         assert cell_kji0 is not None
         return vec.naive_length(
@@ -4467,9 +4480,9 @@ class Grid(BaseResqpy):
     def interface_lengths_kji(self, cell_kji0, points_root = None, cache_resqml_array = True, cache_cp_array = False):
         """Returns 3 interface centre point separation lengths for axes k, j, i.
 
-      note:
-         assumes that x,y and z units are the same
-      """
+        note:
+           assumes that x,y and z units are the same
+        """
         result = np.zeros(3)
         for axis in range(3):
             result[axis] = self.interface_length(cell_kji0,
@@ -4523,10 +4536,11 @@ class Grid(BaseResqpy):
                 bwam.convert_lengths(flat_a[:, 2], crs_z_units_text, global_z_units)  # z
 
     def z_inc_down(self):
-        """Returns True if z increases downwards in the coordinate reference system used by the grid geometry, False otherwise.
+        """Returns True if z increases downwards in the coordinate reference system used by the grid geometry, False
+        otherwise.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert self.crs_root is not None
         return rqet.find_tag_bool(self.crs_root, 'ZIncreasingDownward')
@@ -4580,7 +4594,8 @@ class Grid(BaseResqpy):
                                write_active = None,
                                stratigraphy = True,
                                expand_const_arrays = False):
-        """Create or append to an hdf5 file, writing datasets for the grid geometry (and parent grid mapping) and properties from cached arrays."""
+        """Create or append to an hdf5 file, writing datasets for the grid geometry (and parent grid mapping) and
+        properties from cached arrays."""
 
         # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
         # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
@@ -4695,8 +4710,8 @@ class Grid(BaseResqpy):
     def write_hdf5(self, expand_const_arrays = False):
         """Writes grid geometry arrays to hdf5 (thin wrapper around write_hdf5_from_caches().
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         self.write_hdf5_from_caches(mode = 'a',
                                     geometry = True,
@@ -4825,8 +4840,8 @@ class Grid(BaseResqpy):
     def xy_units(self):
         """Returns the projected view (x, y) units of measure of the coordinate reference system for the grid.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         crs_root = self.extract_crs_root()
         if crs_root is None:
@@ -4836,8 +4851,8 @@ class Grid(BaseResqpy):
     def z_units(self):
         """Returns the vertical (z) units of measure of the coordinate reference system for the grid.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         crs_root = self.extract_crs_root()
         if crs_root is None:
@@ -4845,7 +4860,8 @@ class Grid(BaseResqpy):
         return rqet.find_tag(crs_root, 'VerticalUom').text
 
     def poly_line_for_cell(self, cell_kji0, vertical_ref = 'top'):
-        """Returns a numpy array of shape (4, 3) being the 4 corners in order J-I-, J-I+, J+I+, J+I-; from the top or base face."""
+        """Returns a numpy array of shape (4, 3) being the 4 corners in order J-I-, J-I+, J+I+, J+I-; from the top or
+        base face."""
 
         if vertical_ref == 'top':
             kp = 0
@@ -4901,18 +4917,18 @@ class Grid(BaseResqpy):
     def find_cell_for_x_sect_xz(self, x_sect, x, z):
         """Returns the (k0, j0) or (k0, i0) indices of the cell containing point x,z in the cross section.
 
-      arguments:
-         x_sect (numpy float array of shape (nk, nj or ni, 2, 2, 2 or 3): the cross section x,z or x,y,z data
-         x, z (floats): the point of interest in the cross section space
+        arguments:
+           x_sect (numpy float array of shape (nk, nj or ni, 2, 2, 2 or 3): the cross section x,z or x,y,z data
+           x, z (floats): the point of interest in the cross section space
 
-      note:
-         the x_sect data is in the form returned by x_section_corner_points() or split_gap_x_section_points();
-         the 2nd of the returned pair is either a J index or I index, whichever was not the axis specified
-         when generating the x_sect data; returns (None, None) if point inclusion not detected; if xyz data is
-         provided, the y values are ignored; note that the point of interest x,z coordinates are in the space of
-         x_sect, so if rotation has occurred, the x value is no longer an easting and is typically picked off a
-         cross section plot
-      """
+        note:
+           the x_sect data is in the form returned by x_section_corner_points() or split_gap_x_section_points();
+           the 2nd of the returned pair is either a J index or I index, whichever was not the axis specified
+           when generating the x_sect data; returns (None, None) if point inclusion not detected; if xyz data is
+           provided, the y values are ignored; note that the point of interest x,z coordinates are in the space of
+           x_sect, so if rotation has occurred, the x value is no longer an easting and is typically picked off a
+           cross section plot
+        """
 
         def test_cell(p, x_sect, k0, ji0):
             poly = np.array([
@@ -4996,37 +5012,37 @@ class Grid(BaseResqpy):
                    extra_metadata = {}):
         """Creates an IJK grid node from a grid object and optionally adds as child of root and/or to parts forest.
 
-      arguments:
-         ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the array data for the grid geometry
-         add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-            in the model
-         add_relationships (boolean, default True): if True, relationship xml parts are created relating the
-            new grid part to: the crs, and the hdf5 external part
-         set_as_grid_root (boolean, default True): if True, the new grid node is noted as being the 'main' grid
-            for the model
-         title (string, default 'ROOT'): used as the citation Title text; careful consideration should be given
-            to this argument when dealing with multiple grids in one model, as it is the means by which a
-            human will distinguish them
-         originator (string, optional): the name of the human being who created the ijk grid part;
-            default is to use the login name
-         write_active (boolean, default True): if True, xml for an active cell property is also generated, but
-            only if the active_property_uuid is set and no part exists in the model for that uuid
-         write_geometry (boolean, default True): if False, the geometry node is omitted from the xml
-         extra_metadata (dict): any key value pairs in this dictionary are added as extra metadata xml nodes
+        arguments:
+           ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the array data for the grid geometry
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in the model
+           add_relationships (boolean, default True): if True, relationship xml parts are created relating the
+              new grid part to: the crs, and the hdf5 external part
+           set_as_grid_root (boolean, default True): if True, the new grid node is noted as being the 'main' grid
+              for the model
+           title (string, default 'ROOT'): used as the citation Title text; careful consideration should be given
+              to this argument when dealing with multiple grids in one model, as it is the means by which a
+              human will distinguish them
+           originator (string, optional): the name of the human being who created the ijk grid part;
+              default is to use the login name
+           write_active (boolean, default True): if True, xml for an active cell property is also generated, but
+              only if the active_property_uuid is set and no part exists in the model for that uuid
+           write_geometry (boolean, default True): if False, the geometry node is omitted from the xml
+           extra_metadata (dict): any key value pairs in this dictionary are added as extra metadata xml nodes
 
-      returns:
-         the newly created ijk grid xml node
+        returns:
+           the newly created ijk grid xml node
 
-      notes:
-         this code has the concept of a 'main' grid for a model, which resqml does not; it is vaguely
-            equivalent to a 'root' grid in a simulation model
-         the write_active argument should generally be set to the same value as that passed to the write_hdf5... method;
-         the RESQML standard allows the geometry to be omitted for a grid, controlled here by the write_geometry argument;
-         the explicit geometry may be omitted for regular grids, in which case the arrays should not be written to the hdf5
-         file either
+        notes:
+           this code has the concept of a 'main' grid for a model, which resqml does not; it is vaguely
+              equivalent to a 'root' grid in a simulation model
+           the write_active argument should generally be set to the same value as that passed to the write_hdf5... method;
+           the RESQML standard allows the geometry to be omitted for a grid, controlled here by the write_geometry argument;
+           the explicit geometry may be omitted for regular grids, in which case the arrays should not be written to the hdf5
+           file either
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if ext_uuid is None:
             ext_uuid = self.model.h5_uuid()
@@ -5436,56 +5452,56 @@ class RegularGrid(Grid):
                  extra_metadata = {}):
         """Creates a regular grid object based on dxyz, or derived from a Mesh object.
 
-      arguments:
-         parent_model (model.Model object): the model to which the new grid will be assigned
-         extent_kji (triple positive integers, optional): the number of cells in the grid (nk, nj, ni);
-            required unless grid_root is present
-         dxyz (triple float, optional): use when the I,J,K axes align with the x,y,z axes (possible with inverted
-            directions); the size of each cell (dx, dy, dz); values may be negative
-         dxyz_dkji (numpy float array of shape (3, 3), optional): how x,y,z values increase with each step in each
-            direction K,J,I; first index is KJI, second index is xyz; only one of dxyz, dxyz_dkji and mesh should be
-            present; NB axis ordering is different to that used in Mesh class for dxyz_dij
-         origin (triple float, default (0.0, 0.0, 0.0)): the location in the local coordinate space of the crs of
-            the 'first' corner point of the grid
-         crs_uuid (uuid.UUID, optional): the uuid of the coordinate reference system for the grid
-         use_vertical (boolean, default False): if True and the pillars of the regular grid are vertical then a
-            pillar shape of 'vertical' is used; if False (or the pillars are not vertical), then a pillar shape of
-            'straight' is used
-         mesh (surface.Mesh object, optional): if present, the I,J layout of the grid is based on the mesh, which
-            must be regular, and the K cell size is given by the mesh_dz_dk argument; if present, then dxyz and
-            dxyz_dkji must be None
-         mesh_dz_dk (float, default 1.0): the size of cells in the K axis, which is aligned with the z axis, when
-            starting from a mesh; ignored if mesh is None
-         uuid (optional): the root of the xml tree for the grid part; if present, the RegularGrid object is
-            based on existing data or a mix of that data and other arguments where present
-         set_points_cached (boolean, default False): if True, an explicit geometry is created for the regular grid
-            in the form of the cached points array; will be treated as True if as_irregular_grid is True
-         as_irregular_grid (boolean, default False): if True, the grid is setup such that it will appear as a Grid
-            object when next loaded from disc
-         find_properties (boolean, default True): if True and grid_root is not None, a grid property collection is
-            instantiated as an attribute, holding properties for which this grid is the supporting representation
-         title (str, optional): citation title for new grid; ignored if loading from xml
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if loading from xml
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if loading from xml
+        arguments:
+           parent_model (model.Model object): the model to which the new grid will be assigned
+           extent_kji (triple positive integers, optional): the number of cells in the grid (nk, nj, ni);
+              required unless grid_root is present
+           dxyz (triple float, optional): use when the I,J,K axes align with the x,y,z axes (possible with inverted
+              directions); the size of each cell (dx, dy, dz); values may be negative
+           dxyz_dkji (numpy float array of shape (3, 3), optional): how x,y,z values increase with each step in each
+              direction K,J,I; first index is KJI, second index is xyz; only one of dxyz, dxyz_dkji and mesh should be
+              present; NB axis ordering is different to that used in Mesh class for dxyz_dij
+           origin (triple float, default (0.0, 0.0, 0.0)): the location in the local coordinate space of the crs of
+              the 'first' corner point of the grid
+           crs_uuid (uuid.UUID, optional): the uuid of the coordinate reference system for the grid
+           use_vertical (boolean, default False): if True and the pillars of the regular grid are vertical then a
+              pillar shape of 'vertical' is used; if False (or the pillars are not vertical), then a pillar shape of
+              'straight' is used
+           mesh (surface.Mesh object, optional): if present, the I,J layout of the grid is based on the mesh, which
+              must be regular, and the K cell size is given by the mesh_dz_dk argument; if present, then dxyz and
+              dxyz_dkji must be None
+           mesh_dz_dk (float, default 1.0): the size of cells in the K axis, which is aligned with the z axis, when
+              starting from a mesh; ignored if mesh is None
+           uuid (optional): the root of the xml tree for the grid part; if present, the RegularGrid object is
+              based on existing data or a mix of that data and other arguments where present
+           set_points_cached (boolean, default False): if True, an explicit geometry is created for the regular grid
+              in the form of the cached points array; will be treated as True if as_irregular_grid is True
+           as_irregular_grid (boolean, default False): if True, the grid is setup such that it will appear as a Grid
+              object when next loaded from disc
+           find_properties (boolean, default True): if True and grid_root is not None, a grid property collection is
+              instantiated as an attribute, holding properties for which this grid is the supporting representation
+           title (str, optional): citation title for new grid; ignored if loading from xml
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if loading from xml
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if loading from xml
 
-      returns:
-         a newly created RegularGrid object with inheritance from the Grid class
+        returns:
+           a newly created RegularGrid object with inheritance from the Grid class
 
-      notes:
-         the RESQML standard allows for regular grid geometry pillars to be stored as parametric lines
-         but that is not yet supported by this code base; however, constant dx, dy, dz arrays are supported;
-         alternatively, regular meshes (Grid2d) may be stored in parameterized form and used to generate a
-         regular grid here;
-         if root_grid, dxyz, dxyz_dkji and mesh arguments are all None then unit cube cells aligned with
-         the x,y,z axes will be generated;
-         to store the geometry explicitly use the following methods: make_regular_points_cached(), write_hdf5(),
-         create_xml(..., write_geometry = True);
-         otherwise, avoid write_hdf5() and call create_xml(..., write_geometry = False)
+        notes:
+           the RESQML standard allows for regular grid geometry pillars to be stored as parametric lines
+           but that is not yet supported by this code base; however, constant dx, dy, dz arrays are supported;
+           alternatively, regular meshes (Grid2d) may be stored in parameterized form and used to generate a
+           regular grid here;
+           if root_grid, dxyz, dxyz_dkji and mesh arguments are all None then unit cube cells aligned with
+           the x,y,z axes will be generated;
+           to store the geometry explicitly use the following methods: make_regular_points_cached(), write_hdf5(),
+           create_xml(..., write_geometry = True);
+           otherwise, avoid write_hdf5() and call create_xml(..., write_geometry = False)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if as_irregular_grid:
             set_points_cached = True
@@ -5599,21 +5615,22 @@ class RegularGrid(Grid):
     # override of Grid methods
 
     def point_raw(self, index = None, points_root = None, cache_array = True):
-        """Returns element from points data, indexed as corner point (k0, j0, i0); can optionally be used to cache points data.
+        """Returns element from points data, indexed as corner point (k0, j0, i0); can optionally be used to cache
+        points data.
 
-      arguments:
-         index (3 integers, optional): if not None, the index into the raw points data for the point of interest
-         points_root (ignored)
-         cache_array (boolean, default True): if True, the raw points data is cached in memory as a side effect
+        arguments:
+           index (3 integers, optional): if not None, the index into the raw points data for the point of interest
+           points_root (ignored)
+           cache_array (boolean, default True): if True, the raw points data is cached in memory as a side effect
 
-      returns:
-         (x, y, z) of selected point as a 3 element numpy vector, or None if index is None
+        returns:
+           (x, y, z) of selected point as a 3 element numpy vector, or None if index is None
 
-      notes:
-         this function is typically called either to cache the points data in memory, or to fetch the coordinates of
-         a single corner point;
-         the index should be a triple kji0 with axes ranging over the shared corners nk+1, nj+1, ni+1
-      """
+        notes:
+           this function is typically called either to cache the points data in memory, or to fetch the coordinates of
+           a single corner point;
+           the index should be a triple kji0 with axes ranging over the shared corners nk+1, nj+1, ni+1
+        """
 
         assert cache_array or index is not None
 
@@ -5630,24 +5647,24 @@ class RegularGrid(Grid):
     def half_cell_transmissibility(self, use_property = None, realization = None, tolerance = None):
         """Returns (and caches if realization is None) half cell transmissibilities for this regular grid.
 
-      arguments:
-         use_property (ignored)
-         realization (int, optional) if present, only a property with this realization number will be used
-         tolerance (ignored)
+        arguments:
+           use_property (ignored)
+           realization (int, optional) if present, only a property with this realization number will be used
+           tolerance (ignored)
 
-      returns:
-         numpy float array of shape (nk, nj, ni, 3, 2) where the 3 covers K,J,I and the 2 covers the
-            face polarity: - (0) and + (1); units will depend on the length units of the coordinate reference
-            system for the grid; the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m
-            and ft respectively
+        returns:
+           numpy float array of shape (nk, nj, ni, 3, 2) where the 3 covers K,J,I and the 2 covers the
+              face polarity: - (0) and + (1); units will depend on the length units of the coordinate reference
+              system for the grid; the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m
+              and ft respectively
 
-      notes:
-         the values for - and + polarity will always be equal, the data is duplicated for compatibility with
-         parent Grid class;
-         the returned array is in the logical resqpy arrangement; it must be discombobulated before being
-         added as a property; this method does not write to hdf5, nor create a new property or xml;
-         if realization is None, a grid attribute cached array will be used
-      """
+        notes:
+           the values for - and + polarity will always be equal, the data is duplicated for compatibility with
+           parent Grid class;
+           the returned array is in the logical resqpy arrangement; it must be discombobulated before being
+           added as a property; this method does not write to hdf5, nor create a new property or xml;
+           if realization is None, a grid attribute cached array will be used
+        """
 
         # todo: allow passing of property uuids for ntg, k_k, j, i
 
@@ -5670,19 +5687,19 @@ class RegularGrid(Grid):
     def centre_point(self, cell_kji0 = None, cache_centre_array = False):
         """Returns centre point of a cell or array of centre points of all cells.
 
-      arguments:
-         cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
-            centre point is required; zero based indexing
-         cache_centre_array (boolean, default False): If True, or cell_kji0 is None, an array of centre points
-            is generated and added as an attribute of the grid, with attribute name array_centre_point
+        arguments:
+           cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
+              centre point is required; zero based indexing
+           cache_centre_array (boolean, default False): If True, or cell_kji0 is None, an array of centre points
+              is generated and added as an attribute of the grid, with attribute name array_centre_point
 
-      returns:
-         (x, y, z) 3 element numpy array of floats holding centre point of cell;
-         or numpy 3+1D array if cell_kji0 is None
+        returns:
+           (x, y, z) 3 element numpy array of floats holding centre point of cell;
+           or numpy 3+1D array if cell_kji0 is None
 
-      note:
-         resulting coordinates are in the same (local) crs as the grid points
-      """
+        note:
+           resulting coordinates are in the same (local) crs as the grid points
+        """
 
         if cell_kji0 is None:
             cache_centre_array = True
@@ -5712,20 +5729,20 @@ class RegularGrid(Grid):
     def volume(self, cell_kji0 = None):
         """Returns bulk rock volume of cell or numpy array of bulk rock volumes for all cells.
 
-      arguments:
-         cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
-                               volume is required; zero based indexing
+        arguments:
+           cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
+                                 volume is required; zero based indexing
 
-      returns:
-         float, being the volume of cell identified by cell_kji0;
-         or numpy float array of shape (nk, nj, ni) if cell_kji0 is None
+        returns:
+           float, being the volume of cell identified by cell_kji0;
+           or numpy float array of shape (nk, nj, ni) if cell_kji0 is None
 
-      notes:
-         the function can be used to find the volume of a single cell, or all cells;
-         grid's coordinate reference system must use same units in z as xy (projected);
-         units of result are implicitly determined by coordinates in grid's coordinate reference system;
-         the method currently assumes that the primary i, j, k axes are mutually orthogonal
-      """
+        notes:
+           the function can be used to find the volume of a single cell, or all cells;
+           grid's coordinate reference system must use same units in z as xy (projected);
+           units of result are implicitly determined by coordinates in grid's coordinate reference system;
+           the method currently assumes that the primary i, j, k axes are mutually orthogonal
+        """
 
         vol = np.product(vec.naive_lengths(self.block_dxyz_dkji))
         if cell_kji0 is not None:
@@ -5735,14 +5752,14 @@ class RegularGrid(Grid):
     def thickness(self, cell_kji0 = None, **kwargs):
         """Returns cell thickness (K axial length) for a single cell or full array.
 
-      arguments:
-         cell_kji0 (triple int, optional): if present, the thickness for a single cell is returned;
-            if None, an array is returned
-         all other arguments ignored; present for compatibility with same method in Grid()
+        arguments:
+           cell_kji0 (triple int, optional): if present, the thickness for a single cell is returned;
+              if None, an array is returned
+           all other arguments ignored; present for compatibility with same method in Grid()
 
-      returns:
-         float, or numpy float array filled with a constant
-      """
+        returns:
+           float, or numpy float array filled with a constant
+        """
 
         thick = self.axial_lengths_kji()[0]
         if cell_kji0 is not None:
@@ -5752,14 +5769,14 @@ class RegularGrid(Grid):
     def pinched_out(self, cell_kji0 = None, **kwargs):
         """Returns pinched out boolean (always False) for a single cell or full array.
 
-      arguments:
-         cell_kji0 (triple int, optional): if present, the pinched out flag for a single cell is returned;
-            if None, an array is returned
-         all other arguments ignored; present for compatibility with same method in Grid()
+        arguments:
+           cell_kji0 (triple int, optional): if present, the pinched out flag for a single cell is returned;
+              if None, an array is returned
+           all other arguments ignored; present for compatibility with same method in Grid()
 
-      returns:
-         False, or numpy array filled with False
-      """
+        returns:
+           False, or numpy array filled with False
+        """
 
         if cell_kji0 is not None:
             return False
@@ -5768,17 +5785,17 @@ class RegularGrid(Grid):
     def actual_pillar_shape(self, patch_metadata = False, tolerance = 0.001):
         """Returns actual shape of pillars.
 
-      arguments:
-         patch_metadata (boolean, default False): if True, the actual shape replaces whatever was in the metadata
-         tolerance (float, ignored)
+        arguments:
+           patch_metadata (boolean, default False): if True, the actual shape replaces whatever was in the metadata
+           tolerance (float, ignored)
 
-      returns:
-         string: 'vertical', 'straight' or 'curved'
+        returns:
+           string: 'vertical', 'straight' or 'curved'
 
-      note:
-         setting patch_metadata True will affect the attribute in this Grid object; however, it will not be
-         preserved unless the create_xml() method is called, followed at some point with model.store_epc()
-      """
+        note:
+           setting patch_metadata True will affect the attribute in this Grid object; however, it will not be
+           preserved unless the create_xml() method is called, followed at some point with model.store_epc()
+        """
 
         if np.all(self.block_dxyz_dkji[0, :2] == 0.0):
             return 'vertical'
@@ -5799,15 +5816,15 @@ class RegularGrid(Grid):
                    add_cell_length_properties = True):
         """Creates xml for this RegularGrid object; by default the explicit geometry is not included.
 
-      see docstring for Grid.create_xml()
+        see docstring for Grid.create_xml()
 
-      additional argument:
-         add_cell_length_properties (boolean, default True): if True, 3 constant property arrays with cells as
-            indexable element are created to hold the lengths of the primary axes of the cells; the xml is
-            created for the properties and they are added to the model (no hdf5 write needed)
+        additional argument:
+           add_cell_length_properties (boolean, default True): if True, 3 constant property arrays with cells as
+              indexable element are created to hold the lengths of the primary axes of the cells; the xml is
+              created for the properties and they are added to the model (no hdf5 write needed)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if write_geometry is None:
             write_geometry = (self.grid_representation == 'IjkGrid')

--- a/resqpy/grid_surface.py
+++ b/resqpy/grid_surface.py
@@ -192,27 +192,28 @@ class GridSkin:
                                               start_xyz = None,
                                               nudge = None,
                                               exclude_kji0 = None):
-        """Returns the x,y,z and K,J,I and axis, polarity & segment of the first intersection of the trajectory with the torn skin.
+        """Returns the x,y,z and K,J,I and axis, polarity & segment of the first intersection of the trajectory with the
+        torn skin.
 
-      arguments:
-         trajectory (well.Trajectory object): the trajectory to be intersected with the skin
-         start (int, default 0): the trajectory segment number to start the search from
-         start_xyz (triple float, optional): if present, this point should lie on the start segment and search continues from
-            this point
-         nudge (float, optional): if present and positive, the start point is nudged forward by this distance (grid uom);
-            if present and negative (more typical for skin entry search), the start point is nudged back a little
-         exclude_kji0 (triple int, optional): if present, the indices of a cell to exclude as a possible result
+        arguments:
+           trajectory (well.Trajectory object): the trajectory to be intersected with the skin
+           start (int, default 0): the trajectory segment number to start the search from
+           start_xyz (triple float, optional): if present, this point should lie on the start segment and search continues from
+              this point
+           nudge (float, optional): if present and positive, the start point is nudged forward by this distance (grid uom);
+              if present and negative (more typical for skin entry search), the start point is nudged back a little
+           exclude_kji0 (triple int, optional): if present, the indices of a cell to exclude as a possible result
 
-      returns:
-         5-tuple (triple float, triple int, int, int, int): the first element is the xyz coordinates of the intersection point
-         in the crs of the grid; second element is the kji0 of the cell that is intersected, which might be a pinched out
-         or otherwise inactive cell; 3rd element is 0, 1 or 2 for K, J or I axis of cell face; 4th element is 0 for -ve
-         face, 1 for +ve face; 5th element is the trajectory knot prior to the intersection (also the segment number)
+        returns:
+           5-tuple (triple float, triple int, int, int, int): the first element is the xyz coordinates of the intersection point
+           in the crs of the grid; second element is the kji0 of the cell that is intersected, which might be a pinched out
+           or otherwise inactive cell; 3rd element is 0, 1 or 2 for K, J or I axis of cell face; 4th element is 0 for -ve
+           face, 1 for +ve face; 5th element is the trajectory knot prior to the intersection (also the segment number)
 
-      note:
-         if the GridSkin object has been initialised using single layer tactics, then the k0 value will be zero for any
-         initial entry through a sidewall of the grid or through a fault face
-      """
+        note:
+           if the GridSkin object has been initialised using single layer tactics, then the k0 value will be zero for any
+           initial entry through a sidewall of the grid or through a fault face
+        """
 
         if exclude_kji0 is not None:
             xyz_1, segment_1, tri_index_1, xyz_2, segment_2, tri_index_2 =  \
@@ -367,25 +368,25 @@ def generate_untorn_surface_for_layer_interface(grid,
                                                 border = None):
     """Returns a Surface object generated from the grid layer interface points after any faults are 'healed'.
 
-   arguments:
-      grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
-      k0 (int): the layer number (zero based) to be used
-      ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
-         interface of the layer is to be used
-      quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
-         which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
-         the face; if False, only 2 triangles are used, which gives a non-unique solution
-      border (float, optional): If given, an extra border row of quadrangles is added around the grid mesh
+    arguments:
+       grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
+       k0 (int): the layer number (zero based) to be used
+       ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
+          interface of the layer is to be used
+       quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
+          which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
+          the face; if False, only 2 triangles are used, which gives a non-unique solution
+       border (float, optional): If given, an extra border row of quadrangles is added around the grid mesh
 
-   returns:
-      a resqml_surface.Surface object with a single triangulated patch
+    returns:
+       a resqml_surface.Surface object with a single triangulated patch
 
-   notes:
-      The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
-      written.
-      If a border is specified and the outer grid cells have non-parallel edges, the resulting mesh might be
-      messed up.
-   """
+    notes:
+       The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
+       written.
+       If a border is specified and the outer grid cells have non-parallel edges, the resulting mesh might be
+       messed up.
+    """
 
     surf = rqs.Surface(grid.model)
     kp = 1 if ref_k_faces == 'base' else 0
@@ -422,26 +423,26 @@ def generate_untorn_surface_for_layer_interface(grid,
 def generate_torn_surface_for_layer_interface(grid, k0 = 0, ref_k_faces = 'top', quad_triangles = True):
     """Returns a Surface object generated from the grid layer interface points.
 
-   arguments:
-      grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
-      k0 (int): the layer number (zero based) to be used
-      ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
-         interface of the layer is to be used
-      quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
-         which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
-         the face; if False, only 2 triangles are used, which gives a non-unique solution
+    arguments:
+       grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
+       k0 (int): the layer number (zero based) to be used
+       ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
+          interface of the layer is to be used
+       quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
+          which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
+          the face; if False, only 2 triangles are used, which gives a non-unique solution
 
-   returns:
-      a resqml_surface.Surface object with a single triangulated patch
+    returns:
+       a resqml_surface.Surface object with a single triangulated patch
 
-   notes:
-      The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
-      written.
-      Strictly, the RESQML business rules for a triangulated surface require a separate patch for areas of the
-      surface which are not joined; therefore, if fault tears cut off one area of the surface (eg. a fault running
-      fully across the grid), then more than one patch should be generated; however, at present the code uses a
-      single patch regardless.
-   """
+    notes:
+       The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
+       written.
+       Strictly, the RESQML business rules for a triangulated surface require a separate patch for areas of the
+       surface which are not joined; therefore, if fault tears cut off one area of the surface (eg. a fault running
+       fully across the grid), then more than one patch should be generated; however, at present the code uses a
+       single patch regardless.
+    """
 
     surf = rqs.Surface(grid.model)
     kp = 1 if ref_k_faces == 'base' else 0
@@ -459,27 +460,27 @@ def generate_torn_surface_for_x_section(grid,
                                         as_single_layer = False):
     """Returns a Surface object generated from the grid cross section points.
 
-   arguments:
-      grid (grid.Grid object): the grid object from which a cross section is to be converted to a surface
-      axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
-      ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
-      plus_face (boolean, default False): if False, negative face is used; if True, positive
-      quad_triangles (boolean, default True): if True, 4 triangles are used to represent each cell face, which
-         gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
-         the face; if False, only 2 triangles are used, which gives a non-unique solution
-      as_single_layer (boolean, default False): if True, the top points from the top layer are used together
-         with the basal points from the base layer, to effect a single layer equivalent cross section surface
+    arguments:
+       grid (grid.Grid object): the grid object from which a cross section is to be converted to a surface
+       axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
+       ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
+       plus_face (boolean, default False): if False, negative face is used; if True, positive
+       quad_triangles (boolean, default True): if True, 4 triangles are used to represent each cell face, which
+          gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
+          the face; if False, only 2 triangles are used, which gives a non-unique solution
+       as_single_layer (boolean, default False): if True, the top points from the top layer are used together
+          with the basal points from the base layer, to effect a single layer equivalent cross section surface
 
-   returns:
-      a resqml_surface.Surface object with a single triangulated patch
+    returns:
+       a resqml_surface.Surface object with a single triangulated patch
 
-   notes:
-      The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
-      written.
-      Strictly, the RESQML business rules for a triangulated surface require a separate patch for areas of the
-      surface which are not joined; therefore, a fault running down through the grid should result in separate
-      patches; however, at present the code uses a single patch regardless.
-   """
+    notes:
+       The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
+       written.
+       Strictly, the RESQML business rules for a triangulated surface require a separate patch for areas of the
+       surface which are not joined; therefore, a fault running down through the grid should result in separate
+       patches; however, at present the code uses a single patch regardless.
+    """
 
     assert axis.upper() in ['I', 'J']
 
@@ -511,27 +512,27 @@ def generate_untorn_surface_for_x_section(grid,
                                           as_single_layer = False):
     """Returns a Surface object generated from the grid cross section points for an unfaulted grid.
 
-   arguments:
-      grid (grid.Grid object): the grid object from which a cross section is to be converted to a surface
-      axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
-      ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
-      plus_face (boolean, default False): if False, negative face is used; if True, positive
-      quad_triangles (boolean, default True): if True, 4 triangles are used to represent each cell face, which
-         gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
-         the face; if False, only 2 triangles are used, which gives a non-unique solution
-      as_single_layer (boolean, default False): if True, the top points from the top layer are used together
-         with the basal points from the base layer, to effect a single layer equivalent cross section surface
+    arguments:
+       grid (grid.Grid object): the grid object from which a cross section is to be converted to a surface
+       axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
+       ref_slice0 (int, default 0): the reference value for indices in I or J (as defined in axis)
+       plus_face (boolean, default False): if False, negative face is used; if True, positive
+       quad_triangles (boolean, default True): if True, 4 triangles are used to represent each cell face, which
+          gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
+          the face; if False, only 2 triangles are used, which gives a non-unique solution
+       as_single_layer (boolean, default False): if True, the top points from the top layer are used together
+          with the basal points from the base layer, to effect a single layer equivalent cross section surface
 
-   returns:
-      a resqml_surface.Surface object with a single triangulated patch
+    returns:
+       a resqml_surface.Surface object with a single triangulated patch
 
-   notes:
-      The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
-      written.
-      Strictly, the RESQML business rules for a triangulated surface require a separate patch for areas of the
-      surface which are not joined; therefore, a fault running down through the grid should result in separate
-      patches; however, at present the code uses a single patch regardless.
-   """
+    notes:
+       The resulting surface is assigned to the same model as grid, though xml is not generated and hdf5 is not
+       written.
+       Strictly, the RESQML business rules for a triangulated surface require a separate patch for areas of the
+       surface which are not joined; therefore, a fault running down through the grid should result in separate
+       patches; however, at present the code uses a single patch regardless.
+    """
 
     assert axis.upper() in ['I', 'J']
 
@@ -556,22 +557,22 @@ def generate_untorn_surface_for_x_section(grid,
 def find_intersections_of_trajectory_with_surface(trajectory, surface):
     """Returns an array of triangle indices and an array of xyz of intersections of well trajectory with surface.
 
-   arguments:
-      trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersections for;
-         if a list of trajectories is provided then the return value is a corresponding list
-      surface (surface.Surface object): the triangulated surface with which to intersect the trajectory
+    arguments:
+       trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersections for;
+          if a list of trajectories is provided then the return value is a corresponding list
+       surface (surface.Surface object): the triangulated surface with which to intersect the trajectory
 
-   returns:
-      (numpy int array of shape (N,), numpy float array of shape (N, 3)): the first array is a list of surface
-      triangle indices containing an intersection and the second array is the corresponding list of (x, y, z)
-      intersection points; if the trajectory argument is a list of trajectories, then a correponding list of numpy
-      array pairs is returned
+    returns:
+       (numpy int array of shape (N,), numpy float array of shape (N, 3)): the first array is a list of surface
+       triangle indices containing an intersection and the second array is the corresponding list of (x, y, z)
+       intersection points; if the trajectory argument is a list of trajectories, then a correponding list of numpy
+       array pairs is returned
 
-   notes:
-      interseections are found based on straight line segments between the trajectory control points, this will result
-      in errors where there is significant curvature between neighbouring control points;
-      a given triangle index might appear more than once in the first returned array
-   """
+    notes:
+       interseections are found based on straight line segments between the trajectory control points, this will result
+       in errors where there is significant curvature between neighbouring control points;
+       a given triangle index might appear more than once in the first returned array
+    """
 
     if isinstance(trajectory, list):
         trajectory_list = trajectory
@@ -604,31 +605,31 @@ def find_intersections_of_trajectory_with_layer_interface(trajectory,
                                                           quad_triangles = True):
     """Returns an array of column indices and an array of xyz of intersections of well trajectory with layer interface.
 
-   arguments:
-      trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersections for;
-         if a list of trajectories is provided then the return value is a corresponding list
-      grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
-      k0 (int): the layer number (zero based) to be used
-      ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
-         interface of the layer is to be used
-      heal_faults (boolean, default True): if True, faults will be 'healed' to give an untorn surface before looking
-         for intersections; if False and the trajectory passes through a fault plane without intersecting the layer
-         interface then no intersection will be identified; makes no difference if the grid is unfaulted
-      quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
-         which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
-         the face; if False, only 2 triangles are used, which gives a non-unique solution
+    arguments:
+       trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersections for;
+          if a list of trajectories is provided then the return value is a corresponding list
+       grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
+       k0 (int): the layer number (zero based) to be used
+       ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
+          interface of the layer is to be used
+       heal_faults (boolean, default True): if True, faults will be 'healed' to give an untorn surface before looking
+          for intersections; if False and the trajectory passes through a fault plane without intersecting the layer
+          interface then no intersection will be identified; makes no difference if the grid is unfaulted
+       quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
+          which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
+          the face; if False, only 2 triangles are used, which gives a non-unique solution
 
-   returns:
-      (numpy int array of shape (N, 2), numpy float array of shape (N, 3)): the first array is a list of (j0, i0)
-      indices of columns containing an intersection and the second array is the corresponding list of (x, y, z)
-      intersection points; if the trajectory argument is a list of trajectories, then a correponding list of numpy
-      array pairs is returned
+    returns:
+       (numpy int array of shape (N, 2), numpy float array of shape (N, 3)): the first array is a list of (j0, i0)
+       indices of columns containing an intersection and the second array is the corresponding list of (x, y, z)
+       intersection points; if the trajectory argument is a list of trajectories, then a correponding list of numpy
+       array pairs is returned
 
-   notes:
-      interseections are found based on straight line segments between the trajectory control points, this will result
-      in errors where there is significant curvature between neighbouring control points;
-      a given (j0, i0) column might appear more than once in the first returned array
-   """
+    notes:
+       interseections are found based on straight line segments between the trajectory control points, this will result
+       in errors where there is significant curvature between neighbouring control points;
+       a given (j0, i0) column might appear more than once in the first returned array
+    """
 
     if isinstance(trajectory, list):
         trajectory_list = trajectory
@@ -673,28 +674,28 @@ def find_first_intersection_of_trajectory_with_surface(trajectory,
                                                        return_second = False):
     """Returns xyz and other info of the first intersection of well trajectory with layer interface.
 
-   arguments:
-      trajectory (well.Trajectory object): the wellbore trajectory object(s) to find the intersection for
-      surface (surface.Surface object): the triangulated surface with which to search for intersections
-      start (int, default 0): an index into the trajectory knots to start the search from
-      start_xyz (triple float, optional): if present, should lie on start segment and search starts from this point
-      nudge (float, optional): if present and positive, starting xyz is nudged forward this distance along segment;
-         if present and negative, starting xyz is nudged backward along segment
-      return_second (boolean, default False): if True, a sextuplet is returned with the last 3 elements identifying
-         the 'runner up' intersection in the same trajectory segment, or None, None, None if only one intersection found
+    arguments:
+       trajectory (well.Trajectory object): the wellbore trajectory object(s) to find the intersection for
+       surface (surface.Surface object): the triangulated surface with which to search for intersections
+       start (int, default 0): an index into the trajectory knots to start the search from
+       start_xyz (triple float, optional): if present, should lie on start segment and search starts from this point
+       nudge (float, optional): if present and positive, starting xyz is nudged forward this distance along segment;
+          if present and negative, starting xyz is nudged backward along segment
+       return_second (boolean, default False): if True, a sextuplet is returned with the last 3 elements identifying
+          the 'runner up' intersection in the same trajectory segment, or None, None, None if only one intersection found
 
-   returns:
-      a triplet if return_second is False; a sextuplet if return_second is True; the first triplet is:
-      (numpy float array of shape (3,), int, int): being the (x, y, z) intersection point, and the trajectory segment number,
-      and the triangle index of the first intersection point; or None, None, None if no intersection found;
-      if return_second is True, the 4th, 5th & 6th return values are similar to the first three, conveying information
-      about the second intersection of the same trajectory segment with the surface, or None, None, None if a no second
-      intersection was found
+    returns:
+       a triplet if return_second is False; a sextuplet if return_second is True; the first triplet is:
+       (numpy float array of shape (3,), int, int): being the (x, y, z) intersection point, and the trajectory segment number,
+       and the triangle index of the first intersection point; or None, None, None if no intersection found;
+       if return_second is True, the 4th, 5th & 6th return values are similar to the first three, conveying information
+       about the second intersection of the same trajectory segment with the surface, or None, None, None if a no second
+       intersection was found
 
-   notes:
-      interseections are found based on straight line segments between the trajectory control points, this will result
-      in errors where there is significant curvature between neighbouring control points
-   """
+    notes:
+       interseections are found based on straight line segments between the trajectory control points, this will result
+       in errors where there is significant curvature between neighbouring control points
+    """
 
     if start >= trajectory.knot_count - 1:
         if return_second:
@@ -766,35 +767,36 @@ def find_first_intersection_of_trajectory_with_layer_interface(trajectory,
                                                                start = 0,
                                                                heal_faults = False,
                                                                quad_triangles = True):
-    """Returns xyz and other info of the first intersection of well trajectory (or list of trajectories) with layer interface.
+    """Returns xyz and other info of the first intersection of well trajectory (or list of trajectories) with layer
+    interface.
 
-   arguments:
-      trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersection for;
-         if a list of trajectories is provided then the return value is a corresponding list
-      grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
-      k0 (int): the layer number (zero based) to be used
-      ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
-         interface of the layer is to be used
-      start (int, default 0): an index into the trajectory knots to start the search from; is applied naively to all
-         trajectories when a trajectory list is passed
-      heal_faults (boolean, default False): if True, faults will be 'healed' to give an untorn surface before looking
-         for intersections; if False and the trajectory passes through a fault plane without intersecting the layer
-         interface then no intersection will be identified; makes no difference if the grid is unfaulted
-      quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
-         which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
-         the face; if False, only 2 triangles are used, which gives a non-unique solution
+    arguments:
+       trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersection for;
+          if a list of trajectories is provided then the return value is a corresponding list
+       grid (grid.Grid object): the grid object from which a layer interface is to be converted to a surface
+       k0 (int): the layer number (zero based) to be used
+       ref_k_faces (string): either 'top' (the default) or 'base', indicating whether the top or the base
+          interface of the layer is to be used
+       start (int, default 0): an index into the trajectory knots to start the search from; is applied naively to all
+          trajectories when a trajectory list is passed
+       heal_faults (boolean, default False): if True, faults will be 'healed' to give an untorn surface before looking
+          for intersections; if False and the trajectory passes through a fault plane without intersecting the layer
+          interface then no intersection will be identified; makes no difference if the grid is unfaulted
+       quad_triangles (boolean, optional, default True): if True, 4 triangles are used to represent each cell k face,
+          which gives a unique solution with a shared node of the 4 triangles at the mean point of the 4 corners of
+          the face; if False, only 2 triangles are used, which gives a non-unique solution
 
-   returns:
-      (numpy float array of shape (3,), int, (int, int)): being the (x, y, z) intersection point, and the trajectory segment number,
-      and the (j0, i0) column number of the first intersection point;
-      or None, None, (None, None) if no intersection found;
-      if the trajectory argument is a list of trajectories, then correponding list of numpy array, list of int, list of int pair
-      are returned
+    returns:
+       (numpy float array of shape (3,), int, (int, int)): being the (x, y, z) intersection point, and the trajectory segment number,
+       and the (j0, i0) column number of the first intersection point;
+       or None, None, (None, None) if no intersection found;
+       if the trajectory argument is a list of trajectories, then correponding list of numpy array, list of int, list of int pair
+       are returned
 
-   notes:
-      interseections are found based on straight line segments between the trajectory control points, this will result
-      in errors where there is significant curvature between neighbouring control points
-   """
+    notes:
+       interseections are found based on straight line segments between the trajectory control points, this will result
+       in errors where there is significant curvature between neighbouring control points
+    """
 
     if isinstance(trajectory, list):
         trajectory_list = trajectory
@@ -837,7 +839,8 @@ def find_first_intersection_of_trajectory_with_cell_surface(trajectory,
                                                             start_xyz = None,
                                                             nudge = 0.001,
                                                             quad_triangles = True):
-    """Searches along the trajectory from a starting point until the first intersection with the cell's surface is encountered."""
+    """Searches along the trajectory from a starting point until the first intersection with the cell's surface is
+    encountered."""
 
     cp = grid.corner_points(kji0)
     cell_surface = rqs.Surface(grid.model)
@@ -900,18 +903,18 @@ def point_is_within_cell(xyz, grid, kji0, cell_surface = None, false_on_pinchout
 def create_column_face_mesh_and_surface(grid, col_ji0, axis, polarity, quad_triangles = True, as_single_layer = False):
     """Creates a Mesh and corresponding Surface representing a column face.
 
-   arguments:
-      grid (grid.Grid object)
-      col_ji0 (int pair): the column indices, zero based
-      axis (int): 1 for J face, 2 fo I face
-      polarity (int): 0 for negative face, 1 for positive
-      quad_triangles (boolean, default True): if True, 4 triangles are used per cell face; if False, 2 triangles
-      as_single_layer (boolean, default False): if True, only the top and basal points are used, with the results being
-         equivalent to the grid being treated as a single layer
+    arguments:
+       grid (grid.Grid object)
+       col_ji0 (int pair): the column indices, zero based
+       axis (int): 1 for J face, 2 fo I face
+       polarity (int): 0 for negative face, 1 for positive
+       quad_triangles (boolean, default True): if True, 4 triangles are used per cell face; if False, 2 triangles
+       as_single_layer (boolean, default False): if True, only the top and basal points are used, with the results being
+          equivalent to the grid being treated as a single layer
 
-   returns:
-      surface.Mesh, surface.Surface (or None, surface.Surface if grid has k gaps)
-   """
+    returns:
+       surface.Mesh, surface.Surface (or None, surface.Surface if grid has k gaps)
+    """
 
     assert axis in (1, 2)
 
@@ -967,12 +970,12 @@ def find_intersection_of_trajectory_interval_with_column_face(trajectory,
                                                               quad_triangles = True):
     """Searches for intersection of a single trajectory segment with an I or J column face.
 
-   returns:
-      xyz, k0
+    returns:
+       xyz, k0
 
-   note:
-      does not support k gaps
-   """
+    note:
+       does not support k gaps
+    """
 
     # build a set of faces for the column face
     # extract column face points into a shape ready to become a mesh
@@ -1197,10 +1200,10 @@ def generate_surface_for_blocked_well_cells(blocked_well,
 def trajectory_grid_overlap(trajectory, grid, lazy = False):
     """Returns True if there is some overlap of the xyz boxes for the trajectory and grid, False otherwise.
 
-   notes:
-      overlap of the xyz boxes does not guarantee that the trajectory intersects the grid;
-      a return value of False guarantees that the trajectory does not intersect the grid
-   """
+    notes:
+       overlap of the xyz boxes does not guarantee that the trajectory intersects the grid;
+       a return value of False guarantees that the trajectory does not intersect the grid
+    """
 
     traj_box = np.empty((2, 3))
     traj_box[0] = np.amin(trajectory.control_points, axis = 0)
@@ -1222,37 +1225,37 @@ def populate_blocked_well_from_trajectory(blocked_well,
                                           check_for_reentry = True):
     """Populate an empty blocked well object based on the intersection of its trajectory with a grid.
 
-   arguments:
-      blocked_well (resqpy.well.BlockedWell object): a largely empty blocked well object to be populated by this
-         function; note that the trajectory attribute must be set before calling this function
-      grid (resqpy.grid.Grid object): the grid to intersect the well trajectory with
-      active_only (boolean, default False): if True, intervals which cover inactive cells will be set as
-         unblocked intervals; if False, intervals covering any cell will be set as blocked intervals
-      quad_triangles (boolean, default True): if True, each cell face is represented by 4 triangles when
-         calculating intersections; if False, only 2 triangles are used
-      lazy (boolean, default False): if True, initial penetration must be through a top K face and blocking
-         will cease as soon as the trajectory first leaves the gridded volume; if False, initial entry may be
-         through any external face or a fault face and re-entry will be handled
-      use_single_layer_tactics (boolean, default True): if True and not lazy and the grid does not have k gaps,
-         fault planes and grid sidewall are initially treated as if the grid were a single layer, when looking
-         for penetrations from outwith the grid
-      check_for_reentry (boolean, default True): if True, the trajectory is tracked after leaving the grid through
-         the outer skin (eg. base reservoir) in case of re-entry; if False, blocking stops upon the first exit
-         of the trajectory through the skin; ignored (treated as False) if lazy is True
+    arguments:
+       blocked_well (resqpy.well.BlockedWell object): a largely empty blocked well object to be populated by this
+          function; note that the trajectory attribute must be set before calling this function
+       grid (resqpy.grid.Grid object): the grid to intersect the well trajectory with
+       active_only (boolean, default False): if True, intervals which cover inactive cells will be set as
+          unblocked intervals; if False, intervals covering any cell will be set as blocked intervals
+       quad_triangles (boolean, default True): if True, each cell face is represented by 4 triangles when
+          calculating intersections; if False, only 2 triangles are used
+       lazy (boolean, default False): if True, initial penetration must be through a top K face and blocking
+          will cease as soon as the trajectory first leaves the gridded volume; if False, initial entry may be
+          through any external face or a fault face and re-entry will be handled
+       use_single_layer_tactics (boolean, default True): if True and not lazy and the grid does not have k gaps,
+          fault planes and grid sidewall are initially treated as if the grid were a single layer, when looking
+          for penetrations from outwith the grid
+       check_for_reentry (boolean, default True): if True, the trajectory is tracked after leaving the grid through
+          the outer skin (eg. base reservoir) in case of re-entry; if False, blocking stops upon the first exit
+          of the trajectory through the skin; ignored (treated as False) if lazy is True
 
-   returns:
-      the blocked well object (same object as passed in) if successful; None if unsuccessful
+    returns:
+       the blocked well object (same object as passed in) if successful; None if unsuccessful
 
-   notes:
-      the blocked_well trajectory attribute must be set before calling this function;
-      grids with k gaps might result in very slow processing;
-      the function represents a cell face as 2 or 4 triangles rather than a bilinear patch; setting quad_triangles
-      False is not recommended as the 2 triangle formulation gives a non-unique representation of a face (though
-      the code is designed to use the same representation for a shared face between neighbouring cells);
-      where non-planar faults exist, the triangulation of faces may result in a small misalignment of abutted faces
-      between the opposing sides of the fault; this could potentially result in an extra, small, unblocked interval
-      being introduced as an artefact between the exit point of one cell and the entry point into the abutted cell
-   """
+    notes:
+       the blocked_well trajectory attribute must be set before calling this function;
+       grids with k gaps might result in very slow processing;
+       the function represents a cell face as 2 or 4 triangles rather than a bilinear patch; setting quad_triangles
+       False is not recommended as the 2 triangle formulation gives a non-unique representation of a face (though
+       the code is designed to use the same representation for a shared face between neighbouring cells);
+       where non-planar faults exist, the triangulation of faces may result in a small misalignment of abutted faces
+       between the opposing sides of the fault; this could potentially result in an extra, small, unblocked interval
+       being introduced as an artefact between the exit point of one cell and the entry point into the abutted cell
+    """
 
     def find_next_cell(grid,
                        previous_kji0,

--- a/resqpy/lines.py
+++ b/resqpy/lines.py
@@ -25,7 +25,7 @@ import os
 
 
 class _BasePolyline(BaseResqpy):
-    """Base class to implement shared methods for other classes in this module"""
+    """Base class to implement shared methods for other classes in this module."""
 
     def create_interpretation_and_feature(self,
                                           kind = 'horizon',
@@ -67,8 +67,8 @@ class _BasePolyline(BaseResqpy):
 def load_hdf5_array(object, node, array_attribute, tag = 'Values'):
     """Loads the property array data as an attribute of object, from the hdf5 referenced in xml node.
 
-   :meta private:
-   """
+    :meta private:
+    """
 
     assert (rqet.node_type(node) in ['DoubleHdf5Array', 'IntegerHdf5Array', 'Point3dHdf5Array'])
     # ignore null value
@@ -192,7 +192,7 @@ class Polyline(_BasePolyline):
 
     @property
     def crs_root(self):
-        """XML node corresponding to self.crs_uuid"""
+        """XML node corresponding to self.crs_uuid."""
 
         return self.model.root_for_uuid(self.crs_uuid)
 
@@ -205,24 +205,24 @@ class Polyline(_BasePolyline):
     def from_scaled_polyline(cls, original, scaling, title = None, originator = None, extra_metadata = None):
         """Returns a scaled version of the original polyline.
 
-      arguments:
-         original (Polyline): the polyline from which the new polyline will be sporned
-         scaling (float): the factor by which the original will be scaled
-         title (str, optional): the citation title for the new polyline; inherited from
-            original if None
-         originator (str, optional): the name of the person creating the polyline; inherited
-            from original if None
-         extra_metadata (dict, optional): extra metadata for the new polyline; inherited from
-            original if None
+        arguments:
+           original (Polyline): the polyline from which the new polyline will be sporned
+           scaling (float): the factor by which the original will be scaled
+           title (str, optional): the citation title for the new polyline; inherited from
+              original if None
+           originator (str, optional): the name of the person creating the polyline; inherited
+              from original if None
+           extra_metadata (dict, optional): extra metadata for the new polyline; inherited from
+              original if None
 
-      returns:
-         a new Polyline
+        returns:
+           a new Polyline
 
-      notes:
-         the scaling factor is applied to vectors radiating from the balanced centre of the
-         original polyline to its coordinates; a scaling of 1.0 will result in a copy of the original;
-         if extra_metadata is not None, no extra metadata is inherited from original
-      """
+        notes:
+           the scaling factor is applied to vectors radiating from the balanced centre of the
+           original polyline to its coordinates; a scaling of 1.0 will result in a copy of the original;
+           if extra_metadata is not None, no extra metadata is inherited from original
+        """
 
         if extra_metadata is None:
             extra_metadata = original.extra_metadata
@@ -274,9 +274,9 @@ class Polyline(_BasePolyline):
     def is_clockwise(self, trust_metadata = True):
         """Returns True if first non-straight triplet of nodes is clockwise in the xy plane; False if anti-clockwise.
 
-      note:
-         this method currently assumes that the xy axes are left-handed
-      """
+        note:
+           this method currently assumes that the xy axes are left-handed
+        """
 
         if trust_metadata and self.extra_metadata is not None and 'is_clockwise' in self.extra_metadata.keys():
             return str(self.extra_metadata['is_clockwise']).lower() == 'true'
@@ -305,7 +305,10 @@ class Polyline(_BasePolyline):
         return pip.pip_wn(p, self.coordinates)
 
     def segment_length(self, segment_index, in_xy = False):
-        """Returns the naive length (ie. assuming x,y & z units are the same) of an individual segment of the polyline."""
+        """Returns the naive length (ie.
+
+        assuming x,y & z units are the same) of an individual segment of the polyline.
+        """
 
         successor = self._successor(segment_index)
         d = 2 if in_xy else 3
@@ -318,7 +321,8 @@ class Polyline(_BasePolyline):
         return 0.5 * (self.coordinates[segment_index] + self.coordinates[successor])
 
     def segment_normal(self, segment_index):
-        """For a closed polyline returns a unit vector giving the 2D (xy) direction of an outward facing normal to a segment."""
+        """For a closed polyline returns a unit vector giving the 2D (xy) direction of an outward facing normal to a
+        segment."""
 
         successor = self._successor(segment_index)
         segment_vector = self.coordinates[successor, :2] - self.coordinates[segment_index, :2]
@@ -407,7 +411,8 @@ class Polyline(_BasePolyline):
         return centre
 
     def first_line_intersection(self, x1, y1, x2, y2, half_segment = False):
-        """Returns segment number & x, y of first intersection of (half) bounded line x,y 1 to 2 with polyline, or None, None, None."""
+        """Returns segment number & x, y of first intersection of (half) bounded line x,y 1 to 2 with polyline, or None,
+        None, None."""
 
         seg_count = len(self.coordinates) - 1
         if self.isclosed:
@@ -908,7 +913,7 @@ class PolylineSet(_BasePolyline):
 
     @property
     def crs_root(self):
-        """XML node corresponding to self.crs_uuid"""
+        """XML node corresponding to self.crs_uuid."""
 
         return self.model.root_for_uuid(self.crs_uuid)
 
@@ -935,7 +940,7 @@ class PolylineSet(_BasePolyline):
                    title = None,
                    originator = None,
                    save_polylines = False):
-        """Create xml from polylineset
+        """Create xml from polylineset.
 
         args:
             save_polylines: If true, polylines are also saved individually
@@ -1087,12 +1092,13 @@ class PolylineSet(_BasePolyline):
 
     def get_bool_array(self, closed_node):
         # TODO: Check if also defined boolean arrays
-        """ Returns a boolean array using details in the node location.
+        """Returns a boolean array using details in the node location.
 
         If type of boolean array is BooleanConstantArray, uses the array value and count to generate the array. If type of boolean array is BooleanArrayFromIndexArray, find the "other" value bool and indices of the "other" values, and insert these into an array opposite to the main bool.
 
         args:
-            closed_node: the node under which the boolean array information sits"""
+            closed_node: the node under which the boolean array information sits
+        """
         if rqet.node_type(closed_node) == 'BooleanConstantArray':
             count = rqet.find_tag_int(closed_node, 'Count')
             value = rqet.bool_from_text(rqet.node_text(rqet.find_tag(closed_node, 'Value')))
@@ -1113,7 +1119,7 @@ class PolylineSet(_BasePolyline):
             crs_uuid = None,
             crs_root = None,  # deprecated
             rep_int_root = None):
-        """Returns a list of Polylines objects from a PolylineSet
+        """Returns a list of Polylines objects from a PolylineSet.
 
         note:
             all arguments are optional and by default the data will be taken from self
@@ -1170,7 +1176,7 @@ class PolylineSet(_BasePolyline):
         return polys
 
     def combine_polylines(self, polylines):
-        """Combines the isclosed boolean array, coordinates and count data for a list of polyline objects
+        """Combines the isclosed boolean array, coordinates and count data for a list of polyline objects.
 
         args:
             polylines: list of polyline objects
@@ -1201,7 +1207,7 @@ class PolylineSet(_BasePolyline):
         assert np.sum(self.count_perpol) == len(self.coordinates)
 
     def bool_array_format(self, closed_array):
-        """Determines an appropriate output boolean array format from an input array of bools
+        """Determines an appropriate output boolean array format from an input array of bools.
 
         self.boolnotconstant - set to True if all are not open or all closed
         self.boolvalue - value of isclosed for all polylines, or for the majority of polylines if mixed
@@ -1229,7 +1235,7 @@ class PolylineSet(_BasePolyline):
             self.boolnotconstant = True
 
     def set_interpretation_root(self, rep_int_root, recursive = True):
-        """Updates the rep_int_root for the polylineset
+        """Updates the rep_int_root for the polylineset.
 
         args:
             rep_int_root: new rep_int_root

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -42,22 +42,21 @@ def _pl(i, e = False):
 
 class Model():
     """Class for RESQML (v2) based models.
-   
-   Examples:
 
-         To open an existing dataset::
+    Examples:
 
-            Model(epc_file = 'filename.epc')
+          To open an existing dataset::
 
-         To create a new, empty model ready to populate::
+             Model(epc_file = 'filename.epc')
 
-            Model(epc_file = 'new_file.epc', new_epc = True, create_basics = True, create_hdf5_ext = True)
+          To create a new, empty model ready to populate::
 
-         To copy an existing dataset then open the new copy::
+             Model(epc_file = 'new_file.epc', new_epc = True, create_basics = True, create_hdf5_ext = True)
 
-            Model(epc_file = 'new_file.epc', copy_from = 'existing.epc')
-   
-   """
+          To copy an existing dataset then open the new copy::
+
+             Model(epc_file = 'new_file.epc', copy_from = 'existing.epc')
+    """
 
     def __init__(self,
                  epc_file: Optional[str] = None,
@@ -69,45 +68,45 @@ class Model():
                  copy_from: Optional[str] = None):
         """Create an empty model; load it from epc_file if given.
 
-      Note:
+        Note:
 
-         if epc_file is given and the other arguments indicate that it will be a new dataset (new_epc is True
-         or copy_from is given) then any existing .epc and .h5 file(s) with this name will be deleted
-         immediately
+           if epc_file is given and the other arguments indicate that it will be a new dataset (new_epc is True
+           or copy_from is given) then any existing .epc and .h5 file(s) with this name will be deleted
+           immediately
 
-      Arguments:
-         epc_file (str, optional): if present, and new_epc is False and copy_from is None, the name
-            of an existing epc file which is opened, unzipped and parsed to determine the list of parts
-            and relationships comprising the model; if present, and new_epc is True or copy_from is
-            specified, the name of a new file to be created - any existing file (and .h5 paired hdf5
-            file) will be immediately deleted
-            if None, an empty model is created (ie. with no parts) unless copy_from is present
-         full_load (boolean): only relevant if epc_file is not None and new_epc is False (or copy_from
-            is specified); if True (recommended), the xml for each part is parsed and stored in a tree
-            structure in memory; if False, only the list of parts is loaded
-         epc_subdir (string or list of strings, optional): if present, parts are only included in the load
-            if they are in the top level directory of the epc internal structure, or in the specified
-            subdirectory (or one of the subdirectories in the case of a list); only relevant if epc_file
-            is not None and new_epc is False (or copy_from is specified)
-         new_epc (boolean, default False): if True, a new model is created, empty unless copy_from is given
-         create_basics (boolean, optional): if True and epc_file is None or new_epc is True,
-            then the minimum essential parts are added to the empty Model; this is equivalent to
-            calling the create_root(), create_rels_part() and create_doc_props() methods; if None, defaults
-            to the same value as new_epc
-         create_hdf5_ref (boolean, optional): if True and new_epc is True and create_basics is True
-            and epc_file is not None, then an hdf5 external part is created, equivalent to calling the
-            create_hdf5_ext() method; an empty hdf5 file is also created; if None, defaults to same
-            value as new_epc
-         copy_from: (str, optional): if present, and epc_file is also present, then the epc file
-            named in copy_from, together with its paired h5 file, are copied to epc_file (overwriting
-            any previous instances) before epc_file is opened; this argument is primarily to facilitate
-            repeated testing of code that modifies the resqml dataset, eg. by appending new parts
+        Arguments:
+           epc_file (str, optional): if present, and new_epc is False and copy_from is None, the name
+              of an existing epc file which is opened, unzipped and parsed to determine the list of parts
+              and relationships comprising the model; if present, and new_epc is True or copy_from is
+              specified, the name of a new file to be created - any existing file (and .h5 paired hdf5
+              file) will be immediately deleted
+              if None, an empty model is created (ie. with no parts) unless copy_from is present
+           full_load (boolean): only relevant if epc_file is not None and new_epc is False (or copy_from
+              is specified); if True (recommended), the xml for each part is parsed and stored in a tree
+              structure in memory; if False, only the list of parts is loaded
+           epc_subdir (string or list of strings, optional): if present, parts are only included in the load
+              if they are in the top level directory of the epc internal structure, or in the specified
+              subdirectory (or one of the subdirectories in the case of a list); only relevant if epc_file
+              is not None and new_epc is False (or copy_from is specified)
+           new_epc (boolean, default False): if True, a new model is created, empty unless copy_from is given
+           create_basics (boolean, optional): if True and epc_file is None or new_epc is True,
+              then the minimum essential parts are added to the empty Model; this is equivalent to
+              calling the create_root(), create_rels_part() and create_doc_props() methods; if None, defaults
+              to the same value as new_epc
+           create_hdf5_ref (boolean, optional): if True and new_epc is True and create_basics is True
+              and epc_file is not None, then an hdf5 external part is created, equivalent to calling the
+              create_hdf5_ext() method; an empty hdf5 file is also created; if None, defaults to same
+              value as new_epc
+           copy_from: (str, optional): if present, and epc_file is also present, then the epc file
+              named in copy_from, together with its paired h5 file, are copied to epc_file (overwriting
+              any previous instances) before epc_file is opened; this argument is primarily to facilitate
+              repeated testing of code that modifies the resqml dataset, eg. by appending new parts
 
-      Returns:
-         The newly created Model object
+        Returns:
+           The newly created Model object
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if epc_file and not epc_file.endswith('.epc'):
             epc_file += '.epc'
@@ -151,9 +150,9 @@ class Model():
     def initialize(self):
         """Set model contents to empty.
 
-      note:
-         not usually called directly (semi-private)
-      """
+        note:
+           not usually called directly (semi-private)
+        """
 
         self.epc_file = None
         self.epc_directory = None
@@ -195,48 +194,48 @@ class Model():
               sort_by = None):
         """Returns a list of parts matching all of the arguments passed.
 
-      Arguments:
-         parts_list (list of strings, optional): if present, an 'input' list of parts to be filtered;
-            if None then all the parts in the model are considered
-         obj_type (string, optional): if present, only parts of this resqml type will be included
-         uuid (uuid.UUID, optional): if present, the uuid of a part to select
-         title (string, optional): if present, a citation title or substring to filter on, based on
-            the title_mode argument
-         title_mode (string, default 'is'): one of 'is', 'starts', 'ends', 'contains',
-            'is not', 'does not start', 'does not end', or 'does not contain'; how to compare each
-            part's citation title with the title argument; ignored if title is None
-         title_case_sensitive (boolean, default False): if True, title comparisons are made on a
-            case sensitive basis; otherwise comparisons are insensitive to case
-         extra (dictionary of key:value pairs, optional): if present, only parts which have within
-            their extra metadata all the items in this argument, are included in the filtered list
-         related_uuid (uuid.UUID, optional): if present, only parts which are related to this uuid
-            are included in the filtered list
-         epc_subdir (string, optional): if present, only parts which reside within the specified
-            subdirectory path of the epc are included in the filtered list
-         sort_by (string, optional): one of 'newest', 'oldest', 'title', 'uuid', 'type'
+        Arguments:
+           parts_list (list of strings, optional): if present, an 'input' list of parts to be filtered;
+              if None then all the parts in the model are considered
+           obj_type (string, optional): if present, only parts of this resqml type will be included
+           uuid (uuid.UUID, optional): if present, the uuid of a part to select
+           title (string, optional): if present, a citation title or substring to filter on, based on
+              the title_mode argument
+           title_mode (string, default 'is'): one of 'is', 'starts', 'ends', 'contains',
+              'is not', 'does not start', 'does not end', or 'does not contain'; how to compare each
+              part's citation title with the title argument; ignored if title is None
+           title_case_sensitive (boolean, default False): if True, title comparisons are made on a
+              case sensitive basis; otherwise comparisons are insensitive to case
+           extra (dictionary of key:value pairs, optional): if present, only parts which have within
+              their extra metadata all the items in this argument, are included in the filtered list
+           related_uuid (uuid.UUID, optional): if present, only parts which are related to this uuid
+              are included in the filtered list
+           epc_subdir (string, optional): if present, only parts which reside within the specified
+              subdirectory path of the epc are included in the filtered list
+           sort_by (string, optional): one of 'newest', 'oldest', 'title', 'uuid', 'type'
 
-      Returns:
-         a list of strings being the names of parts which match all filter arguments
+        Returns:
+           a list of strings being the names of parts which match all filter arguments
 
-      Examples:
-         a full list of parts in the model::
-         
-            model.parts()
+        Examples:
+           a full list of parts in the model::
 
-         a list of IjkGrid parts::
-            
-            model.parts(obj_type = 'IjkGridRepresentation')
+              model.parts()
 
-         a list containing the part name for a uuid::
-         
-            model.parts(uuid = 'a869e7cc-5d30-4b31-8502-c74b1d87c777')
+           a list of IjkGrid parts::
 
-         a list of IjkGrid parts with titles beginning LGR, sorted by title::
-            
-            model.parts(obj_type='IjkGridRepresentation', title='LGR', title_mode='starts', sort_by='title')
-      
-      :meta common:
-      """
+              model.parts(obj_type = 'IjkGridRepresentation')
+
+           a list containing the part name for a uuid::
+
+              model.parts(uuid = 'a869e7cc-5d30-4b31-8502-c74b1d87c777')
+
+           a list of IjkGrid parts with titles beginning LGR, sorted by title::
+
+              model.parts(obj_type='IjkGridRepresentation', title='LGR', title_mode='starts', sort_by='title')
+
+        :meta common:
+        """
 
         if not parts_list:
             parts_list = self.list_of_parts()
@@ -361,22 +360,22 @@ class Model():
              multiple_handling = 'exception'):
         """Returns the name of a part matching all of the arguments passed.
 
-      arguments:
-         (as for parts() except no sort_by argument)
-         multiple_handling (string, default 'exception'): one of 'exception', 'none', 'first', 'oldest', 'newest'
+        arguments:
+           (as for parts() except no sort_by argument)
+           multiple_handling (string, default 'exception'): one of 'exception', 'none', 'first', 'oldest', 'newest'
 
-      returns:
-         string being the part name of the single part matching all of the criteria, or None
+        returns:
+           string being the part name of the single part matching all of the criteria, or None
 
-      notes:
-         this method can be used where a single part is being identified; if no parts match the criteria, None is
-         returned; if more than one part matches the criteria, the multiple_handling argument determines what happens:
-         'exception' causes a ValueError exception to be raised; 'none' causes None to be returned; 'first' causes the
-         first part (as stored in the epc file or added) to be returned; 'oldest' causes the part with the oldest
-         creation timestamp in the citation block to be returned; 'newest' causes the newest part to be returned
+        notes:
+           this method can be used where a single part is being identified; if no parts match the criteria, None is
+           returned; if more than one part matches the criteria, the multiple_handling argument determines what happens:
+           'exception' causes a ValueError exception to be raised; 'none' causes None to be returned; 'first' causes the
+           first part (as stored in the epc file or added) to be returned; 'oldest' causes the part with the oldest
+           creation timestamp in the citation block to be returned; 'newest' causes the newest part to be returned
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         pl = self.parts(parts_list = parts_list,
                         obj_type = obj_type,
@@ -414,14 +413,14 @@ class Model():
               sort_by = None):
         """Returns a list of uuids of parts matching all of the arguments passed.
 
-      arguments:
-         (as for parts() method)
+        arguments:
+           (as for parts() method)
 
-      returns:
-         list of uuids
+        returns:
+           list of uuids
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         sort_by_uuid = (sort_by == 'uuid')
         if sort_by_uuid:
@@ -458,14 +457,14 @@ class Model():
              multiple_handling = 'exception'):
         """Returns the uuid of a part matching all of the arguments passed.
 
-      arguments:
-         (as for part())
+        arguments:
+           (as for part())
 
-      returns:
-         uuid of the single part matching all of the criteria, or None
+        returns:
+           uuid of the single part matching all of the criteria, or None
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         part = self.part(parts_list = parts_list,
                          obj_type = obj_type,
@@ -494,14 +493,14 @@ class Model():
               sort_by = None):
         """Returns a list of xml root nodes of parts matching all of the arguments passed.
 
-      arguments:
-         (as for parts() method)
+        arguments:
+           (as for parts() method)
 
-      returns:
-         list of lxml.etree.Element objects
+        returns:
+           list of lxml.etree.Element objects
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         pl = self.parts(parts_list = parts_list,
                         obj_type = obj_type,
@@ -531,14 +530,14 @@ class Model():
              multiple_handling = 'exception'):
         """Returns the xml root node of a part matching all of the arguments passed.
 
-      arguments:
-         (as for part())
+        arguments:
+           (as for part())
 
-      returns:
-         lxml.etree.Element object being the root node of the xml for the single part matching all of the criteria, or None
+        returns:
+           lxml.etree.Element object being the root node of the xml for the single part matching all of the criteria, or None
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         part = self.part(parts_list = parts_list,
                          obj_type = obj_type,
@@ -567,14 +566,14 @@ class Model():
                sort_by = None):
         """Returns a list of citation titles of parts matching all of the arguments passed.
 
-      arguments:
-         (as for parts() method)
+        arguments:
+           (as for parts() method)
 
-      returns:
-         list of strings being the citation titles of matching parts
+        returns:
+           list of strings being the citation titles of matching parts
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         pl = self.parts(parts_list = parts_list,
                         obj_type = obj_type,
@@ -604,14 +603,14 @@ class Model():
               multiple_handling = 'exception'):
         """Returns the citation title of a part matching all of the arguments passed.
 
-      arguments:
-         (as for part())
+        arguments:
+           (as for part())
 
-      returns:
-         string being the citation title of the single part matching all of the criteria, or None
+        returns:
+           string being the citation title of the single part matching all of the criteria, or None
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         part = self.part(parts_list = parts_list,
                          obj_type = obj_type,
@@ -630,16 +629,16 @@ class Model():
     def set_modified(self):
         """Marks the model as having been modified and assigns a new uuid.
 
-      note:
-         this modification tracking functionality is not part of the resqml standard and is only loosely
-         applied by the library code; not usually called directly
-      """
+        note:
+           this modification tracking functionality is not part of the resqml standard and is only loosely
+           applied by the library code; not usually called directly
+        """
 
         self.modified = True
 
     @property
     def crs_root(self):
-        """XML node corresponding to self.crs_uuid"""
+        """XML node corresponding to self.crs_uuid."""
 
         return self.root_for_uuid(self.crs_uuid)
 
@@ -653,20 +652,20 @@ class Model():
     def load_part(self, epc, part_name, is_rels = None):
         """Load and parse xml tree for given part name, storing info in parts forest (or rels forest).
 
-      arguments:
-         epc: an open ZipFile handle for the epc file
-         part_name (string): the name of the 'file' within the epc bundle containing the part (or relationship)
-         is_rels: (boolean, optional): if True, the part to be loaded is a relationship part; if False,
-            it is a main part; if None, its value is derived from the part name
+        arguments:
+           epc: an open ZipFile handle for the epc file
+           part_name (string): the name of the 'file' within the epc bundle containing the part (or relationship)
+           is_rels: (boolean, optional): if True, the part to be loaded is a relationship part; if False,
+              it is a main part; if None, its value is derived from the part name
 
-      returns:
-         boolean: True if part loaded successfully, False if part failed to load
+        returns:
+           boolean: True if part loaded successfully, False if part failed to load
 
-      note:
-         parts forest must already have been initialized before calling this method;
-         if False is returned, calling code should probably delete part from forest;
-         not usually called directly
-      """
+        note:
+           parts forest must already have been initialized before calling this method;
+           if False is returned, calling code should probably delete part from forest;
+           not usually called directly
+        """
 
         # note: epc is 'open' ZipFile handle
         if part_name.startswith('/'):
@@ -719,12 +718,12 @@ class Model():
     def set_epc_file_and_directory(self, epc_file):
         """Sets the full path and directory of the epc_file.
 
-      arguments:
-         epc_file (string): the path of the epc file
+        arguments:
+           epc_file (string): the path of the epc file
 
-      note:
-         not usually needed to be called directly, except perhaps when creating a new dataset
-      """
+        note:
+           not usually needed to be called directly, except perhaps when creating a new dataset
+        """
 
         self.epc_file = epc_file  # full path, if provided as such
         (self.epc_directory, _) = os.path.split(epc_file)
@@ -734,13 +733,13 @@ class Model():
     def fell_part(self, part_name):
         """Removes the named part from the in-memory parts forest.
 
-      arguments:
-         part_name (string): the name of the part to be removed
+        arguments:
+           part_name (string): the name of the part to be removed
 
-      note:
-         no check is made for references or relationships to the part being deleted;
-         not usually called directly
-      """
+        note:
+           no check is made for references or relationships to the part being deleted;
+           not usually called directly
+        """
 
         try:
             self._del_uuid_to_part(part_name)
@@ -762,9 +761,9 @@ class Model():
     def remove_part_from_main_tree(self, part):
         """Removes the named part from the main (Content_Types) tree.
 
-      note:
-         not usually called directly
-      """
+        note:
+           not usually called directly
+        """
 
         for child in self.main_root:
             if rqet.stripped_of_prefix(child.tag) == 'Override':
@@ -779,9 +778,9 @@ class Model():
     def tidy_up_forests(self, tidy_main_tree = True, tidy_others = False, remove_extended_core = True):
         """Removes any parts that do not have any related data in dictionaries.
 
-      note:
-         not usually called directly
-      """
+        note:
+           not usually called directly
+        """
 
         deletion_list = []
         for part, info in self.parts_forest.items():
@@ -820,24 +819,24 @@ class Model():
     def load_epc(self, epc_file, full_load = True, epc_subdir = None, copy_from = None):
         """Load xml parts of model from epc file (HDF5 arrays are not loaded).
 
-      Arguments:
-         epc_file (string): the path of the epc file
-         full_load (boolean): if True (recommended), the xml for each part is parsed and stored
-            in a tree structure in memory; if False, only the list of parts is loaded
-         epc_subdir (string or list of strings, optional): if present, only parts in the top
-            level directory within the epc structure, or in the specified subdirectory(ies) are
-            included in the load
-         copy_from (string, optional): if present, the .epc and .h5 are copied from this source
-            to epc_file (and paired .h5) prior to opening epc_file; any previous files named
-            as epc_file will be overwritten
+        Arguments:
+           epc_file (string): the path of the epc file
+           full_load (boolean): if True (recommended), the xml for each part is parsed and stored
+              in a tree structure in memory; if False, only the list of parts is loaded
+           epc_subdir (string or list of strings, optional): if present, only parts in the top
+              level directory within the epc structure, or in the specified subdirectory(ies) are
+              included in the load
+           copy_from (string, optional): if present, the .epc and .h5 are copied from this source
+              to epc_file (and paired .h5) prior to opening epc_file; any previous files named
+              as epc_file will be overwritten
 
-      Returns:
-         None
+        Returns:
+           None
 
-      Note:
-         when copy_from is specified, the entire contents of the source dataset are copied,
-         regardless of the epc_subdir setting which only affects the subsequent load into memory
-      """
+        Note:
+           when copy_from is specified, the entire contents of the source dataset are copied,
+           regardless of the epc_subdir setting which only affects the subsequent load into memory
+        """
 
         def exclude(name, epc_subdir):
             if epc_subdir is None:
@@ -942,24 +941,24 @@ class Model():
     def store_epc(self, epc_file = None, main_xml_name = '[Content_Types].xml', only_if_modified = False):
         """Write xml parts of model to epc file (HDF5 arrays are not written here).
 
-      Arguments:
-         epc_file (string): the name of the output epc file to be written (any existing file will be
-            overwritten)
-         main_xml_name (string, do not pass): this argument should not be passed as the resqml standard
-            requires the default value; (the argument exists in code because the resqml standard value
-            is based on a slight misunderstanding of the opc standard, so could perhaps change in
-            future versions of resqml)
-         only_if_modified (boolean, default False): if True, the epc file is only written if the model
-            is flagged as having been modified (at least one part added or removed)
+        Arguments:
+           epc_file (string): the name of the output epc file to be written (any existing file will be
+              overwritten)
+           main_xml_name (string, do not pass): this argument should not be passed as the resqml standard
+              requires the default value; (the argument exists in code because the resqml standard value
+              is based on a slight misunderstanding of the opc standard, so could perhaps change in
+              future versions of resqml)
+           only_if_modified (boolean, default False): if True, the epc file is only written if the model
+              is flagged as having been modified (at least one part added or removed)
 
-      Returns:
-         None
+        Returns:
+           None
 
-      Note:
-         the main tree, parts forest and rels forest must all be up to date before calling this method
+        Note:
+           the main tree, parts forest and rels forest must all be up to date before calling this method
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         #      for prefix, uri in ns.items():
         #         et.register_namespace(prefix, uri)
@@ -1011,18 +1010,18 @@ class Model():
     def parts_list_of_type(self, type_of_interest = None, uuid = None):
         """Returns a list of part names for parts of type of interest, optionally matching a uuid.
 
-         arguments:
-            type_of_interest (string): the resqml object class of interest, in string form, eg. 'obj_IjkGridRepresentation'
-            uuid (uuid.UUID object, optional): if present, only a part with this uuid is included in the list
+        arguments:
+           type_of_interest (string): the resqml object class of interest, in string form, eg. 'obj_IjkGridRepresentation'
+           uuid (uuid.UUID object, optional): if present, only a part with this uuid is included in the list
 
-         returns:
-            a list of strings being the part names which match the arguments
+        returns:
+           a list of strings being the part names which match the arguments
 
-         note:
-            usually either a type of interest or a uuid is passed; if neither are passed, all parts are returned;
-            this method is maintained for backward compatibility and for efficiency reasons;
-            it is equivalent to: self.parts(obj_type = type_of_interest, uuid = uuid)
-      """
+        note:
+           usually either a type of interest or a uuid is passed; if neither are passed, all parts are returned;
+           this method is maintained for backward compatibility and for efficiency reasons;
+           it is equivalent to: self.parts(obj_type = type_of_interest, uuid = uuid)
+        """
 
         if type_of_interest and type_of_interest[0].isupper():
             type_of_interest = 'obj_' + type_of_interest
@@ -1062,42 +1061,42 @@ class Model():
     def part_for_uuid(self, uuid):
         """Returns the part name which has the given uuid.
 
-      arguments:
-         uuid (uuid.UUID object or string): the uuid of the part of interest
+        arguments:
+           uuid (uuid.UUID object or string): the uuid of the part of interest
 
-      returns:
-         a string being the part name which matches the uuid, or None if not found
+        returns:
+           a string being the part name which matches the uuid, or None if not found
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.uuid_part_dict.get(bu.uuid_as_int(uuid))
 
     def root_for_uuid(self, uuid):
         """Returns the xml root for the part which has the given uuid.
 
-      arguments:
-         uuid (uuid.UUID object or string): the uuid of the part of interest
+        arguments:
+           uuid (uuid.UUID object or string): the uuid of the part of interest
 
-      returns:
-         the xml root node for the part with the given uuid, or None if not found
+        returns:
+           the xml root node for the part with the given uuid, or None if not found
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.root_for_part(self.part_for_uuid(uuid))
 
     def parts_count_by_type(self, type_of_interest = None):
         """Returns a sorted list of (type, count) for parts.
 
-      arguments:
-         type_of_interest (string, optional): if not None, the returned list only contains one pair, with
-            a count for that type (resqml object class)
+        arguments:
+           type_of_interest (string, optional): if not None, the returned list only contains one pair, with
+              a count for that type (resqml object class)
 
-      returns:
-         list of pairs, each being (string, int) representing part type (resqml object class without leading obj_)
-         and count
-      """
+        returns:
+           list of pairs, each being (string, int) representing part type (resqml object class without leading obj_)
+           and count
+        """
 
         # note: resqml classes start with 'obj_' whilst witsml classes don't!
         if type_of_interest and type_of_interest.startswith('obj_'):
@@ -1129,21 +1128,21 @@ class Model():
     def parts_list_filtered_by_related_uuid(self, parts_list, uuid, uuid_is_source = None):
         """From a list of parts, returns a list of those parts which have a relationship with the given uuid.
 
-      arguments:
-         parts_list (list of strings): input list of parts from which a selection is made
-         uuid (uuid.UUID): the uuid of a part for which related parts are required
-         uuid_is_source (boolean, default None): if None, relationships in either direction qualify;
-            if True, only those where uuid is sourceObject qualify; if False, only those where
-            uuid is destinationObject qualify
+        arguments:
+           parts_list (list of strings): input list of parts from which a selection is made
+           uuid (uuid.UUID): the uuid of a part for which related parts are required
+           uuid_is_source (boolean, default None): if None, relationships in either direction qualify;
+              if True, only those where uuid is sourceObject qualify; if False, only those where
+              uuid is destinationObject qualify
 
-      returns:
-         list of strings being the subset of parts_list which are related to the object with the
-         given uuid
+        returns:
+           list of strings being the subset of parts_list which are related to the object with the
+           given uuid
 
-      note:
-         the part to which the given uuid applies might or might not be in the input parts list;
-         this method scans the relationship info for every present part, looking for uuid in rels
-      """
+        note:
+           the part to which the given uuid applies might or might not be in the input parts list;
+           this method scans the relationship info for every present part, looking for uuid in rels
+        """
 
         if not self.rels_present or parts_list is None or uuid is None:
             return None
@@ -1203,17 +1202,17 @@ class Model():
     def parts_list_filtered_by_supporting_uuid(self, parts_list, uuid):
         """From a list of parts, returns a list of those parts which have the given uuid as supporting representation.
 
-      arguments:
-         parts_list (list of strings): input list of parts from which a selection is made
-         uuid (uuid.UUID): the uuid of a supporting representation part for which related parts are required
+        arguments:
+           parts_list (list of strings): input list of parts from which a selection is made
+           uuid (uuid.UUID): the uuid of a supporting representation part for which related parts are required
 
-      returns:
-         list of strings being the subset of parts_list which have as their supporting representation
-         the object with the given uuid
+        returns:
+           list of strings being the subset of parts_list which have as their supporting representation
+           the object with the given uuid
 
-      note:
-         the part to which the given uuid applies might or might not be in the input parts list
-      """
+        note:
+           the part to which the given uuid applies might or might not be in the input parts list
+        """
 
         if parts_list is None or uuid is None:
             return None
@@ -1229,14 +1228,14 @@ class Model():
     def parts_list_related_to_uuid_of_type(self, uuid, type_of_interest = None):
         """Returns a list of parts of type of interest that relate to part with given uuid.
 
-      arguments:
-         uuid (uuid.UUID): the uuid of a part for which related parts are required
-         type_of_interest (string): the type of parts (resqml object class) of the related
-            parts of interest
+        arguments:
+           uuid (uuid.UUID): the uuid of a part for which related parts are required
+           type_of_interest (string): the type of parts (resqml object class) of the related
+              parts of interest
 
-      returns:
-         list of strings being the part names of the type of interest, related to the uuid
-      """
+        returns:
+           list of strings being the part names of the type of interest, related to the uuid
+        """
 
         parts_list = self.parts_list_of_type(type_of_interest = type_of_interest)
         return self.parts_list_filtered_by_related_uuid(parts_list, uuid)
@@ -1244,35 +1243,35 @@ class Model():
     def external_parts_list(self):
         """Returns a list of part names for external part references.
 
-      Returns:
-         list of strings being the part names for external part references
+        Returns:
+           list of strings being the part names for external part references
 
-      Note:
+        Note:
 
-         in practice, external part references are only used for hdf5 files;
-         furthermore, all current datasets have adopted the practice of using
-         a single hdf5 file for a given epc file
-      """
+           in practice, external part references are only used for hdf5 files;
+           furthermore, all current datasets have adopted the practice of using
+           a single hdf5 file for a given epc file
+        """
 
         return self.parts_list_of_type('obj_EpcExternalPartReference')
 
     def uuid_for_part(self, part_name, is_rels = None):
         """Returns the uuid for the named part.
 
-      arguments:
-         part_name (string): the part name for which the uuid is required
-         is_rels (boolean, optional): if True, the part is a relationship part;
-            if False, it is a main part; if None, its value is determined from the part name
+        arguments:
+           part_name (string): the part name for which the uuid is required
+           is_rels (boolean, optional): if True, the part is a relationship part;
+              if False, it is a main part; if None, its value is determined from the part name
 
-      returns:
-         uuid.UUID for the specified part
+        returns:
+           uuid.UUID for the specified part
 
-      note:
-         this method will fail with an exception if the part is not in this model; a quicker alternative
-         to this method is simply to extract the uuid from the part name using olio.xml_et.uuid_in_part_name()
+        note:
+           this method will fail with an exception if the part is not in this model; a quicker alternative
+           to this method is simply to extract the uuid from the part name using olio.xml_et.uuid_in_part_name()
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if part_name is None:
             return None
@@ -1285,16 +1284,16 @@ class Model():
     def type_of_part(self, part_name, strip_obj = False):
         """Returns content type for the named part (does not apply to rels parts).
 
-      arguments:
-         part_name (string): the part for which the type is required
-         strip_obj (boolean, default False): if True, the leading 'obj_' is removed
-            from the returned string
+        arguments:
+           part_name (string): the part for which the type is required
+           strip_obj (boolean, default False): if True, the leading 'obj_' is removed
+              from the returned string
 
-      returns:
-         string being the type (resqml object class) for the named part
+        returns:
+           string being the type (resqml object class) for the named part
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         part_info = self.parts_forest.get(part_name)
         if part_info is None:
@@ -1307,16 +1306,16 @@ class Model():
     def type_of_uuid(self, uuid, strip_obj = False):
         """Returns content type for the uuid.
 
-      arguments:
-         uuid (uuid.UUID or str): the uuid for which the type is required
-         strip_obj (boolean, default False): if True, the leading 'obj_' is removed
-            from the returned string
+        arguments:
+           uuid (uuid.UUID or str): the uuid for which the type is required
+           strip_obj (boolean, default False): if True, the leading 'obj_' is removed
+              from the returned string
 
-      returns:
-         string being the type (resqml object class) for the named part
+        returns:
+           string being the type (resqml object class) for the named part
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         part_name = self.uuid_part_dict.get(bu.uuid_as_int(uuid))
         return self.type_of_part(part_name, strip_obj = strip_obj)
@@ -1324,14 +1323,14 @@ class Model():
     def tree_for_part(self, part_name, is_rels = None):
         """Returns parsed xml tree for the named part.
 
-      arguments:
-         part_name (string): the part name for which the xml tree is required
-         is_rels (boolean, optional): if True, the part is a relationship part;
-            if False, it is a main part; if None, its value is determined from the part name
+        arguments:
+           part_name (string): the part name for which the xml tree is required
+           is_rels (boolean, optional): if True, the part is a relationship part;
+              if False, it is a main part; if None, its value is determined from the part name
 
-      returns:
-         parsed xml tree (defined in lxml or ElementTree package) for the named part
-      """
+        returns:
+           parsed xml tree (defined in lxml or ElementTree package) for the named part
+        """
 
         if not part_name:
             return None
@@ -1378,16 +1377,16 @@ class Model():
     def root_for_part(self, part_name, is_rels = None):
         """Returns root of parsed xml tree for the named part.
 
-      arguments:
-         part_name (string): the part name for which the root of the xml tree is required
-         is_rels (boolean, optional): if True, the part is a relationship part;
-            if False, it is a main part; if None, its value is determined from the part name
+        arguments:
+           part_name (string): the part name for which the root of the xml tree is required
+           is_rels (boolean, optional): if True, the part is a relationship part;
+              if False, it is a main part; if None, its value is determined from the part name
 
-      returns:
-         root node of the parsed xml tree (defined in lxml or ElementTree package) for the named part
+        returns:
+           root node of the parsed xml tree (defined in lxml or ElementTree package) for the named part
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if not part_name:
             return None
@@ -1399,18 +1398,18 @@ class Model():
     def change_hdf5_uuid_in_hdf5_references(self, node, old_uuid, new_uuid):
         """Scan node for hdf5 references and set the uuid of the hdf5 file itself to new_uuid.
 
-      arguments:
-         node: the root node of an xml tree within which hdf5 internal paths are to have hdf5 uuids changed
-         old_uuid (uuid.UUID or str): the ext uuid currently to be found in the hdf5 references; if None, all will be replaced
-         new_uuid (uuid.UUID or str): the new ext (hdf5) uuid to replace the old one
+        arguments:
+           node: the root node of an xml tree within which hdf5 internal paths are to have hdf5 uuids changed
+           old_uuid (uuid.UUID or str): the ext uuid currently to be found in the hdf5 references; if None, all will be replaced
+           new_uuid (uuid.UUID or str): the new ext (hdf5) uuid to replace the old one
 
-      returns:
-         None
+        returns:
+           None
 
-      note:
-         use this method when the uuid of the hdf5 ext part is changing; if the uuid of the high level part itself is changing
-         use change_uuid_in_hdf5_references() instead
-      """
+        note:
+           use this method when the uuid of the hdf5 ext part is changing; if the uuid of the high level part itself is changing
+           use change_uuid_in_hdf5_references() instead
+        """
 
         count = 0
         old_uuid_str = str(old_uuid)
@@ -1433,19 +1432,19 @@ class Model():
     def change_uuid_in_hdf5_references(self, node, old_uuid, new_uuid):
         """Scan node for hdf5 references using the old_uuid and replace with the new_uuid.
 
-      arguments:
-         node: the root node of an xml tree within which hdf5 internal paths are to have uuids changed
-         old_uuid (uuid.UUID or str): the uuid currently to be found in the hdf5 references
-         new_uuid (uuid.UUID or str): the new uuid to replace the old one
+        arguments:
+           node: the root node of an xml tree within which hdf5 internal paths are to have uuids changed
+           old_uuid (uuid.UUID or str): the uuid currently to be found in the hdf5 references
+           new_uuid (uuid.UUID or str): the new uuid to replace the old one
 
-      returns:
-         None
+        returns:
+           None
 
-      notes:
-         use this method when the uuid of the high level part itself is changing; if the uuid of the hdf5 ext part
-         itself is changing, use change_hdf5_uuid_in_hdf5_references() instead; this method does not modify the
-         internal path names in the hdf5 file itself, if that has already been written
-      """
+        notes:
+           use this method when the uuid of the high level part itself is changing; if the uuid of the hdf5 ext part
+           itself is changing, use change_hdf5_uuid_in_hdf5_references() instead; this method does not modify the
+           internal path names in the hdf5 file itself, if that has already been written
+        """
 
         count = 0
         old_uuid_str = str(old_uuid)
@@ -1470,19 +1469,19 @@ class Model():
     def change_uuid_in_supporting_representation_reference(self, node, old_uuid, new_uuid, new_title = None):
         """Look for supporting representation reference using the old_uuid and replace with the new_uuid.
 
-      arguments:
-         node: the root node of an xml tree within which the supporting representation uuid is to be changed
-         old_uuid (uuid.UUID or str): the uuid currently to be found in the supporting representation reference
-         new_uuid (uuid.UUID or str): the new uuid to replace the old one
-         new_title (string, optional): if present, the title stored in the xml reference block is changed to this
+        arguments:
+           node: the root node of an xml tree within which the supporting representation uuid is to be changed
+           old_uuid (uuid.UUID or str): the uuid currently to be found in the supporting representation reference
+           new_uuid (uuid.UUID or str): the new uuid to replace the old one
+           new_title (string, optional): if present, the title stored in the xml reference block is changed to this
 
-      returns:
-         boolean: True if the change was carried out; False otherwise
+        returns:
+           boolean: True if the change was carried out; False otherwise
 
-      notes:
-         this method is typically used to temporarily set a supporting representation to a locally mocked
-         representation object when the actual supporting representation is not present in the dataset
-      """
+        notes:
+           this method is typically used to temporarily set a supporting representation to a locally mocked
+           representation object when the actual supporting representation is not present in the dataset
+        """
 
         ref_node = rqet.find_tag(node, 'SupportingRepresentation')
         if ref_node is None:
@@ -1503,17 +1502,17 @@ class Model():
     def change_filename_in_hdf5_rels(self, new_hdf5_filename = None):
         """Scan relationships forest for hdf5 external parts and patch in a new filename.
 
-      arguments:
-         new_hdf5_filename: the new filename to patch into the xml; if None, the epc filename is used with
-            no directory path and with the extension changed to .h5
+        arguments:
+           new_hdf5_filename: the new filename to patch into the xml; if None, the epc filename is used with
+              no directory path and with the extension changed to .h5
 
-      returns:
-         None
+        returns:
+           None
 
-      notes:
-         no check is made that the new filename is for an existing file;
-         all hdf5 file references will be modified
-      """
+        notes:
+           no check is made that the new filename is for an existing file;
+           all hdf5 file references will be modified
+        """
 
         if not new_hdf5_filename and self.epc_file and self.epc_file.endswith('.epc'):
             new_hdf5_filename = os.path.split(self.epc_file)[1][:-4] + '.h5'
@@ -1531,26 +1530,26 @@ class Model():
     def copy_part(self, existing_uuid, new_uuid, change_hdf5_refs = False):
         """Makes a new part as a copy of an existing part with only a new uuid set; the new part can then be modified.
 
-         arguments:
-            existing_uuid (uuid.UUID): the uuid of the existing part
-            new_uuid (uuid.UUID): the uuid to inject into the new part after copying of the xml tree
-            change_hdf5_refs (boolean): if True, the new tree is scanned for hdf5 refs using the existing_uuid and
-               they are replaced with the new_uuid
+        arguments:
+           existing_uuid (uuid.UUID): the uuid of the existing part
+           new_uuid (uuid.UUID): the uuid to inject into the new part after copying of the xml tree
+           change_hdf5_refs (boolean): if True, the new tree is scanned for hdf5 refs using the existing_uuid and
+              they are replaced with the new_uuid
 
-         returns:
-            string being the new part name
+        returns:
+           string being the new part name
 
-         notes:
-            Resqml objects have a unique identifier and should be considered immutable; therefore to modify an object,
-            it should first be duplicated; this function does some of the xml work needed for such duplication: the
-            xml tree is copied; the uuid attribute in the root node is changed; the new part is added to the parts
-            forest (with its name matched to the new uuid);
-            NB: relationships are not currently copied or modified;
-            also note that hdf5 data and high level objects maintained by other modules are not duplicated here;
-            use this method to duplicate a part within a model prior to modifying the duplicated part in some way;
-            to import a part from another model, use copy_part_from_other_model() instead; for copying a grid
-            it is best to use the higher level derived_model.copy_grid() function
-      """
+        notes:
+           Resqml objects have a unique identifier and should be considered immutable; therefore to modify an object,
+           it should first be duplicated; this function does some of the xml work needed for such duplication: the
+           xml tree is copied; the uuid attribute in the root node is changed; the new part is added to the parts
+           forest (with its name matched to the new uuid);
+           NB: relationships are not currently copied or modified;
+           also note that hdf5 data and high level objects maintained by other modules are not duplicated here;
+           use this method to duplicate a part within a model prior to modifying the duplicated part in some way;
+           to import a part from another model, use copy_part_from_other_model() instead; for copying a grid
+           it is best to use the higher level derived_model.copy_grid() function
+        """
 
         old_uuid_str = str(existing_uuid)
         new_uuid_str = str(new_uuid)
@@ -1573,22 +1572,22 @@ class Model():
     def root_for_ijk_grid(self, uuid = None, title = None):
         """Return root for IJK Grid part.
 
-      arguments:
-         uuid (uuid.UUID, optional): if present, the uuid of the ijk grid part for which the root is required;
-            if None, a single ijk grid part is expected and the root for that part is returned
-         title (string, optional): if present, the citation title for the grid; defaults to 'ROOT' if more
-            than one ijk grid present and no uuid supplied
+        arguments:
+           uuid (uuid.UUID, optional): if present, the uuid of the ijk grid part for which the root is required;
+              if None, a single ijk grid part is expected and the root for that part is returned
+           title (string, optional): if present, the citation title for the grid; defaults to 'ROOT' if more
+              than one ijk grid present and no uuid supplied
 
-      returns:
-         root node in xml tree for the ijk grid part in this model
+        returns:
+           root node in xml tree for the ijk grid part in this model
 
-      notes:
-         if uuid and title are both supplied, they must match in the corresponding grid part;
-         if a title but no uuid is given, the first ijk grid encountered that has a matching title will be returned;
-         if neither title nor uuid are given, the first ijk grid with title 'ROOT' will be returned, unless there is
-         only one grid part in which case the root npde for that part is returned regardless;
-         failure to find a matching grid part results in an assertion exception
-      """
+        notes:
+           if uuid and title are both supplied, they must match in the corresponding grid part;
+           if a title but no uuid is given, the first ijk grid encountered that has a matching title will be returned;
+           if neither title nor uuid are given, the first ijk grid with title 'ROOT' will be returned, unless there is
+           only one grid part in which case the root npde for that part is returned regardless;
+           failure to find a matching grid part results in an assertion exception
+        """
 
         if title is not None:
             title = title.strip().upper()
@@ -1606,25 +1605,25 @@ class Model():
     def citation_title_for_part(self, part):  # duplicate functionality to title_for_part()
         """Returns the citation title for the specified part.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return rqet.citation_title_for_node(self.root_for_part(part))
 
     def root_for_time_series(self, uuid = None):
         """Return root for time series part.
 
-      argument:
-         uuid (uuid.UUID, optional): if present, the uuid of the time series part for which the root is required;
-            if None, a single time series part is expected and the root for that part is returned
+        argument:
+           uuid (uuid.UUID, optional): if present, the uuid of the time series part for which the root is required;
+              if None, a single time series part is expected and the root for that part is returned
 
-      returns:
-         root node in xml tree for the time series part in this model
+        returns:
+           root node in xml tree for the time series part in this model
 
-      note:
-         if no uuid is given and the model contains more than one time series, the one with the earliest creation
-         date is returned
-      """
+        note:
+           if no uuid is given and the model contains more than one time series, the one with the earliest creation
+           date is returned
+        """
 
         time_series_list = self.parts_list_of_type('obj_TimeSeries', uuid = uuid)
         if len(time_series_list) == 0:
@@ -1644,19 +1643,19 @@ class Model():
     def resolve_grid_root(self, grid_root = None, uuid = None):
         """If grid root argument is None, returns the root for the IJK Grid part instead.
 
-      arguments:
-         grid_root (optional): if not None, this method simply returns this argument
-         uuid (uuid.UUID, optional): if present, the uuid of the ijk grid part for which the root is required;
-            if None, an ijk grid part is sought and the root for that part is returned
+        arguments:
+           grid_root (optional): if not None, this method simply returns this argument
+           uuid (uuid.UUID, optional): if present, the uuid of the ijk grid part for which the root is required;
+              if None, an ijk grid part is sought and the root for that part is returned
 
-      returns:
-         root node in xml tree for the ijk grid part in this model ('ROOT' grid if more than one present)
+        returns:
+           root node in xml tree for the ijk grid part in this model ('ROOT' grid if more than one present)
 
-      notes:
-         if grid_root and uuid are both None and there are multiple grids in the model, the oldest
-         grid with a citation title of 'ROOT' will be returned; an exception will be raised if no
-         grid part is present in the model
-      """
+        notes:
+           if grid_root and uuid are both None and there are multiple grids in the model, the oldest
+           grid with a citation title of 'ROOT' will be returned; an exception will be raised if no
+           grid part is present in the model
+        """
 
         if grid_root is not None:
             if self.grid_root is None:
@@ -1670,24 +1669,24 @@ class Model():
     def grid(self, title = None, uuid = None, find_properties = True):
         """Returns a shared Grid (or RegularGrid) object for this model, by default the 'main' grid.
 
-      arguments:
-         title (string, optional): if present, the citation title of the IjkGridRepresentation
-         uuid (uuid.UUID, optional): if present, the uuid of the IjkGridRepresentation
-         find_properties (boolean, default True): if True, the property_collection attribute
-            of the returned grid object will be populated
+        arguments:
+           title (string, optional): if present, the citation title of the IjkGridRepresentation
+           uuid (uuid.UUID, optional): if present, the uuid of the IjkGridRepresentation
+           find_properties (boolean, default True): if True, the property_collection attribute
+              of the returned grid object will be populated
 
-      returns:
-         grid.Grid object for the specified grid or the main ijk grid part in this model
+        returns:
+           grid.Grid object for the specified grid or the main ijk grid part in this model
 
-      note:
-         if neither title nor uuid are given, the model should contain just one grid, or a grid named 'ROOT';
-         unlike most classes of object, a central list of resqpy Grid objects can be maintained within
-         a Model by using this method which will return a shared object from this list, instantiating a new
-         object and adding it to the list when necessary; an assertion exception will be raised if a
-         suitable grid part is not present in the model
+        note:
+           if neither title nor uuid are given, the model should contain just one grid, or a grid named 'ROOT';
+           unlike most classes of object, a central list of resqpy Grid objects can be maintained within
+           a Model by using this method which will return a shared object from this list, instantiating a new
+           object and adding it to the list when necessary; an assertion exception will be raised if a
+           suitable grid part is not present in the model
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if uuid is None and (title is None or title.upper() == 'ROOT'):
             if self.main_grid is not None:
@@ -1719,15 +1718,15 @@ class Model():
     def add_grid(self, grid_object, check_for_duplicates = False):
         """Add grid object to list of shareable grids for this model.
 
-      arguments:
-         grid_object (grid.Grid object): the ijk grid object to be added to the list
-            of grids in the model
-         check_for_duplicates (boolean, default False): if True, a check is made for any
-            grid objects already in the grid list with the same root as the new grid object
+        arguments:
+           grid_object (grid.Grid object): the ijk grid object to be added to the list
+              of grids in the model
+           check_for_duplicates (boolean, default False): if True, a check is made for any
+              grid objects already in the grid list with the same root as the new grid object
 
-      returns:
-         None
-      """
+        returns:
+           None
+        """
 
         if check_for_duplicates:
             for g in self.grid_list:
@@ -1754,17 +1753,17 @@ class Model():
     def resolve_time_series_root(self, time_series_root = None):
         """If time_series_root is None, finds the root for a time series in the model.
 
-      arguments:
-         time_series_root (optional): if not None, this method simply returns this argument
+        arguments:
+           time_series_root (optional): if not None, this method simply returns this argument
 
-      returns:
-         root node in xml tree for the time series part in this model, or None if there is
-         no time series part
+        returns:
+           root node in xml tree for the time series part in this model, or None if there is
+           no time series part
 
-      note:
-         an assertion exception will be raised if time_series_root is None and there
-         is more than one time series part in the model
-      """
+        note:
+           an assertion exception will be raised if time_series_root is None and there
+           is more than one time series part in the model
+        """
 
         if time_series_root is not None:
             return time_series_root
@@ -1775,19 +1774,19 @@ class Model():
     def h5_uuid_and_path_for_node(self, node, tag = 'Values'):
         """Returns a (hdf5_uuid, hdf5_internal_path) pair for an xml array node.
 
-      arguments:
-         node: xml node for which the array reference is required
-         tag (string, default 'Values'): the tag of the child of node for which the
-            array reference is required
+        arguments:
+           node: xml node for which the array reference is required
+           tag (string, default 'Values'): the tag of the child of node for which the
+              array reference is required
 
-      returns:
-         (uuid.UUID, string) pair being the uuid of the hdf5 external part reference and
-         the hdf5 internal path for the array of interest
+        returns:
+           (uuid.UUID, string) pair being the uuid of the hdf5 external part reference and
+           the hdf5 internal path for the array of interest
 
-      note:
-         this method provides the key data needed to actually access array data within
-         the resqml dataset
-      """
+        note:
+           this method provides the key data needed to actually access array data within
+           the resqml dataset
+        """
 
         child = rqet.find_tag(node, tag)
         if child is None:
@@ -1838,31 +1837,31 @@ class Model():
     def h5_file_name(self, uuid = None, override = True, file_must_exist = True):
         """Returns full path for hdf5 file with given uuid.
 
-      arguments:
-         uuid (uuid.UUID, optional): the uuid of the hdf5 external part reference for which the
-            file name is required; if None, the 'main' hdf5 uuid is used
-         override (boolean, default True): if True, the hdf5 filename stored in the relationship
-            information is preferentially ignored and the hdf5 path is generated from the
-            epc filename and directory; if False, the hdf5 filename is extracted from the
-            relationship information, though the directory of the epc will still be
-            preferentially used
-         file_must_exist (boolean, default True): if True, the existence of the hdf5
-            file is checked and None is returned if the file is not found
+        arguments:
+           uuid (uuid.UUID, optional): the uuid of the hdf5 external part reference for which the
+              file name is required; if None, the 'main' hdf5 uuid is used
+           override (boolean, default True): if True, the hdf5 filename stored in the relationship
+              information is preferentially ignored and the hdf5 path is generated from the
+              epc filename and directory; if False, the hdf5 filename is extracted from the
+              relationship information, though the directory of the epc will still be
+              preferentially used
+           file_must_exist (boolean, default True): if True, the existence of the hdf5
+              file is checked and None is returned if the file is not found
 
-      returns:
-         string being the full path of the hdf5 file
+        returns:
+           string being the full path of the hdf5 file
 
-      notes:
-         depending on the settings of the override and file_must_exist arguments, various
-         file names and directories might be tested in order to determine the returned path;
-         the default arguments will cause a filename based on the epc file and directory
-         to be returned;
-         in practice, a resqml model consists of a pair of files in the same directory,
-         with names like: a.epc and a.h5;
-         to allow copying, moving and renaming of files, the practical approach is simply
-         to assume a one-to-one correspondence between epc and hdf5 files, and assume they
-         are in the same directory
-      """
+        notes:
+           depending on the settings of the override and file_must_exist arguments, various
+           file names and directories might be tested in order to determine the returned path;
+           the default arguments will cause a filename based on the epc file and directory
+           to be returned;
+           in practice, a resqml model consists of a pair of files in the same directory,
+           with names like: a.epc and a.h5;
+           to allow copying, moving and renaming of files, the practical approach is simply
+           to assume a one-to-one correspondence between epc and hdf5 files, and assume they
+           are in the same directory
+        """
 
         if override and self.epc_file and self.epc_file.endswith('.epc'):
             h5_full_path = self.epc_file[:-4] + '.h5'
@@ -1900,22 +1899,22 @@ class Model():
     def h5_access(self, uuid = None, mode = 'r', override = True, file_path = None):
         """Returns an open h5 file handle for the hdf5 file with the given uuid.
 
-      arguments:
-         uuid (uuid.UUID): the uuid of the hdf5 external part reference for which the
-            open file handle is required; required if override is False and file_path is None
-         mode (string): the hdf5 file mode ('r', 'w' or 'a') with which to open the file
-         override (boolean, default True): if True, the h5 filename is generated based on
-            the epc file name, rather than on the filename held in the relationships data
-         file_path (string, optional): if present, is used as the hdf5 file path, otherwise
-            the path will be determined based on the uuid and override arguments
+        arguments:
+           uuid (uuid.UUID): the uuid of the hdf5 external part reference for which the
+              open file handle is required; required if override is False and file_path is None
+           mode (string): the hdf5 file mode ('r', 'w' or 'a') with which to open the file
+           override (boolean, default True): if True, the h5 filename is generated based on
+              the epc file name, rather than on the filename held in the relationships data
+           file_path (string, optional): if present, is used as the hdf5 file path, otherwise
+              the path will be determined based on the uuid and override arguments
 
-      returns:
-         a file handle to the opened hdf5 file
+        returns:
+           a file handle to the opened hdf5 file
 
-      note:
-         an exception will be raised if the hdf5 file cannot be opened; note that sometimes another
-         piece of code accessing the file might cause a 'resource unavailable' exception
-      """
+        note:
+           an exception will be raised if the hdf5 file cannot be opened; note that sometimes another
+           piece of code accessing the file might cause a 'resource unavailable' exception
+        """
 
         if self.h5_currently_open_mode is not None and self.h5_currently_open_mode != mode:
             self.h5_release()
@@ -1937,11 +1936,11 @@ class Model():
     def h5_release(self):
         """Releases (closes) the currently open hdf5 file.
 
-      returns:
-         None
+        returns:
+           None
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.h5_currently_open_root is not None:
             self.h5_currently_open_root.close()
@@ -1952,13 +1951,13 @@ class Model():
     def h5_array_shape_and_type(self, h5_key_pair):
         """Returns the shape and dtype of the array, as stored in the hdf5 file.
 
-      arguments:
-         h5_key_pair (uuid.UUID, string): the uuid of the hdf5 external part reference and the hdf5 internal path for the array
+        arguments:
+           h5_key_pair (uuid.UUID, string): the uuid of the hdf5 external part reference and the hdf5 internal path for the array
 
-      returns:
-         (tuple of ints, type): simply the shape and dtype attributes of the referenced hdf5 array; (None, None) is returned
-         if the hdf5 file is not found, or the array is not found within it
-      """
+        returns:
+           (tuple of ints, type): simply the shape and dtype attributes of the referenced hdf5 array; (None, None) is returned
+           if the hdf5 file is not found, or the array is not found within it
+        """
 
         h5_root = self.h5_access(h5_key_pair[0])
         if h5_root is None:
@@ -1977,30 +1976,30 @@ class Model():
                          required_shape = None):
         """Returns one element from an hdf5 array and/or caches the array.
 
-      arguments:
-         h5_key_pair (uuid.UUID, string): the uuid of the hdf5 external part reference and the hdf5 internal path for the array
-         index (pair or triple int, optional): if None, the only purpose of the call is to ensure that the array is cached in
-            memory; if not None, the (k0, pillar_index) or (k0, j0, i0) index of the cell for which the value is required
-         cache_array (boolean, default False): if True, a copy of the whole array is cached in memory as an attribute of the
-            object; if already cached, the array is not uncached, regardless of this argument
-         object (optional, defaults to self): the object in which a cached version of the array is an attribute, or will be
-            created as an attribute if cache_array is True
-         array_attribute (string): the attribute name to use for the cached version of the array,
-            required to cache or access cached array
-         dtype (string or data type): the data type of the elements of the array (need not match hdf5 array in precision)
-         required_shape (tuple of ints, optional): if not None, the hdf5 array will be reshaped to this shape; if index
-            is not None, it is taken to be applicable to the required shape
+        arguments:
+           h5_key_pair (uuid.UUID, string): the uuid of the hdf5 external part reference and the hdf5 internal path for the array
+           index (pair or triple int, optional): if None, the only purpose of the call is to ensure that the array is cached in
+              memory; if not None, the (k0, pillar_index) or (k0, j0, i0) index of the cell for which the value is required
+           cache_array (boolean, default False): if True, a copy of the whole array is cached in memory as an attribute of the
+              object; if already cached, the array is not uncached, regardless of this argument
+           object (optional, defaults to self): the object in which a cached version of the array is an attribute, or will be
+              created as an attribute if cache_array is True
+           array_attribute (string): the attribute name to use for the cached version of the array,
+              required to cache or access cached array
+           dtype (string or data type): the data type of the elements of the array (need not match hdf5 array in precision)
+           required_shape (tuple of ints, optional): if not None, the hdf5 array will be reshaped to this shape; if index
+              is not None, it is taken to be applicable to the required shape
 
-      returns:
-         if index is None, then None;
-         if index is not None, then the value of the array for the cell identified by index
+        returns:
+           if index is None, then None;
+           if index is not None, then the value of the array for the cell identified by index
 
-      note:
-         this function can be used to access an individual element from an hdf5 array, or to cache a whole array in memory;
-         when accessing an individual element, the index style must match the array indexing; in particular for IJK grid points,
-         a (k0, pillar_index) is needed when the grid has split pillars, whereas a (k0, j0, i0) is needed when the grid does
-         not have any split pillars
-      """
+        note:
+           this function can be used to access an individual element from an hdf5 array, or to cache a whole array in memory;
+           when accessing an individual element, the index style must match the array indexing; in particular for IJK grid points,
+           a (k0, pillar_index) is needed when the grid has split pillars, whereas a (k0, j0, i0) is needed when the grid does
+           not have any split pillars
+        """
 
         def reshaped_index(index, shape_tuple, required_shape):
             tail = len(shape_tuple) - len(index)
@@ -2076,20 +2075,20 @@ class Model():
     def h5_array_slice(self, h5_key_pair, slice_tuple):
         """Loads a slice of an hdf5 array.
 
-      arguments:
-         h5_key_pair (uuid, string): the uuid of the hdf5 ext part and the hdf5 internal path to the
-            required hdf5 array
-         slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
-            function slice()
+        arguments:
+           h5_key_pair (uuid, string): the uuid of the hdf5 ext part and the hdf5 internal path to the
+              required hdf5 array
+           slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
+              function slice()
 
-      returns:
-         numpy array that is a hyper-slice of the hdf5 array, with the same ndim as the source hdf5 array
+        returns:
+           numpy array that is a hyper-slice of the hdf5 array, with the same ndim as the source hdf5 array
 
-      notes:
-         this method always fetches from the hdf5 file and does not attempt local caching; the whole array
-         is not loaded; all axes continue to exist in the returned array, even where the sliced extent of
-         an axis is 1
-      """
+        notes:
+           this method always fetches from the hdf5 file and does not attempt local caching; the whole array
+           is not loaded; all axes continue to exist in the returned array, even where the sliced extent of
+           an axis is 1
+        """
 
         h5_root = self.h5_access(h5_key_pair[0])
         return h5_root[h5_key_pair[1]][slice_tuple]
@@ -2097,17 +2096,17 @@ class Model():
     def h5_overwrite_array_slice(self, h5_key_pair, slice_tuple, array_slice):
         """Overwrites (updates) a slice of an hdf5 array.
 
-      arguments:
-         h5_key_pair (uuid, string): the uuid of the hdf5 ext part and the hdf5 internal path to the
-            required hdf5 array
-         slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
-            function slice()
-         array_slice (numpy array of shape to match slice_tuple): the data to write
+        arguments:
+           h5_key_pair (uuid, string): the uuid of the hdf5 ext part and the hdf5 internal path to the
+              required hdf5 array
+           slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
+              function slice()
+           array_slice (numpy array of shape to match slice_tuple): the data to write
 
-      notes:
-         this method naively updates a slice in an hdf5 array without using mpi to look after parallel updates;
-         metadata (such as uuid or property min, max values) is not modified in any way by the method
-      """
+        notes:
+           this method naively updates a slice in an hdf5 array without using mpi to look after parallel updates;
+           metadata (such as uuid or property min, max values) is not modified in any way by the method
+        """
 
         h5_root = self.h5_access(h5_key_pair[0], mode = 'a')
         dset = h5_root[h5_key_pair[1]]
@@ -2116,9 +2115,9 @@ class Model():
     def create_root(self):
         """Initialises an empty main xml tree for model.
 
-      note:
-         not usually called directly
-      """
+        note:
+           not usually called directly
+        """
 
         assert (self.main_tree is None)
         assert (self.main_root is None)
@@ -2128,22 +2127,22 @@ class Model():
     def add_part(self, content_type, uuid, root, add_relationship_part = True, epc_subdir = None):
         """Adds a (recently created) node as a new part in the model's parts forest.
 
-      arguments:
-         content_type (string): the resqml object class of the new part
-         uuid (uuid.UUID): the uuid for the new part
-         root: the root node of the xml tree for the new part
-         add_relationship_part: (boolean, default True): if True, a relationship part is also
-            created to go with the new part (empty of actual relationships)
-         epc_subdir (string, optional): if present, the subdirectory path within the epc that the
-            part is to be located within; if None, the xml will reside at the top level of the epc
+        arguments:
+           content_type (string): the resqml object class of the new part
+           uuid (uuid.UUID): the uuid for the new part
+           root: the root node of the xml tree for the new part
+           add_relationship_part: (boolean, default True): if True, a relationship part is also
+              created to go with the new part (empty of actual relationships)
+           epc_subdir (string, optional): if present, the subdirectory path within the epc that the
+              part is to be located within; if None, the xml will reside at the top level of the epc
 
-      returns:
-         None
+        returns:
+           None
 
-      notes:
-         NB: xml tree for part is not written to epc file by this function (store_epc() handles that);
-         do not use this function for the main rels extension part: use create_rels_part() instead
-      """
+        notes:
+           NB: xml tree for part is not written to epc file by this function (store_epc() handles that);
+           do not use this function for the main rels extension part: use create_rels_part() instead
+        """
 
         if content_type[0].isupper():
             content_type = 'obj_' + content_type
@@ -2220,16 +2219,16 @@ class Model():
     def new_obj_node(self, flavour, name_space = 'resqml2', is_top_lvl_obj = True):
         """Creates a new main object element and sets attributes (does not add children).
 
-      arguments:
-         flavour (string): the resqml object class (type of part) for which a new xml tree
-            is required
-         name_space (string, default 'resqml2'): the xml namespace identifier to use for the node
-         is_top_lvl_obj (boolean, default True): if True, the xsi:type is set in the xml node,
-            as required for top level objects (parts); if False, the type atttribute is not set
+        arguments:
+           flavour (string): the resqml object class (type of part) for which a new xml tree
+              is required
+           name_space (string, default 'resqml2'): the xml namespace identifier to use for the node
+           is_top_lvl_obj (boolean, default True): if True, the xsi:type is set in the xml node,
+              as required for top level objects (parts); if False, the type atttribute is not set
 
-      returns:
-         newly created root node for xml tree for flavour of object, without any children
-      """
+        returns:
+           newly created root node for xml tree for flavour of object, without any children
+        """
 
         if flavour.startswith('obj_'):
             flavour = flavour[4:]
@@ -2276,19 +2275,19 @@ class Model():
     def create_ref_node(self, flavour, title, uuid, content_type = None, root = None):
         """Create a reference node, optionally add to root.
 
-      arguments:
-         flavour (string): the resqml object class (type of part) for which a
-            reference node is required
-         title (string): used as the Title subelement text in the reference node
-         uuid: (uuid.UUID): the uuid of the part being referenced
-         content_type (string, optional): if None, the referenced content type is
-            determined from the flavour argument (recommended)
-         root (optional): if not None, an xml node to which the reference node is
-            appended as a child
+        arguments:
+           flavour (string): the resqml object class (type of part) for which a
+              reference node is required
+           title (string): used as the Title subelement text in the reference node
+           uuid: (uuid.UUID): the uuid of the part being referenced
+           content_type (string, optional): if None, the referenced content type is
+              determined from the flavour argument (recommended)
+           root (optional): if not None, an xml node to which the reference node is
+              appended as a child
 
-      returns:
-         newly created reference xml node
-      """
+        returns:
+           newly created reference xml node
+        """
 
         assert uuid is not None
 
@@ -2336,13 +2335,13 @@ class Model():
     def uom_node(self, root, uom):
         """Add a generic unit of measure sub element to root.
 
-      arguments:
-         root: xml node to which unit of measure subelement (child) will be added
-         uom (string): the resqml unit of measure
+        arguments:
+           root: xml node to which unit of measure subelement (child) will be added
+           uom (string): the resqml unit of measure
 
-      returns:
-         newly created unit of measure node (having already been added to root)
-      """
+        returns:
+           newly created unit of measure node (having already been added to root)
+        """
 
         assert root is not None and uom is not None and len(uom)
 
@@ -2355,12 +2354,12 @@ class Model():
     def create_rels_part(self):
         """Adds a relationships reference node as a new part in the model's parts forest.
 
-      returns:
-         newly created main relationships reference xml node
+        returns:
+           newly created main relationships reference xml node
 
-      note:
-         there can only be one relationships reference part in the model
-      """
+        note:
+           there can only be one relationships reference part in the model
+        """
 
         rels = rqet.SubElement(self.main_root, ns['content_types'] + 'Default')
         rels.set('Extension', 'rels')
@@ -2373,17 +2372,17 @@ class Model():
     def create_citation(self, root = None, title = '', originator = None):
         """Creates a citation xml node and optionally appends as a child of root.
 
-      arguments:
-         root (optional): if not None, the newly created citation node is appended as
-            a child to this node
-         title (string): the citation title: a human readable string; this is the main point
-            of having a citation node, so the argument should be used wisely
-         originator (string, optional): the name of the human being who created the object
-            which this citation is for; default is to use the login name
+        arguments:
+           root (optional): if not None, the newly created citation node is appended as
+              a child to this node
+           title (string): the citation title: a human readable string; this is the main point
+              of having a citation node, so the argument should be used wisely
+           originator (string, optional): the name of the human being who created the object
+              which this citation is for; default is to use the login name
 
-      returns:
-         newly created citation xml node
-      """
+        returns:
+           newly created citation xml node
+        """
 
         if not title:
             title = '(no title)'
@@ -2426,15 +2425,15 @@ class Model():
     def title_for_root(self, root = None):
         """Returns the Title text from the Citation within the given root node.
 
-      arguments:
-         root: the xml node for the object for which the citation title is required
+        arguments:
+           root: the xml node for the object for which the citation title is required
 
-      returns:
-         string being the Title text from the citation node which is a child of root,
-         or None if not found
+        returns:
+           string being the Title text from the citation node which is a child of root,
+           or None if not found
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         title = rqet.find_tag(rqet.find_tag(root, 'Citation'), 'Title')
         if title is None:
@@ -2445,30 +2444,30 @@ class Model():
     def title_for_part(self, part_name):  # duplicate functionality to citation_title_for_part()
         """Returns the Title text from the Citation for the given main part name (not for rels).
 
-      arguments:
-         part_name (string): the name of the part for which the citation title is required
+        arguments:
+           part_name (string): the name of the part for which the citation title is required
 
-      returns:
-         string being the Title text from the citation node which is a child of the root xml node
-         for the part, or None if not found
+        returns:
+           string being the Title text from the citation node which is a child of the root xml node
+           for the part, or None if not found
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.title_for_root(self.root_for_part(part_name))
 
     def create_unknown(self, root = None):
         """Creates an Unknown node and optionally adds as child of root.
 
-      arguments:
-         root (optional): if present, the newly created Unknown node is appended as a child
-            of this xml node
+        arguments:
+           root (optional): if present, the newly created Unknown node is appended as a child
+              of this xml node
 
-      returns:
-         the newly created Unknown xml node
+        returns:
+           the newly created Unknown xml node
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         unknown = rqet.Element(ns['eml'] + 'Unknown')
         unknown.set(ns['xsi'] + 'type', ns['eml'] + 'DescriptionString')
@@ -2480,20 +2479,20 @@ class Model():
     def create_doc_props(self, add_as_part = True, root = None, originator = None):
         """Creates a document properties stub node and optionally adds as child of root and/or to parts forest.
 
-      arguments:
-         add_as_part (boolean, default True): if True, the newly created node is also added as a part
-         root (optional, usually None): if not None, the newly created node is appended to this root
-            as a child
-         originator (string, optional): used as the creator in the doc props node; if None, the
-            login name is used
+        arguments:
+           add_as_part (boolean, default True): if True, the newly created node is also added as a part
+           root (optional, usually None): if not None, the newly created node is appended to this root
+              as a child
+           originator (string, optional): used as the creator in the doc props node; if None, the
+              login name is used
 
-      returns:
-         the newly created doc props xml node
+        returns:
+           the newly created doc props xml node
 
-      note:
-         the doc props part of a resqml dataset is intended to hold documentation and
-         other stuff that is not covered by the standard; there should be exactly one doc props part
-      """
+        note:
+           the doc props part of a resqml dataset is intended to hold documentation and
+           other stuff that is not covered by the standard; there should be exactly one doc props part
+        """
 
         dp = rqet.Element(ns['cp'] + 'coreProperties')
         dp.text = rqet.null_xml_text
@@ -2581,15 +2580,15 @@ class Model():
     def create_crs_reference(self, crs_root = None, root = None, crs_uuid = None):
         """Creates a node refering to an existing crs node and optionally adds as child of root.
 
-      arguments:
-         crs_root: DEPRECATED, use uuid instead; the root xml node for the coordinate reference system being referenced
-         root: the xml node to which the new reference node is to appended as a child (ie. the xml node
-            for the object that is referring to the crs)
-         crs_uuid: the uuid of the crs
+        arguments:
+           crs_root: DEPRECATED, use uuid instead; the root xml node for the coordinate reference system being referenced
+           root: the xml node to which the new reference node is to appended as a child (ie. the xml node
+              for the object that is referring to the crs)
+           crs_uuid: the uuid of the crs
 
-      returns:
-         newly created crs reference xml node
-      """
+        returns:
+           newly created crs reference xml node
+        """
 
         if crs_uuid is None:
             warnings.warn('use of crs_root is deprecated in Model.create_crs_reference(); use crs_uuid instead')
@@ -2607,14 +2606,14 @@ class Model():
     def create_md_datum_reference(self, md_datum_root, root = None):
         """Creates a node refering to an existing measured depth datum and optionally adds as child of root.
 
-      arguments:
-         md_datum_root: the root xml node for the measured depth datum being referenced
-         root: the xml node to which the new reference node is to appended as a child (ie. the xml node
-            for the object that is referring to the md datum)
+        arguments:
+           md_datum_root: the root xml node for the measured depth datum being referenced
+           root: the xml node to which the new reference node is to appended as a child (ie. the xml node
+              for the object that is referring to the md datum)
 
-      returns:
-         newly created measured depth datum reference xml node
-      """
+        returns:
+           newly created measured depth datum reference xml node
+        """
 
         return self.create_ref_node('MdDatum',
                                     rqet.find_nested_tags_text(md_datum_root, ['Citation', 'Title']),
@@ -2630,19 +2629,19 @@ class Model():
                         file_name = None):
         """Creates an hdf5 external node and optionally adds as child of root and/or to parts forest.
 
-      arguments:
-         add_as_part (boolean, default True): if True the newly created ext node is added to the model
-            as a part
-         root (optional, usually None): if not None, the newly created ext node is appended as a child
-            of this node
-         title (string): used as the Title text in the citation node, usually left at the default 'Hdf Proxy'
-         originator (string, optional): the name of the human being who created the ext object;
-            default is to use the login name
-         file_name (string): the filename to be stored as the Target in the relationship node
+        arguments:
+           add_as_part (boolean, default True): if True the newly created ext node is added to the model
+              as a part
+           root (optional, usually None): if not None, the newly created ext node is appended as a child
+              of this node
+           title (string): used as the Title text in the citation node, usually left at the default 'Hdf Proxy'
+           originator (string, optional): the name of the human being who created the ext object;
+              default is to use the login name
+           file_name (string): the filename to be stored as the Target in the relationship node
 
-      returns:
-         newly created hdf5 external part xml node
-      """
+        returns:
+           newly created hdf5 external part xml node
+        """
 
         ext = self.new_obj_node('EpcExternalPartReference', name_space = 'eml')
 
@@ -2677,18 +2676,18 @@ class Model():
     def create_hdf5_dataset_ref(self, hdf5_uuid, object_uuid, group_tail, root, title = 'Hdf Proxy'):
         """Creates a pair of nodes referencing an hdf5 dataset (array) and adds to root.
 
-      arguments:
-         hdf5_uuid (uuid.UUID): the uuid of the hdf5 external part being referenced
-         object_uuid (uuid.UUID): the uuid of the high level object (part) which owns the hdf5 array
-            being referenced
-         group_tail (string): the tail of the hdf5 internal path, which is appended to the part
-            name section of the internal path
-         root: the xml node to which the newly created hdf5 reference is appended as a child
-         title (string): used as the Title text in the citation node, usually left at the default 'Hdf Proxy'
+        arguments:
+           hdf5_uuid (uuid.UUID): the uuid of the hdf5 external part being referenced
+           object_uuid (uuid.UUID): the uuid of the high level object (part) which owns the hdf5 array
+              being referenced
+           group_tail (string): the tail of the hdf5 internal path, which is appended to the part
+              name section of the internal path
+           root: the xml node to which the newly created hdf5 reference is appended as a child
+           title (string): used as the Title text in the citation node, usually left at the default 'Hdf Proxy'
 
-      returns:
-         the newly created xml node holding the hdf5 internal path
-      """
+        returns:
+           the newly created xml node holding the hdf5 internal path
+        """
 
         assert root is not None
         assert group_tail
@@ -2718,26 +2717,26 @@ class Model():
                                          content_type = 'obj_IjkGridRepresentation'):
         """Craate a supporting representation reference node refering to an IjkGrid and optionally add to root.
 
-      arguments:
-         grid_root: the xml node of the grid object which is the supporting representation being
-            referred to; could also be used for other classes of supporting object; this or support_uuid
-            must be provided
-         support_uuid: the uuid of the grid (or other supporting representation) being referred to;
-            this or grid_root must be provided
-         root: if not None, the newly created supporting representation node is appended as a child
-            to this node
-         title: the Title to use in the supporting representation node
-         content_type: the resqml object class of the supporting representation being referenced;
-            defaults to 'obj_IjkGridRepresentation'
+        arguments:
+           grid_root: the xml node of the grid object which is the supporting representation being
+              referred to; could also be used for other classes of supporting object; this or support_uuid
+              must be provided
+           support_uuid: the uuid of the grid (or other supporting representation) being referred to;
+              this or grid_root must be provided
+           root: if not None, the newly created supporting representation node is appended as a child
+              to this node
+           title: the Title to use in the supporting representation node
+           content_type: the resqml object class of the supporting representation being referenced;
+              defaults to 'obj_IjkGridRepresentation'
 
-      returns:
-         newly created xml node for supporting representation reference
+        returns:
+           newly created xml node for supporting representation reference
 
-      notes:
-         a property array needs a supporting representation which is the structure that the property
-         values belong to; for example, a grid property array has the grid object as the supporting
-         representation; one of grid_root or support_uuid should be passed when calling this method
-      """
+        notes:
+           a property array needs a supporting representation which is the structure that the property
+           values belong to; for example, a grid property array has the grid object as the supporting
+           representation; one of grid_root or support_uuid should be passed when calling this method
+        """
 
         assert grid_root is not None or support_uuid is not None
 
@@ -2763,13 +2762,13 @@ class Model():
     def create_source(self, source, root = None):
         """Create an extra meta data node holding information on the source of the data, optionally add to root.
 
-      arguments:
-         source (string): text describing the source of an object
-         root: if not None, the newly created extra metadata node is appended as a child of this node
+        arguments:
+           source (string): text describing the source of an object
+           root: if not None, the newly created extra metadata node is appended as a child of this node
 
-      returns:
-         the newly created extra metadata xml node
-      """
+        returns:
+           the newly created extra metadata xml node
+        """
 
         emd_node = rqet.Element(ns['resqml2'] + 'ExtraMetadata')
         emd_node.set(ns['xsi'] + 'type', ns['resqml2'] + 'NameValuePair')
@@ -2800,36 +2799,36 @@ class Model():
                      points = False):
         """Create a node for a patch of values, including ref to hdf5 data set, optionally add to root.
 
-      arguments:
-         p_uuid (uuid.UUID): the uuid of the object for which this patch is a component
-         ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the array; required unless
-            const_value and const_count are not None
-         root: if not None, the newly created patch of values xml node is appended as a child
-            to this node
-         patch_index (int, default 0): the patch index number; patches must be numbered
-            sequentially starting at 0
-         hdf5_type (string, default 'DoubleHdf5Array'): the type of the hdf5 array; usually one of
-            'DoubleHdf5Array', 'IntegerHdf5Array', or 'BooleanHdf5Array'; replaced with equivalent
-            constant array type if const_value is not None
-         xsd_type (string, default 'double'): the xsd simple type of each element of the array
-         null_value: Used in a null value sub-node to specify what value in an array of discrete data represents null;
-            if None, a value of -1 is used for signed integers, 2^32 - 1 for uints (even 64 bit uints!)
-         const_value (float, int, or bool, optional): if not None, the patch is created as a constant array;
-            const_count must also be present if const_value is not None
-         const_count (int, optional): the number of elements in (size of) the constant array; required if
-            const_value is not None, ignored otherwise
-         points (bool, default False): if True, the created node will be for a patch of points,
-            otherwise a patch of values
+        arguments:
+           p_uuid (uuid.UUID): the uuid of the object for which this patch is a component
+           ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the array; required unless
+              const_value and const_count are not None
+           root: if not None, the newly created patch of values xml node is appended as a child
+              to this node
+           patch_index (int, default 0): the patch index number; patches must be numbered
+              sequentially starting at 0
+           hdf5_type (string, default 'DoubleHdf5Array'): the type of the hdf5 array; usually one of
+              'DoubleHdf5Array', 'IntegerHdf5Array', or 'BooleanHdf5Array'; replaced with equivalent
+              constant array type if const_value is not None
+           xsd_type (string, default 'double'): the xsd simple type of each element of the array
+           null_value: Used in a null value sub-node to specify what value in an array of discrete data represents null;
+              if None, a value of -1 is used for signed integers, 2^32 - 1 for uints (even 64 bit uints!)
+           const_value (float, int, or bool, optional): if not None, the patch is created as a constant array;
+              const_count must also be present if const_value is not None
+           const_count (int, optional): the number of elements in (size of) the constant array; required if
+              const_value is not None, ignored otherwise
+           points (bool, default False): if True, the created node will be for a patch of points,
+              otherwise a patch of values
 
-      returns:
-         newly created xml node for the patch of values
+        returns:
+           newly created xml node for the patch of values
 
-      note:
-         this function does not write the data to the hdf5; that should be done separately before
-         calling this method;
-         RESQML usually stores array data in the hdf5 file however constant arrays are flagged as
-         such in the xml and no data is stored in the hdf5
-      """
+        note:
+           this function does not write the data to the hdf5; that should be done separately before
+           calling this method;
+           RESQML usually stores array data in the hdf5 file however constant arrays are flagged as
+           such in the xml and no data is stored in the hdf5
+        """
 
         if const_value is None:
             assert ext_uuid is not None
@@ -2901,29 +2900,29 @@ class Model():
     def create_time_series_ref(self, time_series_uuid, root = None):
         """Create a reference node to a time series, optionally add to root.
 
-      arguments:
-         time_series_uuid (uuid.UUID): the uuid of the time series part being referenced
-         root (optional): if present, the newly created time series reference xml node is added
-            as a child to this node
+        arguments:
+           time_series_uuid (uuid.UUID): the uuid of the time series part being referenced
+           root (optional): if present, the newly created time series reference xml node is added
+              as a child to this node
 
-      returns:
-         the newly created time series reference xml node
-      """
+        returns:
+           the newly created time series reference xml node
+        """
 
         return self.create_ref_node('TimeSeries', 'time series', time_series_uuid, root = root)
 
     def create_solitary_point3d(self, flavour, root, xyz):
         """Creates a subelement to root for a solitary point in 3D space.
 
-      arguments:
-         flavour (string): the object class (type) of the point node to be created
-         root: the xml node to which the newly created solitary point node is appended
-            as a child
-         xyz (triple float): the x, y, z coordinates of the solitary point
+        arguments:
+           flavour (string): the object class (type) of the point node to be created
+           root: the xml node to which the newly created solitary point node is appended
+              as a child
+           xyz (triple float): the x, y, z coordinates of the solitary point
 
-      returns:
-         the newly created xml node for the solitary point
-      """
+        returns:
+           the newly created xml node for the solitary point
+        """
 
         # todo: check namespaces
         p3d = rqet.SubElement(root, ns['resqml2'] + flavour)
@@ -2940,19 +2939,19 @@ class Model():
     def create_reciprocal_relationship(self, node_a, rel_type_a, node_b, rel_type_b, avoid_duplicates = True):
         """Adds a node to each of a pair of trees in the rels forest, to represent a two-way relationship.
 
-      arguments:
-         node_a: one of the two xml nodes to be related
-         rel_type_a (string): the Type (role) associated with node_a in the relationship;
-            usually 'sourceObject' or 'destinationObject'
-         node_b: the other xml node to be related
-         rel_type_a (string): the Type (role) associated with node_b in the relationship
-            usually 'sourceObject' or 'destinationObject' (opposite of rel_type_a)
-         avoid_duplicates (boolean, default True): if True, xml for a relationship is not added
-            where it already exists; if False, a duplicate will be created in this situation
+        arguments:
+           node_a: one of the two xml nodes to be related
+           rel_type_a (string): the Type (role) associated with node_a in the relationship;
+              usually 'sourceObject' or 'destinationObject'
+           node_b: the other xml node to be related
+           rel_type_a (string): the Type (role) associated with node_b in the relationship
+              usually 'sourceObject' or 'destinationObject' (opposite of rel_type_a)
+           avoid_duplicates (boolean, default True): if True, xml for a relationship is not added
+              where it already exists; if False, a duplicate will be created in this situation
 
-      returns:
-         None
-      """
+        returns:
+           None
+        """
 
         def id_str(uuid):
             stringy = str(uuid)
@@ -3015,21 +3014,21 @@ class Model():
     def duplicate_node(self, existing_node, add_as_part = True):
         """Creates a deep copy of the xml node (typically from another model) and optionally adds as part.
 
-      arguments:
-         existing_node: the existing xml node, usually in another model, to be duplicated
-         add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-            in this model
+        arguments:
+           existing_node: the existing xml node, usually in another model, to be duplicated
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in this model
 
-      returns:
-         the newly created duplicate xml node
+        returns:
+           the newly created duplicate xml node
 
-      notes:
-         hdf5 data is not copied by this function and any reference to hdf5 arrays will be naively
-         duplicated;
-         the uuid of the part is not changed by this function, so if the source and target models are
-         the same, add as part should be set False and calling code will need to assign a new uuid
-         prior to adding as part
-      """
+        notes:
+           hdf5 data is not copied by this function and any reference to hdf5 arrays will be naively
+           duplicated;
+           the uuid of the part is not changed by this function, so if the source and target models are
+           the same, add as part should be set False and calling code will need to assign a new uuid
+           prior to adding as part
+        """
 
         new_node = copy.deepcopy(existing_node)
         if add_as_part:
@@ -3041,7 +3040,8 @@ class Model():
         return new_node
 
     def force_consolidation_uuid_equivalence(self, immigrant_uuid, resident_uuid):
-        """Forces object identified by immigrant uuid to be teated as equivalent to that with resident uuid during consolidation."""
+        """Forces object identified by immigrant uuid to be teated as equivalent to that with resident uuid during
+        consolidation."""
 
         if self.consolidation is None:
             self.consolidation = cons.Consolidation(self)
@@ -3060,30 +3060,30 @@ class Model():
                                    other_h5_file_name = None):
         """Fully copies part in from another model, with referenced parts, hdf5 data and relationships.
 
-      arguments:
-         other model (Model): the source model from which to copy a part
-         part (string): the part name in the other model to copy into this model
-         realization (int, optional): if present and the part is a property, the realization
-            will be set to this value, instead of the value in use in the other model if any
-         consolidate (boolean, default True): if True and an equivalent part already exists in
-            this model, do not duplicate but instead note uuids as equivalent
-         force (boolean, default False): if True, the part itself is copied without much checking
-            and all references are required to be handled by an entry in the consolidation object
-         cut_refs_to_uuids (list of UUIDs, optional): if present, then xml reference nodes
-            referencing any of the listed uuids are cut out in the copy; use with caution
-         cut_node_types (list of str, optional): if present, any child nodes of a type in the list
-            will be cut out in the copy; use with caution
-         self_h5_file_name (string, optional): h5 file name for this model; can be passed as
-            an optimisation when calling method repeatedly
-         h5_uuid (uuid, optional): UUID for this model's hdf5 external part; can be passed as
-            an optimisation when calling method repeatedly
-         other_h5_file_name (string, optional): h5 file name for other model; can be passed as
-            an optimisation when calling method repeatedly
+        arguments:
+           other model (Model): the source model from which to copy a part
+           part (string): the part name in the other model to copy into this model
+           realization (int, optional): if present and the part is a property, the realization
+              will be set to this value, instead of the value in use in the other model if any
+           consolidate (boolean, default True): if True and an equivalent part already exists in
+              this model, do not duplicate but instead note uuids as equivalent
+           force (boolean, default False): if True, the part itself is copied without much checking
+              and all references are required to be handled by an entry in the consolidation object
+           cut_refs_to_uuids (list of UUIDs, optional): if present, then xml reference nodes
+              referencing any of the listed uuids are cut out in the copy; use with caution
+           cut_node_types (list of str, optional): if present, any child nodes of a type in the list
+              will be cut out in the copy; use with caution
+           self_h5_file_name (string, optional): h5 file name for this model; can be passed as
+              an optimisation when calling method repeatedly
+           h5_uuid (uuid, optional): UUID for this model's hdf5 external part; can be passed as
+              an optimisation when calling method repeatedly
+           other_h5_file_name (string, optional): h5 file name for other model; can be passed as
+              an optimisation when calling method repeatedly
 
-      notes:
-         if the part name already exists in this model, no action is taken;
-         default hdf5 file used in this model and assumed in other_model
-      """
+        notes:
+           if the part name already exists in this model, no action is taken;
+           default hdf5 file used in this model and assumed in other_model
+        """
 
         # todo: double check behaviour around equivalent CRSes, especially any default crs in model
 
@@ -3232,18 +3232,18 @@ class Model():
     def copy_all_parts_from_other_model(self, other_model, realization = None, consolidate = True):
         """Fully copies parts in from another model, with referenced parts, hdf5 data and relationships.
 
-      arguments:
-         other model (Model): the source model from which to copy parts
-         realization (int, optional): if present, the realization attribute of property parts
-            will be set to this value, instead of the value in use in the other model if any
-         consolidate (boolean, default True): if True, where equivalent part already exists in
-            this model, do not duplicate but instead note uuids as equivalent, modifying
-            references and relationships of other copied parts appropriately
+        arguments:
+           other model (Model): the source model from which to copy parts
+           realization (int, optional): if present, the realization attribute of property parts
+              will be set to this value, instead of the value in use in the other model if any
+           consolidate (boolean, default True): if True, where equivalent part already exists in
+              this model, do not duplicate but instead note uuids as equivalent, modifying
+              references and relationships of other copied parts appropriately
 
-      notes:
-         part names already existing in this model are not duplicated;
-         default hdf5 file used in this model and assumed in other_model
-      """
+        notes:
+           part names already existing in this model are not duplicated;
+           default hdf5 file used in this model and assumed in other_model
+        """
 
         assert other_model is not None and other_model is not self
 
@@ -3271,26 +3271,26 @@ class Model():
             self.consolidation.check_map_integrity()
 
     def iter_objs(self, cls):
-        """Iterate over all available objects of given resqpy class within the model
+        """Iterate over all available objects of given resqpy class within the model.
 
-      Note:
+        Note:
 
-         The resqpy class must expose a class attribute `resqml_type`, and must support
-         being created with the signature: `obj = cls(model, uuid=uuid)`.
+           The resqpy class must expose a class attribute `resqml_type`, and must support
+           being created with the signature: `obj = cls(model, uuid=uuid)`.
 
-      Example use::
+        Example use::
 
-         for well in model.iter_objs(cls=resqpy.well.WellboreFeature):
-            print(well.title, well.uuid)
+           for well in model.iter_objs(cls=resqpy.well.WellboreFeature):
+              print(well.title, well.uuid)
 
-      Args:
-         cls: resqpy class to iterate
+        Args:
+           cls: resqpy class to iterate
 
-      Yields:
-         list of instances of cls
+        Yields:
+           list of instances of cls
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         uuids = self.uuids(obj_type = cls.resqml_type)
         for uuid in uuids:
@@ -3304,13 +3304,13 @@ class Model():
             yield rqf.GridConnectionSet(self, uuid = gcs_uuid)
 
     def iter_wellbore_interpretations(self):
-        """ Iterable of all WellboreInterpretations associated with the model
+        """Iterable of all WellboreInterpretations associated with the model.
 
-      Yields:
-         wellbore: instance of :class:`resqpy.organize.WellboreInterpretation`
+        Yields:
+           wellbore: instance of :class:`resqpy.organize.WellboreInterpretation`
 
-      :meta common:
-      """
+        :meta common:
+        """
         import resqpy.organize  # Imported here for speed, module is not always needed
 
         uuids = self.uuids(obj_type = 'WellboreInterpretation')
@@ -3319,13 +3319,13 @@ class Model():
                 yield resqpy.organize.WellboreInterpretation(self, uuid = uuid)
 
     def iter_trajectories(self):
-        """ Iterable of all trajectories associated with the model
+        """Iterable of all trajectories associated with the model.
 
-      Yields:
-         trajectory: instance of :class:`resqpy.well.Trajectory`
+        Yields:
+           trajectory: instance of :class:`resqpy.well.Trajectory`
 
-      :meta common:
-      """
+        :meta common:
+        """
         import resqpy.well  # Imported here for speed, module is not always needed
 
         uuids = self.uuids(obj_type = "WellboreTrajectoryRepresentation")
@@ -3333,13 +3333,13 @@ class Model():
             yield resqpy.well.Trajectory(self, uuid = uuid)
 
     def iter_md_datums(self):
-        """ Iterable of all MdDatum objects associated with the model
+        """Iterable of all MdDatum objects associated with the model.
 
-      Yields:
-         md_datum: instance of :class:`resqpy.well.MdDatum`
+        Yields:
+           md_datum: instance of :class:`resqpy.well.MdDatum`
 
-      :meta common:
-      """
+        :meta common:
+        """
         import resqpy.well  # Imported here to avoid circular imports
 
         uuids = self.uuids(obj_type = 'MdDatum')
@@ -3349,13 +3349,13 @@ class Model():
                 yield datum
 
     def iter_crs(self):
-        """Iterable of all CRS objects associated with the model
-      
-      Yields:
-         crs: instance of :class:`resqpy.crs.CRS`
+        """Iterable of all CRS objects associated with the model.
 
-      :meta common:
-      """
+        Yields:
+           crs: instance of :class:`resqpy.crs.CRS`
+
+        :meta common:
+        """
         import resqpy.crs  # Imported here for speed, module is not always needed
 
         uuids = self.uuids(obj_type = 'LocalDepth3dCrs') + self.uuids(obj_type = 'LocalTime3dCrs')
@@ -3381,48 +3381,48 @@ class Model():
         return results
 
     def as_graph(self, uuids_subset = None):
-        """Return representation of model as nodes and edges, suitable for plotting in a graph
+        """Return representation of model as nodes and edges, suitable for plotting in a graph.
 
-      Note:
-         The graph can be most readily visualised with other packages such as
-         NetworkX and HoloViews, which are not part of resqpy.
+        Note:
+           The graph can be most readily visualised with other packages such as
+           NetworkX and HoloViews, which are not part of resqpy.
 
-         For a guide to plotting graphs interactively, see:
-         http://holoviews.org/user_guide/Network_Graphs.html
+           For a guide to plotting graphs interactively, see:
+           http://holoviews.org/user_guide/Network_Graphs.html
 
-      Example::
+        Example::
 
-         # Create the nodes and edges
-         nodes, edges = model.as_graph()
+           # Create the nodes and edges
+           nodes, edges = model.as_graph()
 
-         # Load into a NetworkX graph
-         import networkx as nx
-         g = nx.Graph()
-         g.add_nodes_from(nodes.items())
-         g.add_edges_from(edges)
+           # Load into a NetworkX graph
+           import networkx as nx
+           g = nx.Graph()
+           g.add_nodes_from(nodes.items())
+           g.add_edges_from(edges)
 
-         # Import holoviews
-         import holoviews as hv
-         from holoviews import opts
-         hv.extension('bokeh')
+           # Import holoviews
+           import holoviews as hv
+           from holoviews import opts
+           hv.extension('bokeh')
 
-         # Plot
-         hv.Graph.from_networkx(g, nx.layout.spring_layout).opts(
-            tools=['hover'], node_color='resqml_type', cmap='Category10'
-         )
+           # Plot
+           hv.Graph.from_networkx(g, nx.layout.spring_layout).opts(
+              tools=['hover'], node_color='resqml_type', cmap='Category10'
+           )
 
-      Args:
-         uuids_subset (iterable): If present, only consider uuids in this list.
-            By default, use all uuids in the model.
+        Args:
+           uuids_subset (iterable): If present, only consider uuids in this list.
+              By default, use all uuids in the model.
 
-      Returns:
-         2-tuple of nodes and edges:
+        Returns:
+           2-tuple of nodes and edges:
 
-         - nodes: dict mapping uuid to attributes (e.g. citation title)
-         - edges: set of unordered pairs of uuids, representing relationships
+           - nodes: dict mapping uuid to attributes (e.g. citation title)
+           - edges: set of unordered pairs of uuids, representing relationships
 
-      :meta common:
-      """
+        :meta common:
+        """
         nodes = {}
         edges = set()
 
@@ -3460,7 +3460,7 @@ class Model():
 
 
 class ModelContext:
-    """Context manager for easy opening and closing of resqpy models
+    """Context manager for easy opening and closing of resqpy models.
 
     When a model is opened this way, any open file handles are safely closed
     when the "with" clause exits. Optionally, the epc can be written back to
@@ -3475,7 +3475,6 @@ class ModelContext:
 
         The "write_hdf5" and "create_xml" methods of individual resqpy objects
         still need to be invoked as usual.
-   
     """
 
     def __init__(self, epc_file, mode = "r") -> None:
@@ -3486,7 +3485,7 @@ class ModelContext:
         - In "read" mode, an existing epc file is opened. Any changes are not
         saved to disk automatically, but can still be saved by calling
         `model.store_epc()`.
-        - In "read/write" mode, changes are written to disk when the context exists. 
+        - In "read/write" mode, changes are written to disk when the context exists.
         - In "create" mode, a new model is created and saved upon exit. Any existing
             model will be deleted.
 

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -1,4 +1,4 @@
-"""Base class for generic resqml objects """
+"""Base class for generic resqml objects."""
 
 import logging
 import warnings
@@ -11,26 +11,25 @@ logger = logging.getLogger(__name__)
 
 
 class BaseResqpy(metaclass = ABCMeta):
-    """Base class for generic resqpy classes
-    
+    """Base class for generic resqpy classes.
+
     Implements generic attributes such as uuid, root, part, title, originator.
 
     Implements generic magic methods, such as pretty printing and testing for
     equality.
-    
+
     Example use::
 
         class AnotherResqpyObject(BaseResqpy):
-            
-            resqml_type = 'obj_anotherresqmlobjectrepresentation'
 
+            resqml_type = 'obj_anotherresqmlobjectrepresentation'
     """
 
     @property
     @abstractmethod
     def resqml_type(self):
         """Definition of which RESQML object the class represents.
-        
+
         Subclasses must overwrite this abstract attribute.
         """
         raise NotImplementedError
@@ -79,7 +78,7 @@ class BaseResqpy(metaclass = ABCMeta):
 
     @property
     def part(self):
-        """Standard part name corresponding to self.uuid"""
+        """Standard part name corresponding to self.uuid."""
 
         # following caused trouble when resqml_type dynamically determined
         #       return rqet.part_name_for_object(self.resqml_type, self.uuid)
@@ -87,13 +86,13 @@ class BaseResqpy(metaclass = ABCMeta):
 
     @property
     def root(self):
-        """XML node corresponding to self.uuid"""
+        """XML node corresponding to self.uuid."""
 
         return self.model.root_for_uuid(self.uuid)
 
     @property
     def citation_title(self):
-        """Citation block title equivalent to self.title"""
+        """Citation block title equivalent to self.title."""
 
         return self.title
 
@@ -127,8 +126,8 @@ class BaseResqpy(metaclass = ABCMeta):
         return False
 
     def create_xml(self, title = None, originator = None, extra_metadata = None, add_as_part = False):
-        """Write citation block to XML
-        
+        """Write citation block to XML.
+
         Note:
 
             `add_as_part` is False by default in this base method. Derived classes should typically
@@ -191,7 +190,7 @@ class BaseResqpy(metaclass = ABCMeta):
     # Generic magic methods
 
     def __eq__(self, other):
-        """Implements equals operator; uses is_equivalent() otherwise compares class type and uuid"""
+        """Implements equals operator; uses is_equivalent() otherwise compares class type and uuid."""
         if hasattr(self, 'is_equivalent'):
             return self.is_equivalent(other)
         if not isinstance(other, self.__class__):
@@ -200,15 +199,15 @@ class BaseResqpy(metaclass = ABCMeta):
         return bu.matching_uuids(self.uuid, other_uuid)
 
     def __ne__(self, other):
-        """Implements not equal operator"""
+        """Implements not equal operator."""
         return not self.__eq__(other)
 
     def __repr__(self):
-        """String representation"""
+        """String representation."""
         return f"{self.__class__.__name__}(uuid={self.uuid}, title={self.title})"
 
     def _repr_html_(self):
-        """IPython / Jupyter representation"""
+        """IPython / Jupyter representation."""
 
         keys_to_display = ('uuid', 'title', 'originator')
         html = f"<h3>{self.__class__.__name__}</h3>\n"
@@ -221,12 +220,18 @@ class BaseResqpy(metaclass = ABCMeta):
 
     @property
     def root_node(self):
-        """DEPRECATED. Alias for root"""
+        """DEPRECATED.
+
+        Alias for root
+        """
         warnings.warn("Attribute 'root_node' is deprecated. Use 'root'", DeprecationWarning)
         return self.root
 
     @property
     def node(self):
-        """DEPRECATED. Alias for root"""
+        """DEPRECATED.
+
+        Alias for root
+        """
         warnings.warn("Attribute 'node' is deprecated. Use 'root'", DeprecationWarning)
         return self.root

--- a/resqpy/olio/box_utilities.py
+++ b/resqpy/olio/box_utilities.py
@@ -39,13 +39,13 @@ import numpy as np
 def extent_of_box(box):  # returns 3 element extent of box (box can be kji or ijk, 0 or 1 based)
     """Returns a 3 integer numpy array holding the size of the box, with the same ordering as the box.
 
-   input argument (unmodified):
-      box: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+    input argument (unmodified):
+       box: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
 
-   returns: numpy int array of shape (3)
-         the extent (shape) of the cuboid defined by box
-   """
+    returns: numpy int array of shape (3)
+          the extent (shape) of the cuboid defined by box
+    """
 
     assert box.ndim == 2 and box.shape == (2, 3)
     return box[1] - box[0] + 1  # numpy array operation
@@ -54,13 +54,13 @@ def extent_of_box(box):  # returns 3 element extent of box (box can be kji or ij
 def volume_of_box(box):
     """Returns the number of cells in the logical 3D cell space defined by box.
 
-   input argument (unmodified):
-      box: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+    input argument (unmodified):
+       box: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
 
-   returns: int
-         the total number of cells in box
-   """
+    returns: int
+          the total number of cells in box
+    """
 
     return (box[1, 0] - box[0, 0] + 1) * (box[1, 1] - box[0, 1] + 1) * (box[1, 2] - box[0, 2] + 1)
 
@@ -72,14 +72,14 @@ def central_cell(box):
 def string_iijjkk1_for_box_kji0(box_kji0):
     """Returns a string representing the box space in simulator protocol, eg. '[1:5, 3:20, 100:103]'.
 
-   input argument (unmodified):
-      box_kji0: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         with python kji ordering and zero start for indices
+    input argument (unmodified):
+       box_kji0: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          with python kji ordering and zero start for indices
 
-   returns: string
-      human readable representation of box in Fortran/simulator ijk protocol starting 1
-   """
+    returns: string
+       human readable representation of box in Fortran/simulator ijk protocol starting 1
+    """
 
     return '[' + str(box_kji0[0, 2] + 1) + ':' + str(box_kji0[1, 2] + 1) + ', ' +  \
                  str(box_kji0[0, 1] + 1) + ':' + str(box_kji0[1, 1] + 1) + ', ' +  \
@@ -89,16 +89,16 @@ def string_iijjkk1_for_box_kji0(box_kji0):
 def spaced_string_iijjkk1_for_box_kji0(box_kji0, colon_separator = ' '):
     """Returns a string representing the box space in simulator input format, eg. '1 5  3 20  100 103'.
 
-   input arguments (unmodified):
-      box_kji0: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         with python kji ordering and zero start for indices
-      colon_separator: string (typically ':' or ' ')
-         the character(s) included in the return string between lower and upper bounds in each direction
+    input arguments (unmodified):
+       box_kji0: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          with python kji ordering and zero start for indices
+       colon_separator: string (typically ':' or ' ')
+          the character(s) included in the return string between lower and upper bounds in each direction
 
-   returns: string
-      ascii representation of box in Fortran/simulator ijk protocol starting 1, suitable for use in include files
-   """
+    returns: string
+       ascii representation of box in Fortran/simulator ijk protocol starting 1, suitable for use in include files
+    """
 
     return str(box_kji0[0, 2] + 1) + colon_separator + str(box_kji0[1, 2] + 1) + '  ' +  \
            str(box_kji0[0, 1] + 1) + colon_separator + str(box_kji0[1, 1] + 1) + '  ' +  \
@@ -106,20 +106,20 @@ def spaced_string_iijjkk1_for_box_kji0(box_kji0, colon_separator = ' '):
 
 
 def box_kji0_from_words_iijjkk1(words):
-    """Returns an integer array of extent [2, 3] converted from a list of words representing logical box
+    """Returns an integer array of extent [2, 3] converted from a list of words representing logical box.
 
-   input argument (unmodified):
-      words: a list of strings with at least 6 elements castable to int
-         [min_i, max_i, min_j, max_j, min_k, max_k] in Fortran/simulator protocol (indices start at 1)
+    input argument (unmodified):
+       words: a list of strings with at least 6 elements castable to int
+          [min_i, max_i, min_j, max_j, min_k, max_k] in Fortran/simulator protocol (indices start at 1)
 
-   returns: 2D numpy int array of shape (2, 3)
-      [min, max][k, j, i] with cell indices in python protocol (zero base)
+    returns: 2D numpy int array of shape (2, 3)
+       [min, max][k, j, i] with cell indices in python protocol (zero base)
 
-   notes:
-      designed to take string format numbers: minI maxI minJ maxJ minK maxK
-      and convert to a pair of integer cell id triplets: min(k, j, i), max(k, j, i)
-      NB: output indices have been decremented by 1 (for python indexing starting at zero)
-   """
+    notes:
+       designed to take string format numbers: minI maxI minJ maxJ minK maxK
+       and convert to a pair of integer cell id triplets: min(k, j, i), max(k, j, i)
+       NB: output indices have been decremented by 1 (for python indexing starting at zero)
+    """
 
     assert len(words) >= 6  # expecting minI maxI minJ maxJ minK maxK value
     box = np.zeros([2, 3], dtype = 'int')
@@ -137,16 +137,16 @@ def box_kji0_from_words_iijjkk1(words):
 def cell_in_box(cell, box):
     """Returns True if cell is within box, otherwise False.
 
-   input arguments (unmodified):
-      cell: numpy int array of shape (3)
-         index of a cell in a 3D cartesian grid, in the same protocol as box (usually python protocol kji, zero base)
-      box: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         in the same protocol as cell
+    input arguments (unmodified):
+       cell: numpy int array of shape (3)
+          index of a cell in a 3D cartesian grid, in the same protocol as box (usually python protocol kji, zero base)
+       box: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          in the same protocol as cell
 
-   returns: boolean
-      True if cell is within box, False otherwise
-   """
+    returns: boolean
+       True if cell is within box, False otherwise
+    """
 
     return (box[0, 0] <= cell[0] <= box[1, 0]) and (box[0, 1] <= cell[1] <= box[1, 1]) and (box[0, 2] <= cell[2] <=
                                                                                             box[1, 2])
@@ -155,16 +155,16 @@ def cell_in_box(cell, box):
 def valid_box(box, host_extent):
     """Returns True if the entire box is within a grid of size host_extent.
 
-   input arguments (unmodified):
-      box: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         in python protocol of zero base, kji (normally) or ijk ordering same as for host_extent
-      host_extent: triple int
-         the extent (shape) of a 3D cartesian grid
+    input arguments (unmodified):
+       box: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          in python protocol of zero base, kji (normally) or ijk ordering same as for host_extent
+       host_extent: triple int
+          the extent (shape) of a 3D cartesian grid
 
-   returns: boolean
-      True if box is a valid box within a grid of shape host_extent, False otherwise
-   """
+    returns: boolean
+       True if box is a valid box within a grid of shape host_extent, False otherwise
+    """
 
     if box.ndim != 2 or box.shape != (2, 3) or box.dtype != 'int':
         return False
@@ -179,13 +179,13 @@ def valid_box(box, host_extent):
 def single_cell_box(cell):
     """Returns a box containing the single given cell; protocol for box matches that of cell.
 
-   input argument (unmodified):
-      cell: numpy int array of shape (3)
-         indices of a cell within a 3D cartesian grid, usually in python protocol (kji ordering, zero base)
+    input argument (unmodified):
+       cell: numpy int array of shape (3)
+          indices of a cell within a 3D cartesian grid, usually in python protocol (kji ordering, zero base)
 
-   returns: numpy int array of shape (2, 3)
-      indices defining a minimal box containing a single cell; protocol is same as that of cell
-   """
+    returns: numpy int array of shape (2, 3)
+       indices defining a minimal box containing a single cell; protocol is same as that of cell
+    """
 
     assert cell.ndim == 1 and cell.size == 3
     box = np.zeros((2, 3), dtype = 'int')
@@ -197,13 +197,13 @@ def single_cell_box(cell):
 def full_extent_box0(extent):
     """Returns a box containing all the cells in a grid of the given extent.
 
-   input argument (unmodified):
-      extent: numpy int array of shape (3)
-         extent (shape) of a 3D cartesian grid, usually in kji python protocol
+    input argument (unmodified):
+       extent: numpy int array of shape (3)
+          extent (shape) of a 3D cartesian grid, usually in kji python protocol
 
-   returns: numpy int array of shape (2, 3)
-      indices defining a maximal box containing the entire grid; kji ordering is same as that of extent; zero base
-   """
+    returns: numpy int array of shape (2, 3)
+       indices defining a maximal box containing the entire grid; kji ordering is same as that of extent; zero base
+    """
 
     assert extent.ndim == 1 and extent.size == 3
     box = np.zeros((2, 3), dtype = 'int')
@@ -230,20 +230,20 @@ def union(box_1, box_2):
 def parent_cell_from_local_box_cell(box, box_cell, based_0_or_1 = 0):
     """Given a box and a local cell index triplet, converts to the equivalent cell index triplet in the host grid.
 
-   input arguments (unmodified):
-      box: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         indices in the same ordering as box_cell; start value (python or Fortran/simulator) given by based_0_or_1
-      box_cell: numpy int array of shape (3)
-         indices of a cell within box, in coords local to box
-         indices in the same ordering as box; start value (python or Fortran/simulator) given by based_0_or_1
-      based_0_or_1: int, value 0 or 1
-         start value (base) for indices of box and box_cell arguments, and of return value
+    input arguments (unmodified):
+       box: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          indices in the same ordering as box_cell; start value (python or Fortran/simulator) given by based_0_or_1
+       box_cell: numpy int array of shape (3)
+          indices of a cell within box, in coords local to box
+          indices in the same ordering as box; start value (python or Fortran/simulator) given by based_0_or_1
+       based_0_or_1: int, value 0 or 1
+          start value (base) for indices of box and box_cell arguments, and of return value
 
-   returns: numpy int array of shape (3)
-      indices defining the cell in the host grid space equivalent to box_cell
-      ordering of indices is same as that of box and box_cell; base is given by based_0_or_1 argument
-   """
+    returns: numpy int array of shape (3)
+       indices defining the cell in the host grid space equivalent to box_cell
+       ordering of indices is same as that of box and box_cell; base is given by based_0_or_1 argument
+    """
 
     assert box.ndim == 2 and box.shape == (2, 3)
     assert box_cell.ndim == 1 and box_cell.size == 3
@@ -253,20 +253,20 @@ def parent_cell_from_local_box_cell(box, box_cell, based_0_or_1 = 0):
 def local_box_cell_from_parent_cell(box, parent_cell, based_0_or_1 = 0):
     """Given a cell index triplet in the host grid, and a box, returns the equivalent local cell index triplet.
 
-   input arguments (unmodified):
-      box: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         indices in the same ordering as parent_cell; start value (python or Fortran/simulator) given by based_0_or_1
-      parent_cell: numpy int array of shape (3)
-         indices of a cell within host grid
-         indices in the same ordering as box; start value (python or Fortran/simulator) given by based_0_or_1
-      based_0_or_1: int, value 0 or 1
-         start value (base) for indices of box and parent_cell arguments, and of return value
+    input arguments (unmodified):
+       box: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          indices in the same ordering as parent_cell; start value (python or Fortran/simulator) given by based_0_or_1
+       parent_cell: numpy int array of shape (3)
+          indices of a cell within host grid
+          indices in the same ordering as box; start value (python or Fortran/simulator) given by based_0_or_1
+       based_0_or_1: int, value 0 or 1
+          start value (base) for indices of box and parent_cell arguments, and of return value
 
-   returns: numpy int array of shape (3); or None
-      indices defining the parent_cell in coords local to box, if the cell is within the box
-      if parent_cell is not within box, None is returned
-   """
+    returns: numpy int array of shape (3); or None
+       indices defining the parent_cell in coords local to box, if the cell is within the box
+       if parent_cell is not within box, None is returned
+    """
 
     assert box.ndim == 2 and box.shape == (2, 3)
     assert parent_cell.ndim == 1 and parent_cell.size == 3
@@ -279,17 +279,17 @@ def local_box_cell_from_parent_cell(box, parent_cell, based_0_or_1 = 0):
 def boxes_overlap(box_a, box_b):
     """Returns True if the two boxes have any overlap in 3D, otherwise False.
 
-   Arguments:
-      box_a: numpy int or float array of shape (2, 3)
-      box_b: numpy int or float array of shape (2, 3)
+    Arguments:
+       box_a: numpy int or float array of shape (2, 3)
+       box_b: numpy int or float array of shape (2, 3)
 
-   if int arrays, each is lower & upper indices in 3 dimensions defining a logical cuboid
-   subset of a 3D cartesian grid protocol of indices for the two boxes must be the same
-   if float arrays, each is min & max x,y,z triplets
+    if int arrays, each is lower & upper indices in 3 dimensions defining a logical cuboid
+    subset of a 3D cartesian grid protocol of indices for the two boxes must be the same
+    if float arrays, each is min & max x,y,z triplets
 
-   returns: boolean
-      True if box_a and box_b overlap, False otherwise
-   """
+    returns: boolean
+       True if box_a and box_b overlap, False otherwise
+    """
 
     return not ((box_a[1, 0] < box_b[0, 0]) or (box_a[0, 0] > box_b[1, 0]) or (box_a[1, 1] < box_b[0, 1]) or
                 (box_a[0, 1] > box_b[1, 1]) or (box_a[1, 2] < box_b[0, 2]) or (box_a[0, 2] > box_b[1, 2]))
@@ -298,29 +298,29 @@ def boxes_overlap(box_a, box_b):
 def overlapping_boxes(established_box, new_box, trim_box):
     """Checks for 3D overlap of two boxes; returns True and sets trim_box if there is overlap, otherwise False.
 
-   Arguments:
-      established_box: numpy int array of shape (2, 3)
-      new_box: numpy int array of shape (2, 3)
-         each is lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         protocol of indices for the two boxes must be the same
+    Arguments:
+       established_box: numpy int array of shape (2, 3)
+       new_box: numpy int array of shape (2, 3)
+          each is lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          protocol of indices for the two boxes must be the same
 
-   output argument (modified):
-      trim_box: numpy int array of shape (2, 3)
-         set to lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         a subset of new_box such that if removed from new_box, a valid box would remain with no overlap with established_box
-         indices protocol is the same as that used for established_box and new_box (if return value is True)
-         if there is no overlap (return value False), all elements of trim_box are set to 0
+    output argument (modified):
+       trim_box: numpy int array of shape (2, 3)
+          set to lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          a subset of new_box such that if removed from new_box, a valid box would remain with no overlap with established_box
+          indices protocol is the same as that used for established_box and new_box (if return value is True)
+          if there is no overlap (return value False), all elements of trim_box are set to 0
 
-   note:
+    note:
 
-      when there is overlap between the boxes, there can be more than one way to trim the new_box,
-      with trim_box fully covering either ij, jk or ik planes of new_box
-      the function selects the trim_box containing the minimum number of cells (minimum 'loss' to trimming)
-      this function does not actually apply the trimming, ie. new_box is not modified here
+       when there is overlap between the boxes, there can be more than one way to trim the new_box,
+       with trim_box fully covering either ij, jk or ik planes of new_box
+       the function selects the trim_box containing the minimum number of cells (minimum 'loss' to trimming)
+       this function does not actually apply the trimming, ie. new_box is not modified here
 
-   returns: boolean
-      True if established_box and new_box overlap (implies trim_box valid), False otherwise (trim_box elements all 0)
-   """
+    returns: boolean
+       True if established_box and new_box overlap (implies trim_box valid), False otherwise (trim_box elements all 0)
+    """
 
     assert established_box.ndim == 2 and established_box.shape == (2, 3) and established_box.dtype == 'int'
     assert new_box.ndim == 2 and new_box.shape == (2, 3) and new_box.dtype == 'int'
@@ -363,25 +363,25 @@ def overlapping_boxes(established_box, new_box, trim_box):
 def trim_box_by_box_returning_new_mask(box_to_be_trimmed, trim_box, mask_kji0):
     """Reduces box_to_be_trimmed by trim_box; trim_box must be a neat subset box at one face of box_to_be_trimmed.
 
-   input/output argument (modified):
-      box_to_be_trimmed: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         indices protocol is python kji ordering with zero base
-         modified to exclude space occupied by trim_box
+    input/output argument (modified):
+       box_to_be_trimmed: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          indices protocol is python kji ordering with zero base
+          modified to exclude space occupied by trim_box
 
-   input arguments (unmodified):
-      trim_box: numpy int array of shape (2, 3)
-         lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
-         indices protocol is python kji ordering with zero base
-         the volume to be removed from box_to_be_trimmed,
-         must be a subset of box_to_be_trimmed completely covering one face of box_to_be_trimmed
-         (thereby ensuring that after trimming, a valid cuboid box results)
-      mask_kji0: numpy 3D boolean array of shape matching extent of input box_to_be_trimmed
-         indices protocol is python kji ordering with zero base
+    input arguments (unmodified):
+       trim_box: numpy int array of shape (2, 3)
+          lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
+          indices protocol is python kji ordering with zero base
+          the volume to be removed from box_to_be_trimmed,
+          must be a subset of box_to_be_trimmed completely covering one face of box_to_be_trimmed
+          (thereby ensuring that after trimming, a valid cuboid box results)
+       mask_kji0: numpy 3D boolean array of shape matching extent of input box_to_be_trimmed
+          indices protocol is python kji ordering with zero base
 
-   returns: numpy 3D boolean array of shape matching extent of output box_to_be_trimmed
-      the return array is a version of mask_kji0 that has been trimmed in accordance with the box trimming
-   """
+    returns: numpy 3D boolean array of shape matching extent of output box_to_be_trimmed
+       the return array is a version of mask_kji0 that has been trimmed in accordance with the box trimming
+    """
 
     local_box = np.zeros((2, 3), dtype = 'int')
     local_box[1] = extent_of_box(box_to_be_trimmed) - 1
@@ -421,8 +421,8 @@ def trim_box_by_box_returning_new_mask(box_to_be_trimmed, trim_box, mask_kji0):
 
 
 def trim_box_to_mask_returning_new_mask(bounding_box_kji0, mask_kji0):
-    """Reduces the coverage of bounding box to the minimum needed to contain True elements of mask; returns trimmed mask.
-   """
+    """Reduces the coverage of bounding box to the minimum needed to contain True elements of mask; returns trimmed
+    mask."""
 
     # NB: bounding box is modified by this function
     assert bounding_box_kji0.ndim == 2 and bounding_box_kji0.shape == (2, 3) and bounding_box_kji0.dtype == 'int'

--- a/resqpy/olio/class_dict.py
+++ b/resqpy/olio/class_dict.py
@@ -96,12 +96,12 @@ class_dict = {
 def readable_class(class_name):
     """Given a resqml object class name as a string, returns a more human readable string.
 
-      argument:
-         class_name (string): the resqml class name, eg. 'obj_IjkGridRepresentation'
+    argument:
+       class_name (string): the resqml class name, eg. 'obj_IjkGridRepresentation'
 
-      returns:
-         a human readable version of the class name, eg. 'Grid (IJK)'
-   """
+    returns:
+       a human readable version of the class name, eg. 'Grid (IJK)'
+    """
 
     if class_name in class_dict.keys():
         return class_dict[class_name]

--- a/resqpy/olio/data/build.py
+++ b/resqpy/olio/data/build.py
@@ -1,4 +1,4 @@
-""" Script to construct JSON database of UOMs and property kinds.
+"""Script to construct JSON database of UOMs and property kinds.
 
 Expects two files to exist in the same folder:
   - Energistics_Unit_of_Measure_Dictionary_V1.0.xml    (from units of measure standard)
@@ -119,11 +119,10 @@ def parse_prefixes(root):
 
 
 def parse_property_kinds(root):
-    """ Return dict of valid RESQML property kinds
+    """Return dict of valid RESQML property kinds.
 
-   Dict keys are the valid property kinds, e.g. 'angle per time'
-   Dict values are the description, which may be None
-   """
+    Dict keys are the valid property kinds, e.g. 'angle per time' Dict values are the description, which may be None
+    """
 
     kind_list = get_nodes_with_name(root, 'ResqmlPropertyKind')[1]
     kind_dict = {}
@@ -138,7 +137,7 @@ def parse_property_kinds(root):
 
 
 def get_nodes_with_name(root, name):
-    """ Find xml child node with given name """
+    """Find xml child node with given name."""
     for child in root:
         if child.get('name') == name:
             return child

--- a/resqpy/olio/dataframe.py
+++ b/resqpy/olio/dataframe.py
@@ -28,16 +28,16 @@ import resqpy.olio.xml_et as rqet
 class DataFrame:
     """Class for storing and retrieving a pandas dataframe of numerical data as a RESQML property.
 
-   notes:
-      actual values are stored either as z values in a Mesh (Grid2d) object, or as a property on
-      such a mesh when multiple raalizations are in use; a regular Mesh object is created to act
-      as a supporting representation; columns are mapped onto I and rows onto J; if a property is
-      used then the indexable elements are 'nodes'; column titles are stored in a related StringLookup
-      object, indexed by column number; column units are optionally treated in the same way (uom for
-      the property is generally set to Euc); all values are stored as floats; use the derived TimeTable
-      class if rows relate to steps in a TimeSeries; use the derived RelPerm class if the rows relate to
-      relative permeability data
-   """
+    notes:
+       actual values are stored either as z values in a Mesh (Grid2d) object, or as a property on
+       such a mesh when multiple raalizations are in use; a regular Mesh object is created to act
+       as a supporting representation; columns are mapped onto I and rows onto J; if a property is
+       used then the indexable elements are 'nodes'; column titles are stored in a related StringLookup
+       object, indexed by column number; column units are optionally treated in the same way (uom for
+       the property is generally set to Euc); all values are stored as floats; use the derived TimeTable
+       class if rows relate to steps in a TimeSeries; use the derived RelPerm class if the rows relate to
+       relative permeability data
+    """
 
     def __init__(
             self,
@@ -53,40 +53,40 @@ class DataFrame:
             extra_metadata = None):
         """Create a new Dataframe object from either a previously stored property or a pandas dataframe.
 
-      arguments:
-         model (model.Model): the model to which the new Dataframe will be attached
-         support_root (lxml.Element, DEPRECATED): use uuid instead
-         uuid (uuid.UUID, optional): the uuid of an existing Grid2dRepresentation
-            object acting as support for a dataframe property (or holding the dataframe as z values)
-         df (pandas.DataFrame, optional): a dataframe from which the new Dataframe is to be created;
-            if both uuid (or support_root) and df are supplied, realization must not be None and a new
-            realization property will be created
-         uom_list (list of str, optional): a list holding the units of measure for each
-            column; if present, length of list must match number of columns in df; ignored if
-            uuid or support_root is not None
-         realization (int, optional): if present, the realization number of the RESQML property
-            holding the dataframe
-         title (str, default 'dataframe'): used as the citation title for the Mesh (and property);
-            ignored if uuid or support_root is not None
-         column_lookup_uuid (uuid, optional): if present, the uuid of a string lookup table holding
-            the column names; if present, the contents and order of the table must match the columns
-            in the dataframe; if absent, a new lookup table will be created; ignored if support_root
-            is not None
-         uom_lookup_uuid (uuid, optional): if present, the uuid of a string lookup table holding
-            the units of measure for each column; if None and uom_list is present, a new table
-            will be created; if both uom_list and uom_lookup_uuid are present, their contents
-            must match; ignored if support_root is not None
-         extra_metadata (dict, optional): if present, a dictionary of extra metadata items, str: str;
-            ignored if uuid (or support_root) is not None
+        arguments:
+           model (model.Model): the model to which the new Dataframe will be attached
+           support_root (lxml.Element, DEPRECATED): use uuid instead
+           uuid (uuid.UUID, optional): the uuid of an existing Grid2dRepresentation
+              object acting as support for a dataframe property (or holding the dataframe as z values)
+           df (pandas.DataFrame, optional): a dataframe from which the new Dataframe is to be created;
+              if both uuid (or support_root) and df are supplied, realization must not be None and a new
+              realization property will be created
+           uom_list (list of str, optional): a list holding the units of measure for each
+              column; if present, length of list must match number of columns in df; ignored if
+              uuid or support_root is not None
+           realization (int, optional): if present, the realization number of the RESQML property
+              holding the dataframe
+           title (str, default 'dataframe'): used as the citation title for the Mesh (and property);
+              ignored if uuid or support_root is not None
+           column_lookup_uuid (uuid, optional): if present, the uuid of a string lookup table holding
+              the column names; if present, the contents and order of the table must match the columns
+              in the dataframe; if absent, a new lookup table will be created; ignored if support_root
+              is not None
+           uom_lookup_uuid (uuid, optional): if present, the uuid of a string lookup table holding
+              the units of measure for each column; if None and uom_list is present, a new table
+              will be created; if both uom_list and uom_lookup_uuid are present, their contents
+              must match; ignored if support_root is not None
+           extra_metadata (dict, optional): if present, a dictionary of extra metadata items, str: str;
+              ignored if uuid (or support_root) is not None
 
-      returns:
-         a newly created Dataframe object
+        returns:
+           a newly created Dataframe object
 
-      notes:
-         when initialising from an existing RESQML object, the supporting mesh and its property should
-         have been originally created using this class; when working with ensembles, each object of this
-         class will only handle the data for one realization, though they may share a common support_root
-      """
+        notes:
+           when initialising from an existing RESQML object, the supporting mesh and its property should
+           have been originally created using this class; when working with ensembles, each object of this
+           class will only handle the data for one realization, though they may share a common support_root
+        """
 
         assert uuid is not None or support_root is not None or df is not None
         assert (uuid is None and support_root is None) or df is None or realization is not None
@@ -275,9 +275,9 @@ class DataFrame:
 class TimeTable(DataFrame):
     """Class for storing and retrieving a pandas dataframe where rows relate to steps in a time series.
 
-   note:
-      inherits from DataFrame class
-   """
+    note:
+       inherits from DataFrame class
+    """
 
     def __init__(
             self,
@@ -293,13 +293,13 @@ class TimeTable(DataFrame):
             uom_lookup_uuid = None):
         """Create a new TimeTable object from either a previously stored property or a pandas dataframe.
 
-      arguments:
-         time_series (resqpy.time_series.TimeSeries): the time series which rows in the dataframe relate to;
-            required if initialising from a dataframe, ignored otherwise
+        arguments:
+           time_series (resqpy.time_series.TimeSeries): the time series which rows in the dataframe relate to;
+              required if initialising from a dataframe, ignored otherwise
 
-      note:
-         see DataFrame class docstring for details of other arguments
-      """
+        note:
+           see DataFrame class docstring for details of other arguments
+        """
 
         # todo: add option to set up time series from a column in the dataframe?
 
@@ -339,19 +339,19 @@ class TimeTable(DataFrame):
 def dataframe_parts_in_model(model, timetables = None, title = None, related_uuid = None):
     """Returns list of part names within model that are representing DataFrame support objects.
 
-   arguments:
-      model (model.Model): the model to be inspected for dataframes
-      timetables (boolean or None): if True, only TimeTable dataframe parts will be included; if False
-         only DataFrame parts that are not representing TimeTable objects will be included; if None,
-         both parts for both types of dataframe will be included
-      title (str, optional): if present, only parts with a citation title exactly matching will be
-         included
-      related_uuid (uuid, optional): if present, only parts relating to this uuid are included
+    arguments:
+       model (model.Model): the model to be inspected for dataframes
+       timetables (boolean or None): if True, only TimeTable dataframe parts will be included; if False
+          only DataFrame parts that are not representing TimeTable objects will be included; if None,
+          both parts for both types of dataframe will be included
+       title (str, optional): if present, only parts with a citation title exactly matching will be
+          included
+       related_uuid (uuid, optional): if present, only parts relating to this uuid are included
 
-   returns:
-      list of str, each element in the list is a part name, within model, which is representing the
-      support for a DataFrame object
-   """
+    returns:
+       list of str, each element in the list is a part name, within model, which is representing the
+       support for a DataFrame object
+    """
 
     df_parts_list = model.parts(obj_type = 'Grid2dRepresentation',
                                 title = title,
@@ -372,16 +372,16 @@ def dataframe_parts_in_model(model, timetables = None, title = None, related_uui
 def timetable_parts_in_model(model, title = None, related_uuid = None):
     """Returns list of part names within model that are representing TimeTable dataframe support objects.
 
-   arguments:
-      model (model.Model): the model to be inspected for dataframes
-      title (str, optional): if present, only parts with a citation title exactly matching will be
-         included
-      related_uuid (uuid, optional): if present, only parts relating to this uuid are included
+    arguments:
+       model (model.Model): the model to be inspected for dataframes
+       title (str, optional): if present, only parts with a citation title exactly matching will be
+          included
+       related_uuid (uuid, optional): if present, only parts relating to this uuid are included
 
-   returns:
-      list of str, each element in the list is a part name, within model, which is representing the support
-      for a TimeTable object
-   """
+    returns:
+       list of str, each element in the list is a part name, within model, which is representing the support
+       for a TimeTable object
+    """
 
     return dataframe_parts_in_model(model, timetables = True, title = title, related_uuid = related_uuid)
 

--- a/resqpy/olio/exceptions.py
+++ b/resqpy/olio/exceptions.py
@@ -1,11 +1,11 @@
-"""Custom exceptions used in resqpy"""
+"""Custom exceptions used in resqpy."""
 
 
 class InvalidUnitError(Exception):
-    """Raised when a unit cannot be converted into a valid RESQML unit of measure"""
+    """Raised when a unit cannot be converted into a valid RESQML unit of measure."""
     pass
 
 
 class IncompatibleUnitsError(Exception):
-    """Raised when two units do not share compatible base units and dimensions"""
+    """Raised when two units do not share compatible base units and dimensions."""
     pass

--- a/resqpy/olio/fine_coarse.py
+++ b/resqpy/olio/fine_coarse.py
@@ -21,26 +21,26 @@ class FineCoarse:
     def __init__(self, fine_extent_kji, coarse_extent_kji, within_fine_box = None, within_coarse_box = None):
         """Partial initialisation function, call other methods to assign ratios and proportions.
 
-      arguments:
-         fine_extent_kji (triple int): the local extent of the fine grid in k, j, i axes, ie (nk, nj, ni).
-         coarse_extent_kji (triple int): the local extent of the coarse grid in k, j, i axes.
-         within_fine_box (numpy int array of shape (2, 3), optional): if present, the subset of a larger
-            fine grid that the mapping refers to; axes are min,max and k,j,i; values are zero based indices;
-            max values are included in box (un-pythonesque); use this in the case of a local grid coarsening
-         within_coarse_box (numpy int array of shape (2, 3), optional): if present, the subset of a larger
-            coarse grid that the mapping refers to; axes are min,max and k,j,i; values are zero based indices;
-            max values are included in box (un-pythonesque); use this in the case of a local grid refinement;
-            required for write_cartref() method to work
+        arguments:
+           fine_extent_kji (triple int): the local extent of the fine grid in k, j, i axes, ie (nk, nj, ni).
+           coarse_extent_kji (triple int): the local extent of the coarse grid in k, j, i axes.
+           within_fine_box (numpy int array of shape (2, 3), optional): if present, the subset of a larger
+              fine grid that the mapping refers to; axes are min,max and k,j,i; values are zero based indices;
+              max values are included in box (un-pythonesque); use this in the case of a local grid coarsening
+           within_coarse_box (numpy int array of shape (2, 3), optional): if present, the subset of a larger
+              coarse grid that the mapping refers to; axes are min,max and k,j,i; values are zero based indices;
+              max values are included in box (un-pythonesque); use this in the case of a local grid refinement;
+              required for write_cartref() method to work
 
-      returns:
-         newly formed FineCoarse object awaiting determination of ratios and proportions by axes.
+        returns:
+           newly formed FineCoarse object awaiting determination of ratios and proportions by axes.
 
-      notes:
-         at most one of within_fine_box and within_coarse_box may be passed; this information is not really
-         used internally by the FineCoarse class but is noted in order to support local grid refinement and
-         local grid coarsening applications;
-         after intialisation, set_* methods should be called to establish the mapping
-      """
+        notes:
+           at most one of within_fine_box and within_coarse_box may be passed; this information is not really
+           used internally by the FineCoarse class but is noted in order to support local grid refinement and
+           local grid coarsening applications;
+           after intialisation, set_* methods should be called to establish the mapping
+        """
 
         assert len(fine_extent_kji) == 3 and len(coarse_extent_kji) == 3
         assert within_fine_box is None or within_coarse_box is None
@@ -158,7 +158,8 @@ class FineCoarse:
         return tuple(base)
 
     def fine_box_for_coarse(self, c_kji0):
-        """Returns a numpy int array of shape (2, 3) being the min, max for k, j, i0 in fine grid for given coarse cell."""
+        """Returns a numpy int array of shape (2, 3) being the min, max for k, j, i0 in fine grid for given coarse
+        cell."""
 
         box = np.empty((2, 3), dtype = int)
         box[0] = self.fine_base_for_coarse(c_kji0)
@@ -166,7 +167,8 @@ class FineCoarse:
         return box
 
     def proportion(self, axis, c0):
-        """Return a numpy vector of floats (summing to one) being the axial relative proportions of fine within coarse."""
+        """Return a numpy vector of floats (summing to one) being the axial relative proportions of fine within
+        coarse."""
 
         if self.equal_proportions[axis]:
             count = self.ratio(axis, c0)
@@ -175,7 +177,8 @@ class FineCoarse:
         return self.vector_proportions[axis][c0]
 
     def proportions_for_axis(self, axis):
-        """Return a numpy vector of floats for fine (summing to one for each coarse slice) being the axial relative proportions."""
+        """Return a numpy vector of floats for fine (summing to one for each coarse slice) being the axial relative
+        proportions."""
 
         if self.equal_proportions[axis]:
             count = self.constant_ratios[axis]
@@ -184,7 +187,8 @@ class FineCoarse:
         return np.concatenate(self.vector_proportions[axis])
 
     def interpolation(self, axis, c0):
-        """Return a numpy vector of floats starting at zero and increasing monotonically to less than one, ready for interpolation."""
+        """Return a numpy vector of floats starting at zero and increasing monotonically to less than one, ready for
+        interpolation."""
 
         count = self.ratio(axis, c0)
         fractions = np.zeros((count,))
@@ -380,34 +384,34 @@ def tartan_refinement(coarse_extent_kji,
                       within_coarse_box = None):
     """Returns a new FineCoarse object set to a tartan grid refinement; fine extent is determined from arguments.
 
-   arguments:
-      coarse_extent_kji (triple int): the extent of the coarse grid being refined
-      coarse_fovea_box (numpy int array of shape (2, 3)): the central box within the coarse grid to receive maximum refinement
-      fovea_ratios_kji (triple int): the maximum refinement ratios, to be applied in the coarse_fovea_box
-      decay_rates_kji (triple float or triple int, optional): controls how quickly refinement ratio reduces in slices away from fovea;
-         if None then default values will be generated; see notes for more details
-      decay_mode (str, default 'exponential'): 'exponential' or 'linear'; see notes
-      within_coarse_box (numpy int array of shape (2, 3), optional): if present, is preserved in FineCoarse for possible use
-         in setting resqml ParentWindow or generating Nexus CARTREF
+    arguments:
+       coarse_extent_kji (triple int): the extent of the coarse grid being refined
+       coarse_fovea_box (numpy int array of shape (2, 3)): the central box within the coarse grid to receive maximum refinement
+       fovea_ratios_kji (triple int): the maximum refinement ratios, to be applied in the coarse_fovea_box
+       decay_rates_kji (triple float or triple int, optional): controls how quickly refinement ratio reduces in slices away from fovea;
+          if None then default values will be generated; see notes for more details
+       decay_mode (str, default 'exponential'): 'exponential' or 'linear'; see notes
+       within_coarse_box (numpy int array of shape (2, 3), optional): if present, is preserved in FineCoarse for possible use
+          in setting resqml ParentWindow or generating Nexus CARTREF
 
-   returns:
-      FineCoarse object holding the tartan refinement mapping
+    returns:
+       FineCoarse object holding the tartan refinement mapping
 
-   notes:
-      each axis is treated independently;
-      the fovea (box of maximum refinement) may be a column of cells (for a vertical well) or any other logical cuboid;
-      the refinement factor is reduced monotonically in slices moving away from the fovea;
-      two refinement factor decay functions are available: 'exponential' and 'linear', with different meaning to decay_rates_kji;
-      for exponential decay, each decay rate should be a float in the range 0.0 to 1.0, with 0.0 causing immediate change
-      to no refinement (factor 1), and 1.0 causing no decay (constant refinement at fovea factor);
-      for linear decay, each decay rate should typically be a non-negative integer (though float is also okay), with 0 causing
-      no decay, 1 causing a reduction in refinement factor of 1 per coarse slice, 2 meaning refinement factor reduces by 2 with
-      each coarse slice etc.;
-      in all cases, the refinement factor is given a lower limit of 1;
-      the factor is rounded to an int for each slice, when working with floats;
-      if decay rates are not passed as arguments, suitable values are generated to give a gradual reduction in refinement to a
-      ratio of one at the boundary of the grid
-   """
+    notes:
+       each axis is treated independently;
+       the fovea (box of maximum refinement) may be a column of cells (for a vertical well) or any other logical cuboid;
+       the refinement factor is reduced monotonically in slices moving away from the fovea;
+       two refinement factor decay functions are available: 'exponential' and 'linear', with different meaning to decay_rates_kji;
+       for exponential decay, each decay rate should be a float in the range 0.0 to 1.0, with 0.0 causing immediate change
+       to no refinement (factor 1), and 1.0 causing no decay (constant refinement at fovea factor);
+       for linear decay, each decay rate should typically be a non-negative integer (though float is also okay), with 0 causing
+       no decay, 1 causing a reduction in refinement factor of 1 per coarse slice, 2 meaning refinement factor reduces by 2 with
+       each coarse slice etc.;
+       in all cases, the refinement factor is given a lower limit of 1;
+       the factor is rounded to an int for each slice, when working with floats;
+       if decay rates are not passed as arguments, suitable values are generated to give a gradual reduction in refinement to a
+       ratio of one at the boundary of the grid
+    """
 
     assert box.valid_box(coarse_fovea_box, coarse_extent_kji)
     assert decay_mode in ['exponential', 'linear']

--- a/resqpy/olio/grid_functions.py
+++ b/resqpy/olio/grid_functions.py
@@ -154,7 +154,7 @@ def infill_block_geometry(extent,
 
 
 def resequence_nexus_corp(corner_points, eight_mode = False, undo = False):
-    """Reorders corner point data in situ, to handle bizarre nexus orderings"""
+    """Reorders corner point data in situ, to handle bizarre nexus orderings."""
 
     # undo False for corp to internal; undo True for internal to corp; only relevant in eight_mode
     assert (corner_points.ndim == 7)
@@ -408,16 +408,16 @@ def translate_corp(corner_points, x_shift = None, y_shift = None, min_xy = None,
 def triangles_for_cell_faces(cp):
     """Returns numpy array of shape (3, 2, 4, 3, 3) with axes being kji, -+, triangle within face, triangle corner, xyz.
 
-   args:
-      cp (numpy float array of shape (2, 2, 2, 3)): single cell corner point array in pagoda protocol
+    args:
+       cp (numpy float array of shape (2, 2, 2, 3)): single cell corner point array in pagoda protocol
 
-   returns:
-      numpy float array of shape (3, 2, 4, 3, 3) holding triangle corner coordinates for cell faces represented with
-      quad triangles
+    returns:
+       numpy float array of shape (3, 2, 4, 3, 3) holding triangle corner coordinates for cell faces represented with
+       quad triangles
 
-   note:
-      resqpy.surface also contains methods for working with cell faces as triangulated sets
-   """
+    note:
+       resqpy.surface also contains methods for working with cell faces as triangulated sets
+    """
 
     tri = np.empty((3, 2, 4, 3, 3))
 
@@ -467,7 +467,8 @@ def triangles_for_cell_faces(cp):
 
 
 def actual_pillar_shape(pillar_points, tolerance = 0.001):
-    """Returns 'curved', 'straight' or 'vertical' for shape of fully defined points array of shape (nk + k_gaps + 1, ..., 3)."""
+    """Returns 'curved', 'straight' or 'vertical' for shape of fully defined points array of shape (nk + k_gaps + 1,
+    ..., 3)."""
 
     assert pillar_points.ndim >= 3 and pillar_points.shape[-1] == 3
 
@@ -499,7 +500,8 @@ def actual_pillar_shape(pillar_points, tolerance = 0.001):
 
 
 def columns_to_nearest_split_face(grid):
-    """Returns a numpy integer array of shape (NJ, NI) being number of cells to nearest split edge (Manhattan distance)."""
+    """Returns a numpy integer array of shape (NJ, NI) being number of cells to nearest split edge (Manhattan
+    distance)."""
 
     if not grid.has_split_coordinate_lines:
         return None

--- a/resqpy/olio/intersection.py
+++ b/resqpy/olio/intersection.py
@@ -13,15 +13,15 @@ import numpy as np
 def line_plane_intersect(line_p, line_v, triangle):
     """Find the intersection of a line with a plane defined by a triangle.
 
-      arguments:
-         line_p (3 element numpy vector): a point on the line
-         line_v (3 element numpy vector): vector being the direction of the line
-         triangle ((3, 3) numpy array): three points on the plane (second index is xyz)
+    arguments:
+       line_p (3 element numpy vector): a point on the line
+       line_v (3 element numpy vector): vector being the direction of the line
+       triangle ((3, 3) numpy array): three points on the plane (second index is xyz)
 
-      returns:
-         point (3 element numpy vector) of intersection of the line with the plane,
-         or None if line is parallel to plane
-   """
+    returns:
+       point (3 element numpy vector) of intersection of the line with the plane,
+       or None if line is parallel to plane
+    """
 
     p01 = triangle[1] - triangle[0]
     p02 = triangle[2] - triangle[0]
@@ -37,17 +37,17 @@ def line_plane_intersect(line_p, line_v, triangle):
 def line_triangle_intersect(line_p, line_v, triangle, line_segment = False):
     """Find the intersection of a line within a triangle in 3D space.
 
-      arguments:
-         line_p (3 element numpy vector): a point on the line
-         line_v (3 element numpy vector): vector being the direction of the line
-         triangle ((3, 3) numpy array): three corners of the triangle (second index is xyz)
-         line_segment (boolean): if True, returns None if intersection is outwith (line_p .. line_p + line_v)
+    arguments:
+       line_p (3 element numpy vector): a point on the line
+       line_v (3 element numpy vector): vector being the direction of the line
+       triangle ((3, 3) numpy array): three corners of the triangle (second index is xyz)
+       line_segment (boolean): if True, returns None if intersection is outwith (line_p .. line_p + line_v)
 
-      returns:
-         point (3 element numpy vector) of intersection of the line within the triangle,
-         or None if line is parallel to plane of triangle or intersection with the plane is
-         outside the triangle
-   """
+    returns:
+       point (3 element numpy vector) of intersection of the line within the triangle,
+       or None if line is parallel to plane of triangle or intersection with the plane is
+       outside the triangle
+    """
 
     p01 = triangle[1] - triangle[0]
     p02 = triangle[2] - triangle[0]
@@ -74,18 +74,18 @@ def line_triangle_intersect(line_p, line_v, triangle, line_segment = False):
 def line_triangles_intersects(line_p, line_v, triangles, line_segment = False):
     """Find the intersections of a line within each of a set of triangles in 3D space.
 
-      arguments:
-         line_p (3 element numpy vector): a point on the line
-         line_v (3 element numpy vector): vector being the direction of the line
-         triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
-         line_segment (boolean, default False): if True, the line is treated as a finite segment between
-            p and p + v, and only intersections within the segment are included
+    arguments:
+       line_p (3 element numpy vector): a point on the line
+       line_v (3 element numpy vector): vector being the direction of the line
+       triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
+       line_segment (boolean, default False): if True, the line is treated as a finite segment between
+          p and p + v, and only intersections within the segment are included
 
-      returns:
-         points ((n, 3) numpy array) of intersection points of the line within the triangles,
-         (nan, nan, nan) where line is parallel to plane of triangle or intersection with the plane is
-         outside the triangle (or beyond the ends of the segment if applicable)
-   """
+    returns:
+       points ((n, 3) numpy array) of intersection points of the line within the triangles,
+       (nan, nan, nan) where line is parallel to plane of triangle or intersection with the plane is
+       outside the triangle (or beyond the ends of the segment if applicable)
+    """
 
     n = triangles.shape[0]  # number of triangles
 
@@ -128,21 +128,21 @@ def intersects_indices(single_line_intersects):
 def line_set_triangles_intersects(line_ps, line_vs, triangles, line_segment = False):
     """Find the intersections of each of set of lines within each of a set of triangles in 3D space.
 
-      arguments:
-         line_ps ((c, 3) numpy array): a point on each of c lines
-         line_vs ((c, 3) numpy array): vectors being the direction of each of the c lines
-         triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
-         line_segment (boolean, default False): if True, each line is treated as a finite segment between
-            p and p + v, and only intersections within the segment are included
+    arguments:
+       line_ps ((c, 3) numpy array): a point on each of c lines
+       line_vs ((c, 3) numpy array): vectors being the direction of each of the c lines
+       triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
+       line_segment (boolean, default False): if True, each line is treated as a finite segment between
+          p and p + v, and only intersections within the segment are included
 
-      returns:
-         points ((c, n, 3) numpy array) of intersections of the lines within the triangles,
-         (nan, nan, nan) where a line is parallel to plane of triangle or intersection with the plane is
-         outside the triangle
+    returns:
+       points ((c, n, 3) numpy array) of intersections of the lines within the triangles,
+       (nan, nan, nan) where a line is parallel to plane of triangle or intersection with the plane is
+       outside the triangle
 
-      note:
-         this function is computationally and memory intensive; it could benefit from parallelisation
-   """
+    note:
+       this function is computationally and memory intensive; it could benefit from parallelisation
+    """
 
     c = line_ps.shape[0]  # number of lines
     n = triangles.shape[0]  # number of triangles
@@ -182,18 +182,18 @@ def line_set_triangles_intersects(line_ps, line_vs, triangles, line_segment = Fa
 def poly_line_triangles_intersects(line_ps, triangles):
     """Find the intersections of each segment of an open poly-line with each of a set of triangles in 3D space.
 
-      arguments:
-         line_ps ((c, 3) numpy array): ordered points on each of c-1 segments of a poly-line
-         triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
+    arguments:
+       line_ps ((c, 3) numpy array): ordered points on each of c-1 segments of a poly-line
+       triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
 
-      returns:
-         points ((c-1, n, 3) numpy array) of intersections of the line segments within the triangles,
-         (nan, nan, nan) where a line segment is parallel to plane of triangle or intersection of
-         the segment with the plane is outside the triangle or beyond the ends of the segment
+    returns:
+       points ((c-1, n, 3) numpy array) of intersections of the line segments within the triangles,
+       (nan, nan, nan) where a line segment is parallel to plane of triangle or intersection of
+       the segment with the plane is outside the triangle or beyond the ends of the segment
 
-      note:
-         this function is computationally and memory intensive; it could benefit from parallelisation
-   """
+    note:
+       this function is computationally and memory intensive; it could benefit from parallelisation
+    """
 
     return line_set_triangles_intersects(line_ps[:-1], line_ps[1:] - line_ps[:-1], triangles, line_segment = True)
 
@@ -201,17 +201,17 @@ def poly_line_triangles_intersects(line_ps, triangles):
 def distilled_intersects(line_set_intersections):
     """Returns lists of line and triangle indices, and corresponding intersection points.
 
-   argument:
-      line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
-         nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
-         this array is as returned by the line_set_triangles_intersects() function or the
-         poly_line_triangles_intersects() function
+    argument:
+       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
+          nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
+          this array is as returned by the line_set_triangles_intersects() function or the
+          poly_line_triangles_intersects() function
 
-      returns:
-         (numpy int array of shape (N,), numpy int array of shape (N,), numpy float array of shape (N, 3)):
-         for N intersections, first array is list of line indices, second is list of triangle indices, the
-         third array contains the (x, y, z) coordinates of the intersection points
-   """
+       returns:
+          (numpy int array of shape (N,), numpy int array of shape (N,), numpy float array of shape (N, 3)):
+          for N intersections, first array is list of line indices, second is list of triangle indices, the
+          third array contains the (x, y, z) coordinates of the intersection points
+    """
 
     lines, triangles = np.where(np.logical_not(np.isnan(line_set_intersections[:, :, 0])))
     return lines, triangles, line_set_intersections[lines, triangles, :]
@@ -220,24 +220,24 @@ def distilled_intersects(line_set_intersections):
 def last_intersects(line_set_intersections):
     """From the result of line_set_triangles_intersects(), returns a vector of intersection points, one per line.
 
-   argument:
-      line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
-         nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
-         this array is as returned by the line_set_triangles_intersects() function or the
-         poly_line_triangles_intersects() function
+    argument:
+       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
+          nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
+          this array is as returned by the line_set_triangles_intersects() function or the
+          poly_line_triangles_intersects() function
 
-   returns:
-      numpy float array (nl, 3): intersection points, where nl is number of lines
+    returns:
+       numpy float array (nl, 3): intersection points, where nl is number of lines
 
-   notes:
-      Use this function to force at most one intersection point per line (with a triangulated surface).
-      Applicable where lines are expected to be very roughly orthogonal to a gently verying untorn
-      surface, eg. pillar lines intersecting an unfaulted horizon.
-      If more than one triangle is intersected by a line, the returned point is for the 'last'
-      triangle intersected by the line (when checking triangles in the order they appear in the
-      list of triangles).
-      If no triangles are intersected by a line, the resulting point will be (nan, nan, nan).
-   """
+    notes:
+       Use this function to force at most one intersection point per line (with a triangulated surface).
+       Applicable where lines are expected to be very roughly orthogonal to a gently verying untorn
+       surface, eg. pillar lines intersecting an unfaulted horizon.
+       If more than one triangle is intersected by a line, the returned point is for the 'last'
+       triangle intersected by the line (when checking triangles in the order they appear in the
+       list of triangles).
+       If no triangles are intersected by a line, the resulting point will be (nan, nan, nan).
+    """
 
     assert line_set_intersections.ndim == 3 and line_set_intersections.shape[2] == 3
     c = line_set_intersections.shape[0]
@@ -253,21 +253,21 @@ def last_intersects(line_set_intersections):
 def triangles_for_line(line_set_intersections, line_index):
     """From the result of line_set_triangles_intersects(), returns a list of intersected triangles for a line.
 
-   arguments:
-      line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
-         nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
-         this array is as returned by the line_set_triangles_intersects() function or the
-         poly_line_triangles_intersects() function
-      line_index (integar): the index of the line for which the intersected triangle list is required
+    arguments:
+       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
+          nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
+          this array is as returned by the line_set_triangles_intersects() function or the
+          poly_line_triangles_intersects() function
+       line_index (integar): the index of the line for which the intersected triangle list is required
 
-   returns:
-      (numpy 1D int array of size N, numpy 2D array of shape (N, 3)): the first of the pair of arrays
-         returned is a list of the triangle indices which the given line intersects; the second array is
-         the list of corresponding intersection points (each x,y,z)
+    returns:
+       (numpy 1D int array of size N, numpy 2D array of shape (N, 3)): the first of the pair of arrays
+          returned is a list of the triangle indices which the given line intersects; the second array is
+          the list of corresponding intersection points (each x,y,z)
 
-   notes:
-      if the line does not intersect any triangles, both the resulting arrays will have size zero
-   """
+    notes:
+       if the line does not intersect any triangles, both the resulting arrays will have size zero
+    """
 
     triangles = np.where(np.logical_not(np.isnan(line_set_intersections[line_index, :, 0])))[0]
     return triangles, line_set_intersections[line_index, triangles, :]
@@ -276,21 +276,21 @@ def triangles_for_line(line_set_intersections, line_index):
 def lines_for_triangle(line_set_intersections, triangle_index):
     """From the result of line_set_triangles_intersects(), returns a list of lines intersecing given triangle.
 
-   arguments:
-      line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
-         nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
-         this array is as returned by the line_set_triangles_intersects() function or the
-         poly_line_triangles_intersects() function
-      triangle_index (integar): the index of the triangle for which the intersecting line list is required
+    arguments:
+       line_set_intersections (numpy float array of shape (nl, nt, 3)): where nl is the number of lines,
+          nt is the number of triangles and the final axis is x,y,z; nan values indicate no intersection;
+          this array is as returned by the line_set_triangles_intersects() function or the
+          poly_line_triangles_intersects() function
+       triangle_index (integar): the index of the triangle for which the intersecting line list is required
 
-   returns:
-      (numpy 1D int array of size N, numpy 2D array of shape (N, 3)): the first of the pair of arrays
-         returned is a list of the indices of lines which intersect with the given triangle; the second
-         array is the list of corresponding intersection points (each x,y,z)
+    returns:
+       (numpy 1D int array of size N, numpy 2D array of shape (N, 3)): the first of the pair of arrays
+          returned is a list of the indices of lines which intersect with the given triangle; the second
+          array is the list of corresponding intersection points (each x,y,z)
 
-   notes:
-      if no lines intersect the triangle, both the resulting arrays will have size zero
-   """
+    notes:
+       if no lines intersect the triangle, both the resulting arrays will have size zero
+    """
 
     lines = np.where(np.logical_not(np.isnan(line_set_intersections[:, triangle_index, 0])))[0]
     return lines, line_set_intersections[lines, triangle_index, :]
@@ -299,19 +299,19 @@ def lines_for_triangle(line_set_intersections, triangle_index):
 def poly_line_triangles_first_intersect(line_ps, triangles, start = 0):
     """Finds the first intersection of a segment of an open poly-line with any of a set of triangles in 3D space.
 
-      arguments:
-         line_ps ((c, 3) numpy array): ordered points on each of c-1 segments of a poly-line
-         triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
-         start (int, default 0): the index of the point in line_ps to start searching from
+    arguments:
+       line_ps ((c, 3) numpy array): ordered points on each of c-1 segments of a poly-line
+       triangles ((n, 3, 3) numpy array): three corners of each of the n triangles (final index is xyz)
+       start (int, default 0): the index of the point in line_ps to start searching from
 
-      returns:
-         (int, numpy float array of shape (3,)) where the int is the line segment index where one or more
-         intersections were found and the floats are the xyz of one intersection of that line segment within
-         the triangles; if no line segments intersect any of the trianges, (None, None) is returned
+    returns:
+       (int, numpy float array of shape (3,)) where the int is the line segment index where one or more
+       intersections were found and the floats are the xyz of one intersection of that line segment within
+       the triangles; if no line segments intersect any of the trianges, (None, None) is returned
 
-      note:
-         this function is computationally and memory intensive; it could benefit from parallelisation
-   """
+    note:
+       this function is computationally and memory intensive; it could benefit from parallelisation
+    """
 
     for c in range(start, len(line_ps) - 1):
         points = line_triangles_intersects(line_ps[c], line_ps[c + 1] - line_ps[c], triangles, line_segment = True)
@@ -325,21 +325,21 @@ def poly_line_triangles_first_intersect(line_ps, triangles, start = 0):
 def line_line_intersect(x1, y1, x2, y2, x3, y3, x4, y4, line_segment = False, half_segment = False):
     """Returns the intersection x',y' of two lines x,y 1 to 2 and x,y 3 to 4.
 
-   arguments:
-      x1, y1, x2, y2: coordinates of two points defining first line
-      x3, y3, x4, y4: coordinates of two points defining second line
-      line_segment (bool, default False): if False, both lines are treated as unbounded; if True second line
-         is treated as segment bounded by both end points and first line bounding depends on half_segment arg
-      half_segment (bool, default False): if True and line_segment is True, first line is bounded only at
-         end point x1, y1, whilst second line is fully bounded; if False and line_segment is True, first line
-         is also treated as fully bounded; ignored if line_segment is False (ie. both lines unbounded)
+    arguments:
+       x1, y1, x2, y2: coordinates of two points defining first line
+       x3, y3, x4, y4: coordinates of two points defining second line
+       line_segment (bool, default False): if False, both lines are treated as unbounded; if True second line
+          is treated as segment bounded by both end points and first line bounding depends on half_segment arg
+       half_segment (bool, default False): if True and line_segment is True, first line is bounded only at
+          end point x1, y1, whilst second line is fully bounded; if False and line_segment is True, first line
+          is also treated as fully bounded; ignored if line_segment is False (ie. both lines unbounded)
 
-   returns:
-      pair of floats being x, y of intersection point; or None, None if no qualifying intersection
+    returns:
+       pair of floats being x, y of intersection point; or None, None if no qualifying intersection
 
-   note:
-      in the case of bounded line segments, both end points are 'included' in the segment
-   """
+    note:
+       in the case of bounded line segments, both end points are 'included' in the segment
+    """
 
     divisor = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
     if divisor == 0.0:

--- a/resqpy/olio/load_data.py
+++ b/resqpy/olio/load_data.py
@@ -65,33 +65,33 @@ def load_corp_array_from_file(file_name,
                               use_numbers_only = None):
     """Loads a nexus corner point (CORP) array from a file, returns a 7D numpy array in pagoda ordering.
 
-      arguments:
-         file_name: The name of an ascii file holding the CORP data (no other keywords with numeric data
-                  should be in the file); write access to the directory is likely to be needed if
-                  use_binary is True
-         extent_kji: The extent of the grid as a list or a 3 element numpy array, in the order [NK, NJ, NI].
-                  If extent_kji is None, the extent is figured out from the data.  It must be
-                  given for 1D or 2D models
-         corp_bin (boolean, default False): if True, input file is in bespoke corp binary format, otherwise ascii
-         swap_bytes (boolean, default True): if True, byte ordering of corp bin data is reversed; only relevant
-                  if corp_bin is True
-         max_lines_for_keyword: the maximum number of lines to search for CORP keyword; set to zero if file is
-                  known to be data only
-         comment_char: A single character string which is interpreted as introducing a comment
-         data_free_of_comments: If True, once the numeric data is encountered, it is assumed that there are no
-                  further comments (allowing a faster load)
-         use_binary: If True, a more recent file containing a pure binary copy of the data is looked for first,
-                  in the same directory; if found, the data is loaded directly from that file; if not found, the
-                  binary file is created after the ascii has been loaded (ready for next time)
-         eight_mode: If True, the data is assumed to be in CORP EIGHT ordering; otherwise the normal ordering
-                  (The code does not look for keywords.); this is not automatically determined from any keyword
-                  in the file
-         use_numbers_only: no longer in use, ignored
+    arguments:
+       file_name: The name of an ascii file holding the CORP data (no other keywords with numeric data
+                should be in the file); write access to the directory is likely to be needed if
+                use_binary is True
+       extent_kji: The extent of the grid as a list or a 3 element numpy array, in the order [NK, NJ, NI].
+                If extent_kji is None, the extent is figured out from the data.  It must be
+                given for 1D or 2D models
+       corp_bin (boolean, default False): if True, input file is in bespoke corp binary format, otherwise ascii
+       swap_bytes (boolean, default True): if True, byte ordering of corp bin data is reversed; only relevant
+                if corp_bin is True
+       max_lines_for_keyword: the maximum number of lines to search for CORP keyword; set to zero if file is
+                known to be data only
+       comment_char: A single character string which is interpreted as introducing a comment
+       data_free_of_comments: If True, once the numeric data is encountered, it is assumed that there are no
+                further comments (allowing a faster load)
+       use_binary: If True, a more recent file containing a pure binary copy of the data is looked for first,
+                in the same directory; if found, the data is loaded directly from that file; if not found, the
+                binary file is created after the ascii has been loaded (ready for next time)
+       eight_mode: If True, the data is assumed to be in CORP EIGHT ordering; otherwise the normal ordering
+                (The code does not look for keywords.); this is not automatically determined from any keyword
+                in the file
+       use_numbers_only: no longer in use, ignored
 
-      returns:
-         A numpy array containing the CORP data in 7D pagoda protocol ordering. The extent of the grid, and hence
-         shape of the array is determined from the corner point data unless extent_kji has been specified.
-   """
+    returns:
+       A numpy array containing the CORP data in 7D pagoda protocol ordering. The extent of the grid, and hence
+       shape of the array is determined from the corner point data unless extent_kji has been specified.
+    """
 
     #   assert(extent_kji is not None or data_free_of_comments)   # no longer a requirement
 
@@ -164,8 +164,8 @@ def load_array_from_file(file_name,
                          use_numbers_only = None):
     """Load an array from an ascii (or pure binary) file.
 
-      Arguments are similar to those for load_corp_array_from_file().
-   """
+    Arguments are similar to those for load_corp_array_from_file().
+    """
 
     if not use_binary:
         return load_array_from_ascii_file(file_name,
@@ -250,47 +250,47 @@ def load_array_from_ascii_file(file_name,
                                use_numbers_only = None):
     """Returns a numpy array with data loaded from an ascii file.
 
-   arguments:
-      file_name: string holding name of the existing ascii data file, eg. 'Cell_depth.dat'
-      extent: a python list of integers specifying the extent (shape) of the array, eg. [148, 270, 103];
-         if None, all data is read and returned as a 'flat' 1D array (data must be free from comments)
-      data_type: the type of individual data elements, one of 'real','float','int', 'integer', 'bool' or 'boolean'
-      keyword: if present, an attempt is made to find the keyword before reading data, if keyword is None or is
-         not found, data is read from the start of the file
-      max_lines_for_keyword: can be used to limit the search for keyword (for speed efficiency)
-      comment_char: a single character string being the character used to introduce a comment in the file
-      data_free_of_comments: if set to True, a faster load is used once any header line comments have been
-         skipped
-      skip_c_space: if True then a line starting 'C' followed by white space is skipped as a comment
-      use_numbers_only: this argument is no longer in use and is ignored
+    arguments:
+       file_name: string holding name of the existing ascii data file, eg. 'Cell_depth.dat'
+       extent: a python list of integers specifying the extent (shape) of the array, eg. [148, 270, 103];
+          if None, all data is read and returned as a 'flat' 1D array (data must be free from comments)
+       data_type: the type of individual data elements, one of 'real','float','int', 'integer', 'bool' or 'boolean'
+       keyword: if present, an attempt is made to find the keyword before reading data, if keyword is None or is
+          not found, data is read from the start of the file
+       max_lines_for_keyword: can be used to limit the search for keyword (for speed efficiency)
+       comment_char: a single character string being the character used to introduce a comment in the file
+       data_free_of_comments: if set to True, a faster load is used once any header line comments have been
+          skipped
+       skip_c_space: if True then a line starting 'C' followed by white space is skipped as a comment
+       use_numbers_only: this argument is no longer in use and is ignored
 
-   returns:
-      a numpy array of shape specified in extent argument with dtype matching data_type
+    returns:
+       a numpy array of shape specified in extent argument with dtype matching data_type
 
-   example call:
-      depth_array = load_data.load_array_from_ascii_file('Cell_depth.dat', [148, 270, 103])
+    example call:
+       depth_array = load_data.load_array_from_ascii_file('Cell_depth.dat', [148, 270, 103])
 
-   notes:
-      In all use cases, this function is designed to load a single array of data from an ascii file
-      that DOES NOT CONTAIN OTHER ARRAYS as well, ie. data for a single simulation keyword in the file.
+    notes:
+       In all use cases, this function is designed to load a single array of data from an ascii file
+       that DOES NOT CONTAIN OTHER ARRAYS as well, ie. data for a single simulation keyword in the file.
 
-      If skip_c_space is True, lines starting 'C ' are
-      also treated as comments.  If data_free_of_comments is True, there must be
-      at least one blank line before the data begins, and no further comments are permitted.
-      (This format is designed to handle data files generated by a commonly used geomodelling package.)
+       If skip_c_space is True, lines starting 'C ' are
+       also treated as comments.  If data_free_of_comments is True, there must be
+       at least one blank line before the data begins, and no further comments are permitted.
+       (This format is designed to handle data files generated by a commonly used geomodelling package.)
 
-      Repeat counts must not be present in the ascii data.
+       Repeat counts must not be present in the ascii data.
 
-      The extent, if present, can contain any number of dimensions, typically 3 for reservoir modelling work.
-      The total number of numbers in the file must match the number of elements in the given extent
-      (ie. the product of the list of numbers in the extent argument).
-      The order of indices in extent should be 'slowest changing' first, eg.: k,j,i
+       The extent, if present, can contain any number of dimensions, typically 3 for reservoir modelling work.
+       The total number of numbers in the file must match the number of elements in the given extent
+       (ie. the product of the list of numbers in the extent argument).
+       The order of indices in extent should be 'slowest changing' first, eg.: k,j,i
 
-      The data_type defaults to 'real'
-      'real' and 'float' are synonymous; 'int' and 'integer' are synonymous;
-      'bool' and 'boolean' are synonymous; default is 'real'
-      The numpy data type will be the default 64 bit float or 64 bit int
-   """
+       The data_type defaults to 'real'
+       'real' and 'float' are synonymous; 'int' and 'integer' are synonymous;
+       'bool' and 'boolean' are synonymous; default is 'real'
+       The numpy data type will be the default 64 bit float or 64 bit int
+    """
     # todo: Code enhancement could cater for 32 bit options (and 8 bit for bool) if needed to reduce memory usage
 
     if extent is None:
@@ -440,22 +440,22 @@ def load_array_from_ascii_file(file_name,
 def load_fault_mask(file_name, direction, fault_mask, use_binary = False):
     """Modifies a 3D numpy boolean array representing fault locations on cell faces in i,j or k.
 
-   arguments:
-      file_name: string giving name of existing ascii file holding nexus MULT keywords in input deck format
-      direction: a single character giving direction of interest, must be 'i', 'j' or 'k'
-      fault_mask: an existing 3D boolean numpy array which must have been initialised to False everywhere
-      use_binary: if True, will attempt to load the boolean mask from a pre-written pure binary file,
-                 which will be created if it does not exist
+    arguments:
+       file_name: string giving name of existing ascii file holding nexus MULT keywords in input deck format
+       direction: a single character giving direction of interest, must be 'i', 'j' or 'k'
+       fault_mask: an existing 3D boolean numpy array which must have been initialised to False everywhere
+       use_binary: if True, will attempt to load the boolean mask from a pre-written pure binary file,
+                  which will be created if it does not exist
 
-   returns:
-      None
+    returns:
+       None
 
-   notes :
-      see nexus keyword reference for format of MULT keyword
+    notes :
+       see nexus keyword reference for format of MULT keyword
 
-      fault_mask element is set to True if corresponding face appears in the MULT data set,
-      whatever function is being applied, and whatever value is specified the function returns None (nothing)
-   """
+       fault_mask element is set to True if corresponding face appears in the MULT data set,
+       whatever function is being applied, and whatever value is specified the function returns None (nothing)
+    """
 
     trans_keyword_dict = {'i': 'TX', 'j': 'TY', 'k': 'TZ'}
 

--- a/resqpy/olio/point_inclusion.py
+++ b/resqpy/olio/point_inclusion.py
@@ -17,17 +17,17 @@ import resqpy.olio.simple_lines as sl
 def pip_cn(p, poly):
     """2D point inclusion: returns True if point is inside polygon (uses crossing number algorithm).
 
-   arguments:
-      p (numpy array, tuple or list of at least 2 floats): xy point to test for inclusion in polygon
-      poly (2D numpy array, tuple or list of tuples or lists of at least 2 floats): the xy points
-         defining a polygon
+    arguments:
+       p (numpy array, tuple or list of at least 2 floats): xy point to test for inclusion in polygon
+       poly (2D numpy array, tuple or list of tuples or lists of at least 2 floats): the xy points
+          defining a polygon
 
-   returns:
-      boolean: True if point is within the polygon
+    returns:
+       boolean: True if point is within the polygon
 
-   note:
-      if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
-   """
+    note:
+       if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
+    """
 
     # p should be a tuple-like object with first two elements x, y
     # poly should be a numpy array with first axis being the different vertices
@@ -50,17 +50,17 @@ def pip_cn(p, poly):
 def pip_wn(p, poly):
     """2D point inclusion: returns True if point is inside polygon (uses winding number algorithm).
 
-   arguments:
-      p (numpy array, tuple or list of at least 2 floats): xy point to test for inclusion in polygon
-      poly (2D numpy array, tuple or list of tuples or lists of at least 2 floats): the xy points
-         defining a polygon
+    arguments:
+       p (numpy array, tuple or list of at least 2 floats): xy point to test for inclusion in polygon
+       poly (2D numpy array, tuple or list of tuples or lists of at least 2 floats): the xy points
+          defining a polygon
 
-   returns:
-      boolean: True if point is within the polygon
+    returns:
+       boolean: True if point is within the polygon
 
-   note:
-      if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
-   """
+    note:
+       if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
+    """
 
     winding = 0
 
@@ -84,19 +84,20 @@ def pip_wn(p, poly):
 
 
 def pip_array_cn(p_a, poly):
-    """array of 2D points inclusion: returns bool array True where point is inside polygon (uses crossing number algorithm).
+    """array of 2D points inclusion: returns bool array True where point is inside polygon (uses crossing number
+    algorithm).
 
-   arguments:
-      p_a (2D numpy float array): set of xy points to test for inclusion in polygon
-      poly (2D numpy array, tuple or list of tuples or lists of at least 2 floats): the xy points
-         defining a polygon
+    arguments:
+       p_a (2D numpy float array): set of xy points to test for inclusion in polygon
+       poly (2D numpy array, tuple or list of tuples or lists of at least 2 floats): the xy points
+          defining a polygon
 
-   returns:
-      numpy boolean vector: True where corresponding point in p_a is within the polygon
+    returns:
+       numpy boolean vector: True where corresponding point in p_a is within the polygon
 
-   note:
-      if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
-   """
+    note:
+       if the polygon is represented by a closed resqpy Polyline, pass Polyline.coordinates as poly
+    """
 
     # p_array should be a numpy array of 2 or more axes; the final axis has extent at least 2, being x, y, ...
     # returned boolean array has shape of p_array less the final axis

--- a/resqpy/olio/random_seed.py
+++ b/resqpy/olio/random_seed.py
@@ -9,12 +9,12 @@ import numpy
 def seed(seed, package = 'all'):
     """Set seed for random number generator of one or more packages, to allow for repeatable behaviour.
 
-   arguments:
-      seed (int or long): the value to use to seed the random number generator(s); a value of None will
-         generally result in an unrepeatable sequence
-      package (string or list of strings): one or more of known packages: 'random' and 'numpy' at present;
-         passing 'all' will cause all packages known to have a random number generator to be re-seeded
-   """
+    arguments:
+       seed (int or long): the value to use to seed the random number generator(s); a value of None will
+          generally result in an unrepeatable sequence
+       package (string or list of strings): one or more of known packages: 'random' and 'numpy' at present;
+          passing 'all' will cause all packages known to have a random number generator to be re-seeded
+    """
 
     known_list = ['random', 'numpy']
 

--- a/resqpy/olio/relperm.py
+++ b/resqpy/olio/relperm.py
@@ -23,9 +23,9 @@ log.debug(f'dataframe.py version {version}')
 class RelPerm(DataFrame):
     """Class for storing and retrieving a pandas dataframe of relative permeability data.
 
-   note:
-      inherits from DataFrame class
-   """
+    note:
+       inherits from DataFrame class
+    """
 
     def __init__(self,
                  model,
@@ -41,17 +41,17 @@ class RelPerm(DataFrame):
                  uom_lookup_uuid = None):
         """Create a new RelPerm object from either a previously stored object or a pandas dataframe.
 
-      arguments:
-         phase_combo (str, optional): the combination of phases whose relative permeability behaviour is described.
-            Options include 'water-oil', 'gas-oil' and 'gas-water'
-         low_sal (boolean, optional): if True, indicates that the water-oil table contains the low-salinity data for
-            relative permeability and capillary pressure
-         table_index (int, optional): the index of the relative permeability
-         table when multiple relative permeability tables are present. Note, indices should start at 1.
+        arguments:
+           phase_combo (str, optional): the combination of phases whose relative permeability behaviour is described.
+              Options include 'water-oil', 'gas-oil' and 'gas-water'
+           low_sal (boolean, optional): if True, indicates that the water-oil table contains the low-salinity data for
+              relative permeability and capillary pressure
+           table_index (int, optional): the index of the relative permeability
+           table when multiple relative permeability tables are present. Note, indices should start at 1.
 
-      note:
-         see DataFrame class docstring for details of other arguments
-      """
+        note:
+           see DataFrame class docstring for details of other arguments
+        """
 
         # check that either a uuid OR dataframe has been provided
         if df is None and uuid is None:
@@ -170,16 +170,16 @@ class RelPerm(DataFrame):
     def interpolate_point(self, saturation, kr_or_pc_col):
         """Returns a tuple of the saturation value and the corresponding interpolated rel. perm. or cap. pressure value.
 
-      arguments:
-         saturation (float): the saturation at which the relative permeability or cap. pressure will be interpolated
-         kr_or_pc_col (str): the column name of the parameter to be interpolated
+        arguments:
+           saturation (float): the saturation at which the relative permeability or cap. pressure will be interpolated
+           kr_or_pc_col (str): the column name of the parameter to be interpolated
 
-      returns:
-         tuple of float, the first element is the saturation and the second element is the interpolated value
+        returns:
+           tuple of float, the first element is the saturation and the second element is the interpolated value
 
-      note:
-         A simple linear interpolation is performed.
-      """
+        note:
+           A simple linear interpolation is performed.
+        """
         df = self.df.copy()
         if kr_or_pc_col.capitalize() not in df.columns or kr_or_pc_col.capitalize() == df.columns[0]:
             raise ValueError('incorrect column name provided for interpolation')
@@ -199,17 +199,17 @@ class RelPerm(DataFrame):
     def df_to_text(self, filepath, filename):
         """Creates a text file from a dataframe of relative permeability and capillary pressure data.
 
-      arguments:
-         filepath (str): location where new text file is written to
-         filename (str): name of the new text file
+        arguments:
+           filepath (str): location where new text file is written to
+           filename (str): name of the new text file
 
-      returns:
-         tuple of float, the first element is the saturation and the second element is the interpolated value
+        returns:
+           tuple of float, the first element is the saturation and the second element is the interpolated value
 
-      note:
-         Only Nexus compatible text files are currently supported. Text files that are compatible with other reservoir
-            simulators may be supported in the future.
-      """
+        note:
+           Only Nexus compatible text files are currently supported. Text files that are compatible with other reservoir
+              simulators may be supported in the future.
+        """
         df = self.df.copy()
         ascii_file = os.path.join(filepath, filename + '.dat')
         df.columns = map(str.upper, df.columns)
@@ -245,9 +245,8 @@ class RelPerm(DataFrame):
                 print(f'Appended to DAT file: {filename} at {filepath}')
 
     def write_hdf5_and_create_xml(self):
-        """Write relative permeability table data to hdf5 file and create xml for RESQML objects to represent dataframe.
-
-      """
+        """Write relative permeability table data to hdf5 file and create xml for RESQML objects to represent
+        dataframe."""
         super().write_hdf5_and_create_xml()
         mesh_root = self.mesh.root
         # create an xml of extra metadata to indicate that this is a relative permeability table
@@ -255,20 +254,21 @@ class RelPerm(DataFrame):
 
 
 def text_to_relperm_dict(relperm_data, is_file = True):
-    """Returns a dictionary that contains dataframes with relative permeability and capillary pressure data and phase combinations.
+    """Returns a dictionary that contains dataframes with relative permeability and capillary pressure data and phase
+    combinations.
 
-   arguments:
-      relperm_data (str): relative or full path of the text file to be processed or string of relative permeability data
-      is_file (boolean): if True, indicates that a text file of relative permeability data has been provided. Default value is True
+    arguments:
+       relperm_data (str): relative or full path of the text file to be processed or string of relative permeability data
+       is_file (boolean): if True, indicates that a text file of relative permeability data has been provided. Default value is True
 
-   returns:
-      dict, each element in the dictionary contains a dataframe, with saturation and rel. permeability/capillary pressure
-      data, and the phase combination being described
+    returns:
+       dict, each element in the dictionary contains a dataframe, with saturation and rel. permeability/capillary pressure
+       data, and the phase combination being described
 
-   note:
-      Only Nexus compatible text files are currently supported. Text files from other reservoir simulators may be
-         supported in the future.
-   """
+    note:
+       Only Nexus compatible text files are currently supported. Text files from other reservoir simulators may be
+          supported in the future.
+    """
     if is_file:
         with open(relperm_data) as f:
             string_original = f.read()
@@ -336,20 +336,20 @@ def relperm_parts_in_model(model,
                            related_uuid = None):
     """Returns list of part names within model that are representing RelPerm dataframe support objects.
 
-   arguments:
-      model (model.Model): the model to be inspected for dataframes
-      phase_combo (str, optional): the combination of phases whose relative permeability behaviour is described.
-         Options include 'water-oil', 'gas-oil', 'gas-water', 'oil-water', 'oil-gas' and 'water-gas'
-      low_sal (boolean, optional): if True, indicates that the water-oil table contains the low-salinity data for
-         relative permeability and capillary pressure
-      table_index (int, optional): the index of the relative permeability table when multiple relative permeability
-         tables are present. Note, indices should start at 1.
-      title (str, optional): if present, only parts with a citation title exactly matching will be included
-      related_uuid (uuid, optional): if present, only parts relating to this uuid are included
+    arguments:
+       model (model.Model): the model to be inspected for dataframes
+       phase_combo (str, optional): the combination of phases whose relative permeability behaviour is described.
+          Options include 'water-oil', 'gas-oil', 'gas-water', 'oil-water', 'oil-gas' and 'water-gas'
+       low_sal (boolean, optional): if True, indicates that the water-oil table contains the low-salinity data for
+          relative permeability and capillary pressure
+       table_index (int, optional): the index of the relative permeability table when multiple relative permeability
+          tables are present. Note, indices should start at 1.
+       title (str, optional): if present, only parts with a citation title exactly matching will be included
+       related_uuid (uuid, optional): if present, only parts relating to this uuid are included
 
-   returns:
-      list of str, each element in the list is a part name, within model, which is representing the support for a RelPerm object
-   """
+    returns:
+       list of str, each element in the list is a part name, within model, which is representing the support for a RelPerm object
+    """
     extra_metadata_orig = {
         'relperm_table': 'true',
         'phase_combo': phase_combo,

--- a/resqpy/olio/rq_print.py
+++ b/resqpy/olio/rq_print.py
@@ -246,8 +246,8 @@ hdf5_dataset_count = 0
 def print_hdf5_line(name, group_or_dataset):
     """Prints information about one dataset (array) in an hdf5 file.
 
-      :meta private:
-   """
+    :meta private:
+    """
 
     global hdf5_dataset_count
     if isinstance(group_or_dataset, h5py.Group):

--- a/resqpy/olio/simple_lines.py
+++ b/resqpy/olio/simple_lines.py
@@ -15,18 +15,18 @@ import numpy as np
 def read_lines(filename):
     """Returns a list of line arrays, read from ascii file.
 
-      argument:
-         filename (string): the path of the ascii file holding a set of poly-lines
+    argument:
+       filename (string): the path of the ascii file holding a set of poly-lines
 
-      returns:
-         list of numpy arrays, each array representing one poly-line
+    returns:
+       list of numpy arrays, each array representing one poly-line
 
-      notes:
-         each line in the file must contain 3 floating point numbers: x, y, z;
-         each poly-line must be terminated with a null marker line: 999.0 999.0 999.0
-         there is no handling of units; elsewhere they will implicitly be assumed to be
-         those of a crs for a grid object
-   """
+    notes:
+       each line in the file must contain 3 floating point numbers: x, y, z;
+       each poly-line must be terminated with a null marker line: 999.0 999.0 999.0
+       there is no handling of units; elsewhere they will implicitly be assumed to be
+       those of a crs for a grid object
+    """
 
     lines_list = []
     end_of_line = np.array([999.0, 999.0, 999.0])
@@ -67,16 +67,16 @@ def read_lines(filename):
 def polygon_line(line, tolerance = 0.001):
     """Returns a copy of the line with the last vertex stripped off if it is close to the first vertex.
 
-      arguments:
-         line (numpy array of floats): representation of a poly-line which might be closed (last vertex
-            matches first vertex)
-         tolerance (float, default = 0.001): the maximum Manhatten distance between two points for them
-            to be treated as coincident
+    arguments:
+       line (numpy array of floats): representation of a poly-line which might be closed (last vertex
+          matches first vertex)
+       tolerance (float, default = 0.001): the maximum Manhatten distance between two points for them
+          to be treated as coincident
 
-      returns:
-         numpy array of floats which is either a copy of line, or a copy of line with the last point
-         removed
-   """
+    returns:
+       numpy array of floats which is either a copy of line, or a copy of line with the last point
+       removed
+    """
 
     last = len(line) - 1
     if last < 1:
@@ -93,20 +93,20 @@ def polygon_line(line, tolerance = 0.001):
 def duplicate_vertices_removed(line, tolerance = 0.001):
     """Returns a copy of the line with neighbouring duplicate vertices removed.
 
-      arguments:
-         line (2D numpy array of floats): representation of a poly-line
-         tolerance (float, default = 0.001): the maximum Manhatten distance between two points for them
-            to be treated as coincident
+    arguments:
+       line (2D numpy array of floats): representation of a poly-line
+       tolerance (float, default = 0.001): the maximum Manhatten distance between two points for them
+          to be treated as coincident
 
-      returns:
-         numpy array of floats which is either a copy of line, or a copy of line with some points
-         removed
+    returns:
+       numpy array of floats which is either a copy of line, or a copy of line with some points
+       removed
 
-      notes:
-         does not treat the line as a closed polyline, use polygon_line() function as well to remove
-         duplicated first/last point;
-         always preserves first and last point, even if they are identical and there are no other vertices
-   """
+    notes:
+       does not treat the line as a closed polyline, use polygon_line() function as well to remove
+       duplicated first/last point;
+       always preserves first and last point, even if they are identical and there are no other vertices
+    """
 
     assert line.ndim == 2
     if len(line) < 3:
@@ -131,22 +131,22 @@ def duplicate_vertices_removed(line, tolerance = 0.001):
 def nearest_pillars(line_list, grid, ref_k = 0, ref_kp = 0):
     """Finds pillars nearest to each point on each line; returns list of lists of (j0, i0).
 
-      arguments:
-         line_list (list of numpy arrays of floats): set of poly-lines, the points of which are used
-            to find the nearest pillars in grid
-         grid (grid.Grid object): the grid whose pillars are compared with the poly-line vertices
-         ref_k (integer, default 0): the reference layer in the grid to compare against the vertices;
-            zero based
-         ref_kp (integer, default 0): 0 to indicate the top corners of the reference layer, 1 for the base
+    arguments:
+       line_list (list of numpy arrays of floats): set of poly-lines, the points of which are used
+          to find the nearest pillars in grid
+       grid (grid.Grid object): the grid whose pillars are compared with the poly-line vertices
+       ref_k (integer, default 0): the reference layer in the grid to compare against the vertices;
+          zero based
+       ref_kp (integer, default 0): 0 to indicate the top corners of the reference layer, 1 for the base
 
-      returns:
-         a list of lists of pairs of integers, each being the (j, i) pillar indices of the nearest pillar
-         to the corresponding vertex of the poly-line; zero based indexing
+    returns:
+       a list of lists of pairs of integers, each being the (j, i) pillar indices of the nearest pillar
+       to the corresponding vertex of the poly-line; zero based indexing
 
-      notes:
-         this is a 2D search in the x, y plane; z values are ignored;
-         poly-line x, y values must implicitly be in the same crs as the grid's points data
-   """
+    notes:
+       this is a 2D search in the x, y plane; z values are ignored;
+       poly-line x, y values must implicitly be in the same crs as the grid's points data
+    """
 
     pillar_list_list = []
     for line in line_list:
@@ -163,25 +163,25 @@ def nearest_pillars(line_list, grid, ref_k = 0, ref_kp = 0):
 def nearest_rods(line_list, projection, grid, axis, ref_slice0 = 0, plus_face = False):
     """Finds rods nearest to each point on each line; returns list of lists of (k0, j0) or (k0, i0).
 
-      arguments:
-         line_list (list of numpy arrays of floats): set of poly-lines, the points of which are used
-            to find the nearest rods in grid
-         projection (string): 'xz' or 'yz'
-         grid (grid.Grid object): the grid whose cross section points are compared with the poly-line vertices
-         axis (string): 'I' or 'J' being the axis removed during slicing
-         ref_slice0 (integer, default 0): the reference slice in the grid to compare against the vertices;
-            zero based
-         plus_face (boolean, default False): which face of the reference slice to use
+    arguments:
+       line_list (list of numpy arrays of floats): set of poly-lines, the points of which are used
+          to find the nearest rods in grid
+       projection (string): 'xz' or 'yz'
+       grid (grid.Grid object): the grid whose cross section points are compared with the poly-line vertices
+       axis (string): 'I' or 'J' being the axis removed during slicing
+       ref_slice0 (integer, default 0): the reference slice in the grid to compare against the vertices;
+          zero based
+       plus_face (boolean, default False): which face of the reference slice to use
 
-      returns:
-         a list of numpy arrays of pairs of integers, each being the (k, j) or (k, i) indices of the
-         nearest rod to the corresponding vertex of the poly-line under projection; zero based indexing
+    returns:
+       a list of numpy arrays of pairs of integers, each being the (k, j) or (k, i) indices of the
+       nearest rod to the corresponding vertex of the poly-line under projection; zero based indexing
 
-      notes:
-         this is a 2D search in the x, z or y, z plane;
-         currently limited to unsplit grids without k gaps;
-         poly-line x, y, z values must implicitly be in the same crs as the grid's points data
-   """
+    notes:
+       this is a 2D search in the x, z or y, z plane;
+       currently limited to unsplit grids without k gaps;
+       poly-line x, y, z values must implicitly be in the same crs as the grid's points data
+    """
 
     assert projection in ['xz', 'yz']
     assert axis.upper() in ['J', 'I']
@@ -196,28 +196,28 @@ def nearest_rods(line_list, projection, grid, axis, ref_slice0 = 0, plus_face = 
 def drape_lines(line_list, pillar_list_list, grid, ref_k = 0, ref_kp = 0, offset = -1.0, snap = False):
     """Roughly drapes lines over grid horizon; draped lines are suitable for 3D visualisation.
 
-      arguments:
-         line_list (list of numpy arrays of floats): the undraped poly-lines
-         pillar_list_list: (list of lists of pairs of integers): as returned by nearest_pillars()
-         grid: (grid.Grid object): the grid to which the poly-lines are to be draped
-         ref_k (integer, default 0): the reference layer in the grid to which the lines will be
-            draped; zero based
-         ref_kp (integer, default 0): 0 to indicate the top corners of the reference layer, 1 for the base
-         offset (float, default -1.0): the vertical offset to add to the z value of pillar points; positive
-            drapes lines deeper, negative shallower (assumes grid's crs has z increasing downwards)
-         snap (boolean, default False): if True, the x & y values of each vertex in the lines are moved to
-            match the pillar point; if False, only the z values are adjusted
+    arguments:
+       line_list (list of numpy arrays of floats): the undraped poly-lines
+       pillar_list_list: (list of lists of pairs of integers): as returned by nearest_pillars()
+       grid: (grid.Grid object): the grid to which the poly-lines are to be draped
+       ref_k (integer, default 0): the reference layer in the grid to which the lines will be
+          draped; zero based
+       ref_kp (integer, default 0): 0 to indicate the top corners of the reference layer, 1 for the base
+       offset (float, default -1.0): the vertical offset to add to the z value of pillar points; positive
+          drapes lines deeper, negative shallower (assumes grid's crs has z increasing downwards)
+       snap (boolean, default False): if True, the x & y values of each vertex in the lines are moved to
+          match the pillar point; if False, only the z values are adjusted
 
-      returns:
-         list of numpy arrays of floats, being the draped equivalents of the line_list
+    returns:
+       list of numpy arrays of floats, being the draped equivalents of the line_list
 
-      notes:
-         the units of the line list must implicitly be those of the crs for the grid;
-         for grids with split coordinate lines (faults), only the primary pillars are currently used;
-         the results of this function are intended for 3D visualisation of an indicative nature;
-         resulting draped lines may penetrate the grid layer faces depending on the 3D geometry and
-         the spacing of the vertices compared to cell sizes
-   """
+    notes:
+       the units of the line list must implicitly be those of the crs for the grid;
+       for grids with split coordinate lines (faults), only the primary pillars are currently used;
+       the results of this function are intended for 3D visualisation of an indicative nature;
+       resulting draped lines may penetrate the grid layer faces depending on the 3D geometry and
+       the spacing of the vertices compared to cell sizes
+    """
 
     assert len(line_list) == len(pillar_list_list)
 
@@ -253,27 +253,27 @@ def drape_lines_to_rods(line_list,
                         snap = False):
     """Roughly drapes lines near grid cross section; draped lines are suitable for 3D visualisation.
 
-      arguments:
-         line_list (list of numpy arrays of floats): the undraped poly-lines
-         rod_list_list: (list of arrays of pairs of integers): as returned by nearest_rods()
-         grid: (grid.Grid object): the grid to which the poly-lines are to be draped
-         axis (string): 'I' or 'J' being the axis removed during slicing
-         ref_slice0 (integer, default 0): the reference slice in the grid to drape to; zero based
-         plus_face (boolean, default False): which face of the reference slice to use
-         offset (float, default -1.0): the horzontal offset to add to the y or x value of rod points
-         snap (boolean, default False): if True, the x & z or y & z values of each vertex in the lines
-            are moved to match the rod point; if False, only the y or x values are adjusted
+    arguments:
+       line_list (list of numpy arrays of floats): the undraped poly-lines
+       rod_list_list: (list of arrays of pairs of integers): as returned by nearest_rods()
+       grid: (grid.Grid object): the grid to which the poly-lines are to be draped
+       axis (string): 'I' or 'J' being the axis removed during slicing
+       ref_slice0 (integer, default 0): the reference slice in the grid to drape to; zero based
+       plus_face (boolean, default False): which face of the reference slice to use
+       offset (float, default -1.0): the horzontal offset to add to the y or x value of rod points
+       snap (boolean, default False): if True, the x & z or y & z values of each vertex in the lines
+          are moved to match the rod point; if False, only the y or x values are adjusted
 
-      returns:
-         list of numpy arrays of floats, being the draped equivalents of the line_list
+    returns:
+       list of numpy arrays of floats, being the draped equivalents of the line_list
 
-      notes:
-         the units of the line list must implicitly be those of the crs for the grid;
-         currently limited to unsplit grids with no k gaps;
-         the results of this function are intended for 3D visualisation of an indicative nature;
-         resulting draped lines may penetrate the grid layer faces depending on the 3D geometry and
-         the spacing of the vertices compared to cell sizes
-   """
+    notes:
+       the units of the line list must implicitly be those of the crs for the grid;
+       currently limited to unsplit grids with no k gaps;
+       the results of this function are intended for 3D visualisation of an indicative nature;
+       resulting draped lines may penetrate the grid layer faces depending on the 3D geometry and
+       the spacing of the vertices compared to cell sizes
+    """
 
     assert projection in ['xz', 'yz']
     assert axis.upper() in ['I', 'J']

--- a/resqpy/olio/time.py
+++ b/resqpy/olio/time.py
@@ -8,15 +8,15 @@ import datetime as dt
 def now(use_utc = False):
     """Returns an iso format string representation of the current time, to the nearest second.
 
-      argument:
-         use_utc (boolean, default False): if True, the current UTC time is used, otherwise local time
+    argument:
+       use_utc (boolean, default False): if True, the current UTC time is used, otherwise local time
 
-      returns:
-         string of form YYYY-MM-DDThh:mm:ssZ representing the current time in iso format
+    returns:
+       string of form YYYY-MM-DDThh:mm:ssZ representing the current time in iso format
 
-      note:
-         this is the format used by the resqml standard for representing date-times
-   """
+    note:
+       this is the format used by the resqml standard for representing date-times
+    """
 
     if use_utc:
         stamp = dt.datetime.utcnow()  # NB: naive use of UTC time

--- a/resqpy/olio/transmission.py
+++ b/resqpy/olio/transmission.py
@@ -27,33 +27,33 @@ def half_cell_t(grid,
                 tolerance = 1.0e-6):
     """Creates a half cell transmissibilty property array for a regular or irregular IJK grid.
 
-   arguments:
-      grid (grid.Grid or grid.RegularGrid): the grid for which half cell transmissibilities are required
-      perm_k, j, i (float arrays of shape (nk, nj, ni), optional): cell permeability values
-         (for each direction), in mD; if None, the permeabilities are found in the grid's property collection
-      ntg (float array of shape (nk, nj, ni), or float, optional): net to gross values to apply to I & J
-         calculations; if a single float, is treated as a constant; if None, net to gross ratio data in the
-         property collection is used
-      realization (int, optional): if present and the property collection is scanned for perm or ntg
-         arrays, only those properties for this realization will be used; ignored if arrays passed in
-      darcy_constant (float, optional): if present, the value to use for the Darcy constant;
-         if None, the grid's length units will determine the value as expected by Nexus
-      tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
-         will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
-         units are implicitly those of the grid's crs length units; ignored if grid is a RegularGrid
+    arguments:
+       grid (grid.Grid or grid.RegularGrid): the grid for which half cell transmissibilities are required
+       perm_k, j, i (float arrays of shape (nk, nj, ni), optional): cell permeability values
+          (for each direction), in mD; if None, the permeabilities are found in the grid's property collection
+       ntg (float array of shape (nk, nj, ni), or float, optional): net to gross values to apply to I & J
+          calculations; if a single float, is treated as a constant; if None, net to gross ratio data in the
+          property collection is used
+       realization (int, optional): if present and the property collection is scanned for perm or ntg
+          arrays, only those properties for this realization will be used; ignored if arrays passed in
+       darcy_constant (float, optional): if present, the value to use for the Darcy constant;
+          if None, the grid's length units will determine the value as expected by Nexus
+       tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
+          will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
+          units are implicitly those of the grid's crs length units; ignored if grid is a RegularGrid
 
-   returns:
-      numpy float array of shape (nk, nj, ni, 3) if grid is a RegularGrid otherwise (nk, nj, ni, 3, 2)
-         where the 3 covers K,J,I and (for irregular grids) the 2 covers the face polarity: - (0) and + (1);
-         units will depend on the length units of the coordinate reference system for
-         the grid (and implicitly on the units of the darcy_constant); if darcy_constant is None,
-         the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft
-         respectively
+    returns:
+       numpy float array of shape (nk, nj, ni, 3) if grid is a RegularGrid otherwise (nk, nj, ni, 3, 2)
+          where the 3 covers K,J,I and (for irregular grids) the 2 covers the face polarity: - (0) and + (1);
+          units will depend on the length units of the coordinate reference system for
+          the grid (and implicitly on the units of the darcy_constant); if darcy_constant is None,
+          the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft
+          respectively
 
-   notes:
-      calls either for half_cell_t_irregular() or half_cell_t_regular() depending on class of grid;
-      see also notes for half_cell_t_irregular() and half_cell_t_regular()
-   """
+    notes:
+       calls either for half_cell_t_irregular() or half_cell_t_regular() depending on class of grid;
+       see also notes for half_cell_t_irregular() and half_cell_t_regular()
+    """
 
     import resqpy.grid as grr
 
@@ -99,34 +99,34 @@ def half_cell_t(grid,
 def half_cell_t_regular(grid, perm_k = None, perm_j = None, perm_i = None, ntg = None, darcy_constant = None):
     """Creates a half cell transmissibilty property array for a RegularGrid.
 
-   arguments:
-      grid (grid.RegularGrid): the grid for which half cell transmissibilities are required
-      perm_k, j, i (float arrays of shape (nk, nj, ni), required): cell permeability values
-         (for each direction), in mD;
-      ntg (float array of shape (nk, nj, ni), or float, optional): net to gross values to apply to I & J
-         calculations; if a single float, is treated as a constant; if None, a value of 1.0 is used
-      darcy_constant (float, required): the value to use for the Darcy constant
+    arguments:
+       grid (grid.RegularGrid): the grid for which half cell transmissibilities are required
+       perm_k, j, i (float arrays of shape (nk, nj, ni), required): cell permeability values
+          (for each direction), in mD;
+       ntg (float array of shape (nk, nj, ni), or float, optional): net to gross values to apply to I & J
+          calculations; if a single float, is treated as a constant; if None, a value of 1.0 is used
+       darcy_constant (float, required): the value to use for the Darcy constant
 
-   returns:
-      numpy float array of shape (nk, nj, ni, 3) where the 3 covers K,J,I;
-         units will depend on the length units of the coordinate reference system for
-         the grid (and implicitly on the units of the darcy_constant); if darcy_constant is None,
-         the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft
-         respectively
+    returns:
+       numpy float array of shape (nk, nj, ni, 3) where the 3 covers K,J,I;
+          units will depend on the length units of the coordinate reference system for
+          the grid (and implicitly on the units of the darcy_constant); if darcy_constant is None,
+          the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft
+          respectively
 
-   notes:
-      the same half cell transmissibility value is applicable to both - and + polarity faces;
-      the axes of the regular grid are assumed to be orthogonal;
-      the net to gross factor is only applied to I & J transmissibilities, not K; the results
-      include the Darcy Constant factor but not any transmissibility multiplier applied at the
-      face; to compute the transmissibilty between neighbouring cells, take the harmonic mean of
-      the two half cell transmissibilities and multiply by any transmissibility multiplier;
-      returned array will need to be re-shaped before storing as a RESQML property
-      with indexable elements of 'faces';
-      the coordinate referemce system for the grid must have the same length units for xy and z;
-      this function is vastly more computationally efficient than the general (irregular grid)
-      function
-   """
+    notes:
+       the same half cell transmissibility value is applicable to both - and + polarity faces;
+       the axes of the regular grid are assumed to be orthogonal;
+       the net to gross factor is only applied to I & J transmissibilities, not K; the results
+       include the Darcy Constant factor but not any transmissibility multiplier applied at the
+       face; to compute the transmissibilty between neighbouring cells, take the harmonic mean of
+       the two half cell transmissibilities and multiply by any transmissibility multiplier;
+       returned array will need to be re-shaped before storing as a RESQML property
+       with indexable elements of 'faces';
+       the coordinate referemce system for the grid must have the same length units for xy and z;
+       this function is vastly more computationally efficient than the general (irregular grid)
+       function
+    """
 
     assert perm_k is not None and perm_j is not None and perm_i is not None
     if ntg is None:
@@ -153,40 +153,40 @@ def half_cell_t_irregular(grid,
                           tolerance = 1.0e-6):
     """Creates a half cell transmissibilty property array for an IJK grid.
 
-   arguments:
-      grid (grid.Grid): the grid for which half cell transmissibilities are required
-      perm_k, j, i (float arrays of shape (nk, nj, ni), reqwuired): cell permeability values
-         (for each direction), in mD;
-      ntg (float array of shape (nk, nj, ni), or float, required): net to gross values to apply to I & J
-         calculations; if a single float, is treated as a constant;
-      darcy_constant (float, required): the value to use for the Darcy constant
-      tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
-         will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
-         units are implicitly those of the grid's crs length units
+    arguments:
+       grid (grid.Grid): the grid for which half cell transmissibilities are required
+       perm_k, j, i (float arrays of shape (nk, nj, ni), reqwuired): cell permeability values
+          (for each direction), in mD;
+       ntg (float array of shape (nk, nj, ni), or float, required): net to gross values to apply to I & J
+          calculations; if a single float, is treated as a constant;
+       darcy_constant (float, required): the value to use for the Darcy constant
+       tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
+          will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
+          units are implicitly those of the grid's crs length units
 
-   returns:
-      numpy float array of shape (nk, nj, ni, 3, 2) where the 3 covers K,J,I and the 2 covers the
-         face polarity: - (0) and + (1);
-         units will depend on the length units of the coordinate reference system for
-         the grid (and implicitly on the units of the darcy_constant); if darcy_constant is None,
-         the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft
-         respectively
+    returns:
+       numpy float array of shape (nk, nj, ni, 3, 2) where the 3 covers K,J,I and the 2 covers the
+          face polarity: - (0) and + (1);
+          units will depend on the length units of the coordinate reference system for
+          the grid (and implicitly on the units of the darcy_constant); if darcy_constant is None,
+          the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft
+          respectively
 
-   notes:
-      the algorithm is equivalent to the half cell transmissibility element of the Nexus NEWTRAN
-      calculation; each resulting value is effectively for the entire face, so area proportional
-      fractions will be needed at faults with throw, or at grid boundaries; the net to gross
-      factor is only applied to I & J transmissibilities, not K; the results
-      include the Darcy Constant factor but not any transmissibility multiplier applied at the
-      face; to compute the transmissibilty between neighbouring cells, take the harmonic mean of
-      the two half cell transmissibilities and multiply by any transmissibility multiplier; if
-      the two cells do not have simple sharing of a common face, first reduce each half cell
-      transmissibility by the proportion of the face that is shared (which may be a different
-      proportion for each of the two juxtaposed cells);
-      returned array will need to be re-ordered and re-shaped before storing as a RESQML property
-      with indexable elements of 'faces per cell';
-      the coordinate referemce system for the grid must have the same length units for xy and z
-   """
+    notes:
+       the algorithm is equivalent to the half cell transmissibility element of the Nexus NEWTRAN
+       calculation; each resulting value is effectively for the entire face, so area proportional
+       fractions will be needed at faults with throw, or at grid boundaries; the net to gross
+       factor is only applied to I & J transmissibilities, not K; the results
+       include the Darcy Constant factor but not any transmissibility multiplier applied at the
+       face; to compute the transmissibilty between neighbouring cells, take the harmonic mean of
+       the two half cell transmissibilities and multiply by any transmissibility multiplier; if
+       the two cells do not have simple sharing of a common face, first reduce each half cell
+       transmissibility by the proportion of the face that is shared (which may be a different
+       proportion for each of the two juxtaposed cells);
+       returned array will need to be re-ordered and re-shaped before storing as a RESQML property
+       with indexable elements of 'faces per cell';
+       the coordinate referemce system for the grid must have the same length units for xy and z
+    """
 
     # NB: axis argument is KJI index; this function also uses axes in xyz space
 
@@ -369,25 +369,25 @@ def half_cell_t_vertical_prism(vpg,
                                tolerance = 1.0e-6):
     """Creates a half cell transmissibilty property array for a vertical prism grid.
 
-   arguments:
-      vpg (VerticalPrismGrid): the grid for which the half cell transmissibilities are required
-      triple_perm_horizontal (numpy float array of shape (N, 3)): the directional permeabilities to apply
-         to each of the three vertical faces per cell
-      perm_k (numpy float array of shape (N,)): the permeability to use for the vertical transmissibilities
-      ntg (numpy float array of shape (N,), optional): if present, acts as a multiplier in the
-         computation of non-vertical transmissibilities
-      darcy_constant (float, optional): the value to use for the Darcy constant; if None, a suitable
-         value will be used depending on the length units of the vpg grid's crs
-      tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
-         will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
-         units are implicitly those of the grid's crs length units
+    arguments:
+       vpg (VerticalPrismGrid): the grid for which the half cell transmissibilities are required
+       triple_perm_horizontal (numpy float array of shape (N, 3)): the directional permeabilities to apply
+          to each of the three vertical faces per cell
+       perm_k (numpy float array of shape (N,)): the permeability to use for the vertical transmissibilities
+       ntg (numpy float array of shape (N,), optional): if present, acts as a multiplier in the
+          computation of non-vertical transmissibilities
+       darcy_constant (float, optional): the value to use for the Darcy constant; if None, a suitable
+          value will be used depending on the length units of the vpg grid's crs
+       tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
+          will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
+          units are implicitly those of the grid's crs length units
 
-   returns:
-      numpy float array of shape (N, 5) being the per-face half cell transmissibilities for each cell
+    returns:
+       numpy float array of shape (N, 5) being the per-face half cell transmissibilities for each cell
 
-   note:
-      order of 5 faces matches those of faces per cell, ie. top, base, then the 3 vertical faces
-   """
+    note:
+       order of 5 faces matches those of faces per cell, ie. top, base, then the 3 vertical faces
+    """
 
     assert triple_perm_horizontal is not None
     assert triple_perm_horizontal.shape == (vpg.cell_count, 3)
@@ -432,27 +432,27 @@ def half_cell_t_vertical_prism(vpg,
 def half_cell_t_2d_triangular_precursor(p, t):
     """Creates a precursor to horizontal transmissibility for prism grids (see notes).
 
-   arguments:
-      p (numpy float array of shape (N, 2 or 3)): the xy(&z) locations of cell vertices
-      t (numpy int array of shape (M, 3)): the triangulation of p for which the transmissibility
-         precursor is required
+    arguments:
+       p (numpy float array of shape (N, 2 or 3)): the xy(&z) locations of cell vertices
+       t (numpy int array of shape (M, 3)): the triangulation of p for which the transmissibility
+          precursor is required
 
-   returns:
-      a pair of numpy float arrays, each of shape (M, 3) being the normal length and flow length
-      relevant for flow across the face opposite each vertex as defined by t
+    returns:
+       a pair of numpy float arrays, each of shape (M, 3) being the normal length and flow length
+       relevant for flow across the face opposite each vertex as defined by t
 
-   notes:
-      this function acts as a precursor to the equivalent of the half cell transmissibility
-      functions but for prism grids; for a resqpy VerticalPrismGrid, the triangulation can
-      be shared by many layers with this function only needing to be called once; the first
-      of the returned values (normal length) is the length of the triangle edge, in xy, when
-      projected onto the normal of the flow direction; multiplying the normal length by a cell
-      height will yield the area needed for transmissibility calculations; the second of the
-      returned values (flow length) is the distance from the trangle centre to the midpoint of
-      the edge and can be used as the distance term for a half cell transmissibilty; this
-      function does not account for dip, it only handles the geometric aspects of half
-      cell transmissibility in the xy plane
-   """
+    notes:
+       this function acts as a precursor to the equivalent of the half cell transmissibility
+       functions but for prism grids; for a resqpy VerticalPrismGrid, the triangulation can
+       be shared by many layers with this function only needing to be called once; the first
+       of the returned values (normal length) is the length of the triangle edge, in xy, when
+       projected onto the normal of the flow direction; multiplying the normal length by a cell
+       height will yield the area needed for transmissibility calculations; the second of the
+       returned values (flow length) is the distance from the trangle centre to the midpoint of
+       the edge and can be used as the distance term for a half cell transmissibilty; this
+       function does not account for dip, it only handles the geometric aspects of half
+       cell transmissibility in the xy plane
+    """
 
     assert p.ndim == 2 and p.shape[1] in [2, 3]
     assert t.ndim == 2 and t.shape[1] == 3
@@ -488,22 +488,22 @@ def half_cell_t_2d_triangular_precursor(p, t):
 def fault_connection_set(grid, skip_inactive = False):
     """Builds a GridConnectionSet for juxtaposed faces where there is a split pillar, with fractional area data.
 
-   arguments:
-      grid (grid.Grid object): the grid for which a fault connection set is required
-      skip_inactive (boolean, default False): if True, connections where either cell is inactive will be excluded
+    arguments:
+       grid (grid.Grid object): the grid for which a fault connection set is required
+       skip_inactive (boolean, default False): if True, connections where either cell is inactive will be excluded
 
-   returns:
-      (GridConnectionSet, numpy float array of shape (count, 2)) where the connection set identifies all cell face
-      pairs where there is juxtaposition and the array contains the fraction of the face areas that are juxtaposed;
-      count is the number of cell face pairs in the connection set
+    returns:
+       (GridConnectionSet, numpy float array of shape (count, 2)) where the connection set identifies all cell face
+       pairs where there is juxtaposition and the array contains the fraction of the face areas that are juxtaposed;
+       count is the number of cell face pairs in the connection set
 
-   notes:
-      the current algorithm is designed for faults where slip has occurred along pillars (fault sticks) – sideways
-      slip will currently cause erroneous results; inaccuracies may also arise as pillars become less straight, less
-      co-planar or less parallel; the combination of non-parallel pillars and layers of non-uniform thickness can
-      produce inaccuracies in some situations; if the grid does not have split pillars (ie. is unfaulted), or if
-      there are no qualifying connections across faults, then (None, None) will be returned
-   """
+    notes:
+       the current algorithm is designed for faults where slip has occurred along pillars (fault sticks) – sideways
+       slip will currently cause erroneous results; inaccuracies may also arise as pillars become less straight, less
+       co-planar or less parallel; the combination of non-parallel pillars and layers of non-uniform thickness can
+       produce inaccuracies in some situations; if the grid does not have split pillars (ie. is unfaulted), or if
+       there are no qualifying connections across faults, then (None, None) will be returned
+    """
 
     def all_nan(pillar):
         # return True if no valid points in pillar
@@ -1145,17 +1145,17 @@ def fault_connection_set(grid, skip_inactive = False):
 def projected_tri_area(pa, pb, pc):
     """Return array holding areas of triangles projected onto each of yz, xz, xy.
 
-   arguments:
-      pa, pb, pc (numpy float array of shape (..., 3): the corner points of a set of triangles (one corner
-         in each of pa, pb & pc, for every triangle); last axis in arrays covers x,y,z
+    arguments:
+       pa, pb, pc (numpy float array of shape (..., 3): the corner points of a set of triangles (one corner
+          in each of pa, pb & pc, for every triangle); last axis in arrays covers x,y,z
 
-   returns:
-      numpy float array of same shape as pa, pb & pc, with the last axis covering yz, xz, xy projections;
-      the return values are the areas of the triangles projected in the three principal x,y,z axes
+    returns:
+       numpy float array of same shape as pa, pb & pc, with the last axis covering yz, xz, xy projections;
+       the return values are the areas of the triangles projected in the three principal x,y,z axes
 
-   note:
-      assumes that units for x, y & z are the same; returned area units are those implicit units squared
-   """
+    note:
+       assumes that units for x, y & z are the same; returned area units are those implicit units squared
+    """
 
     assert pa.shape == pb.shape == pc.shape and pa.shape[-1] == 3
 

--- a/resqpy/olio/triangulation.py
+++ b/resqpy/olio/triangulation.py
@@ -209,27 +209,27 @@ def _dt_simple(po, plot_fn = None, progress_fn = None, container_size_factor = N
 def dt(p, algorithm = None, plot_fn = None, progress_fn = None, container_size_factor = 100.0, return_hull = False):
     """Returns the Delauney Triangulation of 2D point set p.
 
-   arguments:
-      p (numpy float array of shape (N, 2): the x,y coordinates of the points
-      algorithm (string, optional): selects which algorithm to use; current options: ['simple'];
-         if None, the current best algorithm is selected
-      plot_fn (function of form f(p, t), optional): if present, this function is called each time the
-         algorithm feels it is worth refreshing a plot of the progress; p is a copy of the point set,
-         depending on the algorithm with 3 extra points added to form an enveloping triangle
-      progress_fn (function of form f(x), optional): if present, this function is called at regulat
-         intervals by the algorithm, passing increasing values in the range 0.0 to 1.0 as x
-      container_size_factor (float, default 100.0): the larger this number, the more likely the
-         resulting triangulation is to be convex; reduce to 1.0 to allow slight concavities
-      return_hull (boolean, default False): if True, a pair is returned with the second item being
-         a clockwise ordered list of indices into p identifying the points on the boundary of the
-         returned triangulation
+    arguments:
+       p (numpy float array of shape (N, 2): the x,y coordinates of the points
+       algorithm (string, optional): selects which algorithm to use; current options: ['simple'];
+          if None, the current best algorithm is selected
+       plot_fn (function of form f(p, t), optional): if present, this function is called each time the
+          algorithm feels it is worth refreshing a plot of the progress; p is a copy of the point set,
+          depending on the algorithm with 3 extra points added to form an enveloping triangle
+       progress_fn (function of form f(x), optional): if present, this function is called at regulat
+          intervals by the algorithm, passing increasing values in the range 0.0 to 1.0 as x
+       container_size_factor (float, default 100.0): the larger this number, the more likely the
+          resulting triangulation is to be convex; reduce to 1.0 to allow slight concavities
+       return_hull (boolean, default False): if True, a pair is returned with the second item being
+          a clockwise ordered list of indices into p identifying the points on the boundary of the
+          returned triangulation
 
-   returns:
-      numpy int array of shape (M, 3) - being the indices into the first axis of p of the 3 points
-         per triangle in the Delauney Triangulation - and if return_hull is True, another int array
-         of shape (B,) - being indices into p of the clockwise ordered points on the boundary of
-         the triangulation
-   """
+    returns:
+       numpy int array of shape (M, 3) - being the indices into the first axis of p of the 3 points
+          per triangle in the Delauney Triangulation - and if return_hull is True, another int array
+          of shape (B,) - being indices into p of the clockwise ordered points on the boundary of
+          the triangulation
+    """
     assert p.ndim == 2 and p.shape[1] >= 2, 'bad points shape for 2D Delauney Triangulation'
 
     if not algorithm:
@@ -270,26 +270,26 @@ def ccc(p1, p2, p3):
 def voronoi(p, t, b, aoi):
     """Returns dual Voronoi diagram for a Delauney triangulation.
 
-   arguments:
-      p (numpy float array of shape (N, 2)): seed points used in the Delauney triangulation
-      t (numpy int array of shape (M, 3)): the Delauney triangulation of p as returned by dt()
-      b (numpy int array of shape (B,)): clockwise sorted list of indices into p of the boundary
-         points of the triangulation t
-      aoi (lines.Polyline): area of interest; a closed clockwise polyline that must strictly contain
-         all p (no points exactly on or outside the polyline)
+    arguments:
+       p (numpy float array of shape (N, 2)): seed points used in the Delauney triangulation
+       t (numpy int array of shape (M, 3)): the Delauney triangulation of p as returned by dt()
+       b (numpy int array of shape (B,)): clockwise sorted list of indices into p of the boundary
+          points of the triangulation t
+       aoi (lines.Polyline): area of interest; a closed clockwise polyline that must strictly contain
+          all p (no points exactly on or outside the polyline)
 
-   returns:
-      c, v where: c is a numpy float array of shape (M+E, 2) being the circumcircle centres of
-      the M triangles and E boundary points from the aoi polygon line; and v is a list of
-      N Voronoi cell lists of clockwise ints, each int being an index into c
+    returns:
+       c, v where: c is a numpy float array of shape (M+E, 2) being the circumcircle centres of
+       the M triangles and E boundary points from the aoi polygon line; and v is a list of
+       N Voronoi cell lists of clockwise ints, each int being an index into c
 
-   notes:
-      the aoi polyline forms the outer boundary for the Voronoi polygons for points on the
-      outer edge of the triangulation; all points p must lie strictly within the aoi, which
-      must be convex; the triangulation t, of points p, must also have a convex hull; note
-      that the dt() function can produce a triangulation with slight concavities on the hull,
-      especially for smaller values of its container_size_factor argument
-   """
+    notes:
+       the aoi polyline forms the outer boundary for the Voronoi polygons for points on the
+       outer edge of the triangulation; all points p must lie strictly within the aoi, which
+       must be convex; the triangulation t, of points p, must also have a convex hull; note
+       that the dt() function can produce a triangulation with slight concavities on the hull,
+       especially for smaller values of its container_size_factor argument
+    """
 
     # this code assumes that the Voronoi polygon for a seed point visits the circumcentres of
     # all the triangles that make use of the point – currently understood to be always the case
@@ -617,26 +617,26 @@ def voronoi(p, t, b, aoi):
 def triangulated_polygons(p, v, centres = None):
     """Returns triangulation of polygons using centres as extra points.
 
-   arguments:
-      p (2D numpy float array): points used as vertices of polygons
-      v (list of list of ints): ordered indices into p for each polygon
-      centres (2D numpy float array, optional): the points to use as the centre for each polygon
+    arguments:
+       p (2D numpy float array): points used as vertices of polygons
+       v (list of list of ints): ordered indices into p for each polygon
+       centres (2D numpy float array, optional): the points to use as the centre for each polygon
 
-   returns:
-      points, triangles where: points is a copy of p extended with the centre points of polygons;
-      and triangles is a numpy int array of shape (N, 3) being the triangulation of points, where N is
-      equal to the overall length of v
+    returns:
+       points, triangles where: points is a copy of p extended with the centre points of polygons;
+       and triangles is a numpy int array of shape (N, 3) being the triangulation of points, where N is
+       equal to the overall length of v
 
-   notes:
-      if no centres are provided, balanced centre points are computed for the polygons;
-      the polygons must be convex (at least from the perspective of the centre points);
-      the clockwise/anti-clockwise order of the triangle edges will match that of the polygon;
-      the centre point is the first point in each triangle;
-      the order of triangles will match the order of vertices in a flattened view of list v;
-      p and centres may have a shape of 2 or 3 in the second dimension (xy or xyz data);
-      p & v could be the values (c, v) returned by the voronoi() function, in which case the
-      original seed points p passed into voronoi() can be passed as centres here
-   """
+    notes:
+       if no centres are provided, balanced centre points are computed for the polygons;
+       the polygons must be convex (at least from the perspective of the centre points);
+       the clockwise/anti-clockwise order of the triangle edges will match that of the polygon;
+       the centre point is the first point in each triangle;
+       the order of triangles will match the order of vertices in a flattened view of list v;
+       p and centres may have a shape of 2 or 3 in the second dimension (xy or xyz data);
+       p & v could be the values (c, v) returned by the voronoi() function, in which case the
+       original seed points p passed into voronoi() can be passed as centres here
+    """
 
     assert p.ndim == 2 and p.shape[1] in [2, 3]
     assert len(v) > 0

--- a/resqpy/olio/utility.py
+++ b/resqpy/olio/utility.py
@@ -44,7 +44,7 @@ def extent_switch_ijk_kji(extent_in):  # reverse order of elements in extent
 
 
 def cell_count_from_extent(extent):
-    """Returns the number of cells in a grid with the given extent"""
+    """Returns the number of cells in a grid with the given extent."""
     result = 1
     for d in range(len(extent)):  # list, tuple or 1D numpy array
         result *= extent[d]
@@ -73,7 +73,10 @@ def string_xyz(xyz):
 
 
 def horizon_float(k0, plus_or_minus):
-    """Returns a floating point representation of k direction face index; eg. 3.5 for face between layers 3 and 4."""
+    """Returns a floating point representation of k direction face index; eg.
+
+    3.5 for face between layers 3 and 4.
+    """
     result = float(k0)
     if plus_or_minus == '+':
         result += 0.5

--- a/resqpy/olio/uuid.py
+++ b/resqpy/olio/uuid.py
@@ -19,18 +19,18 @@ max_version_string_length = 10
 def switch_on_test_mode(seed = 0):
     """Causes subsequent calls to new_uid() to produce integer sequence starting from successor to seed.
 
-   arguments:
-      seed (integer, default 0): The predecessor to the first uuid returned by subsequent calls to
-         new_uuid()
+    arguments:
+       seed (integer, default 0): The predecessor to the first uuid returned by subsequent calls to
+          new_uuid()
 
-   returns:
-      None
+    returns:
+       None
 
-   notes:
-      call switch_off_test_mode() to reactivate normal behaviour;
-      uuids generated whilst in test mode do not adhere to the iso standard;
-      test mode is intended to allow replicatable behaviour for testing purposes
-   """
+    notes:
+       call switch_off_test_mode() to reactivate normal behaviour;
+       uuids generated whilst in test mode do not adhere to the iso standard;
+       test mode is intended to allow replicatable behaviour for testing purposes
+    """
 
     global test_mode
     global test_latest_int
@@ -41,9 +41,9 @@ def switch_on_test_mode(seed = 0):
 def switch_off_test_mode():
     """Subsequent calls to new_uid() will produce standard uuid values (default behaviour).
 
-   note:
-      this function will have no effect unless switch_on_test_mode() has previously been called
-   """
+    note:
+       this function will have no effect unless switch_on_test_mode() has previously been called
+    """
 
     global test_mode
     test_mode = False
@@ -52,14 +52,14 @@ def switch_off_test_mode():
 def new_uuid():
     """Returns a new uuid based on the time (to 100ns) & MAC address option of the iso standard.
 
-   returns:
-      uuid.UUID object
+    returns:
+       uuid.UUID object
 
-   notes:
-      at present, the multi-processor safe functionality is not deployed, so multiple processors
-      sharing the same MAC address could generate the same uuid simultaneously;
-      an integer sequence is generated when in test mode
-   """
+    notes:
+       at present, the multi-processor safe functionality is not deployed, so multiple processors
+       sharing the same MAC address could generate the same uuid simultaneously;
+       an integer sequence is generated when in test mode
+    """
 
     global test_latest_int
     if test_mode:
@@ -72,12 +72,12 @@ def new_uuid():
 def string_from_uuid(uuid_obj):
     """Returns standard hexadecimal string for uuid; same as str(uuid_obj).
 
-   arguments:
-      uuid_obj (uuid.UUID object): the uuid which is required in hexadecimal string format
+    arguments:
+       uuid_obj (uuid.UUID object): the uuid which is required in hexadecimal string format
 
-   returns:
-      string (40 characters: 36 lowercase hexadecimals and 4 hyphens)
-   """
+    returns:
+       string (40 characters: 36 lowercase hexadecimals and 4 hyphens)
+    """
 
     return str(uuid_obj)
 
@@ -85,18 +85,18 @@ def string_from_uuid(uuid_obj):
 def uuid_from_string(uuid_str):
     """Returns a uuid object for the given uuid string; hyphens are ignored.
 
-   arguments:
-      uuid_str (string): the hexadecimal representation of the 128 bit uuid integer;
-         hyphens are ignored
+    arguments:
+       uuid_str (string): the hexadecimal representation of the 128 bit uuid integer;
+          hyphens are ignored
 
-   returns:
-      uuid.UUID object
+    returns:
+       uuid.UUID object
 
-   notes:
-      if a uuid.UUID object is passed by accident, it is returned;
-      if the string starts with an underscore, the underscore is skipped (to cater for a fesapi quirk);
-      any tail beyond the uuid string is ignored
-   """
+    notes:
+       if a uuid.UUID object is passed by accident, it is returned;
+       if the string starts with an underscore, the underscore is skipped (to cater for a fesapi quirk);
+       any tail beyond the uuid string is ignored
+    """
 
     if uuid_str is None:
         return None
@@ -119,12 +119,12 @@ def uuid_from_string(uuid_str):
 def uuid_as_bytes(uuid_obj):
     """Returns the uuid as a 16 byte bytes sequence; same as uuid_obj.bytes.
 
-   arguments:
-      uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
+    arguments:
+       uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
 
-   returns:
-      bytes (16 bytes long)
-   """
+    returns:
+       bytes (16 bytes long)
+    """
 
     if uuid_obj is None:
         return None
@@ -136,12 +136,12 @@ def uuid_as_bytes(uuid_obj):
 def uuid_as_int(uuid_obj):
     """Returns the uuid as a 128 bit int; same as uuid_obj.int.
 
-   arguments:
-      uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
+    arguments:
+       uuid_obj (uuid.UUID object): the uuid for which a bytes representation is required
 
-   returns:
-      bytes (16 bytes long)
-   """
+    returns:
+       bytes (16 bytes long)
+    """
 
     if uuid_obj is None:
         return None
@@ -153,15 +153,15 @@ def uuid_as_int(uuid_obj):
 def matching_uuids(uuid_a, uuid_b):
     """Returns True if the 2 uuid objects are for the same id; False otherwise.
 
-   arguments:
-      uuid_a, uuid_b (uuid.UUID objects): the two uuids to be compared
+    arguments:
+       uuid_a, uuid_b (uuid.UUID objects): the two uuids to be compared
 
-   returns:
-      boolean: True if the two uuids are the same; False otherwise
+    returns:
+       boolean: True if the two uuids are the same; False otherwise
 
-   note:
-      this function is resilient to uuids being passed in hexadecimal string format
-   """
+    note:
+       this function is resilient to uuids being passed in hexadecimal string format
+    """
 
     if isinstance(uuid_a, str):
         uuid_a = uuid_from_string(uuid_a)  # resilience to accidental string arg
@@ -175,18 +175,18 @@ def matching_uuids(uuid_a, uuid_b):
 def version_string(uuid_obj):
     """Returns an integer string rendering of the time element of the uuid.
 
-   arguments:
-      uuid_obj (uuid.UUID): the uuid for which a string representation of the time component is required
+    arguments:
+       uuid_obj (uuid.UUID): the uuid for which a string representation of the time component is required
 
-   returns:
-      string (of digits)
+    returns:
+       string (of digits)
 
-   notes:
-      this function has nothing to do with the uuid.version attribute, it is used to populate the version
-      field of a resqml citation block;
-      the time component of the uuid is the number of 100ns periods that have elapsed since October 1582
-      (when the Gregorian calendar was adopted), as a 60 bit integer
-   """
+    notes:
+       this function has nothing to do with the uuid.version attribute, it is used to populate the version
+       field of a resqml citation block;
+       the time component of the uuid is the number of 100ns periods that have elapsed since October 1582
+       (when the Gregorian calendar was adopted), as a 60 bit integer
+    """
 
     if isinstance(uuid_obj, str):
         uuid_obj = uuid_from_string(uuid_obj)  # resilience to accidental string arg

--- a/resqpy/olio/vdb.py
+++ b/resqpy/olio/vdb.py
@@ -37,8 +37,8 @@ init_not_packed = ['DAD', 'KID', 'UID', 'UNPACK']
 def coerce(a, dtype):
     """Returns a version of numpy array a with elements coerced to dtype.
 
-      :meta private:
-   """
+    :meta private:
+    """
     if dtype is None or a.dtype == dtype:
         return a
     b = np.empty(a.shape, dtype = dtype)
@@ -64,7 +64,7 @@ def ensemble_vdb_list(run_dir, sort_list = True):
             recursive_vdb_list(entry.path)
 
     def cmp_to_key(mycmp):
-        'Convert a cmp= function into a key= function'
+        """Convert a cmp= function into a key= function."""
 
         class K:
 

--- a/resqpy/olio/vector_utilities.py
+++ b/resqpy/olio/vector_utilities.py
@@ -293,19 +293,19 @@ def rotate_array(rotation_matrix, a):
 def rotate_xyz_array_around_z_axis(a, target_xy_vector):
     """Returns a copy of array a suitable for presenting a cross-section using the resulting x,z values.
 
-   arguments:
-      a (numpy float array of shape (..., 3)): the xyz points to be rotated
-      target_xy_vector (2 (or 3) floats): a vector indicating which direction in source xy space will end up
-         being mapped to the positive x axis in the returned data
+    arguments:
+       a (numpy float array of shape (..., 3)): the xyz points to be rotated
+       target_xy_vector (2 (or 3) floats): a vector indicating which direction in source xy space will end up
+          being mapped to the positive x axis in the returned data
 
-   returns:
-      numpy float array of same shape as a
+    returns:
+       numpy float array of same shape as a
 
-   notes:
-      if the input points of a lie in a vertical plane parallel to the target xy vector, then the resulting
-      points will have constant y values; in general, a full rotation of the points is applied, so resulting
-      y values will indicate distance 'into the page' for non-planar or unaligned data
-   """
+    notes:
+       if the input points of a lie in a vertical plane parallel to the target xy vector, then the resulting
+       points will have constant y values; in general, a full rotation of the points is applied, so resulting
+       y values will indicate distance 'into the page' for non-planar or unaligned data
+    """
 
     target_v = np.zeros(3)
     target_v[:2] = target_xy_vector[:2]
@@ -324,10 +324,10 @@ def unit_vector_from_azimuth_and_inclination(azimuth, inclination):
 def tilt_3d_matrix(azimuth, dip):
     """Returns a 3D rotation matrix for applying a dip in a certain azimuth.
 
-   note:
-      if azimuth is compass bearing in degrees, and dip is in degrees, the resulting matrix can be used
-      to rotate xyz points where x values are eastings, y values are northings and z increases downwards
-   """
+    note:
+       if azimuth is compass bearing in degrees, and dip is in degrees, the resulting matrix can be used
+       to rotate xyz points where x values are eastings, y values are northings and z increases downwards
+    """
 
     matrix = rotation_matrix_3d_axial(2, -azimuth)  # will yield rotation around z axis so azimuth goes north
     matrix = np.dot(matrix, rotation_matrix_3d_axial(0, dip))  # adjust for dip
@@ -389,9 +389,9 @@ def determinant_3x3(a):
 def clockwise(a, b, c):
     """Returns a +ve value if 2D points a,b,c are in clockwise order, 0.0 if in line, -ve for ccw.
 
-   note:
-      assumes positive y-axis is anticlockwise from positive x-axis
-   """
+    note:
+       assumes positive y-axis is anticlockwise from positive x-axis
+    """
 
     return (c[0] - a[0]) * (b[1] - a[1]) - ((c[1] - a[1]) * (b[0] - a[0]))
 
@@ -399,9 +399,9 @@ def clockwise(a, b, c):
 def in_triangle(a, b, c, d):
     """Returns True if point d lies wholly within the triangle pf ccw points a, b, c, projected onto xy plane.
 
-   note:
-      a, b & c must be sorted into anti-clockwise order before calling this function
-   """
+    note:
+       a, b & c must be sorted into anti-clockwise order before calling this function
+    """
 
     return clockwise(a, b, d) < 0.0 and clockwise(b, c, d) < 0.0 and clockwise(c, a, d) < 0.0
 
@@ -409,9 +409,9 @@ def in_triangle(a, b, c, d):
 def in_triangle_edged(a, b, c, d):
     """Returns True if d lies within or on the boudnary of triangle of ccw points a,b,c projected onto xy plane.
 
-   note:
-      a, b & c must be sorted into anti-clockwise order before calling this function
-   """
+    note:
+       a, b & c must be sorted into anti-clockwise order before calling this function
+    """
 
     return clockwise(a, b, d) <= 0.0 and clockwise(b, c, d) <= 0.0 and clockwise(c, a, d) <= 0.0
 
@@ -419,9 +419,9 @@ def in_triangle_edged(a, b, c, d):
 def in_circumcircle(a, b, c, d):
     """Returns True if point d lies within the circumcircle pf ccw points a, b, c, projected onto xy plane.
 
-   note:
-      a, b & c must be sorted into anti-clockwise order before calling this function
-   """
+    note:
+       a, b & c must be sorted into anti-clockwise order before calling this function
+    """
 
     m = np.empty((3, 3))
     m[0, :2] = a[:2] - d[:2]
@@ -438,7 +438,10 @@ def point_distance_to_line_2d(p, l1, l2):
 
 
 def isclose(a, b, tolerance = 1.0e-6):
-    """Returns True if the two points are extremely close to one another (ie. the same point)."""
+    """Returns True if the two points are extremely close to one another (ie.
+
+    the same point).
+    """
 
     #   return np.all(np.isclose(a, b, atol = tolerance))
     # cheap and cheerful alternative to thorough numpy version commented out above
@@ -446,7 +449,10 @@ def isclose(a, b, tolerance = 1.0e-6):
 
 
 def is_close(a, b, tolerance = 1.0e-6):
-    """Returns True if the two points are extremely close to one another (ie. the same point)."""
+    """Returns True if the two points are extremely close to one another (ie.
+
+    the same point).
+    """
 
     return isclose(a, b, tolerance = tolerance)
 
@@ -505,11 +511,11 @@ def area_of_triangles(p, t, xy_projection = False):
 def clockwise_sorted_indices(p, b):
     """Returns a clockwise sorted numpy list of indices b into the points p.
 
-   note:
-      this function is designed for preparing a list of points defining a convex polygon when projected in
-      the xy plane, starting from a subset of the unsorted points; more specifically, it assumes that the
-      mean of p (over axis 0) lies within the polygon and the clockwise ordering is relative to that mean point
-   """
+    note:
+       this function is designed for preparing a list of points defining a convex polygon when projected in
+       the xy plane, starting from a subset of the unsorted points; more specifically, it assumes that the
+       mean of p (over axis 0) lies within the polygon and the clockwise ordering is relative to that mean point
+    """
 
     # note: this function currently assumes that the mean of points bp lies within the hull of bp
     # and that the points form a convex polygon from the perspective of the mean point

--- a/resqpy/olio/volume.py
+++ b/resqpy/olio/volume.py
@@ -12,15 +12,15 @@ def _pyr(ra, ab, ac, ad, db):  # returns 6 * volume of one quad pyramid, defined
 def pyramid_volume(apex, a, b, c, d, crs_is_right_handed = False):
     """Returns volume of a quadrilateral pyramid.
 
-   arguments:
-      apex (triple float): location of the apex of the pyramid
-      a, b, c, d (each triple float): locations of corners of base of pyramid; clockwise viewed from apex
-         for a left handed crs
-      crs_is_right_handed (boolean, default False): set True if xyz axes of crs are right handed
+    arguments:
+       apex (triple float): location of the apex of the pyramid
+       a, b, c, d (each triple float): locations of corners of base of pyramid; clockwise viewed from apex
+          for a left handed crs
+       crs_is_right_handed (boolean, default False): set True if xyz axes of crs are right handed
 
-   returns:
-      float, being the volume of the pyramid; units are implied by crs units in use by the vertices
-   """
+    returns:
+       float, being the volume of the pyramid; units are implied by crs units in use by the vertices
+    """
 
     apex = np.array(apex)
     a = np.array(a)
@@ -36,13 +36,13 @@ def pyramid_volume(apex, a, b, c, d, crs_is_right_handed = False):
 def tetrahedron_volume(a, b, c, d):
     """Returns volume of a tetrahedron.
 
-   arguments:
-      a, b, c, d (each triple float): locations of corners of tetrahedron
-      crs_is_right_handed (boolean, default False): set True if xyz axes of crs are right handed
+    arguments:
+       a, b, c, d (each triple float): locations of corners of tetrahedron
+       crs_is_right_handed (boolean, default False): set True if xyz axes of crs are right handed
 
-   returns:
-      float, being the volume of the tetrahedron; units are implied by crs units in use by the vertices
-   """
+    returns:
+       float, being the volume of the tetrahedron; units are implied by crs units in use by the vertices
+    """
 
     a = np.array(a)
     b = np.array(b)
@@ -102,19 +102,19 @@ def tetra_volumes_slow(cp, centres = None, off_hand = False):
 def tetra_volumes(cp, centres = None, off_hand = False):
     """Returns volume array for all hexahedral cells assuming bilinear faces, using numpy operations.
 
-   arguments:
-      cp (7D numpy array of floats): cell corner point data in Pagoda 7D format [nk, nj, ni, kp, jp, ip, xyz]
-      centres (optional, 4D numpy array of floats): cell centre points [nk, nj, ni, xyz]; calculated if None
-      off_hand (boolean, default False): if True, the handedness of IJK space is the opposite of that for xyz
-         space; if this argument is not set correctly, negative volumes will be returned
+    arguments:
+       cp (7D numpy array of floats): cell corner point data in Pagoda 7D format [nk, nj, ni, kp, jp, ip, xyz]
+       centres (optional, 4D numpy array of floats): cell centre points [nk, nj, ni, xyz]; calculated if None
+       off_hand (boolean, default False): if True, the handedness of IJK space is the opposite of that for xyz
+          space; if this argument is not set correctly, negative volumes will be returned
 
-   returns:
-      numpy 3D array of floats being the cell volumes [nk, nj, ni]
+    returns:
+       numpy 3D array of floats being the cell volumes [nk, nj, ni]
 
-   note:
-      length units are assumed to be consistent in x, y & z; and untis of returned volumes are implicitly
-      those length units cubed
-   """
+    note:
+       length units are assumed to be consistent in x, y & z; and untis of returned volumes are implicitly
+       those length units cubed
+    """
 
     def pyrs(ra, ab, ac, ad, db):  # returns 6 * volume of one quad pyramid (for each cell)
         return np.sum(ra * np.cross(db, ac), axis = -1) + 0.5 * np.sum(ac * np.cross(ad, ab), axis = -1)

--- a/resqpy/olio/weights_and_measures.py
+++ b/resqpy/olio/weights_and_measures.py
@@ -1,4 +1,4 @@
-"""DEPRECATED, use resqpy.weights_and_measures instead"""
+"""DEPRECATED, use resqpy.weights_and_measures instead."""
 
 import warnings
 from resqpy.weights_and_measures import *  # noqa

--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -201,20 +201,20 @@ def length_unit_conversion_applicable(keyword):
 def load_wellspecs(wellspec_file, well = None, column_list = []):
     """Reads the Nexus wellspec file returning a dictionary of well name to pandas dataframe.
 
-   args:
-      wellspec_file (string): file path of ascii input file containing wellspec keywords
-      well (optional, string): if present, only the data for the named well are loaded;
-         if None, data for all wells are loaded
-      column_list (list of strings, optional): if present, each dataframe returned contains
-         these columns, in this order; if None, the resulting dictionary contains only
-         well names as keys (each mapping to None rather than a dataframe); if an empty list,
-         each dataframe contains the columns listed in the corresponding wellspec header, in
-         the order found in the file
+    args:
+       wellspec_file (string): file path of ascii input file containing wellspec keywords
+       well (optional, string): if present, only the data for the named well are loaded;
+          if None, data for all wells are loaded
+       column_list (list of strings, optional): if present, each dataframe returned contains
+          these columns, in this order; if None, the resulting dictionary contains only
+          well names as keys (each mapping to None rather than a dataframe); if an empty list,
+          each dataframe contains the columns listed in the corresponding wellspec header, in
+          the order found in the file
 
-   returns:
-      dictionary (string: pandas dataframe) mapping each well name found in the wellspec file
-         to a dataframe containing the wellspec data
-   """
+    returns:
+       dictionary (string: pandas dataframe) mapping each well name found in the wellspec file
+          to a dataframe containing the wellspec data
+    """
 
     assert wellspec_file, 'no wellspec file specified'
 

--- a/resqpy/olio/write_hdf5.py
+++ b/resqpy/olio/write_hdf5.py
@@ -36,21 +36,21 @@ class H5Register():
     def register_dataset(self, object_uuid, group_tail, a, dtype = None, hdf5_path = None):
         """Register an array to be included as a dataset in the hdf5 file.
 
-      arguments:
-         object_uuid (uuid.UUID): the uuid of the object (part) that this array is for
-         group_tail (string): the remainder of the hdf5 internal path (following RESQML and
-            uuid elements)
-         a (numpy array): the dataset (array) to be registered for writing
-         dtype (type or string): the type of the individual elements within the dataset
-         hdf5_path (string, optional): if present, a full hdf5 internal path to use instead of
-            the default generated from the uuid
+        arguments:
+           object_uuid (uuid.UUID): the uuid of the object (part) that this array is for
+           group_tail (string): the remainder of the hdf5 internal path (following RESQML and
+              uuid elements)
+           a (numpy array): the dataset (array) to be registered for writing
+           dtype (type or string): the type of the individual elements within the dataset
+           hdf5_path (string, optional): if present, a full hdf5 internal path to use instead of
+              the default generated from the uuid
 
-      returns:
-         None
+        returns:
+           None
 
-      note:
-         several arrays might belong to the same object
-      """
+        note:
+           several arrays might belong to the same object
+        """
 
         #     print('registering dataset with uuid ' + str(object_uuid) + ' and group tail ' + group_tail)
         assert (len(group_tail) > 0)
@@ -69,15 +69,15 @@ class H5Register():
     def write_fp(self, fp):
         """Write or append to an hdf5 file, writing the pre-registered datasets (arrays).
 
-      arguments:
-         fp: an already open h5py._hl.files.File object
+        arguments:
+           fp: an already open h5py._hl.files.File object
 
-      returns:
-         None
+        returns:
+           None
 
-      note:
-         the file handle fp must have been opened with mode 'w' or 'a'
-      """
+        note:
+           the file handle fp must have been opened with mode 'w' or 'a'
+        """
 
         # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
         #       this function allows appending to any hdf5 file; calling code should set a new uuid when needed
@@ -100,16 +100,16 @@ class H5Register():
     def write(self, file = None, mode = 'w', release_after = True):
         """Create or append to an hdf5 file, writing the pre-registered datasets (arrays).
 
-      arguments:
-         file: either a string being the file path, or an already open h5py._hl.files.File object;
-            if None (recommended), the file is opened through the model object's hdf5 management
-            functions
-         mode (string, default 'w'): the mode to open the file in; only relevant if file is a path;
-            must be 'w' or 'a' for (over)write or append
+        arguments:
+           file: either a string being the file path, or an already open h5py._hl.files.File object;
+              if None (recommended), the file is opened through the model object's hdf5 management
+              functions
+           mode (string, default 'w'): the mode to open the file in; only relevant if file is a path;
+              must be 'w' or 'a' for (over)write or append
 
-      returns:
-         None
-      """
+        returns:
+           None
+        """
 
         # note: in resqml, an established hdf5 file has a uuid and should therefore be immutable
         #       this function allows appending to any hdf5 file;
@@ -131,24 +131,24 @@ class H5Register():
 def copy_h5(file_in, file_out, uuid_inclusion_list = None, uuid_exclusion_list = None, mode = 'w'):
     """Create a copy of an hdf5, optionally including or excluding arrays with specified uuids.
 
-   arguments:
-      file_in (string): path of existing hdf5 file to be duplicated
-      file_out (string): path of output hdf5 file to be created or appended to (see mode)
-      uuid_inclusion_list (list of uuid.UUID, optional): if present, the uuids to be included
-         in the output file
-      uuid_exclusion_list (list of uuid.UUID, optional): if present, the uuids to be excluded
-         from the output file
-      mode (string, default 'w'): mode to open output file with; must be 'w' or 'a' for
-         (over)write or append respectively
+    arguments:
+       file_in (string): path of existing hdf5 file to be duplicated
+       file_out (string): path of output hdf5 file to be created or appended to (see mode)
+       uuid_inclusion_list (list of uuid.UUID, optional): if present, the uuids to be included
+          in the output file
+       uuid_exclusion_list (list of uuid.UUID, optional): if present, the uuids to be excluded
+          from the output file
+       mode (string, default 'w'): mode to open output file with; must be 'w' or 'a' for
+          (over)write or append respectively
 
-   returns:
-      number of hdf5 groups (uuid's) copied
+    returns:
+       number of hdf5 groups (uuid's) copied
 
-   notes:
-      at most one of uuid_inclusion_list and uuid_exclusion_list should be passed;
-      if neither are passed, all the datasets (arrays) in the input file are copied to the
-      output file
-   """
+    notes:
+       at most one of uuid_inclusion_list and uuid_exclusion_list should be passed;
+       if neither are passed, all the datasets (arrays) in the input file are copied to the
+       output file
+    """
 
     #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
     assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
@@ -202,16 +202,16 @@ def copy_h5(file_in, file_out, uuid_inclusion_list = None, uuid_exclusion_list =
 def copy_h5_path_list(file_in, file_out, hdf5_path_list, mode = 'w'):
     """Create a copy of some hdf5 datasets (or groups), identified as a list of hdf5 internal paths.
 
-   arguments:
-      file_in (string): path of existing hdf5 file to be copied from
-      file_out (string): path of output hdf5 file to be created or appended to (see mode)
-      hdf5_path_list (list of string): the hdf5 internal paths of the datasets (or groups) to be copied
-      mode (string, default 'w'): mode to open output file with; must be 'w' or 'a' for
-         (over)write or append respectively
+    arguments:
+       file_in (string): path of existing hdf5 file to be copied from
+       file_out (string): path of output hdf5 file to be created or appended to (see mode)
+       hdf5_path_list (list of string): the hdf5 internal paths of the datasets (or groups) to be copied
+       mode (string, default 'w'): mode to open output file with; must be 'w' or 'a' for
+          (over)write or append respectively
 
-   returns:
-      number of hdf5 datasets (or groups) copied
-   """
+    returns:
+       number of hdf5 datasets (or groups) copied
+    """
 
     #  note: if both inclusion and exclusion lists are present, exclusion list is ignored
     assert file_out != file_in, 'identical input and output files specified for hdf5 copy'
@@ -246,11 +246,11 @@ def copy_h5_path_list(file_in, file_out, hdf5_path_list, mode = 'w'):
 def change_uuid(file, old_uuid, new_uuid):
     """Changes hdf5 internal path (group name) for part, switching from old to new uuid.
 
-   notes:
-      this is low level functionality not usually called directly;
-      the function assumes that hdf5 internal path names conform to the format that resqpy uses
-      when writing data, namely /RESQML/uuid/tail...
-   """
+    notes:
+       this is low level functionality not usually called directly;
+       the function assumes that hdf5 internal path names conform to the format that resqpy uses
+       when writing data, namely /RESQML/uuid/tail...
+    """
 
     assert file, 'hdf5 file name missing'
     assert old_uuid is not None and new_uuid is not None, 'missing uuid'

--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -30,8 +30,8 @@ else:
 def strip_path(full_path):
     """Returns the filename part of full_path with any directory path removed.
 
-      :meta private:
-   """
+    :meta private:
+    """
 
     return os.path.basename(full_path)
 
@@ -144,10 +144,9 @@ def find_nested_tags(root, tag_list):
 
 def find_nested_tags_cast(root, tag_list, dtype = None):
     """Return value of nested tags as desired dtype.
-   
-   Follows a list of tags in a nested xml hierarchy, returning the stripped text
-   of the node at the deepest level.
-   """
+
+    Follows a list of tags in a nested xml hierarchy, returning the stripped text of the node at the deepest level.
+    """
 
     cast_func = {
         int: node_int,
@@ -162,14 +161,16 @@ def find_nested_tags_cast(root, tag_list, dtype = None):
 
 
 def find_nested_tags_text(root, tag_list):
-    """Follows a list of tags in a nested xml hierarchy, returning the stripped text of the node at the deepest level."""
+    """Follows a list of tags in a nested xml hierarchy, returning the stripped text of the node at the deepest
+    level."""
 
     node = find_nested_tags(root, tag_list)
     return node_text(node)
 
 
 def find_nested_tags_bool(root, tag_list):
-    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as bool."""
+    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as
+    bool."""
 
     node = find_nested_tags(root, tag_list)
     return node_bool(node)
@@ -183,7 +184,8 @@ def find_nested_tags_int(root, tag_list):
 
 
 def find_nested_tags_float(root, tag_list):
-    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as float."""
+    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as
+    float."""
 
     node = find_nested_tags(root, tag_list)
     return node_float(node)
@@ -576,7 +578,8 @@ def time_units_from_node(node):
 
 
 def xyz_handedness(xy_axes, z_inc_down):
-    """Returns xyz true handedness as 'left', 'right' or 'unknown', based on xy_axes (string) and z_inc_down (boolean)."""
+    """Returns xyz true handedness as 'left', 'right' or 'unknown', based on xy_axes (string) and z_inc_down
+    (boolean)."""
 
     if xy_axes is None or z_inc_down is None:
         return 'unknown'
@@ -602,7 +605,8 @@ def xyz_handedness(xy_axes, z_inc_down):
 
 
 def ijk_handedness(geom_node):
-    """Returns ijk true handedness as 'left', 'right' or 'unknown', based on GridIsRightHanded node in grid geometry node."""
+    """Returns ijk true handedness as 'left', 'right' or 'unknown', based on GridIsRightHanded node in grid geometry
+    node."""
 
     if geom_node is None:
         return 'unknown'
@@ -734,7 +738,7 @@ def write_xml(xml_fp, tree, standalone = None):
 
 
 def load_metadata_from_xml(node):
-    """Loads the ExtraMetaData stored in a RESQML part as a dictionary"""
+    """Loads the ExtraMetaData stored in a RESQML part as a dictionary."""
 
     if node is None:
         return None
@@ -748,7 +752,7 @@ def load_metadata_from_xml(node):
 
 
 def create_metadata_xml(node, extra_metadata):
-    """Writes the xml for the given metadata dictionary"""
+    """Writes the xml for the given metadata dictionary."""
 
     if extra_metadata:
         for data in extra_metadata.keys():

--- a/resqpy/olio/zmap_reader.py
+++ b/resqpy/olio/zmap_reader.py
@@ -145,9 +145,9 @@ def read_zmapplusgrid(inputfile, dtype = np.float64):
 def read_roxar_mesh(inputfile, dtype = np.float64):
     """Read RMS text format surface mesh; returns triple (x, y, z) 2D arrays.
 
-   note:
-      the RMS text format was previously known as the Roxar format
-   """
+    note:
+       the RMS text format was previously known as the Roxar format
+    """
 
     return read_mesh(inputfile, dtype = dtype, format = 'rms')
 
@@ -155,8 +155,8 @@ def read_roxar_mesh(inputfile, dtype = np.float64):
 def read_rms_text_mesh(inputfile, dtype = np.float64):
     """Read RMS text format surface mesh; returns triple (x, y, z) 2D arrays.
 
-   note:
-      the RMS text format was previously known as the Roxar format
-   """
+    note:
+       the RMS text format was previously known as the Roxar format
+    """
 
     return read_roxar_mesh(inputfile, dtype = dtype)

--- a/resqpy/organize.py
+++ b/resqpy/organize.py
@@ -83,7 +83,7 @@ def create_xml_has_occurred_during(model, parent_node, hod_pair, tag = 'HasOccur
 
 
 def _alias_for_attribute(attribute_name):
-    """Return an attribute that is a direct alias for an existing attribute"""
+    """Return an attribute that is a direct alias for an existing attribute."""
 
     def fget(self):
         return getattr(self, attribute_name)
@@ -617,12 +617,11 @@ class WellboreFeature(BaseResqpy):
 class FaultInterpretation(BaseResqpy):
     """Class for RESQML Fault Interpretation organizational objects.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      A type of boundary feature, this class contains the data describing an opinion
-      about the characterization of the fault, which includes the attributes listed below.
-
-   """
+       A type of boundary feature, this class contains the data describing an opinion
+       about the characterization of the fault, which includes the attributes listed below.
+    """
 
     resqml_type = "FaultInterpretation"
     valid_domains = ('depth', 'time', 'mixed')
@@ -1184,7 +1183,8 @@ class GeobodyBoundaryInterpretation(BaseResqpy):
                    originator = None,
                    title_suffix = None,
                    reuse = True):
-        """Creates a geobody boundary interpretation organisational xml node from a geobody boundary interpretation object."""
+        """Creates a geobody boundary interpretation organisational xml node from a geobody boundary interpretation
+        object."""
 
         if not self.title:
             self.title = self.genetic_boundary_feature.feature_name
@@ -1400,19 +1400,18 @@ class GeobodyInterpretation(BaseResqpy):
 class WellboreInterpretation(BaseResqpy):
     """Class for RESQML Wellbore Interpretation organizational objects.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      May refer to one of these:
+       May refer to one of these:
 
-      * **Wellbore**. A unique, oriented path from the bottom of a drilled borehole to the surface of the earth.
-        The path must not overlap or cross itself.
-      * **Borehole**. A hole excavated in the earth as a result of drilling or boring operations. The borehole
-        may represent the hole of an entire wellbore (when no sidetracks are present), or a sidetrack extension.
-        A borehole extends from an originating point (the surface location for the initial borehole or kickoff point
-        for sidetracks) to a terminating (bottomhole) point.
-      * **Sidetrack**. A borehole that originates in another borehole as opposed to originating at the surface.
-
-   """
+       * **Wellbore**. A unique, oriented path from the bottom of a drilled borehole to the surface of the earth.
+         The path must not overlap or cross itself.
+       * **Borehole**. A hole excavated in the earth as a result of drilling or boring operations. The borehole
+         may represent the hole of an entire wellbore (when no sidetracks are present), or a sidetrack extension.
+         A borehole extends from an originating point (the surface location for the initial borehole or kickoff point
+         for sidetracks) to a terminating (bottomhole) point.
+       * **Sidetrack**. A borehole that originates in another borehole as opposed to originating at the surface.
+    """
 
     resqml_type = 'WellboreInterpretation'
     valid_domains = ('depth', 'time', 'mixed')
@@ -1455,7 +1454,7 @@ class WellboreInterpretation(BaseResqpy):
                                                         feature_name = self.model.title_for_root(self.feature_root))
 
     def iter_trajectories(self):
-        """ Iterable of associated trajectories """
+        """Iterable of associated trajectories."""
 
         import resqpy.well
 

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -115,37 +115,38 @@ expected_facet_type_dict = {
 class PropertyCollection():
     """Class for RESQML Property collection for any supporting representation (or mix of supporting representations).
 
-   notes:
-      this is a base class inherited by GridPropertyCollection and WellLogCollection (and others to follow), application
-      code usually works with the derived classes;
-      RESQML caters for three simple types of numerical property: Continuous (ie. real data, aka floating point);
-      Discrete (ie. integer data, or boolean); Categorical (integer data, usually non-negative, with an associated
-      look-up table to convert to a string); Points properties are for storing xyz values; resqpy does not currently
-      support Comment properties
-   """
+    notes:
+       this is a base class inherited by GridPropertyCollection and WellLogCollection (and others to follow), application
+       code usually works with the derived classes;
+       RESQML caters for three simple types of numerical property: Continuous (ie. real data, aka floating point);
+       Discrete (ie. integer data, or boolean); Categorical (integer data, usually non-negative, with an associated
+       look-up table to convert to a string); Points properties are for storing xyz values; resqpy does not currently
+       support Comment properties
+    """
 
     def __init__(self, support = None, property_set_root = None, realization = None):
-        """Initialise an empty Property Collection; if support is not None, populate with properties for that representation.
+        """Initialise an empty Property Collection; if support is not None, populate with properties for that
+        representation.
 
-      arguments:
-         support (optional): a grid.Grid object or a well.WellboreFrame object which belongs to a resqpy.Model which includes
-            associated properties; if this argument is given, and property_set_root is None, the properties in the support's
-            parent model which are for this representation (ie. have this grid or wellbore frame as the supporting representation)
-            are added to this collection as part of the initialisation
-         property_set_root (optional): if present, the collection is populated with the properties defined in the xml tree
-            of the property set
-         realization (integer, optional): if present, the single realisation (within an ensemble) that this collection is for;
-            if None, then the collection is either covering a whole ensemble (individual properties can each be flagged with a
-            realisation number), or is for properties that do not have multiple realizations
+        arguments:
+           support (optional): a grid.Grid object or a well.WellboreFrame object which belongs to a resqpy.Model which includes
+              associated properties; if this argument is given, and property_set_root is None, the properties in the support's
+              parent model which are for this representation (ie. have this grid or wellbore frame as the supporting representation)
+              are added to this collection as part of the initialisation
+           property_set_root (optional): if present, the collection is populated with the properties defined in the xml tree
+              of the property set
+           realization (integer, optional): if present, the single realisation (within an ensemble) that this collection is for;
+              if None, then the collection is either covering a whole ensemble (individual properties can each be flagged with a
+              realisation number), or is for properties that do not have multiple realizations
 
-      note:
-         at present, if the collection is being initialised from a property set, the support argument must also be specified;
-         also for now, if not initialising from a property set, all properties related to the support are included, whether
-         the relationship is supporting representation or some other relationship;
-         the full handling of RESQML property sets and property series is still under development
+        note:
+           at present, if the collection is being initialised from a property set, the support argument must also be specified;
+           also for now, if not initialising from a property set, all properties related to the support are included, whether
+           the relationship is supporting representation or some other relationship;
+           the full handling of RESQML property sets and property series is still under development
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert property_set_root is None or support is not None,  \
            'support (grid, wellbore frame, blocked well, mesh, or grid connection set) must be specified when populating property collection from property set'
@@ -201,17 +202,18 @@ class PropertyCollection():
                 self.populate_from_property_set(property_set_root)
 
     def set_support(self, support_uuid = None, support = None, model = None, modify_parts = True):
-        """Sets the supporting object associated with this collection, without loading props, if not done so at initialisation.
+        """Sets the supporting object associated with this collection, without loading props, if not done so at
+        initialisation.
 
-      Arguments:
-         support_uuid: the uuid of the supporting representation which the properties in this collection are for
-         support: a grid.Grid, unstructured.UnstructuredGrid (or derived class), well.WellboreFrame, well.BlockedWell,
-            surface.Mesh, or fault.GridConnectionSet object which the properties in this collection are for
-         model (model.Model object, optional): if present, the model associated with this collection is set to this;
-            otherwise the model is assigned from the supporting object
-         modify_parts (boolean, default True): if True, any parts already in this collection have their individual
-            support_uuid set
-      """
+        Arguments:
+           support_uuid: the uuid of the supporting representation which the properties in this collection are for
+           support: a grid.Grid, unstructured.UnstructuredGrid (or derived class), well.WellboreFrame, well.BlockedWell,
+              surface.Mesh, or fault.GridConnectionSet object which the properties in this collection are for
+           model (model.Model object, optional): if present, the model associated with this collection is set to this;
+              otherwise the model is assigned from the supporting object
+           modify_parts (boolean, default True): if True, any parts already in this collection have their individual
+              support_uuid set
+        """
 
         # when at global level was causing circular reference loading issues as grid imports this module
         import resqpy.grid as grr
@@ -286,20 +288,21 @@ class PropertyCollection():
                         self.dict[part] = tuple(modified)
 
     def supporting_shape(self, indexable_element = None, direction = None):
-        """Returns the shape of the supporting representation with respect to the given indexable element, as a list of ints.
+        """Returns the shape of the supporting representation with respect to the given indexable element, as a list of
+        ints.
 
-      arguments:
-         indexable_element (string, optional): if None, a hard-coded default depending on the supporting representation class
-            will be used
-         direction (string, optional): must be passed if required for the combination of support class and indexable element;
-            currently only used for Grid faces.
+        arguments:
+           indexable_element (string, optional): if None, a hard-coded default depending on the supporting representation class
+              will be used
+           direction (string, optional): must be passed if required for the combination of support class and indexable element;
+              currently only used for Grid faces.
 
-      returns:
-         list of int, being required shape of numpy array, or None if not coded for
+        returns:
+           list of int, being required shape of numpy array, or None if not coded for
 
-      note:
-         individual property arrays will only match this shape if they have the same indexable element and a count of one
-      """
+        note:
+           individual property arrays will only match this shape if they have the same indexable element and a count of one
+        """
 
         # when at global level was causing circular reference loading issues as grid imports this module
         import resqpy.grid as grr
@@ -409,17 +412,17 @@ class PropertyCollection():
     def set_realization(self, realization):
         """Sets the model realization number (within an ensemble) for this collection.
 
-         argument:
-            realization (non-negative integer): the realization number of the whole collection within an ensemble of
-                    collections
+        argument:
+           realization (non-negative integer): the realization number of the whole collection within an ensemble of
+                   collections
 
-         note:
-            the resqml Property classes allow for a realization index to be associated with an individual property
-            array; this module supports this by associating a realization number (equivalent to realization index) for
-            each part (ie. for each property array); however, the collection can be given a realization number which is
-            then applied to each member of the collection as it is added, if no part-specific realization number is
-            provided
-      """
+        note:
+           the resqml Property classes allow for a realization index to be associated with an individual property
+           array; this module supports this by associating a realization number (equivalent to realization index) for
+           each part (ie. for each property array); however, the collection can be given a realization number which is
+           then applied to each member of the collection as it is added, if no part-specific realization number is
+           provided
+        """
 
         # the following assertion might need to be downgraded to a warning, to allow for reassignment of realization numbers
         assert self.realization is None
@@ -428,20 +431,20 @@ class PropertyCollection():
     def add_part_to_dict(self, part, continuous = None, realization = None, trust_uom = True):
         """Add the named part to the dictionary for this collection.
 
-         arguments:
-            part (string): the name of a part (which exists in the support's parent model) to be added to this collection
-            continuous (boolean, optional): whether the property is of a continuous (real) kind; if not None,
-                     is checked against the property's type and an assertion error is raised if there is a mismatch;
-                     should be None or True for Points properties
-            realization (integer, optional): if present, must match this collection's realization number if that is
-                     not None; if this argument is None then the part is assigned the realization number associated
-                     with this collection as a whole; if the xml for the part includes a realization index then that
-                     overrides these other sources to become the realization number
-            trust_uom (boolean, default True): if True, the uom stored in the part's xml is used as the part's uom
-                     in this collection; if False and the uom in the xml is an empty string or 'Euc', then the
-                     part's uom in this collection is set to a guess based on the property kind and min & max values;
-                     note that this guessed value is not used to overwrite the value in the xml
-      """
+        arguments:
+           part (string): the name of a part (which exists in the support's parent model) to be added to this collection
+           continuous (boolean, optional): whether the property is of a continuous (real) kind; if not None,
+                    is checked against the property's type and an assertion error is raised if there is a mismatch;
+                    should be None or True for Points properties
+           realization (integer, optional): if present, must match this collection's realization number if that is
+                    not None; if this argument is None then the part is assigned the realization number associated
+                    with this collection as a whole; if the xml for the part includes a realization index then that
+                    overrides these other sources to become the realization number
+           trust_uom (boolean, default True): if True, the uom stored in the part's xml is used as the part's uom
+                    in this collection; if False and the uom in the xml is an empty string or 'Euc', then the
+                    part's uom in this collection is set to a guess based on the property kind and min & max values;
+                    note that this guessed value is not used to overwrite the value in the xml
+        """
 
         if part is None:
             return
@@ -562,12 +565,12 @@ class PropertyCollection():
     def add_parts_list_to_dict(self, parts_list):
         """Add all the parts named in the parts list to the dictionary for this collection.
 
-      argument:
-         parts_list: a list of strings, each being the name of a part in the support's parent model
+        argument:
+           parts_list: a list of strings, each being the name of a part in the support's parent model
 
-      note:
-         the add_part_to_dict() function is called for each part in the list
-      """
+        note:
+           the add_part_to_dict() function is called for each part in the list
+        """
 
         for part in parts_list:
             self.add_part_to_dict(part)
@@ -575,12 +578,12 @@ class PropertyCollection():
     def remove_part_from_dict(self, part):
         """Remove the named part from the dictionary for this collection.
 
-      argument:
-         part (string): the name of a part which might be in this collection, to be removed
+        argument:
+           part (string): the name of a part which might be in this collection, to be removed
 
-      note:
-         if the part is not in the collection, no action is taken and no exception is raised
-      """
+        note:
+           if the part is not in the collection, no action is taken and no exception is raised
+        """
 
         if part is None:
             return
@@ -591,12 +594,12 @@ class PropertyCollection():
     def remove_parts_list_from_dict(self, parts_list):
         """Remove all the parts named in the parts list from the dictionary for this collection.
 
-      argument:
-         parts_list: a list of strings, each being the name of a part which might be in the collection
+        argument:
+           parts_list: a list of strings, each being the name of a part which might be in the collection
 
-      note:
-         the remove_part_from_dict() function is called for each part in the list
-      """
+        note:
+           the remove_part_from_dict() function is called for each part in the list
+        """
 
         for part in parts_list:
             self.remove_part_from_dict(part)
@@ -604,18 +607,18 @@ class PropertyCollection():
     def inherit_imported_list_from_other_collection(self, other, copy_cached_arrays = True, exclude_inactive = False):
         """Extends this collection's imported list with items from other's imported list.
 
-      arguments:
-         other: another PropertyCollection object with some imported arrays
-         copy_cached_array (boolean, default True): if True, arrays cached with the other
-            collection are copied and cached with this collection
-         exclude_inactive (boolean, default False): if True, any item in the other imported list
-            which has INACTIVE or ACTIVE as the keyword is excluded from the inheritance
+        arguments:
+           other: another PropertyCollection object with some imported arrays
+           copy_cached_array (boolean, default True): if True, arrays cached with the other
+              collection are copied and cached with this collection
+           exclude_inactive (boolean, default False): if True, any item in the other imported list
+              which has INACTIVE or ACTIVE as the keyword is excluded from the inheritance
 
-      note:
-         the imported list is a list of cached imported arrays with basic info for each array;
-         it is used as a staging post before fully incorporating the imported arrays as parts
-         of the support's parent model and writing the arrays to the hdf5 file
-      """
+        note:
+           the imported list is a list of cached imported arrays with basic info for each array;
+           it is used as a staging post before fully incorporating the imported arrays as parts
+           of the support's parent model and writing the arrays to the hdf5 file
+        """
 
         # note: does not inherit parts
         if exclude_inactive:
@@ -636,12 +639,12 @@ class PropertyCollection():
     def inherit_parts_from_other_collection(self, other, ignore_clashes = False):
         """Adds all the parts in the other PropertyCollection to this one.
 
-      Arguments:
-         other: another PropertyCollection object related to the same support as this collection
-         ignore_clashes (boolean, default False): if False, any part in other which is already in
-            this collection will result in an assertion error; if True, such duplicates are
-            simply skipped without modifying the existing part in this collection
-      """
+        Arguments:
+           other: another PropertyCollection object related to the same support as this collection
+           ignore_clashes (boolean, default False): if False, any part in other which is already in
+              this collection will result in an assertion error; if True, such duplicates are
+              simply skipped without modifying the existing part in this collection
+        """
 
         assert self.support_uuid is None or other.support_uuid is None or bu.matching_uuids(
             self.support_uuid, other.support_uuid)
@@ -659,19 +662,19 @@ class PropertyCollection():
     def add_to_imported_list_sampling_other_collection(self, other, flattened_indices):
         """Makes cut down copies of parts from other collection, using indices, and adds to imported list.
 
-      arguments:
-        other (PropertyCollection): the source collection whose arrays will be sampled
-        flattened_indices (1D numpy int array): the indices (in flattened space) of the elements to be copied
+        arguments:
+          other (PropertyCollection): the source collection whose arrays will be sampled
+          flattened_indices (1D numpy int array): the indices (in flattened space) of the elements to be copied
 
-      notes:
-        the values in flattened_indices refer to the source (other) array elements, after flattening;
-        the size of flatted_indices must match the size of the target (self) supporting shape; where different
-        indexable elements are at play, with different implicit sizes, make selective copies of other and
-        call this method once for each group of differently sized properties; for very large collections
-        it might also be necessary to divide the work into smaller groups to reduce memory usage;
-        this method does not write to hdf5 nor create xml – use the usual methods for further processing
-        of the imported list
-      """
+        notes:
+          the values in flattened_indices refer to the source (other) array elements, after flattening;
+          the size of flatted_indices must match the size of the target (self) supporting shape; where different
+          indexable elements are at play, with different implicit sizes, make selective copies of other and
+          call this method once for each group of differently sized properties; for very large collections
+          it might also be necessary to divide the work into smaller groups to reduce memory usage;
+          this method does not write to hdf5 nor create xml – use the usual methods for further processing
+          of the imported list
+        """
 
         source = 'sampled'
         if other.support is not None:
@@ -722,29 +725,28 @@ class PropertyCollection():
             ignore_clashes = False):
         """Adds those parts from the other PropertyCollection which match all arguments that are not None.
 
-      arguments:
-         other: another PropertyCollection object related to the same support as this collection
-         citation_title_match_starts_with (boolean, default False): if True, any citation title that
-            starts with the given citation_title argument will be deemed to have passed that filter
-         ignore_clashes (boolean, default False): if False, any part in other which passes the filters
-            yet is already in this collection will result in an assertion error; if True, such duplicates
-            are simply skipped without modifying the existing part in this collection
+        arguments:
+           other: another PropertyCollection object related to the same support as this collection
+           citation_title_match_starts_with (boolean, default False): if True, any citation title that
+              starts with the given citation_title argument will be deemed to have passed that filter
+           ignore_clashes (boolean, default False): if False, any part in other which passes the filters
+              yet is already in this collection will result in an assertion error; if True, such duplicates
+              are simply skipped without modifying the existing part in this collection
 
-      Other optional arguments (realization, grid, uuid, continuous, count, points, indexable, property_kind, facet_type,
-      facet, citation_title, time_series_uuid, time_index, uom, string_lookup_uuid, categorical):
+        Other optional arguments (realization, grid, uuid, continuous, count, points, indexable, property_kind, facet_type,
+        facet, citation_title, time_series_uuid, time_index, uom, string_lookup_uuid, categorical):
 
-      For each of these arguments: if None, then all members of collection pass this filter;
-      if not None then only those members with the given value pass this filter;
-      finally, the filters for all the attributes must be passed for a given member (part)
-      to be inherited.
+        For each of these arguments: if None, then all members of collection pass this filter;
+        if not None then only those members with the given value pass this filter;
+        finally, the filters for all the attributes must be passed for a given member (part)
+        to be inherited.
 
-      note:
+        note:
 
-         the grid argument is maintained for backward compatibility; it is treated synonymously with support
-         which takes precendence; the categorical boolean argument can be used to filter only Categorical
-         (or non-Categorical) properties
-
-      """
+           the grid argument is maintained for backward compatibility; it is treated synonymously with support
+           which takes precendence; the categorical boolean argument can be used to filter only Categorical
+           (or non-Categorical) properties
+        """
 
         #      log.debug('inheriting parts selectively')
         if support_uuid is None and grid is not None:
@@ -820,19 +822,19 @@ class PropertyCollection():
                                                                     ignore_clashes = False):
         """Adds the example part from other collection and any other parts for the same property at different times.
 
-      arguments:
-         other: another PropertyCollection object related to the same grid as this collection, from which to inherit
-         example_part (string): the part name of an example member of other (which has an associated time_series)
-         citation_title_match_starts_with (booleam, default False): if True, any citation title that starts with
-            the example's citation_title after removing trailing digits, will be deemed to have passed that filter
-         ignore_clashes (boolean, default False): if False, any part in other which passes the filters
-            yet is already in this collection will result in an assertion error; if True, such duplicates
-            are simply skipped without modifying the existing part in this collection
+        arguments:
+           other: another PropertyCollection object related to the same grid as this collection, from which to inherit
+           example_part (string): the part name of an example member of other (which has an associated time_series)
+           citation_title_match_starts_with (booleam, default False): if True, any citation title that starts with
+              the example's citation_title after removing trailing digits, will be deemed to have passed that filter
+           ignore_clashes (boolean, default False): if False, any part in other which passes the filters
+              yet is already in this collection will result in an assertion error; if True, such duplicates
+              are simply skipped without modifying the existing part in this collection
 
-      note:
-         at present, the citation title must match (as well as the other identifying elements) for a part to be
-         inherited
-      """
+        note:
+           at present, the citation title must match (as well as the other identifying elements) for a part to be
+           inherited
+        """
 
         assert other is not None
         assert other.part_in_collection(example_part)
@@ -864,19 +866,19 @@ class PropertyCollection():
                                                                ignore_clashes = False):
         """Adds the example part from other collection and any other parts for same property with different facets.
 
-      arguments:
-         other: another PropertyCollection object related to the same grid as this collection, from which to inherit
-         example_part (string): the part name of an example member of other
-         citation_title_match_starts_with (booleam, default False): if True, any citation title that starts with
-            the example's citation_title after removing trailing digits, will be deemed to have passed that filter
-         ignore_clashes (boolean, default False): if False, any part in other which passes the filters
-            yet is already in this collection will result in an assertion error; if True, such duplicates
-            are simply skipped without modifying the existing part in this collection
+        arguments:
+           other: another PropertyCollection object related to the same grid as this collection, from which to inherit
+           example_part (string): the part name of an example member of other
+           citation_title_match_starts_with (booleam, default False): if True, any citation title that starts with
+              the example's citation_title after removing trailing digits, will be deemed to have passed that filter
+           ignore_clashes (boolean, default False): if False, any part in other which passes the filters
+              yet is already in this collection will result in an assertion error; if True, such duplicates
+              are simply skipped without modifying the existing part in this collection
 
-      note:
-         at present, the citation title must match (as well as the other identifying elements) for a part to be
-         inherited
-      """
+        note:
+           at present, the citation title must match (as well as the other identifying elements) for a part to be
+           inherited
+        """
 
         # the following RESQML limitation could be reported as a warning here, instead of an assertion
         assert not other.points_for_part(example_part), 'facets not allowed for RESQML Points properties'
@@ -904,21 +906,22 @@ class PropertyCollection():
                                                                      example_part,
                                                                      citation_title_match_starts_with = False,
                                                                      ignore_clashes = False):
-        """Adds the example part from other collection and any other parts for same property with different realizations.
+        """Adds the example part from other collection and any other parts for same property with different
+        realizations.
 
-      arguments:
-         other: another PropertyCollection object related to the same support as this collection, from which to inherit
-         example_part (string): the part name of an example member of other
-         citation_title_match_starts_with (booleam, default False): if True, any citation title that starts with
-            the example's citation_title after removing trailing digits, will be deemed to have passed that filter
-         ignore_clashes (boolean, default False): if False, any part in other which passes the filters
-            yet is already in this collection will result in an assertion error; if True, such duplicates
-            are simply skipped without modifying the existing part in this collection
+        arguments:
+           other: another PropertyCollection object related to the same support as this collection, from which to inherit
+           example_part (string): the part name of an example member of other
+           citation_title_match_starts_with (booleam, default False): if True, any citation title that starts with
+              the example's citation_title after removing trailing digits, will be deemed to have passed that filter
+           ignore_clashes (boolean, default False): if False, any part in other which passes the filters
+              yet is already in this collection will result in an assertion error; if True, such duplicates
+              are simply skipped without modifying the existing part in this collection
 
-      note:
-         at present, the citation title must match (as well as the other identifying elements) for a part to be
-         inherited
-      """
+        note:
+           at present, the citation title must match (as well as the other identifying elements) for a part to be
+           inherited
+        """
 
         assert other is not None
         assert other.part_in_collection(example_part)
@@ -945,35 +948,35 @@ class PropertyCollection():
     def number_of_imports(self):
         """Returns the number of property arrays in the imported list for this collection.
 
-      returns:
-         count of number of cached property arrays in the imported list for this collection (non-negative integer)
+        returns:
+           count of number of cached property arrays in the imported list for this collection (non-negative integer)
 
-      note:
-         the importation list is cleared after creation of xml trees for the imported properties, so this
-         function will return zero at that point, until a new list of imports is built up
-      """
+        note:
+           the importation list is cleared after creation of xml trees for the imported properties, so this
+           function will return zero at that point, until a new list of imports is built up
+        """
 
         return len(self.imported_list)
 
     def parts(self):
         """Return list of parts in this collection.
 
-      returns:
-         list of part names (strings) being the members of this collection; there is one part per property array
+        returns:
+           list of part names (strings) being the members of this collection; there is one part per property array
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return list(self.dict.keys())
 
     def uuids(self):
         """Return list of uuids in this collection.
 
-      returns:
-         list of uuids being the members of this collection; there is one uuid per property array
+        returns:
+           list of uuids being the members of this collection; there is one uuid per property array
 
-      :meta common:
-      """
+        :meta common:
+        """
         return [self.model.uuid_for_part(p) for p in self.dict.keys()]
 
     def selective_parts_list(
@@ -997,22 +1000,22 @@ class PropertyCollection():
             categorical = None):
         """Returns a list of parts filtered by those arguments which are not None.
 
-      All arguments are optional.
+        All arguments are optional.
 
-      For each of these arguments: if None, then all members of collection pass this filter;
-      if not None then only those members with the given value pass this filter;
-      finally, the filters for all the attributes must be passed for a given member (part)
-      to be included in the returned list of parts
+        For each of these arguments: if None, then all members of collection pass this filter;
+        if not None then only those members with the given value pass this filter;
+        finally, the filters for all the attributes must be passed for a given member (part)
+        to be included in the returned list of parts
 
-      returns:
-         list of part names (strings) of those parts which match any selection arguments which are not None
+        returns:
+           list of part names (strings) of those parts which match any selection arguments which are not None
 
-      note:
-         the support and grid keyword arguments are maintained for backward compatibility;
-         support_uuid takes precedence over support and both take precedence over grid
+        note:
+           the support and grid keyword arguments are maintained for backward compatibility;
+           support_uuid takes precedence over support and both take precedence over grid
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if support is None:
             support = grid
@@ -1060,17 +1063,17 @@ class PropertyCollection():
             categorical = None):
         """Returns a single part selected by those arguments which are not None.
 
-      For each argument: if None, then all members of collection pass this filter;
-      if not None then only those members with the given value pass this filter;
-      finally, the filters for all the attributes must be passed for a given member (part)
-      to be selected
+        For each argument: if None, then all members of collection pass this filter;
+        if not None then only those members with the given value pass this filter;
+        finally, the filters for all the attributes must be passed for a given member (part)
+        to be selected
 
-      returns:
-         part name (string) of the part which matches all selection arguments which are not None;
-         returns None if no parts match; raises an assertion error if more than one part matches
+        returns:
+           part name (string) of the part which matches all selection arguments which are not None;
+           returns None if no parts match; raises an assertion error if more than one part matches
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if support is None:
             support = grid
@@ -1125,35 +1128,35 @@ class PropertyCollection():
             exclude_null = False):
         """Returns the array of data for a single part selected by those arguments which are not None.
 
-      arguments:
-         dtype (optional, default None): the element data type of the array to be accessed, eg 'float' or 'int';
-            if None (recommended), the dtype of the returned numpy array matches that in the hdf5 dataset
-         masked (boolean, optional, default False): if True, a masked array is returned instead of a simple
-            numpy array; the mask is set to the inactive array attribute of the grid object
-         exclude_null (boolean, default False): it True and masked is True, elements holding the null value
-            will also be masked out
+        arguments:
+           dtype (optional, default None): the element data type of the array to be accessed, eg 'float' or 'int';
+              if None (recommended), the dtype of the returned numpy array matches that in the hdf5 dataset
+           masked (boolean, optional, default False): if True, a masked array is returned instead of a simple
+              numpy array; the mask is set to the inactive array attribute of the grid object
+           exclude_null (boolean, default False): it True and masked is True, elements holding the null value
+              will also be masked out
 
-      Other optional arguments:
-      realization, support, support_uuid, grid, continuous, points, count, indexable, property_kind, facet_type, facet,
-      citation_title, time_series_uuid, time_index, uom, string_lookup_id, categorical:
+        Other optional arguments:
+        realization, support, support_uuid, grid, continuous, points, count, indexable, property_kind, facet_type, facet,
+        citation_title, time_series_uuid, time_index, uom, string_lookup_id, categorical:
 
-      For each of these arguments: if None, then all members of collection pass this filter;
-      if not None then only those members with the given value pass this filter;
-      finally, the filters for all the attributes must be passed for a given member (part)
-      to be selected
+        For each of these arguments: if None, then all members of collection pass this filter;
+        if not None then only those members with the given value pass this filter;
+        finally, the filters for all the attributes must be passed for a given member (part)
+        to be selected
 
-      returns:
-         reference to a cached numpy array containing the actual property data for the part which matches all
-         selection arguments which are not None
+        returns:
+           reference to a cached numpy array containing the actual property data for the part which matches all
+           selection arguments which are not None
 
-      notes:
-         returns None if no parts match; raises an assertion error if more than one part matches;
-         multiple calls will return the same cached array so calling code should copy if duplication is needed;
-         support and grid arguments are for backward compatibilty: support_uuid takes precedence over support and
-         both take precendence over grid
+        notes:
+           returns None if no parts match; raises an assertion error if more than one part matches;
+           multiple calls will return the same cached array so calling code should copy if duplication is needed;
+           support and grid arguments are for backward compatibilty: support_uuid takes precedence over support and
+           both take precendence over grid
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if support is None:
             support = grid
@@ -1183,23 +1186,23 @@ class PropertyCollection():
     def number_of_parts(self):
         """Returns the number of parts (properties) in this collection.
 
-      returns:
-         count of the number of parts (members) in this collection; there is one part per property array (non-negative integer)
+        returns:
+           count of the number of parts (members) in this collection; there is one part per property array (non-negative integer)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return len(self.dict)
 
     def part_in_collection(self, part):
         """Returns True if named part is member of this collection; otherwise False.
 
-      arguments:
-         part (string): part name to be tested for membership of this collection
+        arguments:
+           part (string): part name to be tested for membership of this collection
 
-      returns:
-         boolean
-      """
+        returns:
+           boolean
+        """
 
         return part in self.dict
 
@@ -1227,22 +1230,22 @@ class PropertyCollection():
     def part_str(self, part, include_citation_title = True):
         """Returns a human-readable string identifying the part.
 
-      arguments:
-         part (string): the part name for which a displayable string is required
-         include_citation_title (boolean, default True): if True, the citation title for the part is
-            included in parenthesis at the end of the returned string; otherwise it does not appear
+        arguments:
+           part (string): the part name for which a displayable string is required
+           include_citation_title (boolean, default True): if True, the citation title for the part is
+              included in parenthesis at the end of the returned string; otherwise it does not appear
 
-      returns:
-         a human readable string consisting of the property kind, the facet (if present), the
-         time index (if applicable), and the citation title (if requested)
+        returns:
+           a human readable string consisting of the property kind, the facet (if present), the
+           time index (if applicable), and the citation title (if requested)
 
-      note:
-         the time index is labelled 'timestep' in the returned string; however, resqml differentiates
-         between the simulator timestep number and a time index into a time series; at present this
-         module conflates the two
+        note:
+           the time index is labelled 'timestep' in the returned string; however, resqml differentiates
+           between the simulator timestep number and a time index into a time series; at present this
+           module conflates the two
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         text = self.property_kind_for_part(part)
         facet = self.facet_for_part(part)
@@ -1260,12 +1263,12 @@ class PropertyCollection():
     def part_filename(self, part):
         """Returns a string which can be used as the starting point of a filename relating to part.
 
-      arguments:
-         part (string): the part name for which a partial filename is required
+        arguments:
+           part (string): the part name for which a partial filename is required
 
-      returns:
-         a string suitable as the basis of a filename for the part (typically used when exporting)
-      """
+        returns:
+           a string suitable as the basis of a filename for the part (typically used when exporting)
+        """
 
         text = self.property_kind_for_part(part).replace(' ', '_')
         facet = self.facet_for_part(part)
@@ -1279,14 +1282,14 @@ class PropertyCollection():
     def realization_for_part(self, part):
         """Returns realization number (within ensemble) that the property relates to.
 
-      arguments:
-         part (string): the part name for which the realization number (realization index) is required
+        arguments:
+           part (string): the part name for which the realization number (realization index) is required
 
-      returns:
-         integer or None
+        returns:
+           integer or None
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 0)
 
@@ -1298,28 +1301,28 @@ class PropertyCollection():
     def support_uuid_for_part(self, part):
         """Returns supporting representation object's uuid that the property relates to.
 
-      arguments:
-         part (string): the part name for which the related support object uuid is required
+        arguments:
+           part (string): the part name for which the related support object uuid is required
 
-      returns:
-         uuid.UUID object (or string representation thereof)
-      """
+        returns:
+           uuid.UUID object (or string representation thereof)
+        """
 
         return self.element_for_part(part, 1)
 
     def grid_for_part(self, part):
         """Returns grid object that the property relates to.
 
-      arguments:
-         part (string): the part name for which the related grid object is required
+        arguments:
+           part (string): the part name for which the related grid object is required
 
-      returns:
-         grid.Grid object reference
+        returns:
+           grid.Grid object reference
 
-      note:
-         this method maintained for backward compatibility and kept in base PropertyClass
-         for pragmatic reasons (rather than being method in GridPropertyCollection)
-      """
+        note:
+           this method maintained for backward compatibility and kept in base PropertyClass
+           for pragmatic reasons (rather than being method in GridPropertyCollection)
+        """
 
         import resqpy.grid as grr
         import resqpy.unstructured as rug
@@ -1339,38 +1342,38 @@ class PropertyCollection():
     def uuid_for_part(self, part):
         """Returns UUID object for the property part.
 
-      arguments:
-         part (string): the part name for which the UUID is required
+        arguments:
+           part (string): the part name for which the UUID is required
 
-      returns:
-         uuid.UUID object reference; use str(uuid_for_part()) to convert to string
+        returns:
+           uuid.UUID object reference; use str(uuid_for_part()) to convert to string
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 2)
 
     def node_for_part(self, part):
         """Returns the xml node for the property part.
 
-      arguments:
-         part (string): the part name for which the xml node is required
+        arguments:
+           part (string): the part name for which the xml node is required
 
-      returns:
-         xml Element object reference for the main xml node for the part
-      """
+        returns:
+           xml Element object reference for the main xml node for the part
+        """
 
         return self.element_for_part(part, 3)
 
     def extra_metadata_for_part(self, part):
         """Returns the extra_metadata dictionary for the part.
 
-      arguments:
-         part (string): the part name for which the xml node is required
+        arguments:
+           part (string): the part name for which the xml node is required
 
-      returns:
-         dictionary containing extra_metadata for part
-      """
+        returns:
+           dictionary containing extra_metadata for part
+        """
         try:
             meta = self.element_for_part(part, 18)
         except Exception:
@@ -1381,12 +1384,12 @@ class PropertyCollection():
     def null_value_for_part(self, part):
         """Returns the null value for the (discrete) property part; np.NaN for continuous parts.
 
-      arguments:
-         part (string): the part name for which the null value is required
+        arguments:
+           part (string): the part name for which the null value is required
 
-      returns:
-         int or np.NaN
-      """
+        returns:
+           int or np.NaN
+        """
 
         if self.continuous_for_part(part):
             return np.NaN
@@ -1395,36 +1398,36 @@ class PropertyCollection():
     def continuous_for_part(self, part):
         """Returns True if the property is continuous (including points); False if it is discrete (or categorical).
 
-      arguments:
-         part (string): the part name for which the continuous versus discrete flag is required
+        arguments:
+           part (string): the part name for which the continuous versus discrete flag is required
 
-      returns:
-         True if the part is representing a continuous (or points) property, ie. the array elements are
-         real numbers (float); False if the part is representing a discrete property or a categorical property,
-         ie the array elements are integers (or boolean)
+        returns:
+           True if the part is representing a continuous (or points) property, ie. the array elements are
+           real numbers (float); False if the part is representing a discrete property or a categorical property,
+           ie the array elements are integers (or boolean)
 
-      note:
-         RESQML differentiates between discrete and categorical properties; discrete properties are
-         unbounded integers where the values have numerical significance (eg. could be added together),
-         whilst categorical properties have an associated dictionary mapping from a finite set of integer
-         key values onto strings (eg. {1: 'background', 2: 'channel sand', 3: 'mud drape'}); however, this
-         module treats categorical properties as a special case of discrete properties
+        note:
+           RESQML differentiates between discrete and categorical properties; discrete properties are
+           unbounded integers where the values have numerical significance (eg. could be added together),
+           whilst categorical properties have an associated dictionary mapping from a finite set of integer
+           key values onto strings (eg. {1: 'background', 2: 'channel sand', 3: 'mud drape'}); however, this
+           module treats categorical properties as a special case of discrete properties
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 4)
 
     def points_for_part(self, part):
         """Returns True if the property is a points property; False otherwise.
 
-      arguments:
-         part (string): the part name for which the points flag is required
+        arguments:
+           part (string): the part name for which the points flag is required
 
-      returns:
-         True if the part is representing a points property, ie. the array has an extra dimension of extent 3
-         covering the xyz axes; False if the part is representing a non-points property
-      """
+        returns:
+           True if the part is representing a points property, ie. the array has an extra dimension of extent 3
+           covering the xyz axes; False if the part is representing a non-points property
+        """
 
         return self.element_for_part(part, 21)
 
@@ -1447,17 +1450,17 @@ class PropertyCollection():
     def count_for_part(self, part):
         """Returns the Count value for the property part; usually 1.
 
-      arguments:
-         part (string): the part name for which the count is required
+        arguments:
+           part (string): the part name for which the count is required
 
-      returns:
-         integer reflecting the count attribute for the part (usually one); if greater than one,
-         the array has an extra axis, cycling fastest, having this extent
+        returns:
+           integer reflecting the count attribute for the part (usually one); if greater than one,
+           the array has an extra axis, cycling fastest, having this extent
 
-      note:
-         this mechanism allows a vector of values to be associated with a single indexable element
-         in the supporting representation
-      """
+        note:
+           this mechanism allows a vector of values to be associated with a single indexable element
+           in the supporting representation
+        """
 
         return self.element_for_part(part, 5)
 
@@ -1472,17 +1475,17 @@ class PropertyCollection():
     def indexable_for_part(self, part):
         """Returns the text of the IndexableElement for the property part; usually 'cells' for grid properties.
 
-      arguments:
-         part (string): the part name for which the indexable element is required
+        arguments:
+           part (string): the part name for which the indexable element is required
 
-      returns:
-         string, usually 'cells' when the supporting representation is a grid or 'nodes' when a wellbore frame
+        returns:
+           string, usually 'cells' when the supporting representation is a grid or 'nodes' when a wellbore frame
 
-      note:
-         see tail of Representations.xsd for overview of indexable elements usable for other object classes
+        note:
+           see tail of Representations.xsd for overview of indexable elements usable for other object classes
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 6)
 
@@ -1494,20 +1497,20 @@ class PropertyCollection():
     def property_kind_for_part(self, part):
         """Returns the resqml property kind for the property part.
 
-      arguments:
-         part (string): the part name for which the property kind is required
+        arguments:
+           part (string): the part name for which the property kind is required
 
-      returns:
-         standard resqml property kind or local property kind for this part, as a string, eg. 'porosity'
+        returns:
+           standard resqml property kind or local property kind for this part, as a string, eg. 'porosity'
 
-      notes:
-         see attributes of this module named supported_property_kind_list and supported_local_property_kind_list
-         for the property kinds which this module can relate to simulator keywords (Nexus); however, other property
-         kinds should be handled okay in a generic way;
-         for bespoke (local) property kinds, this is the property kind title as stored in the xml reference node
+        notes:
+           see attributes of this module named supported_property_kind_list and supported_local_property_kind_list
+           for the property kinds which this module can relate to simulator keywords (Nexus); however, other property
+           kinds should be handled okay in a generic way;
+           for bespoke (local) property kinds, this is the property kind title as stored in the xml reference node
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 7)
 
@@ -1524,19 +1527,19 @@ class PropertyCollection():
     def facet_type_for_part(self, part):
         """If relevant, returns the resqml Facet Facet for the property part, eg. 'direction'; otherwise None.
 
-      arguments:
-         part (string): the part name for which the facet type is required
+        arguments:
+           part (string): the part name for which the facet type is required
 
-      returns:
-         standard resqml facet type for this part (string), or None
+        returns:
+           standard resqml facet type for this part (string), or None
 
-      notes:
-         resqml refers to Facet Facet and Facet Value; the equivalents in this module are facet_type and facet;
-         the resqml standard allows a property to have any number of facets; this module currently limits a
-         property to having at most one facet; the facet_type and facet should be either both None or both not None
+        notes:
+           resqml refers to Facet Facet and Facet Value; the equivalents in this module are facet_type and facet;
+           the resqml standard allows a property to have any number of facets; this module currently limits a
+           property to having at most one facet; the facet_type and facet should be either both None or both not None
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 8)
 
@@ -1548,17 +1551,17 @@ class PropertyCollection():
     def facet_for_part(self, part):
         """If relevant, returns the resqml Facet Value for the property part, eg. 'I'; otherwise None.
 
-      arguments:
-         part (string): the part name for which the facet value is required
+        arguments:
+           part (string): the part name for which the facet value is required
 
-      returns:
-         facet value for this part (string), for the facet type returned by the facet_type_for_part() function,
-         or None
+        returns:
+           facet value for this part (string), for the facet type returned by the facet_type_for_part() function,
+           or None
 
-      see notes for facet_type_for_part()
+        see notes for facet_type_for_part()
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 9)
 
@@ -1570,17 +1573,17 @@ class PropertyCollection():
     def citation_title_for_part(self, part):
         """Returns the citation title for the property part.
 
-      arguments:
-         part (string): the part name for which the citation title is required
+        arguments:
+           part (string): the part name for which the citation title is required
 
-      returns:
-         citation title (string) for this part
+        returns:
+           citation title (string) for this part
 
-      note:
-         for simulation grid properties, the citation title is often a property keyword specific to a simulator
+        note:
+           for simulation grid properties, the citation title is often a property keyword specific to a simulator
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 10)
 
@@ -1597,12 +1600,12 @@ class PropertyCollection():
     def time_series_uuid_for_part(self, part):
         """If the property has an associated time series (is not static), returns the uuid for the time series.
 
-      arguments:
-         part (string): the part name for which the time series uuid is required
+        arguments:
+           part (string): the part name for which the time series uuid is required
 
-      returns:
-         time series uuid (uuid.UUID) for this part
-      """
+        returns:
+           time series uuid (uuid.UUID) for this part
+        """
 
         return self.element_for_part(part, 11)
 
@@ -1614,14 +1617,14 @@ class PropertyCollection():
     def time_index_for_part(self, part):
         """If the property has an associated time series (is not static), returns the time index within the time series.
 
-      arguments:
-         part (string): the part name for which the time index is required
+        arguments:
+           part (string): the part name for which the time index is required
 
-      returns:
-         time index (integer) for this part
+        returns:
+           time index (integer) for this part
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.element_for_part(part, 12)
 
@@ -1633,18 +1636,18 @@ class PropertyCollection():
     def minimum_value_for_part(self, part):
         """Returns the minimum value for the property part, as stored in the xml.
 
-      arguments:
-         part (string): the part name for which the minimum value is required
+        arguments:
+           part (string): the part name for which the minimum value is required
 
-      returns:
-         minimum value (as float or int) for this part, or None if metadata item is not set
+        returns:
+           minimum value (as float or int) for this part, or None if metadata item is not set
 
-      note:
-         this method merely returns the minimum value recorded in the xml for the property, it does not check
-         the array data
+        note:
+           this method merely returns the minimum value recorded in the xml for the property, it does not check
+           the array data
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         mini = self.element_for_part(part, 13)
         if mini:
@@ -1657,18 +1660,18 @@ class PropertyCollection():
     def maximum_value_for_part(self, part):
         """Returns the maximum value for the property part, as stored in the xml.
 
-      arguments:
-         part (string): the part name for which the maximum value is required
+        arguments:
+           part (string): the part name for which the maximum value is required
 
-      returns:
-         maximum value (as float ir int) for this part, or None if metadata item is not set
+        returns:
+           maximum value (as float ir int) for this part, or None if metadata item is not set
 
-      note:
-         this method merely returns the maximum value recorded in the xml for the property, it does not check
-         the array data
+        note:
+           this method merely returns the maximum value recorded in the xml for the property, it does not check
+           the array data
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         maxi = self.element_for_part(part, 14)
         if maxi:
@@ -1681,17 +1684,17 @@ class PropertyCollection():
     def patch_min_max_for_part(self, part, minimum = None, maximum = None, model = None):
         """Updates the minimum and/ox maximum values stored in the metadata, optionally updating xml tree too.
 
-      arguments:
-         part (str): the part name of the property
-         minimum (float or int, optional): the new minimum value to be set in the metadata (unchanged if None)
-         maximum (float or int, optional): the new maximum value to be set in the metadata (unchanged if None)
-         model (model.Model, optional): if present and containing xml for the part, that xml is also patched
+        arguments:
+           part (str): the part name of the property
+           minimum (float or int, optional): the new minimum value to be set in the metadata (unchanged if None)
+           maximum (float or int, optional): the new maximum value to be set in the metadata (unchanged if None)
+           model (model.Model, optional): if present and containing xml for the part, that xml is also patched
 
-      notes:
-         this method is rarely needed: only if a property array is being re-populated after being initialised
-         with temporary values; the xml tree for the part in the model will only be updated where the minimum
-         and/or maximum nodes already exist in the tree
-      """
+        notes:
+           this method is rarely needed: only if a property array is being re-populated after being initialised
+           with temporary values; the xml tree for the part in the model will only be updated where the minimum
+           and/or maximum nodes already exist in the tree
+        """
 
         info = list(self.dict[part])
         if minimum is not None:
@@ -1716,14 +1719,14 @@ class PropertyCollection():
     def uom_for_part(self, part):
         """Returns the resqml units of measure for the property part.
 
-      arguments:
-         part (string): the part name for which the units of measure is required
+        arguments:
+           part (string): the part name for which the units of measure is required
 
-      returns:
-         resqml units of measure (string) for this part
+        returns:
+           resqml units of measure (string) for this part
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # NB: this field is not set correctly in data sets generated by DGI
         return self.element_for_part(part, 15)
@@ -1734,14 +1737,15 @@ class PropertyCollection():
         return self.unique_element_list(15, sort_list = sort_list)
 
     def string_lookup_uuid_for_part(self, part):
-        """If the property has an associated string lookup (is categorical), returns the uuid for the string table lookup.
+        """If the property has an associated string lookup (is categorical), returns the uuid for the string table
+        lookup.
 
-      arguments:
-         part (string): the part name for which the string lookup uuid is required
+        arguments:
+           part (string): the part name for which the string lookup uuid is required
 
-      returns:
-         string lookup uuid (uuid.UUID) for this part
-      """
+        returns:
+           string lookup uuid (uuid.UUID) for this part
+        """
 
         return self.element_for_part(part, 16)
 
@@ -1763,36 +1767,36 @@ class PropertyCollection():
     def part_is_categorical(self, part):
         """Returns True if the property is categorical (not conintuous and has an associated string lookup).
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return not self.continuous_for_part(part) and self.string_lookup_uuid_for_part(part) is not None
 
     def constant_value_for_part(self, part):
         """Returns the value (float or int) of a constant array part, or None for an hdf5 array.
 
-      note:
-         a constant array can optionally be expanded and written to the hdf5, in which case it will
-         not have a constant value assigned when the dataset is read from file
-      :meta common:
-      """
+        note:
+           a constant array can optionally be expanded and written to the hdf5, in which case it will
+           not have a constant value assigned when the dataset is read from file
+        :meta common:
+        """
 
         return self.element_for_part(part, 20)
 
     def override_min_max(self, part, min_value, max_value):
         """Sets the minimum and maximum values in the metadata for the part.
 
-      arguments:
-         part (string): the part name for which the minimum and maximum values are to be set
-         min_value (float or int or string): the minimum value to be stored in the metadata
-         max_value (float or int or string): the maximum value to be stored in the metadata
+        arguments:
+           part (string): the part name for which the minimum and maximum values are to be set
+           min_value (float or int or string): the minimum value to be stored in the metadata
+           max_value (float or int or string): the maximum value to be stored in the metadata
 
-      note:
-         this function is typically called if the existing min & max metadata is missing or
-         distrusted; the min and max values passed in are typically the result of numpy
-         min and max function calls (possibly skipping NaNs) on the property array or
-         a version of it masked for inactive cells
-      """
+        note:
+           this function is typically called if the existing min & max metadata is missing or
+           distrusted; the min and max values passed in are typically the result of numpy
+           min and max function calls (possibly skipping NaNs) on the property array or
+           a version of it masked for inactive cells
+        """
 
         if part not in self.dict:
             return
@@ -1802,7 +1806,8 @@ class PropertyCollection():
         self.dict[part] = tuple(property_part)
 
     def establish_time_set_kind(self):
-        """Re-evaulates the time set kind attribute based on all properties having same time index in the same time series."""
+        """Re-evaulates the time set kind attribute based on all properties having same time index in the same time
+        series."""
 
         self.time_set_kind_attr = 'single time'
         #  note: other option of 'equivalent times' not catered for in this code
@@ -1830,14 +1835,16 @@ class PropertyCollection():
         return self.time_set_kind_attr
 
     def time_set_kind(self):
-        """Returns the time set kind attribute based on all properties having same time index in the same time series."""
+        """Returns the time set kind attribute based on all properties having same time index in the same time
+        series."""
 
         if self.time_set_kind_attr is None:
             self.establish_time_set_kind()
         return self.time_set_kind_attr
 
     def establish_has_single_property_kind(self):
-        """Re-evaluates the has single property kind attribute depending on whether all properties are of the same kind."""
+        """Re-evaluates the has single property kind attribute depending on whether all properties are of the same
+        kind."""
 
         self.has_single_property_kind_flag = True
         common_property_kind = None
@@ -1879,7 +1886,8 @@ class PropertyCollection():
         return self.has_single_indexable_element_flag
 
     def establish_has_multiple_realizations(self):
-        """Re-evaluates the has multiple realizations attribute based on whether properties belong to more than one realization."""
+        """Re-evaluates the has multiple realizations attribute based on whether properties belong to more than one
+        realization."""
 
         self.has_multiple_realizations_flag = False
         common_realization = None
@@ -1901,15 +1909,16 @@ class PropertyCollection():
     def has_multiple_realizations(self):
         """Returns the has multiple realizations flag based on whether properties belong to more than one realization.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.has_multiple_realizations_flag is None:
             self.establish_has_multiple_realizations()
         return self.has_multiple_realizations_flag
 
     def establish_has_single_uom(self):
-        """Re-evaluates the has single uom attribute depending on whether all properties have the same units of measure."""
+        """Re-evaluates the has single uom attribute depending on whether all properties have the same units of
+        measure."""
 
         self.has_single_uom_flag = True
         common_uom = None
@@ -1934,10 +1943,10 @@ class PropertyCollection():
     def assign_realization_numbers(self):
         """Assigns a distinct realization number to each property, after checking for compatibility.
 
-      note:
-         this method does not modify realization information in any established xml; it is intended primarily as
-         a convenience to allow realization based processing of any collection of compatible properties
-      """
+        note:
+           this method does not modify realization information in any established xml; it is intended primarily as
+           a convenience to allow realization based processing of any collection of compatible properties
+        """
 
         assert self.has_single_property_kind(), 'attempt to assign realization numbers to properties of differing kinds'
         assert self.has_single_indexable_element(
@@ -1956,26 +1965,27 @@ class PropertyCollection():
         self.has_multiple_realizations_flag = (realization > 1)
 
     def masked_array(self, simple_array, exclude_inactive = True, exclude_value = None, points = False):
-        """Returns a masked version of simple_array, using inactive mask associated with support for this property collection.
+        """Returns a masked version of simple_array, using inactive mask associated with support for this property
+        collection.
 
-      arguments:
-         simple_array (numpy array): an unmasked numpy array with the same shape as property arrays for the support
-            (and indexable element) associated with this collection
-         exclude_inactive (boolean, default True): elements which are flagged as inactive in the supporting representation
-            are masked out if this argument is True
-         exclude_value (float or int, optional): if present, elements which match this value are masked out; if not None
-            then usually set to np.NaN for continuous data or null_value_for_part() for discrete data
-         points (boolean, default False): if True, the simple array is expected to have an extra dimension of extent 3,
-            relative to the inactive attribute of the support
+        arguments:
+           simple_array (numpy array): an unmasked numpy array with the same shape as property arrays for the support
+              (and indexable element) associated with this collection
+           exclude_inactive (boolean, default True): elements which are flagged as inactive in the supporting representation
+              are masked out if this argument is True
+           exclude_value (float or int, optional): if present, elements which match this value are masked out; if not None
+              then usually set to np.NaN for continuous data or null_value_for_part() for discrete data
+           points (boolean, default False): if True, the simple array is expected to have an extra dimension of extent 3,
+              relative to the inactive attribute of the support
 
-      returns:
-         a masked version of the array, with the mask set to exclude cells which are inactive in the support
+        returns:
+           a masked version of the array, with the mask set to exclude cells which are inactive in the support
 
-      notes:
-         when requesting a reference to a cached copy of a property array (using other functions), a masked argument
-         can be used to apply the inactive mask; this function is therefore rarely needed by calling code (it is used
-         internally by this module); the simple_array need not be part of this collection
-      """
+        notes:
+           when requesting a reference to a cached copy of a property array (using other functions), a masked argument
+           can be used to apply the inactive mask; this function is therefore rarely needed by calling code (it is used
+           internally by this module); the simple_array need not be part of this collection
+        """
 
         mask = None
         if (exclude_inactive and self.support is not None and hasattr(self.support, 'inactive') and
@@ -2026,31 +2036,31 @@ class PropertyCollection():
     def cached_part_array_ref(self, part, dtype = None, masked = False, exclude_null = False):
         """Returns a numpy array containing the data for the property part; the array is cached in this collection.
 
-      arguments:
-         part (string): the part name for which the array reference is required
-         dtype (optional, default None): the element data type of the array to be accessed, eg 'float' or 'int';
-            if None (recommended), the dtype of the returned numpy array matches that in the hdf5 dataset
-         masked (boolean, default False): if True, a masked array is returned instead of a simple numpy array;
-            the mask is set to the inactive array attribute of the support object if present
-         exclude_null (boolean, default False): if True, and masked is also True, then elements of the array
-            holding the null value will also be masked out
+        arguments:
+           part (string): the part name for which the array reference is required
+           dtype (optional, default None): the element data type of the array to be accessed, eg 'float' or 'int';
+              if None (recommended), the dtype of the returned numpy array matches that in the hdf5 dataset
+           masked (boolean, default False): if True, a masked array is returned instead of a simple numpy array;
+              the mask is set to the inactive array attribute of the support object if present
+           exclude_null (boolean, default False): if True, and masked is also True, then elements of the array
+              holding the null value will also be masked out
 
-      returns:
-         reference to a cached numpy array containing the actual property data; multiple calls will return
-         the same cached array so calling code should copy if duplication is needed
+        returns:
+           reference to a cached numpy array containing the actual property data; multiple calls will return
+           the same cached array so calling code should copy if duplication is needed
 
-      notes:
-         this function is the usual way to get at the actual property array; at present, the funtion only works
-         if the entire array is stored as a single patch in the hdf5 file (resqml allows multiple patches per
-         array); the masked functionality can be used to apply a common mask, stored in the supporting
-         representation object with the attribute name 'inactive', to multiple properties (this will only work
-         if the indexable element is set to the typical value for the class of supporting representation, eg.
-         'cells' for grid objects); if exclude_null is set True then null value elements will also be masked out
-         (as long as masked is True); however, it is recommended simply to use np.NaN values in floating point
-         property arrays if the commonality is not needed
+        notes:
+           this function is the usual way to get at the actual property array; at present, the funtion only works
+           if the entire array is stored as a single patch in the hdf5 file (resqml allows multiple patches per
+           array); the masked functionality can be used to apply a common mask, stored in the supporting
+           representation object with the attribute name 'inactive', to multiple properties (this will only work
+           if the indexable element is set to the typical value for the class of supporting representation, eg.
+           'cells' for grid objects); if exclude_null is set True then null value elements will also be masked out
+           (as long as masked is True); however, it is recommended simply to use np.NaN values in floating point
+           property arrays if the commonality is not needed
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         model = self.model
         cached_array_name = _cache_name(part)
@@ -2122,19 +2132,19 @@ class PropertyCollection():
     def h5_slice(self, part, slice_tuple):
         """Returns a subset of the array for part, without loading the whole array.
 
-      arguments:
-         part (string): the part name for which the array slice is required
-         slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
-            function slice()
+        arguments:
+           part (string): the part name for which the array slice is required
+           slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
+              function slice()
 
-      returns:
-         numpy array that is a hyper-slice of the hdf5 array, with the same ndim as the source hdf5 array
+        returns:
+           numpy array that is a hyper-slice of the hdf5 array, with the same ndim as the source hdf5 array
 
-      note:
-         this method always fetches from the hdf5 file and does not attempt local caching; the whole array
-         is not loaded; all axes continue to exist in the returned array, even where the sliced extent of
-         an axis is 1
-      """
+        note:
+           this method always fetches from the hdf5 file and does not attempt local caching; the whole array
+           is not loaded; all axes continue to exist in the returned array, even where the sliced extent of
+           an axis is 1
+        """
 
         h5_key_pair = self.h5_key_pair_for_part(part)
         if h5_key_pair is None:
@@ -2144,21 +2154,21 @@ class PropertyCollection():
     def h5_overwrite_slice(self, part, slice_tuple, array_slice, update_cache = True):
         """Overwrites a subset of the array for part, in the hdf5 file.
 
-      arguments:
-         part (string): the part name for which the array slice is to be overwritten
-         slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
-            function slice()
-         array_slice (numpy array of shape to match slice_tuple): the data to be written
-         update_cache (boolean, default True): if True and the part is currently cached within this
-            PropertyCollection, then the cached array is also updated; if False, the part is uncached
+        arguments:
+           part (string): the part name for which the array slice is to be overwritten
+           slice_tuple (tuple of slice objects): each element should be constructed using the python built-in
+              function slice()
+           array_slice (numpy array of shape to match slice_tuple): the data to be written
+           update_cache (boolean, default True): if True and the part is currently cached within this
+              PropertyCollection, then the cached array is also updated; if False, the part is uncached
 
-      notes:
-         this method naively writes the slice to hdf5 without using mpi to look after parallel writes;
-         if a cached copy of the array is updated, this is in an unmasked form; if calling code has a
-         reterence to a masked version of the array then the mask will not be updated by this method;
-         if the part is not currently cached, this method will not cause it to become cached,
-         regardless of the update_cache argument
-      """
+        notes:
+           this method naively writes the slice to hdf5 without using mpi to look after parallel writes;
+           if a cached copy of the array is updated, this is in an unmasked form; if calling code has a
+           reterence to a masked version of the array then the mask will not be updated by this method;
+           if the part is not currently cached, this method will not cause it to become cached,
+           regardless of the update_cache argument
+        """
 
         h5_key_pair = self.h5_key_pair_for_part(part)
         assert h5_key_pair is not None
@@ -2210,21 +2220,21 @@ class PropertyCollection():
     def facets_array_ref(self, use_32_bit = False, indexable_element = None):  # todo: add masked argument
         """Returns a +1D array of all parts with first axis being over facet values; Use facet_list() for lookup.
 
-      arguments:
-         use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
-         indexable_element (string, optional): the indexable element for the properties in the collection; if None, will
-            be determined from the data
+        arguments:
+           use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
+           indexable_element (string, optional): the indexable element for the properties in the collection; if None, will
+              be determined from the data
 
-      returns:
-         numpy array containing all the data in the collection, the first axis being over facet values and the rest of
-         the axes matching the shape of the individual property arrays
+        returns:
+           numpy array containing all the data in the collection, the first axis being over facet values and the rest of
+           the axes matching the shape of the individual property arrays
 
-      notes:
-         the property collection should be constructed so as to hold a suitably coherent set of properties before
-         calling this method;
-         the facet_list() method will return the facet values that correspond to slices in the first axis of the
-         resulting array
-      """
+        notes:
+           the property collection should be constructed so as to hold a suitably coherent set of properties before
+           calling this method;
+           the facet_list() method will return the facet values that correspond to slices in the first axis of the
+           resulting array
+        """
 
         assert self.support is not None, 'attempt to build facets array for property collection without supporting representation'
         assert self.number_of_parts() > 0, 'attempt to build facets array for empty property collection'
@@ -2269,29 +2279,29 @@ class PropertyCollection():
                                indexable_element = None):
         """Returns a +1D array of all parts with first axis being over realizations.
 
-      arguments:
-         use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
-         fill_missing (boolean, default True): if True, the first axis of the resulting numpy array will range from 0 to
-            the maximum realization number present and slices for any missing realizations will be filled with fill_value;
-            if False, the extent of the first axis will only cpver the number pf realizations actually present (see also notes)
-         fill_value (int or float, optional): the value to use for missing realization slices; if None, will default to
-            np.NaN if data is continuous, -1 otherwise; irrelevant if fill_missing is False
-         indexable_element (string, optional): the indexable element for the properties in the collection; if None, will
-            be determined from the data
+        arguments:
+           use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
+           fill_missing (boolean, default True): if True, the first axis of the resulting numpy array will range from 0 to
+              the maximum realization number present and slices for any missing realizations will be filled with fill_value;
+              if False, the extent of the first axis will only cpver the number pf realizations actually present (see also notes)
+           fill_value (int or float, optional): the value to use for missing realization slices; if None, will default to
+              np.NaN if data is continuous, -1 otherwise; irrelevant if fill_missing is False
+           indexable_element (string, optional): the indexable element for the properties in the collection; if None, will
+              be determined from the data
 
-      returns:
-         numpy array containing all the data in the collection, the first axis being over realizations and the rest of
-         the axes matching the shape of the individual property arrays
+        returns:
+           numpy array containing all the data in the collection, the first axis being over realizations and the rest of
+           the axes matching the shape of the individual property arrays
 
-      notes:
-         the property collection should be constructed so as to hold a suitably coherent set of properties before
-         calling this method;
-         if fill_missing is False, the realization axis indices range from zero to the number of realizations present;
-         if True, the realization axis indices range from zero to the maximum realization number and slices for missing
-         realizations will be filled with the fill_value
+        notes:
+           the property collection should be constructed so as to hold a suitably coherent set of properties before
+           calling this method;
+           if fill_missing is False, the realization axis indices range from zero to the number of realizations present;
+           if True, the realization axis indices range from zero to the maximum realization number and slices for missing
+           realizations will be filled with the fill_value
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert self.support is not None, 'attempt to build realizations array for property collection without supporting representation'
         assert self.number_of_parts() > 0, 'attempt to build realizations array for empty property collection'
@@ -2353,30 +2363,30 @@ class PropertyCollection():
                               indexable_element = None):
         """Returns a +1D array of all parts with first axis being over time indices.
 
-      arguments:
-         use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
-         fill_missing (boolean, default True): if True, the first axis of the resulting numpy array will range from 0 to
-            the maximum time index present and slices for any missing indices will be filled with fill_value; if False,
-            the extent of the first axis will only cpver the number pf time indices actually present (see also notes)
-         fill_value (int or float, optional): the value to use for missing time index slices; if None, will default to
-            np.NaN if data is continuous, -1 otherwise; irrelevant if fill_missing is False
-         indexable_element (string, optional): the indexable element for the properties in the collection; if None, will
-            be determined from the data
+        arguments:
+           use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
+           fill_missing (boolean, default True): if True, the first axis of the resulting numpy array will range from 0 to
+              the maximum time index present and slices for any missing indices will be filled with fill_value; if False,
+              the extent of the first axis will only cpver the number pf time indices actually present (see also notes)
+           fill_value (int or float, optional): the value to use for missing time index slices; if None, will default to
+              np.NaN if data is continuous, -1 otherwise; irrelevant if fill_missing is False
+           indexable_element (string, optional): the indexable element for the properties in the collection; if None, will
+              be determined from the data
 
-      returns:
-         numpy array containing all the data in the collection, the first axis being over time indices and the rest of
-         the axes matching the shape of the individual property arrays
+        returns:
+           numpy array containing all the data in the collection, the first axis being over time indices and the rest of
+           the axes matching the shape of the individual property arrays
 
-      notes:
-         the property collection should be constructed so as to hold a suitably coherent set of properties before
-         calling this method;
-         if fill_missing is False, the time axis indices range from zero to the number of time indices present,
-         with the list of tine index values available by calling the method time_index_list(sort_list = True);
-         if fill_missing is True, the time axis indices range from zero to the maximum time index and slices for
-         missing time indices will be filled with the fill_value
+        notes:
+           the property collection should be constructed so as to hold a suitably coherent set of properties before
+           calling this method;
+           if fill_missing is False, the time axis indices range from zero to the number of time indices present,
+           with the list of tine index values available by calling the method time_index_list(sort_list = True);
+           if fill_missing is True, the time axis indices range from zero to the maximum time index and slices for
+           missing time indices will be filled with the fill_value
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert self.support is not None, 'attempt to build time series array for property collection without supporting representation'
         assert self.number_of_parts() > 0, 'attempt to build time series array for empty property collection'
@@ -2434,19 +2444,19 @@ class PropertyCollection():
     def combobulated_face_array(self, resqml_a):
         """Returns a logically ordered copy of RESQML faces-per-cell property array resqml_a.
 
-      argument:
-         resqml_a (numpy array of shape (..., 6): a RESQML property array with indexable element faces per cell
+        argument:
+           resqml_a (numpy array of shape (..., 6): a RESQML property array with indexable element faces per cell
 
-      returns:
-         numpy array of shape (..., 3, 2) where the 3 covers K,J,I and the 2 the -/+ face polarities being a resqpy logically
-            arranged copy of resqml_a
+        returns:
+           numpy array of shape (..., 3, 2) where the 3 covers K,J,I and the 2 the -/+ face polarities being a resqpy logically
+              arranged copy of resqml_a
 
-      notes:
-         this method is for properties of IJK grids only;
-         RESQML documentation is not entirely clear about the required ordering of -I, +I, -J, +J faces;
-         current implementation assumes count = 1 for the property;
-         does not currently support points properties
-      """
+        notes:
+           this method is for properties of IJK grids only;
+           RESQML documentation is not entirely clear about the required ordering of -I, +I, -J, +J faces;
+           current implementation assumes count = 1 for the property;
+           does not currently support points properties
+        """
 
         assert resqml_a.shape[-1] == 6
 
@@ -2460,22 +2470,23 @@ class PropertyCollection():
         return resqpy_a
 
     def discombobulated_face_array(self, resqpy_a):
-        """Returns a RESQML format copy of logical face property array a, re-ordered and reshaped regarding the six facial directions.
+        """Returns a RESQML format copy of logical face property array a, re-ordered and reshaped regarding the six
+        facial directions.
 
-      argument:
-         resqpy_a (numpy array of shape (..., 3, 2)): the penultimate array axis represents K,J,I and the final axis is -/+ face
-            polarity; the resqpy logically arranged property array to be converted to illogical RESQML ordering and shape
+        argument:
+           resqpy_a (numpy array of shape (..., 3, 2)): the penultimate array axis represents K,J,I and the final axis is -/+ face
+              polarity; the resqpy logically arranged property array to be converted to illogical RESQML ordering and shape
 
-      returns:
-         numpy array of shape (..., 6) being a copy of resqpy_a with slices reordered before collapsing the last 2 axes into 1;
-            ready to be stored as a RESQML property array with indexable element faces per cell
+        returns:
+           numpy array of shape (..., 6) being a copy of resqpy_a with slices reordered before collapsing the last 2 axes into 1;
+              ready to be stored as a RESQML property array with indexable element faces per cell
 
-      notes:
-         this method is for properties of IJK grids only;
-         RESQML documentation is not entirely clear about the required ordering of -I, +I, -J, +J faces;
-         current implementation assumes count = 1 for the property;
-         does not currently support points properties
-      """
+        notes:
+           this method is for properties of IJK grids only;
+           RESQML documentation is not entirely clear about the required ordering of -I, +I, -J, +J faces;
+           current implementation assumes count = 1 for the property;
+           does not currently support points properties
+        """
 
         assert resqpy_a.ndim >= 2 and resqpy_a.shape[-2] == 3 and resqpy_a.shape[-1] == 2
 
@@ -2508,47 +2519,48 @@ class PropertyCollection():
                               discrete_cycle = None,
                               trust_min_max = False,
                               fix_zero_at = None):
-        """Returns a triplet of: a numpy float array containing the data normalized between 0.0 and 1.0, the min value, the max value.
+        """Returns a triplet of: a numpy float array containing the data normalized between 0.0 and 1.0, the min value,
+        the max value.
 
-      arguments:
-         part (string): the part name for which the normalized array reference is required
-         masked (boolean, optional, default False): if True, the masked version of the property array is used to
-            determine the range of values to map onto the normalized range of 0 to 1 (the mask removes inactive cells
-            from having any impact); if False, the values of inactive cells are included in the operation; the returned
-            normalized array is masked or not depending on this argument
-         use_logarithm (boolean, optional, default False): if False, the property values are linearly mapped to the
-            normalized range; if True, the logarithm (base 10) of the property values are mapped to the normalized range
-         discrete_cycle (positive integer, optional, default None): if a value is supplied and the property array
-            contains integer data (discrete or categorical), the modulus of the property values are calculated
-            against this value before conversion to floating point and mapping to the normalized range
-         trust_min_max (boolean, optional, default False): if True, the minimum and maximum values from the property's
-            metadata is used as the range of the property values; if False, the values are determined using numpy
-            min and max operations
-         fix_zero_at (float, optional): if present, a value between 0.0 and 1.0 (typically 0.0 or 0.5) to pin zero at
+        arguments:
+           part (string): the part name for which the normalized array reference is required
+           masked (boolean, optional, default False): if True, the masked version of the property array is used to
+              determine the range of values to map onto the normalized range of 0 to 1 (the mask removes inactive cells
+              from having any impact); if False, the values of inactive cells are included in the operation; the returned
+              normalized array is masked or not depending on this argument
+           use_logarithm (boolean, optional, default False): if False, the property values are linearly mapped to the
+              normalized range; if True, the logarithm (base 10) of the property values are mapped to the normalized range
+           discrete_cycle (positive integer, optional, default None): if a value is supplied and the property array
+              contains integer data (discrete or categorical), the modulus of the property values are calculated
+              against this value before conversion to floating point and mapping to the normalized range
+           trust_min_max (boolean, optional, default False): if True, the minimum and maximum values from the property's
+              metadata is used as the range of the property values; if False, the values are determined using numpy
+              min and max operations
+           fix_zero_at (float, optional): if present, a value between 0.0 and 1.0 (typically 0.0 or 0.5) to pin zero at
 
-      returns:
-         (normalized_array, min_value, max_value) where:
-         normalized_array is a numpy array of floats, masked or unmasked depending on the masked argument, with values
-         ranging between 0 and 1; in the case of a masked array the values for excluded cells are meaningless and may
-         lie outside the range 0 to 1
-         min_value and max_value: the property values that have been mapped to 0 and 1 respectively
+        returns:
+           (normalized_array, min_value, max_value) where:
+           normalized_array is a numpy array of floats, masked or unmasked depending on the masked argument, with values
+           ranging between 0 and 1; in the case of a masked array the values for excluded cells are meaningless and may
+           lie outside the range 0 to 1
+           min_value and max_value: the property values that have been mapped to 0 and 1 respectively
 
-      notes:
-         this function is typically used to map property values onto the range required for colouring in;
-         in case of failure, (None, None, None) is returned;
-         if use_logarithm is True, the min_value and max_value returned are the log10 values, not the original
-         property values;
-         also, if use logarithm is True and the minimum property value is not greater than zero, then values less than
-         0.0001 are set to 0.0001, prior to taking the logarithm;
-         fix_zero_at is mutually incompatible with use_logarithm; to force the normalised data to have a true zero,
-         set fix_zero_at to 0.0; for divergent data fixing zero at 0.5 will often be appropriate;
-         fixing zero at 0.0 or 1.0 may result in normalised values being clipped;
-         for floating point data, NaN values will be handled okay; if all data are NaN, (None, NaN, NaN) is returned;
-         for integer data, null values are not currently supported (though the RESQML metadata can hold a null value);
-         the masked argument is most applicable to properties for grid objects; note that NaN values are excluded when
-         determining the min and max regardless of the value of the masked argument;
-         not applicable to points properties
-      """
+        notes:
+           this function is typically used to map property values onto the range required for colouring in;
+           in case of failure, (None, None, None) is returned;
+           if use_logarithm is True, the min_value and max_value returned are the log10 values, not the original
+           property values;
+           also, if use logarithm is True and the minimum property value is not greater than zero, then values less than
+           0.0001 are set to 0.0001, prior to taking the logarithm;
+           fix_zero_at is mutually incompatible with use_logarithm; to force the normalised data to have a true zero,
+           set fix_zero_at to 0.0; for divergent data fixing zero at 0.5 will often be appropriate;
+           fixing zero at 0.0 or 1.0 may result in normalised values being clipped;
+           for floating point data, NaN values will be handled okay; if all data are NaN, (None, NaN, NaN) is returned;
+           for integer data, null values are not currently supported (though the RESQML metadata can hold a null value);
+           the masked argument is most applicable to properties for grid objects; note that NaN values are excluded when
+           determining the min and max regardless of the value of the masked argument;
+           not applicable to points properties
+        """
 
         assert not self.points_for_part(part), 'property normalisation not available for points properties'
         assert fix_zero_at is None or not use_logarithm
@@ -2629,14 +2641,14 @@ class PropertyCollection():
     def uncache_part_array(self, part):
         """Removes the cached copy of the array of data for the named property part.
 
-      argument:
-         part (string): the part name for which the cached array is to be removed
+        argument:
+           part (string): the part name for which the cached array is to be removed
 
-      note:
-         this function applies a python delattr() which will mark the array as no longer being in use
-         here; however, actual freeing of the memory only happens when all other references to the
-         array are released
-      """
+        note:
+           this function applies a python delattr() which will mark the array as no longer being in use
+           here; however, actual freeing of the memory only happens when all other references to the
+           array are released
+        """
 
         cached_array_name = _cache_name(part)
         if cached_array_name is not None and hasattr(self, cached_array_name):
@@ -2661,44 +2673,44 @@ class PropertyCollection():
                                           points = False):
         """Caches array and adds to the list of imported properties (but not to the collection dict).
 
-      arguments:
-         cached_array: a numpy array to be added to the imported list for this collection (prior to being added
-            as a part); for a constant array set cached_array to None (and use const_value)
-         source_info (string): typically the name of a file from which the array has been read but can be any
-            information regarding the source of the data
-         keyword (string): this will be used as the citation title when a part is generated for the array
-         discrete (boolean, optional, default False): if True, the array should contain integer (or boolean)
-            data; if False, float
-         uom (string, optional, default None): the resqml units of measure for the data
-         time_index (integer, optional, default None): if not None, the time index to be used when creating
-            a part for the array
-         null_value (int or float, optional, default None): if present, this is used in the metadata to
-            indicate that this value is to be interpreted as a null value wherever it appears in the data
-         property_kind (string): resqml property kind, or None
-         local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
-         facet_type (string): resqml facet type, or None
-         facet (string): resqml facet, or None
-         realization (int): realization number, or None
-         indexable_element (string, optional): the indexable element in the supporting representation
-         count (int, default 1): the number of values per indexable element; if greater than one then this
-            must be the fastest cycling axis in the cached array, ie last index
-         const_value (int, float or bool, optional): the value with which a constant array is filled;
-            required if cached_array is None, must be None otherwise
-         points (bool, default False): if True, this is a points property with an extra dimension of extent 3
+        arguments:
+           cached_array: a numpy array to be added to the imported list for this collection (prior to being added
+              as a part); for a constant array set cached_array to None (and use const_value)
+           source_info (string): typically the name of a file from which the array has been read but can be any
+              information regarding the source of the data
+           keyword (string): this will be used as the citation title when a part is generated for the array
+           discrete (boolean, optional, default False): if True, the array should contain integer (or boolean)
+              data; if False, float
+           uom (string, optional, default None): the resqml units of measure for the data
+           time_index (integer, optional, default None): if not None, the time index to be used when creating
+              a part for the array
+           null_value (int or float, optional, default None): if present, this is used in the metadata to
+              indicate that this value is to be interpreted as a null value wherever it appears in the data
+           property_kind (string): resqml property kind, or None
+           local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
+           facet_type (string): resqml facet type, or None
+           facet (string): resqml facet, or None
+           realization (int): realization number, or None
+           indexable_element (string, optional): the indexable element in the supporting representation
+           count (int, default 1): the number of values per indexable element; if greater than one then this
+              must be the fastest cycling axis in the cached array, ie last index
+           const_value (int, float or bool, optional): the value with which a constant array is filled;
+              required if cached_array is None, must be None otherwise
+           points (bool, default False): if True, this is a points property with an extra dimension of extent 3
 
-      returns:
-         uuid of nascent property object
+        returns:
+           uuid of nascent property object
 
-      note:
-         the process of importing property arrays follows these steps:
-         1. read (or generate) array of data into a numpy array in memory (cache)
-         2. add to the imported list using this function (which also takes takes note of some metadata)
-         3. write imported list arrays to hdf5 file
-         4. create resqml xml nodes for imported list arrays and add as parts to model
-         5. include newly added parts in collection
+        note:
+           the process of importing property arrays follows these steps:
+           1. read (or generate) array of data into a numpy array in memory (cache)
+           2. add to the imported list using this function (which also takes takes note of some metadata)
+           3. write imported list arrays to hdf5 file
+           4. create resqml xml nodes for imported list arrays and add as parts to model
+           5. include newly added parts in collection
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert (cached_array is not None and const_value is None) or (cached_array is None and const_value is not None)
         assert not points or not discrete
@@ -2753,14 +2765,14 @@ class PropertyCollection():
     def write_hdf5_for_imported_list(self, file_name = None, mode = 'a', expand_const_arrays = False):
         """Create or append to an hdf5 file, writing datasets for the imported arrays.
 
-      arguments:
-         file_name (str, optional): if present, this hdf5 filename will override the default
-         mode (str, default 'a'): the mode to open the hdf5 file in, either 'a' (append), or 'w' (overwrite)
-         expand_const_arrays (boolean, default False): if True, constant arrays will be written in full to
-            the hdf5 file and the same argument should be used when creating the xml
+        arguments:
+           file_name (str, optional): if present, this hdf5 filename will override the default
+           mode (str, default 'a'): the mode to open the hdf5 file in, either 'a' (append), or 'w' (overwrite)
+           expand_const_arrays (boolean, default False): if True, constant arrays will be written in full to
+              the hdf5 file and the same argument should be used when creating the xml
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # NB: imported array data must all have been cached prior to calling this function
         assert self.imported_list is not None
@@ -2804,44 +2816,45 @@ class PropertyCollection():
                                                             find_local_property_kinds = True,
                                                             expand_const_arrays = False,
                                                             extra_metadata = {}):
-        """Add imported or generated grid property arrays as parts in parent model, creating xml; hdf5 should already have been written.
+        """Add imported or generated grid property arrays as parts in parent model, creating xml; hdf5 should already
+        have been written.
 
-      arguments:
-         ext_uuid: uuid for the hdf5 external part, which must be known to the model's hdf5 dictionary
-         support_uuid (optional): the uuid of the supporting representation that the imported properties relate to
-         time_series_uuid (optional): the uuid of the full or reduced time series for which any recurrent properties'
-            timestep numbers can be used as a time index; in the case of a reduced series, the selected_time_indices_list
-            argument must be passed and the properties timestep numbers are found in the list with the position yielding
-            the time index for the reduced list; time_series_uuid should be present if there are any recurrent properties
-            in the imported list
-         selected_time_indices_list (list of int, optional): if time_series_uuid is for a reduced time series then this
-            argument must be present and its length must match the number of timestamps in the reduced series; the values
-            in the list are indices in the full time series
-         string_lookup_uuid (optional): if present, the uuid of the string table lookup which any non-continuous
-            properties relate to (ie. they are all taken to be categorical)
-         property_kind_uuid (optional): if present, the uuid of the bespoke (local) property kind for all the
-            property arrays in the imported list (except those with an individual local property kind uuid)
-         find_local_property_kinds (boolean, default True): if True, local property kind uuids need not be provided as
-            long as the property kinds are set to match the titles of the appropriate local property kind objects
-         expand_const_arrays (boolean, default False): if True, the hdf5 write must also have been called with the
-            same argument and the xml will treat the constant arrays as normal arrays
-         extra_metadata (optional): if present, a dictionary of extra metadata to be added for the part
+        arguments:
+           ext_uuid: uuid for the hdf5 external part, which must be known to the model's hdf5 dictionary
+           support_uuid (optional): the uuid of the supporting representation that the imported properties relate to
+           time_series_uuid (optional): the uuid of the full or reduced time series for which any recurrent properties'
+              timestep numbers can be used as a time index; in the case of a reduced series, the selected_time_indices_list
+              argument must be passed and the properties timestep numbers are found in the list with the position yielding
+              the time index for the reduced list; time_series_uuid should be present if there are any recurrent properties
+              in the imported list
+           selected_time_indices_list (list of int, optional): if time_series_uuid is for a reduced time series then this
+              argument must be present and its length must match the number of timestamps in the reduced series; the values
+              in the list are indices in the full time series
+           string_lookup_uuid (optional): if present, the uuid of the string table lookup which any non-continuous
+              properties relate to (ie. they are all taken to be categorical)
+           property_kind_uuid (optional): if present, the uuid of the bespoke (local) property kind for all the
+              property arrays in the imported list (except those with an individual local property kind uuid)
+           find_local_property_kinds (boolean, default True): if True, local property kind uuids need not be provided as
+              long as the property kinds are set to match the titles of the appropriate local property kind objects
+           expand_const_arrays (boolean, default False): if True, the hdf5 write must also have been called with the
+              same argument and the xml will treat the constant arrays as normal arrays
+           extra_metadata (optional): if present, a dictionary of extra metadata to be added for the part
 
-      returns:
-         list of uuid.UUID, being the uuids of the newly added property parts
+        returns:
+           list of uuid.UUID, being the uuids of the newly added property parts
 
-      notes:
-         the imported list should have been built up, and associated hdf5 arrays written, before calling this method;
-         the imported list is cleared as a deliberate side-effect of this method (so a new set of imports can be
-         started hereafter);
-         discrete and categorical properties cannot be mixed in the same import list - process as separate lists;
-         all categorical properties in the import list must refer to the same string table lookup;
-         when importing categorical properties, establish the xml for the string table lookup before calling this method;
-         if importing properties of a bespoke (local) property kind, ensure the property kind objects exist as parts in
-         the model before calling this method
+        notes:
+           the imported list should have been built up, and associated hdf5 arrays written, before calling this method;
+           the imported list is cleared as a deliberate side-effect of this method (so a new set of imports can be
+           started hereafter);
+           discrete and categorical properties cannot be mixed in the same import list - process as separate lists;
+           all categorical properties in the import list must refer to the same string table lookup;
+           when importing categorical properties, establish the xml for the string table lookup before calling this method;
+           if importing properties of a bespoke (local) property kind, ensure the property kind objects exist as parts in
+           the model before calling this method
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.imported_list is None:
             return []
@@ -2957,73 +2970,73 @@ class PropertyCollection():
                    expand_const_arrays = False):
         """Create a property xml node for a single property related to a given supporting representation node.
 
-      arguments:
-         ext_uuid (uuid.UUID): the uuid of the hdf5 external part
-         property_array (numpy array): the actual property array (used to populate xml min & max values);
-            may be None if min_value and max_value are passed or add_min_max is False
-         title (string): used for the citation Title text for the property; often set to a simulator keyword for
-            grid properties
-         property_kind (string): the resqml property kind of the property; in the case of a bespoke (local)
-            property kind, this is used as the title in the local property kind reference and the
-            property_kind_uuid argument must also be passed or find_local_property_kinds set True
-         support_uuid (uuid.UUID, optional): if None, the support for the collection is used
-         p_uuid (uuid.UUID, optional): if None, a new uuid is generated for the property; otherwise this
-            uuid is used
-         facet_type (string, optional): if present, a resqml facet type whose value is supplied in the facet argument
-         facet (string, optional): required if facet_type is supplied; the value of the facet
-         discrete (boolean, default False): if True, a discrete or categorical property node is created (depending
-            on whether string_lookup_uuid is None or present); if False (default), a continuous property node is created
-         time_series_uuid (uuid.UUID, optional): if present, the uuid of the time series that this (recurrent)
-            property relates to
-         time_index (int, optional): if time_series_uuid is not None, this argument is required and provides
-            the time index into the time series for this property array
-         uom (string): the resqml unit of measure for the property (only used for continuous properties)
-         null_value (optional): the value that is to be interpreted as null if it appears in the property array
-         originator (string, optional): the name of the human being who created the property object;
-            default is to use the login name
-         source (string, optional): if present, an extra metadata node is added as a child to the property
-            node, with this string indicating the source of the property data
-         add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-            in the model
-         add_relationships (boolean, default True): if True, relationship xml parts are created relating the
-            new property part to: the support, the hdf5 external part; and the time series part (if applicable)
-         add_min_max (boolean, default True): if True, min and max values are included as children in the
-            property node
-         min_value (optional): if present and add_min_max is True, this is used as the minimum value (otherwise it
-            is calculated from the property array)
-         max_value (optional): if present and add_min_max is True, this is used as the maximum value (otherwise it
-            is calculated from the property array)
-         realization (int, optional): if present, is used as the realization number in the property node; if None,
-            no realization child is created
-         string_lookup_uuid (optional): if present, and discrete is True, a categorical property node is created
-            which refers to this string table lookup
-         property_kind_uuid (optional): if present, the property kind is a local property kind; must be None for a
-            standard property kind
-         find_local_property_kinds (boolean, default True): if True and property_kind is not in standard supported
-            property kind list and property_kind_uuid is None, the citation titles of PropertyKind objects in the
-            model are compared with property_kind and if a match is found, that local property kind is used
-         indexable_element (string, optional): if present, is used as the indexable element in the property node;
-            if None, 'cells' are used for grid properties and 'nodes' for wellbore frame properties
-         count (int, default 1): the number of values per indexable element; if greater than one then this axis
-            must cycle fastest in the array, ie. be the last index
-         points (bool, default False): if True, this is a points property
-         extra_metadata (dictionary, optional): if present, adds extra metadata in the xml
-         const_value (float or int, optional): if present, create xml for a constant array filled with this value
-         expand_const_arrays (boolean, default False): if True, the hdf5 write must also have been called with the
-            same argument and the xml will treat a constant array as a normal array
+        arguments:
+           ext_uuid (uuid.UUID): the uuid of the hdf5 external part
+           property_array (numpy array): the actual property array (used to populate xml min & max values);
+              may be None if min_value and max_value are passed or add_min_max is False
+           title (string): used for the citation Title text for the property; often set to a simulator keyword for
+              grid properties
+           property_kind (string): the resqml property kind of the property; in the case of a bespoke (local)
+              property kind, this is used as the title in the local property kind reference and the
+              property_kind_uuid argument must also be passed or find_local_property_kinds set True
+           support_uuid (uuid.UUID, optional): if None, the support for the collection is used
+           p_uuid (uuid.UUID, optional): if None, a new uuid is generated for the property; otherwise this
+              uuid is used
+           facet_type (string, optional): if present, a resqml facet type whose value is supplied in the facet argument
+           facet (string, optional): required if facet_type is supplied; the value of the facet
+           discrete (boolean, default False): if True, a discrete or categorical property node is created (depending
+              on whether string_lookup_uuid is None or present); if False (default), a continuous property node is created
+           time_series_uuid (uuid.UUID, optional): if present, the uuid of the time series that this (recurrent)
+              property relates to
+           time_index (int, optional): if time_series_uuid is not None, this argument is required and provides
+              the time index into the time series for this property array
+           uom (string): the resqml unit of measure for the property (only used for continuous properties)
+           null_value (optional): the value that is to be interpreted as null if it appears in the property array
+           originator (string, optional): the name of the human being who created the property object;
+              default is to use the login name
+           source (string, optional): if present, an extra metadata node is added as a child to the property
+              node, with this string indicating the source of the property data
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in the model
+           add_relationships (boolean, default True): if True, relationship xml parts are created relating the
+              new property part to: the support, the hdf5 external part; and the time series part (if applicable)
+           add_min_max (boolean, default True): if True, min and max values are included as children in the
+              property node
+           min_value (optional): if present and add_min_max is True, this is used as the minimum value (otherwise it
+              is calculated from the property array)
+           max_value (optional): if present and add_min_max is True, this is used as the maximum value (otherwise it
+              is calculated from the property array)
+           realization (int, optional): if present, is used as the realization number in the property node; if None,
+              no realization child is created
+           string_lookup_uuid (optional): if present, and discrete is True, a categorical property node is created
+              which refers to this string table lookup
+           property_kind_uuid (optional): if present, the property kind is a local property kind; must be None for a
+              standard property kind
+           find_local_property_kinds (boolean, default True): if True and property_kind is not in standard supported
+              property kind list and property_kind_uuid is None, the citation titles of PropertyKind objects in the
+              model are compared with property_kind and if a match is found, that local property kind is used
+           indexable_element (string, optional): if present, is used as the indexable element in the property node;
+              if None, 'cells' are used for grid properties and 'nodes' for wellbore frame properties
+           count (int, default 1): the number of values per indexable element; if greater than one then this axis
+              must cycle fastest in the array, ie. be the last index
+           points (bool, default False): if True, this is a points property
+           extra_metadata (dictionary, optional): if present, adds extra metadata in the xml
+           const_value (float or int, optional): if present, create xml for a constant array filled with this value
+           expand_const_arrays (boolean, default False): if True, the hdf5 write must also have been called with the
+              same argument and the xml will treat a constant array as a normal array
 
-      returns:
-         the newly created property xml node
+        returns:
+           the newly created property xml node
 
-      notes:
-         this function doesn't write the actual array data to the hdf5 file: that should be done
-         before calling this function;
-         this code (and elsewhere) only supports at most one facet per property, though the RESQML standard
-         allows for multiple facets;
-         RESQML does not allow facets for points properties;
-         if the xml has not been created for the support object, then xml will not be created for relationships
-         between the properties and the supporting representation
-      """
+        notes:
+           this function doesn't write the actual array data to the hdf5 file: that should be done
+           before calling this function;
+           this code (and elsewhere) only supports at most one facet per property, though the RESQML standard
+           allows for multiple facets;
+           RESQML does not allow facets for points properties;
+           if the xml has not been created for the support object, then xml will not be created for relationships
+           between the properties and the supporting representation
+        """
 
         #      log.debug('creating property node for ' + title)
         # currently assumes discrete properties to be 32 bit integers and continuous to be 64 bit reals
@@ -3285,16 +3298,16 @@ class PropertyCollection():
                                 add_relationships = True):
         """Creates an xml node for a property set to represent this collection of properties.
 
-      arguments:
-         title (string): to be used as citation title
-         ps_uuid (string, optional): if present, used as the uuid for the property set, otherwise a new uuid is generated
-         originator (string, optional): if present, used as the citation creator (otherwise login name is used)
-         add_as_part (boolean, default True): if True, the property set is added to the model as a part
-         add_relationships (boolean, default True): if True, the relationships to the member properties are added
+        arguments:
+           title (string): to be used as citation title
+           ps_uuid (string, optional): if present, used as the uuid for the property set, otherwise a new uuid is generated
+           originator (string, optional): if present, used as the citation creator (otherwise login name is used)
+           add_as_part (boolean, default True): if True, the property set is added to the model as a part
+           add_relationships (boolean, default True): if True, the relationships to the member properties are added
 
-      note:
-         xml for individual properties should exist before calling this method
-      """
+        note:
+           xml for individual properties should exist before calling this method
+        """
 
         assert self.model is not None, 'cannot create xml for property set as model is not set'
         assert self.number_of_parts() > 0, 'cannot create xml for property set as no parts in collection'
@@ -3356,32 +3369,32 @@ class PropertyCollection():
                                     perm_k_ratio = 1.0):
         """Returns five parts: net to gross ratio, porosity, permeability rock I, J & K; each returned part may be None.
 
-      arguments:
-         realization: (int, optional): if present, only properties with the given realization are considered; if None,
-            all properties in the collection are considered
-         share_perm_parts (boolean, default False): if True, the permeability I part will also be returned for J and/or K
-            if no other properties are found for those directions; if False, None will be returned for such parts
-         perm_k_mode (string, optional): if present, indicates what action to take when no K direction permeability is
-            found; valid values are:
-            'none': same as None, perm K part return value will be None
-            'shared': if share_perm_parts is True, then perm I value will be used for perm K, else same as None
-            'ratio': multiply IJ permeability by the perm_k_ratio argument
-            'ntg': multiply IJ permeability by ntg and by perm_k_ratio
-            'ntg squared': multiply IJ permeability by square of ntg and by perm_k_ratio
-         perm_k_ratio (float, default 1.0): a Kv:Kh ratio, typically in the range zero to one, applied if generating
-            a K permeability array (perm_k_mode is 'ratio', 'ntg' or 'ntg squared' and no existing K permeability found);
-            ignored otherwise
+        arguments:
+           realization: (int, optional): if present, only properties with the given realization are considered; if None,
+              all properties in the collection are considered
+           share_perm_parts (boolean, default False): if True, the permeability I part will also be returned for J and/or K
+              if no other properties are found for those directions; if False, None will be returned for such parts
+           perm_k_mode (string, optional): if present, indicates what action to take when no K direction permeability is
+              found; valid values are:
+              'none': same as None, perm K part return value will be None
+              'shared': if share_perm_parts is True, then perm I value will be used for perm K, else same as None
+              'ratio': multiply IJ permeability by the perm_k_ratio argument
+              'ntg': multiply IJ permeability by ntg and by perm_k_ratio
+              'ntg squared': multiply IJ permeability by square of ntg and by perm_k_ratio
+           perm_k_ratio (float, default 1.0): a Kv:Kh ratio, typically in the range zero to one, applied if generating
+              a K permeability array (perm_k_mode is 'ratio', 'ntg' or 'ntg squared' and no existing K permeability found);
+              ignored otherwise
 
-      returns:
-         tuple of 5 strings being part names for: net to gross ratio, porosity, perm i, perm j, perm k (respectively);
-         any of the returned elements may be None if no appropriate property was identified
+        returns:
+           tuple of 5 strings being part names for: net to gross ratio, porosity, perm i, perm j, perm k (respectively);
+           any of the returned elements may be None if no appropriate property was identified
 
-      note:
-         if generating a K permeability array, the data is appended to the hdf5 file and the xml is created, however
-         the epc re-write must be carried out by the calling code
+        note:
+           if generating a K permeability array, the data is appended to the hdf5 file and the xml is created, however
+           the epc re-write must be carried out by the calling code
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         ntg_part = poro_part = perm_i_part = perm_j_part = perm_k_part = None
         try:
@@ -3525,9 +3538,9 @@ class PropertyCollection():
                                          perm_k_ratio = 1.0):
         """Same as basic_static_property_parts() method but returning a dictionary with 5 items.
 
-      note:
-         returned dictionary contains following keys: 'NTG', 'PORO', 'PERMI', 'PERMJ', 'PERMK'
-      """
+        note:
+           returned dictionary contains following keys: 'NTG', 'PORO', 'PERMI', 'PERMJ', 'PERMK'
+        """
 
         five_parts = self.basic_static_property_parts(realization = realization,
                                                       share_perm_parts = share_perm_parts,
@@ -3548,11 +3561,11 @@ class PropertyCollection():
                                     perm_k_ratio = 1.0):
         """Returns five uuids: net to gross ratio, porosity, permeability rock I, J & K; each returned uuid may be None.
 
-      note:
-         see basic_static_property_parts() method for argument documentation
+        note:
+           see basic_static_property_parts() method for argument documentation
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         five_parts = self.basic_static_property_parts(realization = realization,
                                                       share_perm_parts = share_perm_parts,
@@ -3573,9 +3586,9 @@ class PropertyCollection():
                                          perm_k_ratio = 1.0):
         """Same as basic_static_property_uuids() method but returning a dictionary with 5 items.
 
-      note:
-         returned dictionary contains following keys: 'NTG', 'PORO', 'PERMI', 'PERMJ', 'PERMK'
-      """
+        note:
+           returned dictionary contains following keys: 'NTG', 'PORO', 'PERMI', 'PERMJ', 'PERMK'
+        """
 
         five_uuids = self.basic_static_property_uuids(realization = realization,
                                                       share_perm_parts = share_perm_parts,
@@ -3613,18 +3626,18 @@ class Property(BaseResqpy):
     def __init__(self, parent_model, uuid = None, title = None, support_uuid = None, extra_metadata = None):
         """Initialises a resqpy Property object, either for an existing RESQML property, or empty for support.
 
-      arguments:
-         parent_model (model.Model): the model to which the property belongs
-         uuid (uuid.UUID, optional): required if initialising from an existing RESQML property object
-         title (str, optional): the citation title to use for the property; ignored if uuid is present
-         support_uuid (uuid.UUID, optional): identifies the supporting representation for the property;
-            ignored if uuid is present
-         extra_metadata (dict, optional): if present, the dictionary items are added as extra metadata;
-            ignored if uuid is present
+        arguments:
+           parent_model (model.Model): the model to which the property belongs
+           uuid (uuid.UUID, optional): required if initialising from an existing RESQML property object
+           title (str, optional): the citation title to use for the property; ignored if uuid is present
+           support_uuid (uuid.UUID, optional): identifies the supporting representation for the property;
+              ignored if uuid is present
+           extra_metadata (dict, optional): if present, the dictionary items are added as extra metadata;
+              ignored if uuid is present
 
-      returns:
-         new resqpy Property object
-      """
+        returns:
+           new resqpy Property object
+        """
 
         self.collection = PropertyCollection()
         super().__init__(model = parent_model, uuid = uuid, title = title, extra_metadata = extra_metadata)
@@ -3655,9 +3668,9 @@ class Property(BaseResqpy):
     def from_singleton_collection(cls, property_collection: PropertyCollection):
         """Populates a new Property from a PropertyCollection containing just one part.
 
-      arguments:
-         property_collection (PropertyCollection): the singleton collection from which to populate this Property
-      """
+        arguments:
+           property_collection (PropertyCollection): the singleton collection from which to populate this Property
+        """
 
         # Validate
         assert property_collection.model is not None
@@ -3706,60 +3719,60 @@ class Property(BaseResqpy):
                    extra_metadata = {}):
         """Populates a new Property from a numpy array and metadata; NB. Writes data to hdf5 and adds part to model.
 
-      arguments:
-         parent_model (model.Model): the model to which the new property belongs
-         cached_array: a numpy array to be made into a property; for a constant array set cached_array to None
-            (and use const_value)
-         source_info (string): typically the name of a file from which the array has been read but can be any
-            information regarding the source of the data
-         keyword (string): this will be used as the citation title for the property
-         support_uuid (uuid): the uuid of the supporting representation
-         property_kind (string): resqml property kind (required unless a local propery kind is identified with
-            local_property_kind_uuid)
-         local_property_kind_uuid (uuid.UUID or string, optional): uuid of local property kind, or None if a
-            standard property kind applies or if the local property kind is identified by its name (see
-            find_local_property_kind)
-         indexable_element (string): the indexable element in the supporting representation; if None
-            then the 'typical' indexable element for the class of supporting representation will be assumed
-         facet_type (string, optional): resqml facet type, or None; resqpy only supports at most one facet per
-            property though RESQML allows for multiple)
-         facet (string, optional): resqml facet, or None; resqpy only supports at most one facet per property
-            though RESQML allows for multiple)
-         discrete (boolean, optional, default False): if True, the array should contain integer (or boolean)
-            data, if False, float; set True for any discrete data including categorical
-         uom (string, optional, default None): the resqml units of measure for the data; required for
-            continuous (float) array
-         null_value (int, optional, default None): if present, this is used in the metadata to indicate that
-            the value is to be interpreted as a null value wherever it appears in the discrete data; not used
-            for continuous data where NaN is always the null value
-         time_series_uuid (optional): the uuid of the full or reduced time series that the time_index is for
-         time_index (integer, optional, default None): if not None, the time index for the property (see also
-            time_series_uuid)
-         realization (int, optional): realization number, or None
-         count (int, default 1): the number of values per indexable element; if greater than one then this
-            must be the fastest cycling axis in the cached array, ie last index
-         const_value (int, float or bool, optional): the value with which a constant array is filled;
-            required if cached_array is None, must be None otherwise
-         string_lookup_uuid (optional): if present, the uuid of the string table lookup which the categorical data
-            relates to; if None, the property will not be configured as categorical
-         find_local_property_kind (boolean, default True): if True, local property kind uuid need not be provided as
-            long as the property_kind is set to match the title of the appropriate local property kind object
-         expand_const_arrays (boolean, default False): if True, and a const_value is given, the array will be fully
-            expanded and written to the hdf5 file; the xml will then not indicate that it is constant
-         extra_metadata (optional): if present, a dictionary of extra metadata to be added for the part
+        arguments:
+           parent_model (model.Model): the model to which the new property belongs
+           cached_array: a numpy array to be made into a property; for a constant array set cached_array to None
+              (and use const_value)
+           source_info (string): typically the name of a file from which the array has been read but can be any
+              information regarding the source of the data
+           keyword (string): this will be used as the citation title for the property
+           support_uuid (uuid): the uuid of the supporting representation
+           property_kind (string): resqml property kind (required unless a local propery kind is identified with
+              local_property_kind_uuid)
+           local_property_kind_uuid (uuid.UUID or string, optional): uuid of local property kind, or None if a
+              standard property kind applies or if the local property kind is identified by its name (see
+              find_local_property_kind)
+           indexable_element (string): the indexable element in the supporting representation; if None
+              then the 'typical' indexable element for the class of supporting representation will be assumed
+           facet_type (string, optional): resqml facet type, or None; resqpy only supports at most one facet per
+              property though RESQML allows for multiple)
+           facet (string, optional): resqml facet, or None; resqpy only supports at most one facet per property
+              though RESQML allows for multiple)
+           discrete (boolean, optional, default False): if True, the array should contain integer (or boolean)
+              data, if False, float; set True for any discrete data including categorical
+           uom (string, optional, default None): the resqml units of measure for the data; required for
+              continuous (float) array
+           null_value (int, optional, default None): if present, this is used in the metadata to indicate that
+              the value is to be interpreted as a null value wherever it appears in the discrete data; not used
+              for continuous data where NaN is always the null value
+           time_series_uuid (optional): the uuid of the full or reduced time series that the time_index is for
+           time_index (integer, optional, default None): if not None, the time index for the property (see also
+              time_series_uuid)
+           realization (int, optional): realization number, or None
+           count (int, default 1): the number of values per indexable element; if greater than one then this
+              must be the fastest cycling axis in the cached array, ie last index
+           const_value (int, float or bool, optional): the value with which a constant array is filled;
+              required if cached_array is None, must be None otherwise
+           string_lookup_uuid (optional): if present, the uuid of the string table lookup which the categorical data
+              relates to; if None, the property will not be configured as categorical
+           find_local_property_kind (boolean, default True): if True, local property kind uuid need not be provided as
+              long as the property_kind is set to match the title of the appropriate local property kind object
+           expand_const_arrays (boolean, default False): if True, and a const_value is given, the array will be fully
+              expanded and written to the hdf5 file; the xml will then not indicate that it is constant
+           extra_metadata (optional): if present, a dictionary of extra metadata to be added for the part
 
-      returns:
-         new Property object built from numpy array; the hdf5 data has been written, xml created and the part
-         added to the model
+        returns:
+           new Property object built from numpy array; the hdf5 data has been written, xml created and the part
+           added to the model
 
-      notes:
-         this method writes to the hdf5 file and creates the xml node, which is added as a part to the model;
-         calling code must still call the model's store_epc() method;
-         this from_array() method is a convenience method calling self.collection.set_support(),
-         self.prepare_import(), self.write_hdf5() and self.create_xml()
+        notes:
+           this method writes to the hdf5 file and creates the xml node, which is added as a part to the model;
+           calling code must still call the model's store_epc() method;
+           this from_array() method is a convenience method calling self.collection.set_support(),
+           self.prepare_import(), self.write_hdf5() and self.create_xml()
 
-      :meta common:
-      """
+        :meta common:
+        """
         # Validate
         assert parent_model is not None
         assert cached_array is not None or const_value is not None
@@ -3804,18 +3817,18 @@ class Property(BaseResqpy):
     def array_ref(self, dtype = None, masked = False, exclude_null = False):
         """Returns a (cached) numpy array containing the property values.
 
-      arguments:
-         dtype (str or type, optional): the required dtype of the array (usually float, int or bool)
-         masked (boolean, default False): if True, a numpy masked array is returned, with the mask determined by
-            the inactive cell mask in the case of a Grid property
-         exclude_null (boolean, default False): if True and masked is True, elements whose value is the null value
-            (NaN for floats) will be masked out
+        arguments:
+           dtype (str or type, optional): the required dtype of the array (usually float, int or bool)
+           masked (boolean, default False): if True, a numpy masked array is returned, with the mask determined by
+              the inactive cell mask in the case of a Grid property
+           exclude_null (boolean, default False): if True and masked is True, elements whose value is the null value
+              (NaN for floats) will be masked out
 
-      returns:
-         numpy array
+        returns:
+           numpy array
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return self.collection.cached_part_array_ref(self.part,
                                                      dtype = dtype,
@@ -3829,8 +3842,8 @@ class Property(BaseResqpy):
     def is_continuous(self):
         """Returns boolean indicating that the property contains continuous (ie. float) data.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.collection.continuous_for_part(self.part)
 
     def is_points(self):
@@ -3841,8 +3854,8 @@ class Property(BaseResqpy):
     def is_categorical(self):
         """Returns boolean indicating that the property contains categorical data.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.collection.part_is_categorical(self.part)
 
     def null_value(self):
@@ -3856,15 +3869,15 @@ class Property(BaseResqpy):
     def indexable_element(self):
         """Returns string being the indexable element for the property.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.collection.indexable_for_part(self.part)
 
     def property_kind(self):
         """Returns string being the property kind for the property.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.collection.property_kind_for_part(self.part)
 
     def local_property_kind_uuid(self):
@@ -3874,19 +3887,19 @@ class Property(BaseResqpy):
     def facet_type(self):
         """Returns string being the facet type for the property, or None if no facet present.
 
-      note: resqpy currently supports at most one facet per property, though RESQML allows for multiple.
+        note: resqpy currently supports at most one facet per property, though RESQML allows for multiple.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.collection.facet_type_for_part(self.part)
 
     def facet(self):
         """Returns string being the facet value for the property, or None if no facet present.
 
-      note: resqpy currently supports at most one facet per property, though RESQML allows for multiple.
+        note: resqpy currently supports at most one facet per property, though RESQML allows for multiple.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.collection.facet_for_part(self.part)
 
     def time_series_uuid(self):
@@ -3908,8 +3921,8 @@ class Property(BaseResqpy):
     def uom(self):
         """Returns string being the units of measure (for a continuous property, otherwise None).
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.collection.uom_for_part(self.part)
 
     def string_lookup_uuid(self):
@@ -3943,9 +3956,9 @@ class Property(BaseResqpy):
                        points = False):
         """Takes a numpy array and metadata and sets up a single array import list; not usually called directly.
 
-      note:
-         see the documentation for the convenience method from_array()
-      """
+        note:
+           see the documentation for the convenience method from_array()
+        """
         assert self.collection.number_of_parts() == 0
         assert not self.collection.imported_list
         self.collection.add_cached_array_to_imported_list(cached_array,
@@ -3968,9 +3981,9 @@ class Property(BaseResqpy):
     def write_hdf5(self, file_name = None, mode = 'a', expand_const_arrays = False):
         """Writes the array data to the hdf5 file; not usually called directly.
 
-      notes:
-         see the documentation for the convenience method from_array();
-      """
+        notes:
+           see the documentation for the convenience method from_array();
+        """
         if not self.collection.imported_list:
             log.warning('no imported Property array to write to hdf5')
             return
@@ -3989,11 +4002,11 @@ class Property(BaseResqpy):
                    extra_metadata = {}):
         """Creates an xml tree for the property and adds it as a part to the model; not usually called directly.
 
-      note:
-         see the documentation for the convenience method from_array()
-         NB. this method has the deliberate side effect of modifying the uuid and title of self to match those
-         of the property collection part!
-      """
+        note:
+           see the documentation for the convenience method from_array()
+           NB. this method has the deliberate side effect of modifying the uuid and title of self to match those
+           of the property collection part!
+        """
         if not self.collection.imported_list:
             log.warning('no imported Property array to create xml for')
             return
@@ -4024,24 +4037,24 @@ class GridPropertyCollection(PropertyCollection):
     def __init__(self, grid = None, property_set_root = None, realization = None):
         """Creates a new property collection related to an IJK grid.
 
-      arguments:
-         grid (grid.Grid object, optional): must be present unless creating a completely blank, empty collection
-         property_set_root (optional): if present, the collection is populated with the properties defined in the xml tree
-            of the property set; grid must not be None when using this argument
-         realization (integer, optional): if present, the single realisation (within an ensemble) that this collection is for;
-            if None, then the collection is either covering a whole ensemble (individual properties can each be flagged with a
-            realisation number), or is for properties that do not have multiple realizations
+        arguments:
+           grid (grid.Grid object, optional): must be present unless creating a completely blank, empty collection
+           property_set_root (optional): if present, the collection is populated with the properties defined in the xml tree
+              of the property set; grid must not be None when using this argument
+           realization (integer, optional): if present, the single realisation (within an ensemble) that this collection is for;
+              if None, then the collection is either covering a whole ensemble (individual properties can each be flagged with a
+              realisation number), or is for properties that do not have multiple realizations
 
-      returns:
-         the new GridPropertyCollection object
+        returns:
+           the new GridPropertyCollection object
 
-      note:
-         usually a grid should be passed, however a completely blank collection may be created prior to using
-         collection inheritance methods to populate from another collection, in which case the grid can be lazily left
-         as None here
+        note:
+           usually a grid should be passed, however a completely blank collection may be created prior to using
+           collection inheritance methods to populate from another collection, in which case the grid can be lazily left
+           as None here
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if grid is not None:
             log.debug('initialising grid property collection for grid: ' + str(rqet.citation_title_for_node(grid.root)))
@@ -4066,9 +4079,9 @@ class GridPropertyCollection(PropertyCollection):
     def set_grid(self, grid, grid_root = None, modify_parts = True):
         """Sets the supporting representation object for the collection to be the given grid.
 
-      note:
-         this method does not need to be called if the grid was passed during object initialisation.
-      """
+        note:
+           this method does not need to be called if the grid was passed during object initialisation.
+        """
 
         self.set_support(support = grid, modify_parts = modify_parts)
         self._copy_support_to_grid_attributes()
@@ -4076,20 +4089,20 @@ class GridPropertyCollection(PropertyCollection):
     def h5_slice_for_box(self, part, box):
         """Returns a subset of the array for part, without loading the whole array (unless already cached).
 
-      arguments:
-         part (string): the part name for which the array slice is required
-         box (numpy int array of shape (2, 3)): the min, max indices for K, J, I axes for which an array
-            extract is required
+        arguments:
+           part (string): the part name for which the array slice is required
+           box (numpy int array of shape (2, 3)): the min, max indices for K, J, I axes for which an array
+              extract is required
 
-      returns:
-         numpy array that is a hyper-slice of the hdf5 array
+        returns:
+           numpy array that is a hyper-slice of the hdf5 array
 
-      note:
-         this method always fetches from the hdf5 file and does not attempt local caching; the whole array
-         is not loaded; all axes continue to exist in the returned array, even where the sliced extent of
-         an axis is 1; the upper indices indicated in the box are included in the data (unlike the python
-         protocol)
-      """
+        note:
+           this method always fetches from the hdf5 file and does not attempt local caching; the whole array
+           is not loaded; all axes continue to exist in the returned array, even where the sliced extent of
+           an axis is 1; the upper indices indicated in the box are included in the data (unlike the python
+           protocol)
+        """
 
         slice_tuple = (slice(box[0, 0], box[1, 0] + 1), slice(box[0, 1],
                                                               box[1, 1] + 1), slice(box[0, 2], box[1, 2] + 1))
@@ -4103,32 +4116,33 @@ class GridPropertyCollection(PropertyCollection):
                                                                            realization = None,
                                                                            copy_all_realizations = False,
                                                                            uncache_other_arrays = True):
-        """Extends this collection's imported list with properties from other collection, optionally extracting for a box.
+        """Extends this collection's imported list with properties from other collection, optionally extracting for a
+        box.
 
-      arguments:
-         other: another GridPropertyCollection object which might relate to a different grid object
-         box: (numpy int array of shape (2, 3), optional): if present, a logical ijk cuboid subset of the source arrays
-            is extracted, box axes are (min:max, kji0); if None, the full arrays are copied
-         refinement (resqpy.olio.fine_coarse.FineCoarse object, optional): if present, other is taken to be a collection
-            for a coarser grid and the property values are sampled for a finer grid based on the refinement mapping
-         coarsening (resqpy.olio.fine_coarse.FineCoarse object, optional): if present, other is taken to be a collection
-            for a finer grid and the property values are upscaled for a coarser grid based on the coarsening mapping
-         realization (int, optional): if present, only properties for this realization are copied; if None, only
-            properties without a realization number are copied unless copy_all_realizations is True
-         copy_all_realizations (boolean, default False): if True (and realization is None), all properties are copied;
-            if False, only properties with a realization of None are copied; ignored if realization is not None
-         uncache_other_arrays (boolean, default True): if True, after each array is copied, the original is uncached from
-            the source collection (to free up memory)
+        arguments:
+           other: another GridPropertyCollection object which might relate to a different grid object
+           box: (numpy int array of shape (2, 3), optional): if present, a logical ijk cuboid subset of the source arrays
+              is extracted, box axes are (min:max, kji0); if None, the full arrays are copied
+           refinement (resqpy.olio.fine_coarse.FineCoarse object, optional): if present, other is taken to be a collection
+              for a coarser grid and the property values are sampled for a finer grid based on the refinement mapping
+           coarsening (resqpy.olio.fine_coarse.FineCoarse object, optional): if present, other is taken to be a collection
+              for a finer grid and the property values are upscaled for a coarser grid based on the coarsening mapping
+           realization (int, optional): if present, only properties for this realization are copied; if None, only
+              properties without a realization number are copied unless copy_all_realizations is True
+           copy_all_realizations (boolean, default False): if True (and realization is None), all properties are copied;
+              if False, only properties with a realization of None are copied; ignored if realization is not None
+           uncache_other_arrays (boolean, default True): if True, after each array is copied, the original is uncached from
+              the source collection (to free up memory)
 
-      notes:
-         this function can be used to copy properties between one grid object and another compatible one, for example
-         after a grid manipulation has generated a new version of the geometry; it can also be used to select an ijk box
-         subset of the property data and/or refine or coarsen the property data;
-         if a box is supplied, the first index indicates min (0) or max (1) and the second index indicates k (0), j (1) or i (2);
-         the values in box are zero based and cells matching the maximum indices are included (unlike with python ranges);
-         when coarsening or refining, this function ignores the 'within...box' attributes of the FineCoarse object so
-         the box argument must be used to effect a local grid coarsening or refinement
-      """
+        notes:
+           this function can be used to copy properties between one grid object and another compatible one, for example
+           after a grid manipulation has generated a new version of the geometry; it can also be used to select an ijk box
+           subset of the property data and/or refine or coarsen the property data;
+           if a box is supplied, the first index indicates min (0) or max (1) and the second index indicates k (0), j (1) or i (2);
+           the values in box are zero based and cells matching the maximum indices are included (unlike with python ranges);
+           when coarsening or refining, this function ignores the 'within...box' attributes of the FineCoarse object so
+           the box argument must be used to effect a local grid coarsening or refinement
+        """
 
         # todo: optional use of active cell mask in coarsening
 
@@ -4453,36 +4467,37 @@ class GridPropertyCollection(PropertyCollection):
                                        facet = None,
                                        realization = None,
                                        use_binary = True):
-        """Reads a property array from an ascii (or pure binary) file, caches and adds to imported list (but not collection dict).
+        """Reads a property array from an ascii (or pure binary) file, caches and adds to imported list (but not
+        collection dict).
 
-      arguments:
-         file_name (string): the name of the file to read the array data from; should contain data for one array only, without
-            the keyword
-         keyword (string): the keyword to associate with the imported data, which will become the citation title
-         extent_kji (optional, default None): if present, [nk, nj, ni] being the extent (shape) of the array to be imported;
-            if None, the shape of the grid associated with this collection is used
-         discrete (boolean, optional, default False): if True, integer data is imported, if False, float data
-         uom (string, optional, default None): the resqml units of measure applicable to the data
-         time_index (integer, optional, default None): if present, this array is for time varying data and this value is the
-            index into a time series associated with this collection
-         null_value (int or float, optional, default None): if present, this is used in the metadata to indicate that
-            this value is to be interpreted as a null value wherever it appears in the data (this does not change the
-            data during import)
-         property_kind (string): resqml property kind, or None
-         local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None for standard property kind
-         facet_type (string): resqml facet type, or None
-         facet (string): resqml facet, or None
-         realization (int): realization number, or None
-         use_binary (boolean, optional, default True): if True, and an up-to-date pure binary version of the file exists,
-            then the data is loaded from that instead of from the ascii file; if True but the binary version does not
-            exist (or is older than the ascii file), the pure binary version is written as a side effect of the import;
-            if False, the ascii file is used even if a pure binary equivalent exists, and no binary file is written
+        arguments:
+           file_name (string): the name of the file to read the array data from; should contain data for one array only, without
+              the keyword
+           keyword (string): the keyword to associate with the imported data, which will become the citation title
+           extent_kji (optional, default None): if present, [nk, nj, ni] being the extent (shape) of the array to be imported;
+              if None, the shape of the grid associated with this collection is used
+           discrete (boolean, optional, default False): if True, integer data is imported, if False, float data
+           uom (string, optional, default None): the resqml units of measure applicable to the data
+           time_index (integer, optional, default None): if present, this array is for time varying data and this value is the
+              index into a time series associated with this collection
+           null_value (int or float, optional, default None): if present, this is used in the metadata to indicate that
+              this value is to be interpreted as a null value wherever it appears in the data (this does not change the
+              data during import)
+           property_kind (string): resqml property kind, or None
+           local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None for standard property kind
+           facet_type (string): resqml facet type, or None
+           facet (string): resqml facet, or None
+           realization (int): realization number, or None
+           use_binary (boolean, optional, default True): if True, and an up-to-date pure binary version of the file exists,
+              then the data is loaded from that instead of from the ascii file; if True but the binary version does not
+              exist (or is older than the ascii file), the pure binary version is written as a side effect of the import;
+              if False, the ascii file is used even if a pure binary equivalent exists, and no binary file is written
 
-      note:
-         this function only performs the first importation step of actually reading the array into memory; other steps
-         must follow to include the array as a part in the resqml model and in this collection of properties (see doc
-         string for add_cached_array_to_imported_list() for the sequence of steps)
-      """
+        note:
+           this function only performs the first importation step of actually reading the array into memory; other steps
+           must follow to include the array as a part in the resqml model and in this collection of properties (see doc
+           string for add_cached_array_to_imported_list() for the sequence of steps)
+        """
 
         log.debug(f'importing {keyword} array from file {file_name}')
         # note: code in resqml_import adds imported arrays to model and to dict
@@ -4523,23 +4538,23 @@ class GridPropertyCollection(PropertyCollection):
     def import_vdb_static_property_to_cache(self, vdbase, keyword, grid_name = 'ROOT', uom = None, realization = None):
         """Reads a vdb static property array, caches and adds to imported list (but not collection dict).
 
-      arguments:
-         vdbase: an object of class vdb.VDB, already initialised with the path of the vdb
-         keyword (string): the Nexus keyword (or equivalent) of the static property to be loaded
-         grid_name (string): the grid name as used in the vdb
-         uom (string): The resqml unit of measure that applies to the data
-         realization (optional, int): The realization number that this property belongs to; use None
-            if not applicable
+        arguments:
+           vdbase: an object of class vdb.VDB, already initialised with the path of the vdb
+           keyword (string): the Nexus keyword (or equivalent) of the static property to be loaded
+           grid_name (string): the grid name as used in the vdb
+           uom (string): The resqml unit of measure that applies to the data
+           realization (optional, int): The realization number that this property belongs to; use None
+              if not applicable
 
-      returns:
-         cached array containing the property data; the cached array is in an unpacked state
-         (ie. can be directly indexed with [k0, j0, i0])
+        returns:
+           cached array containing the property data; the cached array is in an unpacked state
+           (ie. can be directly indexed with [k0, j0, i0])
 
-      note:
-         when importing from a vdb (or other sources), use methods such as this to build up a list
-         of imported arrays; then write hdf5 for the imported arrays; finally create xml for imported
-         properties
-      """
+        note:
+           when importing from a vdb (or other sources), use methods such as this to build up a list
+           of imported arrays; then write hdf5 for the imported arrays; finally create xml for imported
+           properties
+        """
 
         log.info('importing vdb static property {} array'.format(keyword))
         keyword = keyword.upper()
@@ -4578,28 +4593,29 @@ class GridPropertyCollection(PropertyCollection):
                                                time_index = None,
                                                uom = None,
                                                realization = None):
-        """Reads a vdb recurrent property array for one timestep, caches and adds to imported list (but not collection dict).
+        """Reads a vdb recurrent property array for one timestep, caches and adds to imported list (but not collection
+        dict).
 
-      arguments:
-         vdbase: an object of class vdb.VDB, already initialised with the path of the vdb
-         timestep (int): The Nexus timestep number at which the property array was generated; NB. this is
-            not necessarily the same as a resqml time index
-         keyword (string): the Nexus keyword (or equivalent) of the recurrent property to be loaded
-         grid_name (string): the grid name as used in the vdb
-         time_index (int, optional): if present, used as the time index, otherwise timestep is used
-         uom (string): The resqml unit of measure that applies to the data
-         realization (optional, int): The realization number that this property belongs to; use None
-            if not applicable
+        arguments:
+           vdbase: an object of class vdb.VDB, already initialised with the path of the vdb
+           timestep (int): The Nexus timestep number at which the property array was generated; NB. this is
+              not necessarily the same as a resqml time index
+           keyword (string): the Nexus keyword (or equivalent) of the recurrent property to be loaded
+           grid_name (string): the grid name as used in the vdb
+           time_index (int, optional): if present, used as the time index, otherwise timestep is used
+           uom (string): The resqml unit of measure that applies to the data
+           realization (optional, int): The realization number that this property belongs to; use None
+              if not applicable
 
-      returns:
-         cached array containing the property data; the cached array is in an unpacked state
-         (ie. can be directly indexed with [k0, j0, i0])
+        returns:
+           cached array containing the property data; the cached array is in an unpacked state
+           (ie. can be directly indexed with [k0, j0, i0])
 
-      notes:
-         when importing from a vdb (or other sources), use methods such as this to build up a list
-         of imported arrays; then write hdf5 for the imported arrays; finally create xml for imported
-         properties
-      """
+        notes:
+           when importing from a vdb (or other sources), use methods such as this to build up a list
+           of imported arrays; then write hdf5 for the imported arrays; finally create xml for imported
+           properties
+        """
 
         log.info('importing vdb recurrent property {0} array for timestep {1}'.format(keyword, str(timestep)))
         if time_index is None:
@@ -4638,30 +4654,30 @@ class GridPropertyCollection(PropertyCollection):
                                     realization = None):
         """Reads a property array from a pure binary file, caches and adds to imported list (but not collection dict).
 
-      arguments:
-         file_name (string): the name of the file to read the array data from; should contain data for one array only in
-            'pure binary' format (as used by ab_* suite of utilities)
-         keyword (string): the keyword to associate with the imported data, which will become the citation title
-         extent_kji (optional, default None): if present, [nk, nj, ni] being the extent (shape) of the array to be imported;
-            if None, the shape of the grid associated with this collection is used
-         discrete (boolean, optional, default False): if True, integer data is imported, if False, float data
-         uom (string, optional, default None): the resqml units of measure applicable to the data
-         time_index (integer, optional, default None): if present, this array is for time varying data and this value is the
-            index into a time series associated with this collection
-         null_value (int or float, optional, default None): if present, this is used in the metadata to indicate that
-            this value is to be interpreted as a null value wherever it appears in the data (this does not change the
-            data during import)
-         property_kind (string): resqml property kind, or None
-         local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
-         facet_type (string): resqml facet type, or None
-         facet (string): resqml facet, or None
-         realization (int): realization number, or None
+        arguments:
+           file_name (string): the name of the file to read the array data from; should contain data for one array only in
+              'pure binary' format (as used by ab_* suite of utilities)
+           keyword (string): the keyword to associate with the imported data, which will become the citation title
+           extent_kji (optional, default None): if present, [nk, nj, ni] being the extent (shape) of the array to be imported;
+              if None, the shape of the grid associated with this collection is used
+           discrete (boolean, optional, default False): if True, integer data is imported, if False, float data
+           uom (string, optional, default None): the resqml units of measure applicable to the data
+           time_index (integer, optional, default None): if present, this array is for time varying data and this value is the
+              index into a time series associated with this collection
+           null_value (int or float, optional, default None): if present, this is used in the metadata to indicate that
+              this value is to be interpreted as a null value wherever it appears in the data (this does not change the
+              data during import)
+           property_kind (string): resqml property kind, or None
+           local_property_kind_uuid (uuid.UUID or string): uuid of local property kind, or None
+           facet_type (string): resqml facet type, or None
+           facet (string): resqml facet, or None
+           realization (int): realization number, or None
 
-      note:
-         this function only performs the first importation step of actually reading the array into memory; other steps
-         must follow to include the array as a part in the resqml model and in this collection of properties (see doc
-         string for add_cached_array_to_imported_list() for the sequence of steps)
-      """
+        note:
+           this function only performs the first importation step of actually reading the array into memory; other steps
+           must follow to include the array as a part in the resqml model and in this collection of properties (see doc
+           string for add_cached_array_to_imported_list() for the sequence of steps)
+        """
 
         if self.imported_list is None:
             self.imported_list = []
@@ -4699,25 +4715,25 @@ class GridPropertyCollection(PropertyCollection):
     def decoarsen_imported_list(self, decoarsen_array = None, reactivate = True):
         """Decoarsen imported Nexus properties if needed.
 
-      arguments:
-         decoarsen_array (int array, optional): if present, the naturalised cell index of the coarsened host cell, for each fine cell;
-            if None, the ICOARS keyword is searched for in the imported list and if not found KID data is used to derive the mapping
-         reactivate (boolean, default True): if True, the parent grid will have decoarsened cells' inactive flag set to that of the
-            host cell
+        arguments:
+           decoarsen_array (int array, optional): if present, the naturalised cell index of the coarsened host cell, for each fine cell;
+              if None, the ICOARS keyword is searched for in the imported list and if not found KID data is used to derive the mapping
+           reactivate (boolean, default True): if True, the parent grid will have decoarsened cells' inactive flag set to that of the
+              host cell
 
-      returns:
-         a copy of the array used for decoarsening, if established, or None if no decoarsening array was identified
+        returns:
+           a copy of the array used for decoarsening, if established, or None if no decoarsening array was identified
 
-      notes:
-         a return value of None indicates that no decoarsening occurred;
-         coarsened values are redistributed quite naively, with coarse volumes being split equally between fine cells, similarly for
-         length and area based properties; default used for most properties is simply to replicate the coarse value;
-         the ICOARS array itself is left unchanged, which means the method should only be called once for an imported list;
-         if no array is passed and no ICOARS array found, the KID values are inspected and the decoarsen array reverse engineered;
-         the method must be called before the imported arrays are written to hdf5;
-         reactivation only modifies the grid object attribute and does not write to hdf5, so the method should be called prior to
-         writing the grid in this situation
-      """
+        notes:
+           a return value of None indicates that no decoarsening occurred;
+           coarsened values are redistributed quite naively, with coarse volumes being split equally between fine cells, similarly for
+           length and area based properties; default used for most properties is simply to replicate the coarse value;
+           the ICOARS array itself is left unchanged, which means the method should only be called once for an imported list;
+           if no array is passed and no ICOARS array found, the KID values are inspected and the decoarsen array reverse engineered;
+           the method must be called before the imported arrays are written to hdf5;
+           reactivation only modifies the grid object attribute and does not write to hdf5, so the method should be called prior to
+           writing the grid in this situation
+        """
         # imported_list is list pf:
         # (0: uuid, 1: file_name, 2: keyword, 3: cached_name, 4: discrete, 5: uom, 6: time_index, 7: null_value, 8: min_value, 9: max_value,
         # 10: property_kind, 11: facet_type, 12: facet, 13: realization, 14: indexable_element, 15: count, 16: local_property_kind_uuid,
@@ -4892,32 +4908,32 @@ class GridPropertyCollection(PropertyCollection):
             nan_substitute_value = None):
         """Writes the property array to a file in a format suitable for including as nexus input.
 
-      arguments:
-         part (string): the part name for which the array is to be exported
-         file_name (string): the path of the file to be created (any existing file will be overwritten)
-         keyword (string, optional, default None): if not None, the Nexus keyword to be included in the
-            ascii export file (otherwise data only is written, without a keyword)
-         headers (boolean, optional, default True): if True, some header comments are included in the
-            ascii export file, using a Nexus comment character
-         append (boolean, optional, default False): if True, any existing file is appended to rather than
-            overwritten
-         columns (integer, optional, default 20): the maximum number of data items to be written per line
-         decimals (integer, optional, default 3): the number of decimal places included in the values
-            written to the ascii export file (ignored for integer data)
-         blank_line_after_i_block (boolean, optional, default True): if True, a blank line is inserted
-            after each I-block of data (ie. when the J index changes)
-         blank_line_after_j_block (boolean, optional, default False): if True, a blank line is inserted
-            after each J-block of data (ie. when the K index changes)
-         space_separated (boolean, optional, default False): if True, a space is inserted between values;
-            if False, a tab is used
-         use_binary (boolean, optional, default False): if True, a pure binary copy of the array is
-            written
-         binary_only (boolean, optional, default False): if True, and if use_binary is True, then no
-            ascii file is generated; if False (or if use_binary is False) then an ascii file is written
-         nan_substitute_value (float, optional, default None): if a value is supplied, any not-a-number
-            values are replaced with this value in the exported file (the cached property array remains
-            unchanged); if None, then 'nan' or 'Nan' will appear in the ascii export file
-      """
+        arguments:
+           part (string): the part name for which the array is to be exported
+           file_name (string): the path of the file to be created (any existing file will be overwritten)
+           keyword (string, optional, default None): if not None, the Nexus keyword to be included in the
+              ascii export file (otherwise data only is written, without a keyword)
+           headers (boolean, optional, default True): if True, some header comments are included in the
+              ascii export file, using a Nexus comment character
+           append (boolean, optional, default False): if True, any existing file is appended to rather than
+              overwritten
+           columns (integer, optional, default 20): the maximum number of data items to be written per line
+           decimals (integer, optional, default 3): the number of decimal places included in the values
+              written to the ascii export file (ignored for integer data)
+           blank_line_after_i_block (boolean, optional, default True): if True, a blank line is inserted
+              after each I-block of data (ie. when the J index changes)
+           blank_line_after_j_block (boolean, optional, default False): if True, a blank line is inserted
+              after each J-block of data (ie. when the K index changes)
+           space_separated (boolean, optional, default False): if True, a space is inserted between values;
+              if False, a tab is used
+           use_binary (boolean, optional, default False): if True, a pure binary copy of the array is
+              written
+           binary_only (boolean, optional, default False): if True, and if use_binary is True, then no
+              ascii file is generated; if False (or if use_binary is False) then an ascii file is written
+           nan_substitute_value (float, optional, default None): if a value is supplied, any not-a-number
+              values are replaced with this value in the exported file (the cached property array remains
+              unchanged); if None, then 'nan' or 'Nan' will appear in the ascii export file
+        """
 
         array_ref = self.cached_part_array_ref(part)
         assert (array_ref is not None)
@@ -4956,18 +4972,18 @@ class GridPropertyCollection(PropertyCollection):
             nan_substitute_value = None):
         """Writes the property array to a file using a filename generated from the citation title etc.
 
-      arguments:
-         part (string): the part name for which the array is to be exported
-         directory (string): the path of the diractory into which the file will be written
-         use_title_for_keyword (boolean, optional, default False): if True, the citation title for the property part
-            is used as a keyword in the ascii export file
-         for other arguments, see the docstring for the write_nexus_property() function
+        arguments:
+           part (string): the part name for which the array is to be exported
+           directory (string): the path of the diractory into which the file will be written
+           use_title_for_keyword (boolean, optional, default False): if True, the citation title for the property part
+              is used as a keyword in the ascii export file
+           for other arguments, see the docstring for the write_nexus_property() function
 
-      note:
-         the generated filename consists of the citation title (with spaces replaced with underscores);
-         the facet type and facet, if present;
-         _t_ and the time_index, if the part has a time index
-      """
+        note:
+           the generated filename consists of the citation title (with spaces replaced with underscores);
+           the facet type and facet, if present;
+           _t_ and the time_index, if the part has a time index
+        """
 
         title = self.citation_title_for_part(part).replace(' ', '_')
         if use_title_for_keyword:
@@ -5010,15 +5026,15 @@ class GridPropertyCollection(PropertyCollection):
                                nan_substitute_value = None):
         """Writes a set of files, one for each part in the collection.
 
-      arguments:
-         directory (string): the path of the diractory into which the files will be written
-         for other arguments, see the docstrings for the write_nexus_property_generating_filename() and
-            write_nexus_property() functions
+        arguments:
+           directory (string): the path of the diractory into which the files will be written
+           for other arguments, see the docstrings for the write_nexus_property_generating_filename() and
+              write_nexus_property() functions
 
-      note:
-         the generated filenames are based on the citation titles etc., as for
-         write_nexus_property_generating_filename()
-      """
+        note:
+           the generated filenames are based on the citation titles etc., as for
+           write_nexus_property_generating_filename()
+        """
 
         for part in self.dict.keys():
             self.write_nexus_property_generating_filename(part,
@@ -5041,52 +5057,50 @@ class WellLogCollection(PropertyCollection):
     def __init__(self, frame = None, property_set_root = None, realization = None):
         """Creates a new property collection related to a wellbore frame.
 
-      arguments:
-         frame (well.WellboreFrame object, optional): must be present unless creating a completely blank, empty collection.
-            See :class:`resqpy.well.WellboreFrame`
-         property_set_root (optional): if present, the collection is populated with the properties defined in the xml tree
-            of the property set; frame must not be None when using this argument
-         realization (integer, optional): if present, the single realisation (within an ensemble) that this collection is for;
-            if None, then the collection is either covering a whole ensemble (individual properties can each be flagged with a
-            realisation number), or is for properties that do not have multiple realizations
+        arguments:
+           frame (well.WellboreFrame object, optional): must be present unless creating a completely blank, empty collection.
+              See :class:`resqpy.well.WellboreFrame`
+           property_set_root (optional): if present, the collection is populated with the properties defined in the xml tree
+              of the property set; frame must not be None when using this argument
+           realization (integer, optional): if present, the single realisation (within an ensemble) that this collection is for;
+              if None, then the collection is either covering a whole ensemble (individual properties can each be flagged with a
+              realisation number), or is for properties that do not have multiple realizations
 
-      returns:
-         the new WellLogCollection object
+        returns:
+           the new WellLogCollection object
 
-      note:
-         usually a wellbore frame should be passed, however a completely blank collection may be created prior to using
-         collection inheritance methods to populate from another collection, in which case the frame can be lazily left
-         as None here;
-         for actual well logs, the realization argument will usually be None; for synthetic logs created from an ensemble
-         it may be of use
-
-      """
+        note:
+           usually a wellbore frame should be passed, however a completely blank collection may be created prior to using
+           collection inheritance methods to populate from another collection, in which case the frame can be lazily left
+           as None here;
+           for actual well logs, the realization argument will usually be None; for synthetic logs created from an ensemble
+           it may be of use
+        """
 
         super().__init__(support = frame, property_set_root = property_set_root, realization = realization)
 
     def add_log(self, title, data, unit, discrete = False, realization = None, write = True, source_info = ''):
-        """Add a well log to the collection, and optionally save to HDF / XML
-      
-      Note:
-         If write=False, the data are not written to the model and are saved to be written later.
-         To write the data, you can subsequently call::
+        """Add a well log to the collection, and optionally save to HDF / XML.
 
-            logs.write_hdf5_for_imported_list()
-            logs.create_xml_for_imported_list_and_add_parts_to_model()
+        Note:
+           If write=False, the data are not written to the model and are saved to be written later.
+           To write the data, you can subsequently call::
 
-      Args:
-         title (str): Name of log, typically the mnemonic
-         data (array-like): log data to write. Must have same length as frame MDs
-         unit (str): Unit of measure
-         discrete (bool): by default False, i.e. continuous
-         realization (int): If given, assign data to a realisation.
-         write (bool): If True, write XML and HDF5.
-         source_info (str): curve description or other human readable text
+              logs.write_hdf5_for_imported_list()
+              logs.create_xml_for_imported_list_and_add_parts_to_model()
 
-      Returns:
-         uuids: list of uuids of newly added properties. Only returned if write=True.
+        Args:
+           title (str): Name of log, typically the mnemonic
+           data (array-like): log data to write. Must have same length as frame MDs
+           unit (str): Unit of measure
+           discrete (bool): by default False, i.e. continuous
+           realization (int): If given, assign data to a realisation.
+           write (bool): If True, write XML and HDF5.
+           source_info (str): curve description or other human readable text
 
-      """
+        Returns:
+           uuids: list of uuids of newly added properties. Only returned if write=True.
+        """
         # Validate
         if self.support is None:
             raise ValueError('Supporting WellboreFrame not present')
@@ -5118,25 +5132,25 @@ class WellLogCollection(PropertyCollection):
             return None
 
     def iter_logs(self):
-        """ Generator that yields component Log objects.
-      
-      Yields:
-         instances of :class:`resqpy.property.WellLog` .
+        """Generator that yields component Log objects.
 
-      Example::
+        Yields:
+           instances of :class:`resqpy.property.WellLog` .
 
-         for log in log_collection.logs():
-            print(log.title)
-      """
+        Example::
+
+           for log in log_collection.logs():
+              print(log.title)
+        """
 
         return (WellLog(collection = self, uuid = uuid) for uuid in self.uuids())
 
     def to_df(self, include_units = False):
-        """ Return pandas dataframe of log data
+        """Return pandas dataframe of log data.
 
-      Args:
-         include_units (bool): include unit in column names
-      """
+        Args:
+           include_units (bool): include unit in column names
+        """
 
         assert self.support is not None
 
@@ -5162,14 +5176,13 @@ class WellLogCollection(PropertyCollection):
         return df
 
     def to_las(self):
-        """ Return a lasio.LASFile object, which can then be written to disk
+        """Return a lasio.LASFile object, which can then be written to disk.
 
-      Example::
+        Example::
 
-         las = collection.to_las()
-         las.write('example_logs.las', version=2)
-
-      """
+           las = collection.to_las()
+           las.write('example_logs.las', version=2)
+        """
         las = lasio.LASFile()
 
         las.well.WELL = str(self.support.wellbore_interpretation.title)
@@ -5200,19 +5213,19 @@ class WellLogCollection(PropertyCollection):
     def set_wellbore_frame(self, frame):
         """Sets the supporting representation object for the property collection to be the given wellbore frame object.
 
-      note:
-         this method does not need to be called if the wellbore frame was identified at the time the collection
-         was initialised
-      """
+        note:
+           this method does not need to be called if the wellbore frame was identified at the time the collection
+           was initialised
+        """
 
         self.set_support(support = frame)
 
 
 class WellLog:
-    """ Thin wrapper class around RESQML properties for well logs """
+    """Thin wrapper class around RESQML properties for well logs."""
 
     def __init__(self, collection, uuid):
-        """ Create a well log from a part name """
+        """Create a well log from a part name."""
 
         self.collection: PropertyCollection = collection
         self.model = collection.model
@@ -5230,11 +5243,11 @@ class WellLog:
         self.uom = self.collection.uom_for_part(part)
 
     def values(self):
-        """ Return log data as numpy array
+        """Return log data as numpy array.
 
-      Note:
-         may return 2D numpy array with shape (num_depths, num_columns).
-      """
+        Note:
+           may return 2D numpy array with shape (num_depths, num_columns).
+        """
 
         part = self.model.part_for_uuid(self.uuid)
         return self.collection.cached_part_array_ref(part)
@@ -5255,18 +5268,18 @@ class StringLookup(BaseResqpy):
                  originator = None):
         """Creates a new string lookup (RESQML obj_StringTableLookup) object.
 
-      arguments:
-         parent_model: the model to which this string lookup belongs
-         root_node (optional): if present, the root xml node for the StringTableLookup from which this object is populated
-         int_to_str_dict (optional): if present, a dictionary mapping from integers to strings, used to populate the lookup;
-            ignored if root_node is present
-         title (string, optional): if present, is used as the citation title for the object; ignored if root_node is not None
+        arguments:
+           parent_model: the model to which this string lookup belongs
+           root_node (optional): if present, the root xml node for the StringTableLookup from which this object is populated
+           int_to_str_dict (optional): if present, a dictionary mapping from integers to strings, used to populate the lookup;
+              ignored if root_node is present
+           title (string, optional): if present, is used as the citation title for the object; ignored if root_node is not None
 
-      returns:
-         the new StringLookup object
+        returns:
+           the new StringLookup object
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         self.min_index = None
         self.max_index = None
@@ -5350,8 +5363,8 @@ class StringLookup(BaseResqpy):
     def get_string(self, key):
         """Returns the string associated with the integer key, or None if not found.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if key < self.min_index or key > self.max_index:
             return None
@@ -5364,8 +5377,8 @@ class StringLookup(BaseResqpy):
     def get_list(self):
         """Returns a list of values, sorted by key.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.stored_as_list:
             return self.str_list
@@ -5374,8 +5387,8 @@ class StringLookup(BaseResqpy):
     def length(self):
         """Returns the nominal length of the lookup table.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.stored_as_list:
             return len(self.str_list)
@@ -5384,8 +5397,8 @@ class StringLookup(BaseResqpy):
     def get_index_for_string(self, string):
         """Returns the integer key for the given string (exact match required), or None if not found.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.stored_as_list:
             try:
@@ -5403,13 +5416,13 @@ class StringLookup(BaseResqpy):
     def create_xml(self, title = None, originator = None, add_as_part = True, reuse = True):
         """Creates an xml node for the string table lookup.
 
-      arguments:
-         title (string, optional): if present, overrides the object's title attribute to be used as citation title
-         originator (string, optional): if present, used as the citation creator (otherwise login name is used)
-         add_as_part (boolean, default True): if True, the property set is added to the model as a part
+        arguments:
+           title (string, optional): if present, overrides the object's title attribute to be used as citation title
+           originator (string, optional): if present, used as the citation creator (otherwise login name is used)
+           add_as_part (boolean, default True): if True, the property set is added to the model as a part
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if title:
             self.title = title
@@ -5538,10 +5551,11 @@ class PropertyKind(BaseResqpy):
 
 
 class WellIntervalProperty:
-    """Thin wrapper class around interval properties for a Wellbore Frame or Blocked Wellbore (ie interval or cell well logss)."""
+    """Thin wrapper class around interval properties for a Wellbore Frame or Blocked Wellbore (ie interval or cell well
+    logss)."""
 
     def __init__(self, collection, part):
-        """Create an interval log or blocked well log from a part name"""
+        """Create an interval log or blocked well log from a part name."""
 
         self.collection: PropertyCollection = collection
         self.model = collection.model
@@ -5554,13 +5568,14 @@ class WellIntervalProperty:
         self.uom = self.collection.uom_for_part(part)
 
     def values(self):
-        """Return interval log or blocked well log as numpy array"""
+        """Return interval log or blocked well log as numpy array."""
 
         return self.collection.cached_part_array_ref(self.part)
 
 
 class WellIntervalPropertyCollection(PropertyCollection):
-    """Class for RESQML property collection for a WellboreFrame for interval or blocked well logs, inheriting from PropertyCollection."""
+    """Class for RESQML property collection for a WellboreFrame for interval or blocked well logs, inheriting from
+    PropertyCollection."""
 
     def __init__(self, frame = None, property_set_root = None, realization = None):
         """Creates a new property collection related to interval or blocked well logs and a wellbore frame."""
@@ -5568,7 +5583,7 @@ class WellIntervalPropertyCollection(PropertyCollection):
         super().__init__(support = frame, property_set_root = property_set_root, realization = realization)
 
     def logs(self):
-        """Generator that yields component Interval log or Blocked well log objects"""
+        """Generator that yields component Interval log or Blocked well log objects."""
         return (WellIntervalProperty(collection = self, part = part) for part in self.parts())
 
     def to_pandas(self, include_units = False):
@@ -5595,14 +5610,14 @@ def same_property_kind(pk_a, pk_b):
 
 
 def create_transmisibility_multiplier_property_kind(model):
-    """Create a local property kind 'transmisibility multiplier' for a given model
+    """Create a local property kind 'transmisibility multiplier' for a given model.
 
-   argument:
-      model: resqml model object
+    argument:
+       model: resqml model object
 
-   returns:
-      property kind uuid
-   """
+    returns:
+       property kind uuid
+    """
     log.debug("Making a new property kind 'Transmissibility multiplier'")
     tmult_kind = PropertyKind(parent_model = model,
                               title = 'transmissibility multiplier',
@@ -5616,16 +5631,16 @@ def create_transmisibility_multiplier_property_kind(model):
 def property_kind_and_facet_from_keyword(keyword):
     """If keyword is recognised, returns equivalent resqml PropertyKind and Facet info.
 
-   argument:
-      keyword (string): Nexus grid property keyword
+    argument:
+       keyword (string): Nexus grid property keyword
 
-   returns:
-      (property_kind, facet_type, facet) as defined in resqml standard; some or all may be None
+    returns:
+       (property_kind, facet_type, facet) as defined in resqml standard; some or all may be None
 
-   note:
-      this function may now return the local property kind 'transmissibility multiplier'; calling code must ensure that
-      the local property kind object is created if not already present
-   """
+    note:
+       this function may now return the local property kind 'transmissibility multiplier'; calling code must ensure that
+       the local property kind object is created if not already present
+    """
 
     # note: this code doesn't cater for a property having more than one facet, eg. direction and phase
 
@@ -5778,7 +5793,7 @@ def property_kind_and_facet_from_keyword(keyword):
 
 
 def infer_property_kind(name, unit):
-    """ Guess a valid property kind """
+    """Guess a valid property kind."""
 
     # Currently unit is ignored
 
@@ -5800,23 +5815,23 @@ def infer_property_kind(name, unit):
 def guess_uom(property_kind, minimum, maximum, support, facet_type = None, facet = None):
     """Returns a guess at the units of measure for the given kind of property.
 
-   arguments:
-      property_kind (string): a valid resqml property kind, lowercase
-      minimum: the minimum value in the data for which the units are being guessed
-      maximum: the maximum value in the data for which the units are being guessed
-      support: the grid.Grid or well.WellboreFrame object which the property data relates to
-      facet_type (string, optional): a valid resqml facet type, lowercase, one of:
-              'direction', 'what', 'netgross', 'qualifier', 'conditions', 'statistics'
-      facet: (string, present if facet_type is present): the value relating to the facet_type,
-               eg. 'I' for direction, or 'oil' for 'what'
+    arguments:
+       property_kind (string): a valid resqml property kind, lowercase
+       minimum: the minimum value in the data for which the units are being guessed
+       maximum: the maximum value in the data for which the units are being guessed
+       support: the grid.Grid or well.WellboreFrame object which the property data relates to
+       facet_type (string, optional): a valid resqml facet type, lowercase, one of:
+               'direction', 'what', 'netgross', 'qualifier', 'conditions', 'statistics'
+       facet: (string, present if facet_type is present): the value relating to the facet_type,
+                eg. 'I' for direction, or 'oil' for 'what'
 
-   returns:
-      a valid resqml unit of measure (uom) for the property_kind, or None
+    returns:
+       a valid resqml unit of measure (uom) for the property_kind, or None
 
-   note:
-      the resqml standard allows a property to have any number of facets; however,
-      this module currently only supports zero or one facet per property
-   """
+    note:
+       the resqml standard allows a property to have any number of facets; however,
+       this module currently only supports zero or one facet per property
+    """
 
     def crs_m_or_ft(crs_node):  # NB. models not-so-rarely use metres for xy and feet for z
         if crs_node is None:
@@ -5946,29 +5961,29 @@ def selective_version_of_collection(
         categorical = None):
     """Returns a new PropertyCollection with those parts which match all arguments that are not None.
 
-   arguments:
-      collection: an existing PropertyCollection from which a subset will be returned as a new object;
-                  the existing collection might often be the 'main' collection holding all the properties
-                  for a supporting representation (grid or wellbore frame)
+    arguments:
+       collection: an existing PropertyCollection from which a subset will be returned as a new object;
+                   the existing collection might often be the 'main' collection holding all the properties
+                   for a supporting representation (grid or wellbore frame)
 
-   Other optional arguments:
-   realization, support_uuid, grid, uuid, continuous, points, count, indexable, property_kind, facet_type, facet,
-   citation_title, time_series_uuid, time_index, uom, string_lookup_uuid, categorical:
+    Other optional arguments:
+    realization, support_uuid, grid, uuid, continuous, points, count, indexable, property_kind, facet_type, facet,
+    citation_title, time_series_uuid, time_index, uom, string_lookup_uuid, categorical:
 
-   for each of these arguments: if None, then all members of collection pass this filter;
-   if not None then only those members with the given value pass this filter;
-   finally, the filters for all the attributes must be passed for a given member
-   to be included in the returned collection.
+    for each of these arguments: if None, then all members of collection pass this filter;
+    if not None then only those members with the given value pass this filter;
+    finally, the filters for all the attributes must be passed for a given member
+    to be included in the returned collection.
 
-   returns:
-      a new PropertyCollection containing those properties which match the filter parameters that are not None
+    returns:
+       a new PropertyCollection containing those properties which match the filter parameters that are not None
 
-   note:
-      the grid keyword argument is maintained for backward compatibility: support_uuid argument takes precedence;
-      the categorical boolean argument can be used to select only
-      categorical (or non-categorical) properties, even though this is not explicitly held as a field in the
-      internal dictionary
-   """
+    note:
+       the grid keyword argument is maintained for backward compatibility: support_uuid argument takes precedence;
+       the categorical boolean argument can be used to select only
+       categorical (or non-categorical) properties, even though this is not explicitly held as a field in the
+       internal dictionary
+    """
 
     assert collection is not None
     view = PropertyCollection()
@@ -6001,16 +6016,16 @@ def selective_version_of_collection(
 def property_over_time_series_from_collection(collection, example_part):
     """Returns a new PropertyCollection with parts like the example part, over all indices in its time series.
 
-   arguments:
-      collection: an existing PropertyCollection from which a subset will be returned as a new object;
-                  the existing collection might often be the 'main' collection holding all the properties
-                  for a grid
-      example_part (string): the part name of an example member of collection (which has an associated time_series)
+    arguments:
+       collection: an existing PropertyCollection from which a subset will be returned as a new object;
+                   the existing collection might often be the 'main' collection holding all the properties
+                   for a grid
+       example_part (string): the part name of an example member of collection (which has an associated time_series)
 
-   returns:
-      a new PropertyCollection containing those memners of collection which have the same property kind
-      (and facet, if any) as the example part and which have the same associated time series
-   """
+    returns:
+       a new PropertyCollection containing those memners of collection which have the same property kind
+       (and facet, if any) as the example part and which have the same associated time series
+    """
 
     assert collection is not None and example_part is not None
     assert collection.part_in_collection(example_part)
@@ -6026,23 +6041,23 @@ def property_over_time_series_from_collection(collection, example_part):
 def property_collection_for_keyword(collection, keyword):
     """Returns a new PropertyCollection with parts that match the property kind and facet deduced for the keyword.
 
-   arguments:
-      collection: an existing PropertyCollection from which a subset will be returned as a new object;
-                  the existing collection might often be the 'main' collection holding all the properties
-                  for a supporting representation (grid or wellbore frame)
-      keyword (string): a simulator keyword for which the property kind (and facet, if any) can be deduced
+    arguments:
+       collection: an existing PropertyCollection from which a subset will be returned as a new object;
+                   the existing collection might often be the 'main' collection holding all the properties
+                   for a supporting representation (grid or wellbore frame)
+       keyword (string): a simulator keyword for which the property kind (and facet, if any) can be deduced
 
-   returns:
-      a new PropertyCollection containing those memners of collection which have the property kind
-      (and facet, if any) as that deduced for the keyword
+    returns:
+       a new PropertyCollection containing those memners of collection which have the property kind
+       (and facet, if any) as that deduced for the keyword
 
-   note:
-      this function is particularly relevant to grid property collections for simulation models;
-      the handling of simulator keywords in this module is based on the main grid property keywords
-      for Nexus; if the resqml dataset was generated from simulator data using this module then
-      the result of this function should be reliable; resqml data sets from other sources might use facets
-      if a different way, leading to an omission in the results of this function
-   """
+    note:
+       this function is particularly relevant to grid property collections for simulation models;
+       the handling of simulator keywords in this module is based on the main grid property keywords
+       for Nexus; if the resqml dataset was generated from simulator data using this module then
+       the result of this function should be reliable; resqml data sets from other sources might use facets
+       if a different way, leading to an omission in the results of this function
+    """
 
     assert collection is not None and keyword
     (property_kind, facet_type, facet) = property_kind_and_facet_from_keyword(keyword)
@@ -6056,7 +6071,7 @@ def property_collection_for_keyword(collection, keyword):
 
 
 def reformat_column_edges_to_resqml_format(array):
-    """Converts an array of shape (nj,ni,2,2) to shape (nj,ni,4) in RESQML edge ordering"""
+    """Converts an array of shape (nj,ni,2,2) to shape (nj,ni,4) in RESQML edge ordering."""
     newarray = np.empty((array.shape[0], array.shape[1], 4), dtype = array.dtype)
     newarray[:, :, 0] = array[:, :, 1, 0]
     newarray[:, :, 1] = array[:, :, 0, 1]
@@ -6080,21 +6095,19 @@ def reformat_column_edges_from_resqml_format(array):
 
 
 def _cache_name_for_uuid(uuid):
-    """
-      Returns the attribute name used for the cached copy of the property array for the given uuid.
+    """Returns the attribute name used for the cached copy of the property array for the given uuid.
 
-      :meta private:
-   """
+    :meta private:
+    """
 
     return 'c_' + bu.string_from_uuid(uuid)
 
 
 def _cache_name(part):
-    """
-      Returns the attribute name used for the cached copy of the property array for the given part.
+    """Returns the attribute name used for the cached copy of the property array for the given part.
 
-      :meta private:
-   """
+    :meta private:
+    """
 
     if part is None:
         return None
@@ -6105,11 +6118,10 @@ def _cache_name(part):
 
 
 def dtype_flavour(continuous, use_32_bit):
-    """
-      Returns the numpy elemental data type depending on the two boolean flags.
+    """Returns the numpy elemental data type depending on the two boolean flags.
 
-      :meta private:
-   """
+    :meta private:
+    """
 
     if continuous:
         if use_32_bit:

--- a/resqpy/rq_import.py
+++ b/resqpy/rq_import.py
@@ -75,10 +75,11 @@ def import_nexus(
         grid_title = 'ROOT',
         mode = 'w',
         progress_fn = None):
-    """Read a simulation grid geometry and optionally grid properties and return a resqml model in memory & written to disc.
+    """Read a simulation grid geometry and optionally grid properties and return a resqml model in memory & written to
+    disc.
 
-      Input may be from nexus ascii input files, or nexus vdb output.
-   """
+    Input may be from nexus ascii input files, or nexus vdb output.
+    """
 
     if resqml_file_root.endswith('.epc'):
         resqml_file_root = resqml_file_root[:-4]
@@ -637,71 +638,72 @@ def import_vdb_ensemble(
         split_pillars = True,
         split_tolerance = 0.01,  # applies to each of x, y, z differences
         progress_fn = None):
-    """Adds properties from all vdb's within an ensemble directory tree to a single RESQML dataset, referencing a shared grid.
+    """Adds properties from all vdb's within an ensemble directory tree to a single RESQML dataset, referencing a shared
+    grid.
 
-   args:
-      epc_file (string): filename of epc file to be extended with ensemble properties
-      ensemble_run_dir (string): path of main ensemble run directory; vdb's within this directory tree are source of import
-      existing_epc (boolean, default False): if True, the epc_file must already exist and contain the compatible grid
-      keyword_list (list of strings, optional): if present, only properties for keywords within the list are included
-      property_kind_list (list of strings, optional): if present, only properties which are mapped to these resqml property
-         kinds are included in the import
-      vdb_static_properties (boolean, default True): if False, no static properties are included, regardless of keyword and/or
-         property kind matches
-      vdb_recurrent_properties (boolean, default True): if False, no recurrent properties are included, regardless of keyword
-         and/or property kind matches
-      decoarsen (boolean, default True): if True and ICOARSE property exists for a grid in a case, the associated property
-         data is decoarsened; if False, the property data is as stored in the vdb
-      timestep_selection (string, default 'all'): may be 'first', 'last', 'first and last', or 'all', controlling which
-         reporting timesteps are included when loading recurrent data
-      create_property_set_per_realization (boolean, default True): if True, a property set object is created for each realization
-      create_property_set_per_timestep (boolean, default True): if True, a property set object is created for each timestep
-         included in the recurrent data import
-      create_complete_property_set (boolean, default False): if True, a property set object is created containing all the
-         properties imported; only really useful to differentiate from other properties related to the grid
-      extent_ijk (triple int, optional): this and remaining arguments are only used if existing_epc is False; the extent
-         is only needed in case automatic determination of the extent fails
-      corp_xy_units (string, default 'metres'): the units of x & y values in the vdb corp data; should be 'metres' or 'feet'
-      corp_z_units (string, default 'metres'): the units of z values in the vdb corp data; should be 'metres' or 'feet'
-      corp_z_inc_down (boolean, default True): set to True if corp z values are depth; False if elevation
-      ijk_handedness (string, default 'right'): set to the handedness of the IJK axes in the Nexus model; 'right' or 'left'
-      geometry_defined_everywhere (boolean, default True): set to False if inactive cells do not have valid geometry;
-         deprecated - use treat_as_nan argument instead
-      treat_as_nan (string, optional): if not None, one of 'dots', 'ij_dots', 'inactive'; controls which inactive cells
-         have their geometry set to undefined
-      resqml_xy_units (string, default 'metres'): the units of x & y values to use in the generated resqml grid;
-         should be 'metres' or 'feet'
-      resqml_z_units (string, default 'metres'): the units of z values to use in the generated resqml grid;
-         should be 'metres' or 'feet'
-      resqml_z_inc_down (boolean, default True): set to True if resqml z values are to be depth; False for elevations
-      shift_to_local (boolean, default True): if True, the resqml coordinate reference system will use a local origin
-      local_origin_place (string, default 'centre'): where to place the local origin; 'centre' or 'minimum'; only
-         relevant if shift_to_local is True
-      max_z_void (float, default 0.1): the tolerance of voids between layers, in z direction; voids greater than this
-         will cause the grid import to fail
-      split_pillars (boolean, default True): if False, a grid is generated without split pillars
-      split_tolerance (float, default 0.01): the tolerance applied to each of x, y, & z values, beyond which a corner
-         point (and hence pillar) will be split
-      progress_fn (function(float), optional): if present, this function is called at intervals during processing; it
-         must accept one floating point argument which will range from 0.0 to 1.0
+    args:
+       epc_file (string): filename of epc file to be extended with ensemble properties
+       ensemble_run_dir (string): path of main ensemble run directory; vdb's within this directory tree are source of import
+       existing_epc (boolean, default False): if True, the epc_file must already exist and contain the compatible grid
+       keyword_list (list of strings, optional): if present, only properties for keywords within the list are included
+       property_kind_list (list of strings, optional): if present, only properties which are mapped to these resqml property
+          kinds are included in the import
+       vdb_static_properties (boolean, default True): if False, no static properties are included, regardless of keyword and/or
+          property kind matches
+       vdb_recurrent_properties (boolean, default True): if False, no recurrent properties are included, regardless of keyword
+          and/or property kind matches
+       decoarsen (boolean, default True): if True and ICOARSE property exists for a grid in a case, the associated property
+          data is decoarsened; if False, the property data is as stored in the vdb
+       timestep_selection (string, default 'all'): may be 'first', 'last', 'first and last', or 'all', controlling which
+          reporting timesteps are included when loading recurrent data
+       create_property_set_per_realization (boolean, default True): if True, a property set object is created for each realization
+       create_property_set_per_timestep (boolean, default True): if True, a property set object is created for each timestep
+          included in the recurrent data import
+       create_complete_property_set (boolean, default False): if True, a property set object is created containing all the
+          properties imported; only really useful to differentiate from other properties related to the grid
+       extent_ijk (triple int, optional): this and remaining arguments are only used if existing_epc is False; the extent
+          is only needed in case automatic determination of the extent fails
+       corp_xy_units (string, default 'metres'): the units of x & y values in the vdb corp data; should be 'metres' or 'feet'
+       corp_z_units (string, default 'metres'): the units of z values in the vdb corp data; should be 'metres' or 'feet'
+       corp_z_inc_down (boolean, default True): set to True if corp z values are depth; False if elevation
+       ijk_handedness (string, default 'right'): set to the handedness of the IJK axes in the Nexus model; 'right' or 'left'
+       geometry_defined_everywhere (boolean, default True): set to False if inactive cells do not have valid geometry;
+          deprecated - use treat_as_nan argument instead
+       treat_as_nan (string, optional): if not None, one of 'dots', 'ij_dots', 'inactive'; controls which inactive cells
+          have their geometry set to undefined
+       resqml_xy_units (string, default 'metres'): the units of x & y values to use in the generated resqml grid;
+          should be 'metres' or 'feet'
+       resqml_z_units (string, default 'metres'): the units of z values to use in the generated resqml grid;
+          should be 'metres' or 'feet'
+       resqml_z_inc_down (boolean, default True): set to True if resqml z values are to be depth; False for elevations
+       shift_to_local (boolean, default True): if True, the resqml coordinate reference system will use a local origin
+       local_origin_place (string, default 'centre'): where to place the local origin; 'centre' or 'minimum'; only
+          relevant if shift_to_local is True
+       max_z_void (float, default 0.1): the tolerance of voids between layers, in z direction; voids greater than this
+          will cause the grid import to fail
+       split_pillars (boolean, default True): if False, a grid is generated without split pillars
+       split_tolerance (float, default 0.01): the tolerance applied to each of x, y, & z values, beyond which a corner
+          point (and hence pillar) will be split
+       progress_fn (function(float), optional): if present, this function is called at intervals during processing; it
+          must accept one floating point argument which will range from 0.0 to 1.0
 
-   returns:
-      resqpy.Model object containing properties for all the realisations; hdf5 and epc files having been updated
+    returns:
+       resqpy.Model object containing properties for all the realisations; hdf5 and epc files having been updated
 
-   note:
-      if existing_epc is True, the epc file must already exist and contain one grid (or one grid named ROOT) which must
-      have the correct extent for all realisations within the ensemble; if existing_epc is False, the resqml dataset is
-      created afresh with a grid extracted from the first realisation in the ensemble; either way, the single grid is used
-      as the representative grid in the ensemble resqml dataset being generated;
-      all vdb directories within the directory tree headed by ensemble_run_dir are included in the import; by
-      default all properties will be imported; the keyword_list, property_kind_list, vdb_static_properties,
-      vdb_recurrent_properties and timestep_selection arguments can be used to filter the required properties;
-      if both keyword_list and property_kind_list are provided, a property must match an item in both lists in order
-      to be included; if recurrent properties are being included then all vdb's should contain the same number of reporting
-      steps in their recurrent data and these should relate to the same set of timestamps; timestamp data is extracted from a
-      summary file for the first realisation; no check is made to ensure that reporting timesteps in different realisations
-      are actually for the same date.
-   """
+    note:
+       if existing_epc is True, the epc file must already exist and contain one grid (or one grid named ROOT) which must
+       have the correct extent for all realisations within the ensemble; if existing_epc is False, the resqml dataset is
+       created afresh with a grid extracted from the first realisation in the ensemble; either way, the single grid is used
+       as the representative grid in the ensemble resqml dataset being generated;
+       all vdb directories within the directory tree headed by ensemble_run_dir are included in the import; by
+       default all properties will be imported; the keyword_list, property_kind_list, vdb_static_properties,
+       vdb_recurrent_properties and timestep_selection arguments can be used to filter the required properties;
+       if both keyword_list and property_kind_list are provided, a property must match an item in both lists in order
+       to be included; if recurrent properties are being included then all vdb's should contain the same number of reporting
+       steps in their recurrent data and these should relate to the same set of timestamps; timestamp data is extracted from a
+       summary file for the first realisation; no check is made to ensure that reporting timesteps in different realisations
+       are actually for the same date.
+    """
 
     assert epc_file.endswith('.epc')
     assert vdb_static_properties or vdb_recurrent_properties, 'no properties selected for ensemble import'
@@ -953,7 +955,8 @@ def add_ab_properties(
     ab_property_list = None
 ):  # list of (file_name, keyword, property_kind, facet_type, facet, uom, time_index, null_value,
     #          discrete, realization)
-    """Process a list of pure binary property array files, adding as parts of model, related to grid (hdf5 file is appended to)."""
+    """Process a list of pure binary property array files, adding as parts of model, related to grid (hdf5 file is
+    appended to)."""
 
     assert ab_property_list, 'property list is empty or missing'
 
@@ -1143,10 +1146,10 @@ def grid_from_cp(model,
                  known_to_be_straight = False):
     """Create a resqpy.grid.Grid object from a 7D corner point array.
 
-   notes:
-      this function sets up all the geometry arrays in memory but does not write to hdf5 nor create xml: use Grid methods;
-      geometry_defined_everywhere is deprecated, use treat_as_nan instead
-   """
+    notes:
+       this function sets up all the geometry arrays in memory but does not write to hdf5 nor create xml: use Grid methods;
+       geometry_defined_everywhere is deprecated, use treat_as_nan instead
+    """
 
     if treat_as_nan is None:
         if not geometry_defined_everywhere:

--- a/resqpy/strata.py
+++ b/resqpy/strata.py
@@ -54,14 +54,14 @@ valid_contact_modes = ['baselap', 'erosion', 'extended', 'proportional']
 class StratigraphicUnitFeature(BaseResqpy):
     """Class for RESQML Stratigraphic Unit Feature objects.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      A stratigraphic unit that can have a well-known (e.g., "Jurassic") chronostratigraphic top and
-      chronostratigraphic bottom. These chronostratigraphic units have no associated interpretations or representations.
+       A stratigraphic unit that can have a well-known (e.g., "Jurassic") chronostratigraphic top and
+       chronostratigraphic bottom. These chronostratigraphic units have no associated interpretations or representations.
 
-      BUSINESS RULE: The name must reference a well-known chronostratigraphic unit (such as "Jurassic"),
-      for example, from the International Commission on Stratigraphy (http://www.stratigraphy.org).
-   """
+       BUSINESS RULE: The name must reference a well-known chronostratigraphic unit (such as "Jurassic"),
+       for example, from the International Commission on Stratigraphy (http://www.stratigraphy.org).
+    """
 
     resqml_type = 'StratigraphicUnitFeature'
 
@@ -75,21 +75,21 @@ class StratigraphicUnitFeature(BaseResqpy):
                  extra_metadata = None):
         """Initialises a stratigraphic unit feature object.
 
-      arguments:
-         parent_model (model.Model): the model with which the new feature will be associated
-         uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic unit feature from which
-            this object will be initialised
-         top_unit_uuid (uuid.UUID, optional): the uuid of a geologic or stratigraphic unit feature which is
-            at the top of the new unit; ignored if uuid is not None
-         bottom_unit_uuid (uuid.UUID, optional): the uuid of a geologic or stratigraphic unit feature which is
-            at the bottom of the new unit; ignored if uuid is not None
-         title (str, optional): the citation title (feature name) of the new feature; ignored if uuid is not None
-         originator (str, optional): the name of the person creating the new feature; ignored if uuid is not None
-         extra_metadata (dict, optional): extra metadata items for the new feature
+        arguments:
+           parent_model (model.Model): the model with which the new feature will be associated
+           uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic unit feature from which
+              this object will be initialised
+           top_unit_uuid (uuid.UUID, optional): the uuid of a geologic or stratigraphic unit feature which is
+              at the top of the new unit; ignored if uuid is not None
+           bottom_unit_uuid (uuid.UUID, optional): the uuid of a geologic or stratigraphic unit feature which is
+              at the bottom of the new unit; ignored if uuid is not None
+           title (str, optional): the citation title (feature name) of the new feature; ignored if uuid is not None
+           originator (str, optional): the name of the person creating the new feature; ignored if uuid is not None
+           extra_metadata (dict, optional): extra metadata items for the new feature
 
-      returns:
-         a new stratigraphic unit feature resqpy object
-      """
+        returns:
+           a new stratigraphic unit feature resqpy object
+        """
 
         # todo: clarify with Energistics whether the 2 references are to other StratigraphicUnitFeatures or what?
         self.top_unit_uuid = top_unit_uuid
@@ -104,14 +104,14 @@ class StratigraphicUnitFeature(BaseResqpy):
     def is_equivalent(self, other, check_extra_metadata = True):
         """Returns True if this feature is essentially the same as the other; otherwise False.
 
-      arguments:
-         other (StratigraphicUnitFeature): the other feature to compare this one against
-         check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
-            features to be deemed equivalent; if False, extra metadata is ignored in the comparison
+        arguments:
+           other (StratigraphicUnitFeature): the other feature to compare this one against
+           check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
+              features to be deemed equivalent; if False, extra metadata is ignored in the comparison
 
-      returns:
-         bool: True if this feature is essentially the same as the other feature; False otherwise
-      """
+        returns:
+           bool: True if this feature is essentially the same as the other feature; False otherwise
+        """
 
         if not isinstance(other, StratigraphicUnitFeature):
             return False
@@ -137,17 +137,17 @@ class StratigraphicUnitFeature(BaseResqpy):
     def create_xml(self, add_as_part = True, originator = None, reuse = True, add_relationships = True):
         """Creates xml for this stratigraphic unit feature.
 
-      arguments:
-         add_as_part (bool, default True): if True, the feature is added to the parent model as a high level part
-         originator (str, optional): if present, is used as the originator field of the citation block
-         reuse (bool, default True): if True, the parent model is inspected for any equivalent feature and, if found,
-            the uuid of this feature is set to that of the equivalent part
-         add_relationships (bool, default True): if True and add_as_part is True, relationships are created with
-            the referenced top and bottom units, if present
+        arguments:
+           add_as_part (bool, default True): if True, the feature is added to the parent model as a high level part
+           originator (str, optional): if present, is used as the originator field of the citation block
+           reuse (bool, default True): if True, the parent model is inspected for any equivalent feature and, if found,
+              the uuid of this feature is set to that of the equivalent part
+           add_relationships (bool, default True): if True and add_as_part is True, relationships are created with
+              the referenced top and bottom units, if present
 
-      returns:
-         lxml.etree._Element: the root node of the newly created xml tree for the feature
-      """
+        returns:
+           lxml.etree._Element: the root node of the newly created xml tree for the feature
+        """
 
         if reuse and self.try_reuse():
             return self.root  # check for reusable (equivalent) object
@@ -186,12 +186,12 @@ class StratigraphicUnitFeature(BaseResqpy):
 class GeologicUnitInterpretation(BaseResqpy):
     """Class for RESQML Geologic Unit Interpretation objects.
 
-   These objects can be parts in their own right. NB: Various more specialised classes also derive from this.
+    These objects can be parts in their own right. NB: Various more specialised classes also derive from this.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      The main class for data describing an opinion of a volume-based geologic feature or unit.
-   """
+       The main class for data describing an opinion of a volume-based geologic feature or unit.
+    """
 
     resqml_type = 'GeologicUnitInterpretation'
 
@@ -207,31 +207,31 @@ class GeologicUnitInterpretation(BaseResqpy):
             extra_metadata = None):
         """Initialises an geologic unit interpretation object.
 
-      arguments:
-         parent_model (model.Model): the model with which the new interpretation will be associated
-         uuid (uuid.UUID, optional): the uuid of an existing RESQML geologic unit interpretation from which
-            this object will be initialised
-         title (str, optional): the citation title (feature name) of the new interpretation;
-            ignored if uuid is not None
-         domain (str, default 'time'): 'time', 'depth' or 'mixed', being the domain of the interpretation;
-            ignored if uuid is not None
-         geologic_unit_feature (organize.GeologicUnitFeature or StratigraphicUnitFeature, optional): the feature
-            which this object is an interpretation of; ignored if uuid is not None
-         composition (str, optional): the interpreted composition of the geologic unit; if present, must be
-            in valid_compositions; ignored if uuid is not None
-         material_implacement (str, optional): the interpeted material implacement of the geologic unit;
-            if present, must be in valid_implacements, ie. 'autochtonous' or 'allochtonous';
-            ignored if uuid is not None
-         extra_metadata (dict, optional): extra metadata items for the new interpretation
+        arguments:
+           parent_model (model.Model): the model with which the new interpretation will be associated
+           uuid (uuid.UUID, optional): the uuid of an existing RESQML geologic unit interpretation from which
+              this object will be initialised
+           title (str, optional): the citation title (feature name) of the new interpretation;
+              ignored if uuid is not None
+           domain (str, default 'time'): 'time', 'depth' or 'mixed', being the domain of the interpretation;
+              ignored if uuid is not None
+           geologic_unit_feature (organize.GeologicUnitFeature or StratigraphicUnitFeature, optional): the feature
+              which this object is an interpretation of; ignored if uuid is not None
+           composition (str, optional): the interpreted composition of the geologic unit; if present, must be
+              in valid_compositions; ignored if uuid is not None
+           material_implacement (str, optional): the interpeted material implacement of the geologic unit;
+              if present, must be in valid_implacements, ie. 'autochtonous' or 'allochtonous';
+              ignored if uuid is not None
+           extra_metadata (dict, optional): extra metadata items for the new interpretation
 
-      returns:
-         a new geologic unit interpretation resqpy object which may be the basis of a derived class object
+        returns:
+           a new geologic unit interpretation resqpy object which may be the basis of a derived class object
 
-      note:
-         the RESQML 2.0.1 schema definition includes a spurious trailing space in the names of two compositions;
-         resqpy removes such spaces in the composition attribute as presented to calling code (but includes them
-         in xml)
-      """
+        note:
+           the RESQML 2.0.1 schema definition includes a spurious trailing space in the names of two compositions;
+           resqpy removes such spaces in the composition attribute as presented to calling code (but includes them
+           in xml)
+        """
 
         self.domain = domain
         self.geologic_unit_feature = geologic_unit_feature  # InterpretedFeature RESQML field
@@ -267,15 +267,15 @@ class GeologicUnitInterpretation(BaseResqpy):
     def is_equivalent(self, other, check_extra_metadata = True):
         """Returns True if this interpretation is essentially the same as the other; otherwise False.
 
-      arguments:
-         other (GeologicUnitInterpretation or StratigraphicUnitInterpretation): the other interpretation to
-            compare this one against
-         check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
-            interpretations to be deemed equivalent; if False, extra metadata is ignored in the comparison
+        arguments:
+           other (GeologicUnitInterpretation or StratigraphicUnitInterpretation): the other interpretation to
+              compare this one against
+           check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
+              interpretations to be deemed equivalent; if False, extra metadata is ignored in the comparison
 
-      returns:
-         bool: True if this interpretation is essentially the same as the other; False otherwise
-      """
+        returns:
+           bool: True if this interpretation is essentially the same as the other; False otherwise
+        """
 
         # this method is coded to allow use by the derived StratigraphicUnitInterpretation class
         if other is None or not isinstance(other, type(self)):
@@ -301,17 +301,17 @@ class GeologicUnitInterpretation(BaseResqpy):
     def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
         """Creates a geologic unit interpretation xml tree.
 
-      arguments:
-         add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
-         add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with
-            the referenced geologic unit feature
-         originator (str, optional): if present, is used as the originator field of the citation block
-         reuse (bool, default True): if True, the parent model is inspected for any equivalent interpretation and, if found,
-            the uuid of this interpretation is set to that of the equivalent part
+        arguments:
+           add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
+           add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with
+              the referenced geologic unit feature
+           originator (str, optional): if present, is used as the originator field of the citation block
+           reuse (bool, default True): if True, the parent model is inspected for any equivalent interpretation and, if found,
+              the uuid of this interpretation is set to that of the equivalent part
 
-      returns:
-         lxml.etree._Element: the root node of the newly created xml tree for the interpretation
-      """
+        returns:
+           lxml.etree._Element: the root node of the newly created xml tree for the interpretation
+        """
 
         # note: related feature xml must be created first and is referenced here
         # this method is coded to allow use by the derived StratigraphicUnitInterpretation class
@@ -363,11 +363,11 @@ class GeologicUnitInterpretation(BaseResqpy):
 class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
     """Class for RESQML Stratigraphic Unit Interpretation objects.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      Interpretation of a stratigraphic unit which includes the knowledge of the top, the bottom,
-      the deposition mode.
-   """
+       Interpretation of a stratigraphic unit which includes the knowledge of the top, the bottom,
+       the deposition mode.
+    """
 
     resqml_type = 'StratigraphicUnitInterpretation'
 
@@ -387,40 +387,40 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
             extra_metadata = None):
         """Initialises a stratigraphic unit interpretation object.
 
-      arguments:
-         parent_model (model.Model): the model with which the new interpretation will be associated
-         uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic unit interpretation from which
-            this object will be initialised
-         title (str, optional): the citation title (feature name) of the new interpretation;
-            ignored if uuid is not None
-         domain (str, default 'time'): 'time', 'depth' or 'mixed', being the domain of the interpretation;
-            ignored if uuid is not None
-         stratigraphic_unit_feature (StratigraphicUnitFeature, optional): the feature which this object is
-            an interpretation of; ignored if uuid is not None
-         composition (str, optional): the interpreted composition of the stratigraphic unit; if present, must be
-            in valid_compositions; ignored if uuid is not None
-         material_implacement (str, optional): the interpeted material implacement of the stratigraphic unit;
-            if present, must be in valid_implacements, ie. 'autochtonous' or 'allochtonous';
-            ignored if uuid is not None
-         deposition_mode (str, optional): indicates whether deposition within the unit is interpreted as parallel
-            to top, base or another boundary, or is proportional to thickness; if present, must be in
-            valid_deposition_modes; ignored if uuid is not None
-         min_thickness (float, optional): the minimum thickness of the unit; ignored if uuid is not None
-         max_thickness (float, optional): the maximum thickness of the unit; ignored if uuid is not None
-         thickness_uom (str, optional): the length unit of measure of the minimum and maximum thickness; required
-            if either thickness argument is provided and uuid is None; if present, must be a valid length uom
-         extra_metadata (dict, optional): extra metadata items for the new interpretation
+        arguments:
+           parent_model (model.Model): the model with which the new interpretation will be associated
+           uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic unit interpretation from which
+              this object will be initialised
+           title (str, optional): the citation title (feature name) of the new interpretation;
+              ignored if uuid is not None
+           domain (str, default 'time'): 'time', 'depth' or 'mixed', being the domain of the interpretation;
+              ignored if uuid is not None
+           stratigraphic_unit_feature (StratigraphicUnitFeature, optional): the feature which this object is
+              an interpretation of; ignored if uuid is not None
+           composition (str, optional): the interpreted composition of the stratigraphic unit; if present, must be
+              in valid_compositions; ignored if uuid is not None
+           material_implacement (str, optional): the interpeted material implacement of the stratigraphic unit;
+              if present, must be in valid_implacements, ie. 'autochtonous' or 'allochtonous';
+              ignored if uuid is not None
+           deposition_mode (str, optional): indicates whether deposition within the unit is interpreted as parallel
+              to top, base or another boundary, or is proportional to thickness; if present, must be in
+              valid_deposition_modes; ignored if uuid is not None
+           min_thickness (float, optional): the minimum thickness of the unit; ignored if uuid is not None
+           max_thickness (float, optional): the maximum thickness of the unit; ignored if uuid is not None
+           thickness_uom (str, optional): the length unit of measure of the minimum and maximum thickness; required
+              if either thickness argument is provided and uuid is None; if present, must be a valid length uom
+           extra_metadata (dict, optional): extra metadata items for the new interpretation
 
-      returns:
-         a new stratigraphic unit interpretation resqpy object
+        returns:
+           a new stratigraphic unit interpretation resqpy object
 
-      notes:
-         if given, the thickness_uom must be a valid RESQML length unit of measure; the set of valid uoms is
-         returned by: weights_and_measures.valid_uoms(quantity = 'length');
-         the RESQML 2.0.1 schema definition includes a spurious trailing space in the names of two compositions;
-         resqpy removes such spaces in the composition attribute as presented to calling code (but includes them
-         in xml)
-      """
+        notes:
+           if given, the thickness_uom must be a valid RESQML length unit of measure; the set of valid uoms is
+           returned by: weights_and_measures.valid_uoms(quantity = 'length');
+           the RESQML 2.0.1 schema definition includes a spurious trailing space in the names of two compositions;
+           resqpy removes such spaces in the composition attribute as presented to calling code (but includes them
+           in xml)
+        """
 
         self.deposition_mode = deposition_mode
         self.min_thickness = min_thickness
@@ -472,14 +472,14 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
     def is_equivalent(self, other, check_extra_metadata = True):
         """Returns True if this interpretation is essentially the same as the other; otherwise False.
 
-      arguments:
-         other (StratigraphicUnitInterpretation): the other interpretation to compare this one against
-         check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
-            interpretations to be deemed equivalent; if False, extra metadata is ignored in the comparison
+        arguments:
+           other (StratigraphicUnitInterpretation): the other interpretation to compare this one against
+           check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
+              interpretations to be deemed equivalent; if False, extra metadata is ignored in the comparison
 
-      returns:
-         bool: True if this interpretation is essentially the same as the other; False otherwise
-      """
+        returns:
+           bool: True if this interpretation is essentially the same as the other; False otherwise
+        """
         if not super().is_equivalent(other):
             return False
         if self.deposition_mode is not None and other.deposition_mode is not None:
@@ -490,17 +490,17 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
     def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
         """Creates a stratigraphic unit interpretation xml tree.
 
-      arguments:
-         add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
-         add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with
-            the referenced stratigraphic unit feature
-         originator (str, optional): if present, is used as the originator field of the citation block
-         reuse (bool, default True): if True, the parent model is inspected for any equivalent interpretation and, if found,
-            the uuid of this interpretation is set to that of the equivalent part
+        arguments:
+           add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
+           add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with
+              the referenced stratigraphic unit feature
+           originator (str, optional): if present, is used as the originator field of the citation block
+           reuse (bool, default True): if True, the parent model is inspected for any equivalent interpretation and, if found,
+              the uuid of this interpretation is set to that of the equivalent part
 
-      returns:
-         lxml.etree._Element: the root node of the newly created xml tree for the interpretation
-      """
+        returns:
+           lxml.etree._Element: the root node of the newly created xml tree for the interpretation
+        """
 
         if reuse and self.try_reuse():
             return self.root
@@ -539,14 +539,14 @@ class StratigraphicUnitInterpretation(GeologicUnitInterpretation):
 class StratigraphicColumn(BaseResqpy):
     """Class for RESQML stratigraphic column objects.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      A global interpretation of the stratigraphy, which can be made up of
-      several ranks of stratigraphic unit interpretations.
+       A global interpretation of the stratigraphy, which can be made up of
+       several ranks of stratigraphic unit interpretations.
 
-      All stratigraphic column rank interpretations that make up a stratigraphic column
-      must be ordered by age.
-   """
+       All stratigraphic column rank interpretations that make up a stratigraphic column
+       must be ordered by age.
+    """
 
     resqml_type = 'StratigraphicColumn'
 
@@ -555,16 +555,16 @@ class StratigraphicColumn(BaseResqpy):
     def __init__(self, parent_model, uuid = None, rank_uuid_list = None, title = None, extra_metadata = None):
         """Initialises a Stratigraphic Column object.
 
-      arguments:
-         parent_model (model.Model): the model with which the new stratigraphic column will be associated
-         uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic column from which
-            this object will be initialised
-         rank_uuid_list (list of uuid, optional): if not initialising for an existing stratigraphic column,
-            the ranks can be established from this list of uuids for existing stratigraphic column ranks;
-            ranks should be ordered from geologically oldest to youngest with increasing index values
-         title (str, optional): the citation title of the new stratigraphic column; ignored if uuid is not None
-         extra_metadata (dict, optional): extra metadata items for the new feature
-      """
+        arguments:
+           parent_model (model.Model): the model with which the new stratigraphic column will be associated
+           uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic column from which
+              this object will be initialised
+           rank_uuid_list (list of uuid, optional): if not initialising for an existing stratigraphic column,
+              the ranks can be established from this list of uuids for existing stratigraphic column ranks;
+              ranks should be ordered from geologically oldest to youngest with increasing index values
+           title (str, optional): the citation title of the new stratigraphic column; ignored if uuid is not None
+           extra_metadata (dict, optional): extra metadata items for the new feature
+        """
 
         self.ranks = []  # list of Stratigraphic Column Rank Interpretation objects, maintained in rank index order
 
@@ -592,12 +592,12 @@ class StratigraphicColumn(BaseResqpy):
     def add_rank(self, rank):
         """Adds another stratigraphic column rank to this stratigraphic column.
 
-      arguments:
-         rank (StratigraphicColumnRank): an established rank to be added to this stratigraphic column
+        arguments:
+           rank (StratigraphicColumnRank): an established rank to be added to this stratigraphic column
 
-      note:
-         ranks should be ordered from geologically oldest to youngest, with increasing index values
-      """
+        note:
+           ranks should be ordered from geologically oldest to youngest, with increasing index values
+        """
 
         assert rank is not None and rank.index is not None
         self.ranks.append(rank)
@@ -610,14 +610,14 @@ class StratigraphicColumn(BaseResqpy):
     def is_equivalent(self, other, check_extra_metadata = True):
         """Returns True if this interpretation is essentially the same as the other; otherwise False.
 
-      arguments:
-         other (StratigraphicColumn): the other stratigraphic column to compare this one against
-         check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
-            columns to be deemed equivalent; if False, extra metadata is ignored in the comparison
+        arguments:
+           other (StratigraphicColumn): the other stratigraphic column to compare this one against
+           check_extra_metadata (bool, default True): if True, then extra metadata items must match for the two
+              columns to be deemed equivalent; if False, extra metadata is ignored in the comparison
 
-      returns:
-         bool: True if this stratigraphic column is essentially the same as the other; False otherwise
-      """
+        returns:
+           bool: True if this stratigraphic column is essentially the same as the other; False otherwise
+        """
 
         if not isinstance(other, StratigraphicColumn):
             return False
@@ -635,17 +635,17 @@ class StratigraphicColumn(BaseResqpy):
     def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
         """Creates xml tree for a stratigraphic column object.
 
-      arguments:
-         add_as_part (bool, default True): if True, the stratigraphic column is added to the parent model as a high level part
-         add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with each of
-            the referenced stratigraphic column rank interpretations
-         originator (str, optional): if present, is used as the originator field of the citation block
-         reuse (bool, default True): if True, the parent model is inspected for any equivalent stratigraphic column and,
-            if found, the uuid of this stratigraphic column is set to that of the equivalent part
+        arguments:
+           add_as_part (bool, default True): if True, the stratigraphic column is added to the parent model as a high level part
+           add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with each of
+              the referenced stratigraphic column rank interpretations
+           originator (str, optional): if present, is used as the originator field of the citation block
+           reuse (bool, default True): if True, the parent model is inspected for any equivalent stratigraphic column and,
+              if found, the uuid of this stratigraphic column is set to that of the equivalent part
 
-      returns:
-         lxml.etree._Element: the root node of the newly created xml tree for the stratigraphic column
-      """
+        returns:
+           lxml.etree._Element: the root node of the newly created xml tree for the stratigraphic column
+        """
 
         assert self.ranks, 'attempt to create xml for stratigraphic column without any contributing ranks'
 
@@ -675,8 +675,8 @@ class StratigraphicColumn(BaseResqpy):
 class StratigraphicColumnRank(BaseResqpy):
     """Class for RESQML StratigraphicColumnRankInterpretation objects.
 
-   A list of stratigraphic unit interpretations, ordered from geologically oldest to youngest.
-   """
+    A list of stratigraphic unit interpretations, ordered from geologically oldest to youngest.
+    """
 
     resqml_type = 'StratigraphicColumnRankInterpretation'
 
@@ -694,22 +694,22 @@ class StratigraphicColumnRank(BaseResqpy):
             extra_metadata = None):
         """Initialises a Stratigraphic Column Rank resqpy object (RESQML StratigraphicColumnRankInterpretation).
 
-      arguments:
-         parent_model (model.Model): the model with which the new interpretation will be associated
-         uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic column rank interpretation
-            from which this object will be initialised
-         domain (str, default 'time'): 'time', 'depth' or 'mixed', being the domain of the interpretation;
-            ignored if uuid is not None
-         rank_index (int, optional): the rank index (RESQML index) for this rank when multiple ranks are used;
-            will default to zero if not set; ignored if uuid is not None
-         earth_model_feature_uuid (uuid.UUID, optional): the uuid of an existing organization feature of kind
-            'earth model' which this stratigraphic column is for; ignored if uuid is not None
-         strata_uuid_list (list of uuid.UUID, optional): a list of uuids of existing stratigraphic unit
-            interpretations, ordered from geologically oldest to youngest; ignored if uuid is not None
-         title (str, optional): the citation title (feature name) of the new interpretation;
-            ignored if uuid is not None
-         extra_metadata (dict, optional): extra metadata items for the new stratigraphic column rank interpretation
-      """
+        arguments:
+           parent_model (model.Model): the model with which the new interpretation will be associated
+           uuid (uuid.UUID, optional): the uuid of an existing RESQML stratigraphic column rank interpretation
+              from which this object will be initialised
+           domain (str, default 'time'): 'time', 'depth' or 'mixed', being the domain of the interpretation;
+              ignored if uuid is not None
+           rank_index (int, optional): the rank index (RESQML index) for this rank when multiple ranks are used;
+              will default to zero if not set; ignored if uuid is not None
+           earth_model_feature_uuid (uuid.UUID, optional): the uuid of an existing organization feature of kind
+              'earth model' which this stratigraphic column is for; ignored if uuid is not None
+           strata_uuid_list (list of uuid.UUID, optional): a list of uuids of existing stratigraphic unit
+              interpretations, ordered from geologically oldest to youngest; ignored if uuid is not None
+           title (str, optional): the citation title (feature name) of the new interpretation;
+              ignored if uuid is not None
+           extra_metadata (dict, optional): extra metadata items for the new stratigraphic column rank interpretation
+        """
 
         self.feature_uuid = earth_model_feature_uuid  # interpreted earth model feature uuid
         self.domain = domain
@@ -749,10 +749,10 @@ class StratigraphicColumnRank(BaseResqpy):
     def set_units(self, strata_uuid_list):
         """Discard any previous units and set list of units based on ordered list of uuids.
 
-      arguments:
-         strata_uuid_list (list of uuid.UUID): the uuids of the stratigraphic unit interpretations which constitute
-            this stratigraphic column, ordered from geologically oldest to youngest
-      """
+        arguments:
+           strata_uuid_list (list of uuid.UUID): the uuids of the stratigraphic unit interpretations which constitute
+              this stratigraphic column, ordered from geologically oldest to youngest
+        """
 
         self.units = []
         for i, uuid in enumerate(strata_uuid_list):
@@ -770,19 +770,19 @@ class StratigraphicColumnRank(BaseResqpy):
     def set_contacts_from_horizons(self, horizon_uuids, older_contact_mode = None, younger_contact_mode = None):
         """Sets the list of contacts from an ordered list of horizons, of length one less than the number of units.
 
-      arguments:
-         horizon_uuids (list of uuid.UUID): list of horizon interpretation uuids, ordered from geologically oldest
-            to youngest, with one horizon for each neighbouring pair of stratigraphic units in this column
-         older_contact_mode (str, optional): if present, the contact mode to set for the older unit for all of the
-            contacts; must be in valid_contact_modes
-         younger_contact_mode (str, optional): if present, the contact mode to set for the younger unit for all of
-            the contacts; must be in valid_contact_modes
+        arguments:
+           horizon_uuids (list of uuid.UUID): list of horizon interpretation uuids, ordered from geologically oldest
+              to youngest, with one horizon for each neighbouring pair of stratigraphic units in this column
+           older_contact_mode (str, optional): if present, the contact mode to set for the older unit for all of the
+              contacts; must be in valid_contact_modes
+           younger_contact_mode (str, optional): if present, the contact mode to set for the younger unit for all of
+              the contacts; must be in valid_contact_modes
 
-      notes:
-         units must be established and sorted before calling this method; any previous contacts are discarded;
-         if differing modes are required for the various contacts, leave the contact mode arguments as None,
-         then interate over the contacts setting each mode individually (after this method returns)
-      """
+        notes:
+           units must be established and sorted before calling this method; any previous contacts are discarded;
+           if differing modes are required for the various contacts, leave the contact mode arguments as None,
+           then interate over the contacts setting each mode individually (after this method returns)
+        """
 
         # this method uses older unit as subject, younger as direct object
         # todo: check this is consistent with any RESQML usage guidance and/or any RMS usage
@@ -829,17 +829,17 @@ class StratigraphicColumnRank(BaseResqpy):
     def create_xml(self, add_as_part = True, add_relationships = True, originator = None, reuse = True):
         """Creates a stratigraphic column rank interpretation xml tree.
 
-      arguments:
-         add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
-         add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with
-            the referenced geologic unit feature
-         originator (str, optional): if present, is used as the originator field of the citation block
-         reuse (bool, default True): if True, the parent model is inspected for any equivalent interpretation and, if found,
-            the uuid of this interpretation is set to that of the equivalent part
+        arguments:
+           add_as_part (bool, default True): if True, the interpretation is added to the parent model as a high level part
+           add_relationships (bool, default True): if True and add_as_part is True, a relationship is created with
+              the referenced geologic unit feature
+           originator (str, optional): if present, is used as the originator field of the citation block
+           reuse (bool, default True): if True, the parent model is inspected for any equivalent interpretation and, if found,
+              the uuid of this interpretation is set to that of the equivalent part
 
-      returns:
-         lxml.etree._Element: the root node of the newly created xml tree for the interpretation
-      """
+        returns:
+           lxml.etree._Element: the root node of the newly created xml tree for the interpretation
+        """
 
         # note: xml for referenced objects must be created before calling this method
 
@@ -932,9 +932,9 @@ class BinaryContactInterpretation:
             part_of_uuid = None):  # optional
         """Creates a new binary contact interpretation internal object.
 
-      note:
-         if an existing xml node is present, then all the later arguments are ignored
-      """
+        note:
+           if an existing xml node is present, then all the later arguments are ignored
+        """
         # index (non-negative integer, should increase with decreasing age for horizon contacts)
         # contact relationship (one of valid_contact_relationships)
         # subject (reference to e.g. stratigraphic unit interpretation)
@@ -975,9 +975,9 @@ class BinaryContactInterpretation:
     def _load_from_xml(self, bci_node):
         """Populates this binary contact interpretation based on existing xml.
 
-      arguments:
-         bci_node (lxml.etree._Element): the root xml node for the binary contact interpretation sub-tree
-      """
+        arguments:
+           bci_node (lxml.etree._Element): the root xml node for the binary contact interpretation sub-tree
+        """
 
         assert bci_node is not None
 
@@ -1009,14 +1009,15 @@ class BinaryContactInterpretation:
            f'missing or invalid contact verb {self.verb} in xml for binary contact interpretation'
 
     def create_xml(self, parent_node = None):
-        """Generates xml sub-tree for this contact interpretation, for inclusion as element of high level interpretation.
+        """Generates xml sub-tree for this contact interpretation, for inclusion as element of high level
+        interpretation.
 
-      arguments:
-         parent_node (lxml.etree._Element, optional): if present, the created sub-tree is added as a child to this node
+        arguments:
+           parent_node (lxml.etree._Element, optional): if present, the created sub-tree is added as a child to this node
 
-      returns:
-         lxml.etree._Element: the root node of the newly created xml sub-tree for the contact interpretation
-      """
+        returns:
+           lxml.etree._Element: the root node of the newly created xml sub-tree for the contact interpretation
+        """
 
         bci = rqet.Element(ns['resqml2'] + 'ContactInterpretation')
         bci.set(ns['xsi'] + 'type', ns['resqml2'] + 'BinaryContactInterpretationPart')

--- a/resqpy/surface.py
+++ b/resqpy/surface.py
@@ -30,7 +30,7 @@ import resqpy.organize as rqo
 
 
 class _BaseSurface(BaseResqpy):
-    """Base class to implement shared methods for other classes in this module"""
+    """Base class to implement shared methods for other classes in this module."""
 
     def create_interpretation_and_feature(self,
                                           kind = 'horizon',
@@ -75,9 +75,9 @@ class TriangulatedPatch:
     def __init__(self, parent_model, patch_index = None, patch_node = None, crs_uuid = None):
         """Create an empty TriangulatedPatch (TrianglePatch) node and optionally load from xml.
 
-      note:
-         not usually instantiated directly by application code
-      """
+        note:
+           not usually instantiated directly by application code
+        """
 
         self.model = parent_model
         self.node = patch_node
@@ -118,14 +118,13 @@ class TriangulatedPatch:
     def triangles_and_points(self):
         """Returns arrays representing the patch.
 
-      Returns:
-         Tuple (triangles, points):
+        Returns:
+           Tuple (triangles, points):
 
-         * triangles (int array of shape[:, 3]): integer indices into points array,
-           being the nodes of the corners of the triangles
-         * points (float array of shape[:, 3]): flat array of xyz points, indexed by triangles
-
-      """
+           * triangles (int array of shape[:, 3]): integer indices into points array,
+             being the nodes of the corners of the triangles
+           * points (float array of shape[:, 3]): flat array of xyz points, indexed by triangles
+        """
         if self.triangles is not None:
             return (self.triangles, self.points)
         assert self.triangle_count is not None and self.node_count is not None
@@ -166,11 +165,11 @@ class TriangulatedPatch:
     def set_to_horizontal_plane(self, depth, box_xyz, border = 0.0):
         """Populate this (empty) patch with two triangles defining a flat, horizontal plane at a given depth.
 
-         arguments:
-            depth (float): z value to use in all points in the triangulated patch
-            box_xyz (float[2, 3]): the min, max values of x, y (&z) giving the area to be covered (z ignored)
-            border (float): an optional border width added around the x,y area defined by box_xyz
-      """
+        arguments:
+           depth (float): z value to use in all points in the triangulated patch
+           box_xyz (float[2, 3]): the min, max values of x, y (&z) giving the area to be covered (z ignored)
+           border (float): an optional border width added around the x,y area defined by box_xyz
+        """
 
         # expand area by border
         box = box_xyz.copy()
@@ -405,19 +404,19 @@ class TriangulatedPatch:
     def column_from_triangle_index(self, triangle_index):
         """For patch freshly built from fully defined mesh, returns (j, i) for given triangle index.
 
-      argument:
-         triangle_index (int or numpy int array): the triangle index (or array of indices) for which column(s) are being
-         sought
+        argument:
+           triangle_index (int or numpy int array): the triangle index (or array of indices) for which column(s) are being
+           sought
 
-      returns:
-         pair of ints or pair of numpy int arrays: the (j0, i0) indices of the column(s) which the triangle(s) is/are
-         part of
+        returns:
+           pair of ints or pair of numpy int arrays: the (j0, i0) indices of the column(s) which the triangle(s) is/are
+           part of
 
-      notes:
-         this function will only work if the surface has been freshly constructed with data from a mesh without NaNs,
-         otherwise (None, None) will be returned;
-         if triangle_index is a numpy int array, a pair of similarly shaped numpy arrays is returned
-      """
+        notes:
+           this function will only work if the surface has been freshly constructed with data from a mesh without NaNs,
+           otherwise (None, None) will be returned;
+           if triangle_index is a numpy int array, a pair of similarly shaped numpy arrays is returned
+        """
 
         if self.quad_triangles is None or self.ni is None:
             return (None, None)
@@ -505,7 +504,8 @@ class TriangulatedPatch:
         return axis, polarity
 
     def vertical_rescale_points(self, ref_depth, scaling_factor):
-        """Modify the z values of points for this patch by stretching the distance from reference depth by scaling factor."""
+        """Modify the z values of points for this patch by stretching the distance from reference depth by scaling
+        factor."""
 
         _, _ = self.triangles_and_points()  # ensure points are loaded
         z_values = self.points[:, 2].copy()
@@ -532,54 +532,55 @@ class Surface(_BaseSurface):
                  crs_uuid = None,
                  originator = None,
                  extra_metadata = {}):
-        """Create an empty Surface object (RESQML TriangulatedSetRepresentation) and optionally populates from xml, point set or mesh.
+        """Create an empty Surface object (RESQML TriangulatedSetRepresentation) and optionally populates from xml,
+        point set or mesh.
 
-      arguments:
-         parent_model (model.Model object): the model to which this surface belongs
-         uuid (uuid.UUID, optional): if present, the surface is initialised from an existing RESQML object with this uuid
-         surface_root (xml tree root node, optional): DEPRECATED: alternative to using uuid
-         point_set (PointSet object, optional): if present, the surface is initialised as a Delaunay
-            triangulation of the points in the point set; ignored if extracting from xml
-         mesh (Mesh object, optional): if present, the surface is initialised as a triangulation of
-            the mesh; ignored if extracting from xml or if point_set is present
-         mesh_file (string, optional): the path of an ascii file holding a mesh in RMS text or zmap+ format;
-            ignored if extracting from xml or point_set or mesh is present
-         mesh_format (string, optional): 'rms' or 'zmap'; required if initialising from mesh_file
-         tsurf_file (string, optional): the path of an ascii file holding details of triangles and points in GOCAD-Tsurf format;
-            ignored if extraction from xml or point_set or mesh is present
-         quad_triangles (boolean, default False): if initialising from mesh or mesh_file, each 'square'
-            is represented by 2 triangles if quad_triangles is False, 4 triangles if True
-         title (string, optional): used as the citation title for the new object, ignored if
-            extracting from xml
-         surface_role (string, default 'map'): 'map' or 'pick'; ignored if root_node is not None
-         crs_uuid (uuid.UUID, optional): if present and not extracting from xml, is set as the crs uuid
-            applicable to mesh etc. data
-         originator (str, optional): the name of the person creating the object; defaults to login id; ignored
-            when initialising from an existing RESQML object
-         extra_metadata (dict): items in this dictionary are added as extra metadata; ignored
-            when initialising from an existing RESQML object
+        arguments:
+           parent_model (model.Model object): the model to which this surface belongs
+           uuid (uuid.UUID, optional): if present, the surface is initialised from an existing RESQML object with this uuid
+           surface_root (xml tree root node, optional): DEPRECATED: alternative to using uuid
+           point_set (PointSet object, optional): if present, the surface is initialised as a Delaunay
+              triangulation of the points in the point set; ignored if extracting from xml
+           mesh (Mesh object, optional): if present, the surface is initialised as a triangulation of
+              the mesh; ignored if extracting from xml or if point_set is present
+           mesh_file (string, optional): the path of an ascii file holding a mesh in RMS text or zmap+ format;
+              ignored if extracting from xml or point_set or mesh is present
+           mesh_format (string, optional): 'rms' or 'zmap'; required if initialising from mesh_file
+           tsurf_file (string, optional): the path of an ascii file holding details of triangles and points in GOCAD-Tsurf format;
+              ignored if extraction from xml or point_set or mesh is present
+           quad_triangles (boolean, default False): if initialising from mesh or mesh_file, each 'square'
+              is represented by 2 triangles if quad_triangles is False, 4 triangles if True
+           title (string, optional): used as the citation title for the new object, ignored if
+              extracting from xml
+           surface_role (string, default 'map'): 'map' or 'pick'; ignored if root_node is not None
+           crs_uuid (uuid.UUID, optional): if present and not extracting from xml, is set as the crs uuid
+              applicable to mesh etc. data
+           originator (str, optional): the name of the person creating the object; defaults to login id; ignored
+              when initialising from an existing RESQML object
+           extra_metadata (dict): items in this dictionary are added as extra metadata; ignored
+              when initialising from an existing RESQML object
 
-      returns:
-         a newly created surface object
+        returns:
+           a newly created surface object
 
-      notes:
-         there are 6 ways to initialise a surface object, in order of precendence:
-         1. extracting from xml
-         2. as a Delaunay triangulation of points in a PointSet
-         3. as a simple triangulation of a Mesh object
-         4. as a simple triangulation of a mesh in an ascii file
-         5. from a GOCAD-TSurf format file
-         5. as an empty surface
-         if an empty surface is created, 'set_from_...' methods are available to then set for one of:
-         - a horizontal plane
-         - a single triangle
-         - a 'sail' (a triangle wrapped onto a sphere)
-         - etc.
-         the quad_triangles option is only applied if initialising from a mesh or mesh_file that is fully
-         defined (ie. no NaN's)
+        notes:
+           there are 6 ways to initialise a surface object, in order of precendence:
+           1. extracting from xml
+           2. as a Delaunay triangulation of points in a PointSet
+           3. as a simple triangulation of a Mesh object
+           4. as a simple triangulation of a mesh in an ascii file
+           5. from a GOCAD-TSurf format file
+           5. as an empty surface
+           if an empty surface is created, 'set_from_...' methods are available to then set for one of:
+           - a horizontal plane
+           - a single triangle
+           - a 'sail' (a triangle wrapped onto a sphere)
+           - etc.
+           the quad_triangles option is only applied if initialising from a mesh or mesh_file that is fully
+           defined (ie. no NaN's)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert surface_role in ['map', 'pick']
 
@@ -660,15 +661,15 @@ class Surface(_BaseSurface):
     def triangles_and_points(self):
         """Returns arrays representing combination of all the patches in the surface.
 
-      Returns:
-         Tuple (triangles, points):
+        Returns:
+           Tuple (triangles, points):
 
-         * triangles (int array of shape[:, 3]): integer indices into points array,
-           being the nodes of the corners of the triangles
-         * points (float array of shape[:, 3]): flat array of xyz points, indexed by triangles
+           * triangles (int array of shape[:, 3]): integer indices into points array,
+             being the nodes of the corners of the triangles
+           * points (float array of shape[:, 3]): flat array of xyz points, indexed by triangles
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.triangles is not None:
             return (self.triangles, self.points)
@@ -708,12 +709,12 @@ class Surface(_BaseSurface):
     def set_from_point_set(self, point_set, convexity_parameter = 5.0):
         """Populate this (empty) Surface object with a Delaunay triangulation of points in a PointSet object.
 
-      arguments:
-         point_set (PointSet): the set of points to be triangulated to form a surface
-         convexity_parameter (float, default 5.0): controls how likely the resulting triangulation is to be
-            convex; reduce to 1.0 to allow slightly more concavities; increase to 100.0 or more for very little
-            chance of even a slight concavity
-      """
+        arguments:
+           point_set (PointSet): the set of points to be triangulated to form a surface
+           convexity_parameter (float, default 5.0): controls how likely the resulting triangulation is to be
+              convex; reduce to 1.0 to allow slightly more concavities; increase to 100.0 or more for very little
+              chance of even a slight concavity
+        """
 
         p = point_set.full_array_ref()
         log.debug('number of points going into dt: ' + str(len(p)))
@@ -725,13 +726,13 @@ class Surface(_BaseSurface):
     def set_from_irregular_mesh(self, mesh_xyz, quad_triangles = False):
         """Populate this (empty) Surface object from an untorn mesh array of shape (N, M, 3).
 
-         arguments:
-            mesh_xyz (numpy float array of shape (N, M, 3)): a 2D lattice of points in 3D space
-            quad_triangles: (boolean, optional, default False): if True, each quadrangle is represented by
-               4 triangles in the surface, with the mean of the 4 corner points used as a common centre node;
-               if False (the default), only 2 triangles are used for each quadrangle; note that the 2 triangle
-               mode gives a non-unique triangulated result
-      """
+        arguments:
+           mesh_xyz (numpy float array of shape (N, M, 3)): a 2D lattice of points in 3D space
+           quad_triangles: (boolean, optional, default False): if True, each quadrangle is represented by
+              4 triangles in the surface, with the mean of the 4 corner points used as a common centre node;
+              if False (the default), only 2 triangles are used for each quadrangle; note that the 2 triangle
+              mode gives a non-unique triangulated result
+        """
 
         mesh_shape = mesh_xyz.shape
         assert len(mesh_shape) == 3 and mesh_shape[2] == 3
@@ -743,9 +744,9 @@ class Surface(_BaseSurface):
     def set_from_sparse_mesh(self, mesh_xyz):
         """Populate this (empty) Surface object from a mesh array of shape (N, M, 3) with NaNs.
 
-         arguments:
-            mesh_xyz (numpy float array of shape (N, M, 3)): a 2D lattice of points in 3D space, with NaNs in z
-      """
+        arguments:
+           mesh_xyz (numpy float array of shape (N, M, 3)): a 2D lattice of points in 3D space, with NaNs in z
+        """
 
         mesh_shape = mesh_xyz.shape
         assert len(mesh_shape) == 3 and mesh_shape[2] == 3
@@ -766,13 +767,13 @@ class Surface(_BaseSurface):
     def set_from_torn_mesh(self, mesh_xyz, quad_triangles = False):
         """Populate this (empty) Surface object from a torn mesh array of shape (nj, ni, 2, 2, 3).
 
-         arguments:
-            mesh_xyz (numpy float array of shape (nj, ni, 2, 2, 3)): corner points of 2D faces in 3D space
-            quad_triangles: (boolean, optional, default False): if True, each quadrangle (face) is represented
-               by 4 triangles in the surface, with the mean of the 4 corner points used as a common centre node;
-               if False (the default), only 2 triangles are used for each quadrangle; note that the 2 triangle
-               mode gives a non-unique triangulated result
-      """
+        arguments:
+           mesh_xyz (numpy float array of shape (nj, ni, 2, 2, 3)): corner points of 2D faces in 3D space
+           quad_triangles: (boolean, optional, default False): if True, each quadrangle (face) is represented
+              by 4 triangles in the surface, with the mean of the 4 corner points used as a common centre node;
+              if False (the default), only 2 triangles are used for each quadrangle; note that the 2 triangle
+              mode gives a non-unique triangulated result
+        """
 
         mesh_shape = mesh_xyz.shape
         assert len(mesh_shape) == 5 and mesh_shape[2:] == (2, 2, 3)
@@ -784,22 +785,22 @@ class Surface(_BaseSurface):
     def column_from_triangle_index(self, triangle_index):
         """For surface freshly built from fully defined mesh, returns (j, i) for given triangle index.
 
-      argument:
-         triangle_index (int or numpy int array): the triangle index (or array of indices) for which column(s) is/are
-         being sought
+        argument:
+           triangle_index (int or numpy int array): the triangle index (or array of indices) for which column(s) is/are
+           being sought
 
-      returns:
-         pair of ints or pair of numpy int arrays: the (j0, i0) indices of the column(s) which the triangle(s) is/are
-         part of
+        returns:
+           pair of ints or pair of numpy int arrays: the (j0, i0) indices of the column(s) which the triangle(s) is/are
+           part of
 
-      notes:
-         this function will only work if the surface has been freshly constructed with data from a mesh without NaNs,
-         otherwise (None, None) will be returned;
-         the information needed to map from triangle to column is not persistently stored as part of a resqml surface;
-         if triangle_index is a numpy int array, a pair of similarly shaped numpy arrays is returned
+        notes:
+           this function will only work if the surface has been freshly constructed with data from a mesh without NaNs,
+           otherwise (None, None) will be returned;
+           the information needed to map from triangle to column is not persistently stored as part of a resqml surface;
+           if triangle_index is a numpy int array, a pair of similarly shaped numpy arrays is returned
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert len(self.patch_list) == 1
         return self.patch_list[0].column_from_triangle_index(triangle_index)
@@ -814,7 +815,8 @@ class Surface(_BaseSurface):
         self.uuid = bu.new_uuid()
 
     def set_to_multi_cell_faces_from_corner_points(self, cp, quad_triangles = True):
-        """Populates this (empty) surface to represent faces of a set of cells, from corner points of shape (N, 2, 2, 2, 3)."""
+        """Populates this (empty) surface to represent faces of a set of cells, from corner points of shape (N, 2, 2, 2,
+        3)."""
 
         assert cp.size % 24 == 0
         cp = cp.reshape((-1, 2, 2, 2, 3))
@@ -828,18 +830,19 @@ class Surface(_BaseSurface):
         self.uuid = bu.new_uuid()
 
     def cell_axis_and_polarity_from_triangle_index(self, triangle_index):
-        """For surface freshly built for cell faces, returns (cell_number, face_axis, polarity) for given triangle index.
+        """For surface freshly built for cell faces, returns (cell_number, face_axis, polarity) for given triangle
+        index.
 
-      argument:
-         triangle_index (int or numpy int array): the triangle index (or array of indices) for which cell face
-            information is required
+        argument:
+           triangle_index (int or numpy int array): the triangle index (or array of indices) for which cell face
+              information is required
 
-      returns:
-         triple int: (cell_number, axis, polarity)
+        returns:
+           triple int: (cell_number, axis, polarity)
 
-      note:
-         if the surface was built for a single cell, the returned cell number will be zero
-      """
+        note:
+           if the surface was built for a single cell, the returned cell number will be zero
+        """
 
         triangles_per_face = 4 if self.patch_list[0].quad_triangles else 2
         face_index = triangle_index // triangles_per_face
@@ -848,15 +851,16 @@ class Surface(_BaseSurface):
         return cell_number, axis, polarity
 
     def set_to_horizontal_plane(self, depth, box_xyz, border = 0.0):
-        """Populate this (empty) surface with a patch of two triangles defining a flat, horizontal plane at a given depth.
+        """Populate this (empty) surface with a patch of two triangles defining a flat, horizontal plane at a given
+        depth.
 
-         arguments:
-            depth (float): z value to use in all points in the triangulated patch
-            box_xyz (float[2, 3]): the min, max values of x, y (&z) giving the area to be covered (z ignored)
-            border (float): an optional border width added around the x,y area defined by box_xyz
+           arguments:
+              depth (float): z value to use in all points in the triangulated patch
+              box_xyz (float[2, 3]): the min, max values of x, y (&z) giving the area to be covered (z ignored)
+              border (float): an optional border width added around the x,y area defined by box_xyz
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         tri_patch = TriangulatedPatch(self.model, patch_index = 0, crs_uuid = self.crs_uuid)
         tri_patch.set_to_horizontal_plane(depth, box_xyz, border = border)
@@ -924,7 +928,8 @@ class Surface(_BaseSurface):
         self.set_from_mesh_file(filename, 'rms', quad_triangles = quad_triangles)
 
     def vertical_rescale_points(self, ref_depth = None, scaling_factor = 1.0):
-        """Modify the z values of points for this surface by stretching the distance from reference depth by scaling factor."""
+        """Modify the z values of points for this surface by stretching the distance from reference depth by scaling
+        factor."""
 
         if scaling_factor == 1.0:
             return
@@ -942,8 +947,8 @@ class Surface(_BaseSurface):
     def write_hdf5(self, file_name = None, mode = 'a'):
         """Create or append to an hdf5 file, writing datasets for the triangulated patches after caching arrays.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.uuid is None:
             self.uuid = bu.new_uuid()
@@ -965,23 +970,23 @@ class Surface(_BaseSurface):
                    originator = None):
         """Creates a triangulated surface xml node from this surface object and optionally adds as part of model.
 
-         arguments:
-            ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the surface arrays
-            add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-               in the model
-            add_relationships (boolean, default True): if True, a relationship xml part is created relating the
-               new triangulated representation part to the crs part (and optional interpretation part)
-            crs_uuid (optional): the uuid of the coordinate reference system applicable to the surface points data;
-               if None, the main crs for the model is assumed to apply
-            title (string): used as the citation Title text; should be meaningful to a human
-            originator (string, optional): the name of the human being who created the triangulated representation part;
-               default is to use the login name
+           arguments:
+              ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the surface arrays
+              add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+                 in the model
+              add_relationships (boolean, default True): if True, a relationship xml part is created relating the
+                 new triangulated representation part to the crs part (and optional interpretation part)
+              crs_uuid (optional): the uuid of the coordinate reference system applicable to the surface points data;
+                 if None, the main crs for the model is assumed to apply
+              title (string): used as the citation Title text; should be meaningful to a human
+              originator (string, optional): the name of the human being who created the triangulated representation part;
+                 default is to use the login name
 
-         returns:
-            the newly created triangulated representation (surface) xml node
+           returns:
+              the newly created triangulated representation (surface) xml node
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if ext_uuid is None:
             ext_uuid = self.model.h5_uuid()
@@ -1092,20 +1097,21 @@ class Surface(_BaseSurface):
 
 
 class CombinedSurface:
-    """Class allowing a collection of Surface objects to be treated as a single surface (not a RESQML class in its own right)."""
+    """Class allowing a collection of Surface objects to be treated as a single surface (not a RESQML class in its own
+    right)."""
 
     def __init__(self, surface_list, crs_uuid = None):
         """Initialise a CombinedSurface object from a list of Surface (and/or CombinedSurface) objects.
 
-      arguments:
-         surface_list (list of Surface and/or CombinedSurface objects): the new object is the combination of these surfaces
-         crs_uuid (uuid.UUID, optional): if present, all contributing surfaces must refer to this crs
+        arguments:
+           surface_list (list of Surface and/or CombinedSurface objects): the new object is the combination of these surfaces
+           crs_uuid (uuid.UUID, optional): if present, all contributing surfaces must refer to this crs
 
-      note:
-         all contributing surfaces should be established before initialising this object;
-         all contributing surfaces must refer to the same crs; this class of object is not part of the RESQML
-         standard and cannot be saved in a RESQML dataset - it is a high level derived object class
-      """
+        note:
+           all contributing surfaces should be established before initialising this object;
+           all contributing surfaces must refer to the same crs; this class of object is not part of the RESQML
+           standard and cannot be saved in a RESQML dataset - it is a high level derived object class
+        """
 
         assert len(surface_list) > 0
         self.surface_list = surface_list
@@ -1130,7 +1136,8 @@ class CombinedSurface:
             self.points_count_list.append(len(p))
 
     def surface_index_for_triangle_index(self, tri_index):
-        """For a triangle index in the combined surface, returns the index of the surface containing rhe triangle and local triangle index."""
+        """For a triangle index in the combined surface, returns the index of the surface containing rhe triangle and
+        local triangle index."""
 
         for s_i in range(len(self.surface_list)):
             if tri_index < self.triangle_count_list[s_i]:
@@ -1178,39 +1185,39 @@ class PointSet(_BaseSurface):
                  extra_metadata = None):
         """Creates an empty Point Set object and optionally populates from xml or other source.
 
-      arguments:
-         parent_model (model.Model object): the model to which the new point set belongs
-         point_set_root (xml node, optional): DEPRECATED, use uuid instead;
-            if present, the new point set is created based on the xml
-         uuid (uuid.UUID, optional): if present, the object is populated from the RESQML PointSetRepresentation
-            with this uuid
-         load_hdf5 (boolean, default False): if True and point_set_root is present, the actual points are
-            pre-loaded into a numpy array; otherwise the points will be loaded on demand
-         points_array (numpy float array of shape (..., 2 or 3), optional): if present, the xy(&z) data which
-            will constitute the point set; missing z will be set to zero; ignored if point_set_root is not None
-         crs_uuid (uuid.UUID, optional): if present, identifies the coordinate reference system for the points;
-            ignored if point_set_root is not None; if None, 'imported' points will be associated with the
-            default crs of the parent model
-         polyset (optional): if present, creates a pointset from points in a polylineset
-         polyline (optional): if present and random_point_count is None or zero, creates a pointset from
-            points in a polyline; if present and random_point_count is set, creates random points within
-            the (closed, convex) polyline
-         random_point_count (int, optional): if present and polyline is present then the number of random
-            points to generate within the (closed) polyline in the xy plane, with z set to 0.0
-         charisma_file (optional): if present, creates a pointset from a charisma 3d interpretation file
-         irap_file (optional): if present, creates a pointset from an IRAP classic points format file
-         title (str, optional): the citation title to use for a new point set;
-            ignored if uuid or point_set_root is not None
-         originator (str, optional): the name of the person creating the point set, defaults to login id;
-            ignored if uuid or point_set_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the point set;
-            ignored if uuid or point_set_root is not None
+        arguments:
+           parent_model (model.Model object): the model to which the new point set belongs
+           point_set_root (xml node, optional): DEPRECATED, use uuid instead;
+              if present, the new point set is created based on the xml
+           uuid (uuid.UUID, optional): if present, the object is populated from the RESQML PointSetRepresentation
+              with this uuid
+           load_hdf5 (boolean, default False): if True and point_set_root is present, the actual points are
+              pre-loaded into a numpy array; otherwise the points will be loaded on demand
+           points_array (numpy float array of shape (..., 2 or 3), optional): if present, the xy(&z) data which
+              will constitute the point set; missing z will be set to zero; ignored if point_set_root is not None
+           crs_uuid (uuid.UUID, optional): if present, identifies the coordinate reference system for the points;
+              ignored if point_set_root is not None; if None, 'imported' points will be associated with the
+              default crs of the parent model
+           polyset (optional): if present, creates a pointset from points in a polylineset
+           polyline (optional): if present and random_point_count is None or zero, creates a pointset from
+              points in a polyline; if present and random_point_count is set, creates random points within
+              the (closed, convex) polyline
+           random_point_count (int, optional): if present and polyline is present then the number of random
+              points to generate within the (closed) polyline in the xy plane, with z set to 0.0
+           charisma_file (optional): if present, creates a pointset from a charisma 3d interpretation file
+           irap_file (optional): if present, creates a pointset from an IRAP classic points format file
+           title (str, optional): the citation title to use for a new point set;
+              ignored if uuid or point_set_root is not None
+           originator (str, optional): the name of the person creating the point set, defaults to login id;
+              ignored if uuid or point_set_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the point set;
+              ignored if uuid or point_set_root is not None
 
-      returns:
-         newly created PointSet object
+        returns:
+           newly created PointSet object
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         self.crs_uuid = crs_uuid
         self.patch_count = None
@@ -1379,8 +1386,8 @@ class PointSet(_BaseSurface):
     def full_array_ref(self):
         """Return a single numpy float array of shape (N, 3) containing all points from all patches.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.full_array is not None:
             return self.full_array
@@ -1420,8 +1427,8 @@ class PointSet(_BaseSurface):
     def write_hdf5(self, file_name = None, mode = 'a'):
         """Create or append to an hdf5 file, writing datasets for the point set patches after caching arrays.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if not file_name:
             file_name = self.model.h5_file_name()
@@ -1443,23 +1450,23 @@ class PointSet(_BaseSurface):
                    originator = None):
         """Creates a point set representation xml node from this point set object and optionally adds as part of model.
 
-         arguments:
-            ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the points array(s)
-            add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-               in the model
-            add_relationships (boolean, default True): if True, a relationship xml part is created relating the
-               new point set part to the crs part (and optional interpretation part)
-            root (optional, usually None): if not None, the newly created point set representation node is appended
-               as a child to this node
-            title (string): used as the citation Title text; should be meaningful to a human
-            originator (string, optional): the name of the human being who created the point set representation part;
-               default is to use the login name
+           arguments:
+              ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the points array(s)
+              add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+                 in the model
+              add_relationships (boolean, default True): if True, a relationship xml part is created relating the
+                 new point set part to the crs part (and optional interpretation part)
+              root (optional, usually None): if not None, the newly created point set representation node is appended
+                 as a child to this node
+              title (string): used as the citation Title text; should be meaningful to a human
+              originator (string, optional): the name of the human being who created the point set representation part;
+                 default is to use the login name
 
-         returns:
-            the newly created point set representation xml node
+           returns:
+              the newly created point set representation xml node
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if ext_uuid is None:
             ext_uuid = self.model.h5_uuid()
@@ -1533,13 +1540,13 @@ class PointSet(_BaseSurface):
         return ps_node
 
     def convert_to_charisma(self, file_name):
-        """Output to Charisma 3D interepretation format from a pointset
+        """Output to Charisma 3D interepretation format from a pointset.
 
-      If file_name exists, it will be overwritten.
+        If file_name exists, it will be overwritten.
 
-      args:
-          file_name: output file name to save to
-      """
+        args:
+            file_name: output file name to save to
+        """
         #      hznname = self.title.replace(" ","_")
         lines = []
         self.load_all_patches()
@@ -1551,13 +1558,13 @@ class PointSet(_BaseSurface):
                 f.write(item)
 
     def convert_to_irap(self, file_name):
-        """Output to IRAP simple points format from a pointset
+        """Output to IRAP simple points format from a pointset.
 
-      If file_name exists, it will be overwritten.
+        If file_name exists, it will be overwritten.
 
-      args:
-          file_name: output file name to save to
-      """
+        args:
+            file_name: output file name to save to
+        """
         #      hznname = self.title.replace(" ","_")
         lines = []
         self.load_all_patches()
@@ -1595,57 +1602,57 @@ class Mesh(_BaseSurface):
                  extra_metadata = None):
         """Initialises a Mesh object from xml, or a regular mesh from arguments.
 
-      arguments:
-         parent_model (model.Model object): the model to which this Mesh object will be associated
-         root_node (optional): DEPRECATED, use uuid instead; the root node for an obj_Grid2dRepresentation part;
-            remaining arguments are ignored if uuid or root_node is not None
-         uuid (uuid.UUID, optional): the uuid of an existing RESQML obj_Grid2dRepresentation object from which
-            this resqpy Mesh object is populated
-         mesh_file (string, optional): file name, required if initialising from an RMS text or zmap+ ascii file
-         mesh_format (string, optional): 'rms' or 'zmap', required if initialising from an ascii file
-         mesh_flavour (string, default 'explicit'): required flavour when reading from a mesh file; one of:
-            'explicit', 'regular' (z values discarded), 'reg&z', 'ref&z'
-         xyz_values (numpy int array of shape (nj, ni, 3), optional): can be used to create an explicit
-            mesh directly from the full array of points
-         nj (int, optional): when generating a regular or 'ref&z' mesh, the number of nodes (NB. not 'cells')
-            in the j axis of the regular mesh
-         ni (int, optional): the number of nodes in the i axis of the regular or ref&z mesh
-         origin (triple float, optional): the xyz origin of the regular mesh; use z value of zero if irrelevant
-         dxyz_dij (numpy float array of shape (2, 3), optional): the xyz increment for each step in i and j axes;
-            use z increments of zero if not applicable; eg. [[50.0, 0.0, 0.0], [0.0, 50.0, 0.0]] for mesh with
-            50 (m or ft) spacing where the I axis aligns with x axis and the J axis aligns with y axis; first of
-            the two triplets relates to the I axis
-         z_values (numpy int array of shape (nj, ni), optional): z values used when creating a ref&z flavour
-            mesh; z_supporting_mesh_uuid must also be supplied
-         z_supporting_mesh_uuid (uuid.UUID, optional): used to specify the supporting mesh when creating a
-            ref&z or reg&z flavour mesh; z_values must also be supplied
-         surface_role (string, default 'map'): 'map' or 'pick'; ignored if root_node is not None
-         crs_uuid (uuid.Uuid or string, optional): required if generating a regular mesh, the uuid of the crs
-         title (str, optional): the citation title to use for a new mesh;
-            ignored if uuid or root_node is not None
-         originator (str, optional): the name of the person creating the mesh, defaults to login id;
-            ignored if uuid or root_node is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the mesh;
-            ignored if uuid or root_node is not None
+        arguments:
+           parent_model (model.Model object): the model to which this Mesh object will be associated
+           root_node (optional): DEPRECATED, use uuid instead; the root node for an obj_Grid2dRepresentation part;
+              remaining arguments are ignored if uuid or root_node is not None
+           uuid (uuid.UUID, optional): the uuid of an existing RESQML obj_Grid2dRepresentation object from which
+              this resqpy Mesh object is populated
+           mesh_file (string, optional): file name, required if initialising from an RMS text or zmap+ ascii file
+           mesh_format (string, optional): 'rms' or 'zmap', required if initialising from an ascii file
+           mesh_flavour (string, default 'explicit'): required flavour when reading from a mesh file; one of:
+              'explicit', 'regular' (z values discarded), 'reg&z', 'ref&z'
+           xyz_values (numpy int array of shape (nj, ni, 3), optional): can be used to create an explicit
+              mesh directly from the full array of points
+           nj (int, optional): when generating a regular or 'ref&z' mesh, the number of nodes (NB. not 'cells')
+              in the j axis of the regular mesh
+           ni (int, optional): the number of nodes in the i axis of the regular or ref&z mesh
+           origin (triple float, optional): the xyz origin of the regular mesh; use z value of zero if irrelevant
+           dxyz_dij (numpy float array of shape (2, 3), optional): the xyz increment for each step in i and j axes;
+              use z increments of zero if not applicable; eg. [[50.0, 0.0, 0.0], [0.0, 50.0, 0.0]] for mesh with
+              50 (m or ft) spacing where the I axis aligns with x axis and the J axis aligns with y axis; first of
+              the two triplets relates to the I axis
+           z_values (numpy int array of shape (nj, ni), optional): z values used when creating a ref&z flavour
+              mesh; z_supporting_mesh_uuid must also be supplied
+           z_supporting_mesh_uuid (uuid.UUID, optional): used to specify the supporting mesh when creating a
+              ref&z or reg&z flavour mesh; z_values must also be supplied
+           surface_role (string, default 'map'): 'map' or 'pick'; ignored if root_node is not None
+           crs_uuid (uuid.Uuid or string, optional): required if generating a regular mesh, the uuid of the crs
+           title (str, optional): the citation title to use for a new mesh;
+              ignored if uuid or root_node is not None
+           originator (str, optional): the name of the person creating the mesh, defaults to login id;
+              ignored if uuid or root_node is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the mesh;
+              ignored if uuid or root_node is not None
 
-      returns:
-         the newly created Mesh object
+        returns:
+           the newly created Mesh object
 
-      notes:
-         a mesh is a set of x,y,z (or x,y) points organised into a 2D lattice indexed by j,i; the z values are
-         sometimes not applicable and then can be set to zero; 3 flavours of mesh are supported (the RESQML
-         standard might allow for others): regular, where a constant xyz delta is applied with each step in i
-         and j, starting from an origin, to yield a planar surface; explicit, where the full xyz (or xy) data
-         is held as an array; 'ref & z', where another mesh is referred to for xy data, and z values are held
-         in an array;
-         there are 5 ways to initialise a Mesh object, in order of precedence:
-         1. pass root_node to initialise from xml
-         2. pass mesh_file, mesh_format and crs_uuid to load an explicit mesh from an ascii file
-         3. pass xyz_values and crs_uuid to create an explicit mesh from a numpy array
-         4. pass nj, ni, origin, dxyz_dij and crs_uuid to initialise a regular mesh directly
-         5. pass z_values, z_supporting_mesh_uuid and crs_uuid to initialise a 'ref & z' mesh
-         6. leave all optional arguments as None for an empty Mesh object
-      """
+        notes:
+           a mesh is a set of x,y,z (or x,y) points organised into a 2D lattice indexed by j,i; the z values are
+           sometimes not applicable and then can be set to zero; 3 flavours of mesh are supported (the RESQML
+           standard might allow for others): regular, where a constant xyz delta is applied with each step in i
+           and j, starting from an origin, to yield a planar surface; explicit, where the full xyz (or xy) data
+           is held as an array; 'ref & z', where another mesh is referred to for xy data, and z values are held
+           in an array;
+           there are 5 ways to initialise a Mesh object, in order of precedence:
+           1. pass root_node to initialise from xml
+           2. pass mesh_file, mesh_format and crs_uuid to load an explicit mesh from an ascii file
+           3. pass xyz_values and crs_uuid to create an explicit mesh from a numpy array
+           4. pass nj, ni, origin, dxyz_dij and crs_uuid to initialise a regular mesh directly
+           5. pass z_values, z_supporting_mesh_uuid and crs_uuid to initialise a 'ref & z' mesh
+           6. leave all optional arguments as None for an empty Mesh object
+        """
 
         assert surface_role in ['map', 'pick']
 
@@ -1892,9 +1899,9 @@ class Mesh(_BaseSurface):
     def full_array_ref(self):
         """Populates a full 2D(+1) numpy array of shape (nj, ni, 3) with xyz values, caches and returns.
 
-      note:
-         z values may be zero or not applicable when using the mesh as support for properties.
-      """
+        note:
+           z values may be zero or not applicable when using the mesh as support for properties.
+        """
 
         if self.full_array is not None:
             return self.full_array
@@ -1997,25 +2004,25 @@ class Mesh(_BaseSurface):
                    originator = None):
         """Creates a grid 2d representation xml node from this mesh object and optionally adds as part of model.
 
-         arguments:
-            ext_uuid (uuid.UUID, optional): the uuid of the hdf5 external part holding the mesh array
-            crs_root (DEPRECATED): ignored, crs must now be established at time of initialisation
-            use_xy_only (boolean, default False): if True and the flavour of this mesh is explicit, only
-               the xy coordinates are stored in the hdf5 dataset, otherwise xyz are stored
-            add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-               in the model
-            add_relationships (boolean, default True): if True, a relationship xml part is created relating the
-               new grid 2d part to the crs part (and optional interpretation part), and to the represented
-               interpretation if present
-            root (optional, usually None): if not None, the newly created grid 2d representation node is appended
-               as a child to this node
-            title (string, optional): used as the citation Title text; should be meaningful to a human
-            originator (string, optional): the name of the human being who created the grid 2d representation part;
-               default is to use the login name
+        arguments:
+           ext_uuid (uuid.UUID, optional): the uuid of the hdf5 external part holding the mesh array
+           crs_root (DEPRECATED): ignored, crs must now be established at time of initialisation
+           use_xy_only (boolean, default False): if True and the flavour of this mesh is explicit, only
+              the xy coordinates are stored in the hdf5 dataset, otherwise xyz are stored
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in the model
+           add_relationships (boolean, default True): if True, a relationship xml part is created relating the
+              new grid 2d part to the crs part (and optional interpretation part), and to the represented
+              interpretation if present
+           root (optional, usually None): if not None, the newly created grid 2d representation node is appended
+              as a child to this node
+           title (string, optional): used as the citation Title text; should be meaningful to a human
+           originator (string, optional): the name of the human being who created the grid 2d representation part;
+              default is to use the login name
 
-         returns:
-            the newly created grid 2d representation (mesh) xml node
-      """
+        returns:
+           the newly created grid 2d representation (mesh) xml node
+        """
 
         if crs_root is not None:
             warnings.warn('crs_root argument is deprecated and ignored in Mesh.create_xml()')

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -83,13 +83,13 @@ class TimeDuration:
 class AnyTimeSeries(BaseResqpy):
     """Abstract class for a RESQML Time Series; use resqpy TimeSeries or GeologicTimeSeries.
 
-   notes:
-      this class has no direct initialisation method;
-      call the any_time_series() function to generate the appropriate derived class object for a given uuid;
-      the resqpy code differentiates between time series on a human timeframe, where the timestamps are
-      used without a year offset, and those on a geologic timeframe, where the timestamps are ignored and
-      only the year offset is significant
-   """
+    notes:
+       this class has no direct initialisation method;
+       call the any_time_series() function to generate the appropriate derived class object for a given uuid;
+       the resqpy code differentiates between time series on a human timeframe, where the timestamps are
+       used without a year offset, and those on a geologic timeframe, where the timestamps are ignored and
+       only the year offset is significant
+    """
 
     resqml_type = 'TimeSeries'
 
@@ -133,29 +133,29 @@ class AnyTimeSeries(BaseResqpy):
     def number_of_timestamps(self):
         """Returns the number of timestamps in the series.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return len(self.timestamps)
 
     def timestamp(self, index, as_string = True):
         """Returns an individual timestamp, indexed by its position in the series.
 
-      arguments:
-         index (int): the time index for which the timestamp is required
-         as_string (boolean, default True): if True and this is series is on a geologic timeframe, the return
-            value is a string, otherwise an int; for human timeframe series, this argument has no effect
+        arguments:
+           index (int): the time index for which the timestamp is required
+           as_string (boolean, default True): if True and this is series is on a geologic timeframe, the return
+              value is a string, otherwise an int; for human timeframe series, this argument has no effect
 
-      returns:
-         string or int being the selected timestamp
+        returns:
+           string or int being the selected timestamp
 
-      notes:
-         index may be negative in which case it is taken to be relative to the end of the series
-         with the last timestamp being referenced by an index of -1;
-         the string form of a geologic timestamp is a positive number in millions of years,
-         with the suffix Ma
+        notes:
+           index may be negative in which case it is taken to be relative to the end of the series
+           with the last timestamp being referenced by an index of -1;
+           the string form of a geologic timestamp is a positive number in millions of years,
+           with the suffix Ma
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # individual timestamp is in iso format with a Z appended, eg: 2019-08-23T14:30:00Z
         if not -len(self.timestamps) <= index < len(self.timestamps):
@@ -168,27 +168,27 @@ class AnyTimeSeries(BaseResqpy):
     def iter_timestamps(self, as_string = True):
         """Iterator over timestamps.
 
-      :meta common:
-      """
+        :meta common:
+        """
         for index in len(self.timestamps):
             yield self.timestamp(index, as_string = as_string)
 
     def last_timestamp(self, as_string = True):
         """Returns the last timestamp in the series.
 
-      :meta common:
-      """
+        :meta common:
+        """
         return self.timestamp(-1, as_string = as_string) if self.timestamps else None
 
     def index_for_timestamp(self, timestamp):
         """Returns the index for a given timestamp.
 
-      note:
-         this method uses a simplistic string or int comparison;
-         if the timestamp is not found, None is returned
+        note:
+           this method uses a simplistic string or int comparison;
+           if the timestamp is not found, None is returned
 
-      :meta common:
-      """
+        :meta common:
+        """
         as_string = not isinstance(timestamp, int)
         for index in range(len(self.timestamps)):
             if self.timestamp(index, as_string = as_string) == timestamp:
@@ -198,18 +198,18 @@ class AnyTimeSeries(BaseResqpy):
     def create_xml(self, add_as_part = True, title = None, originator = None, reuse = True):
         """Create a RESQML time series xml node from a TimeSeries or GeologicTimeSeries object, optionally add as part.
 
-      arguments:
-         add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-            in the model
-         title (string): used as the citation Title text for the new time series node
-         originator (string, optional): the name of the human being who created the time series object;
-            default is to use the login name
+        arguments:
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in the model
+           title (string): used as the citation Title text for the new time series node
+           originator (string, optional): the name of the human being who created the time series object;
+              default is to use the login name
 
-      returns:
-         the newly created time series xml node
+        returns:
+           the newly created time series xml node
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if reuse and self.try_reuse():
             return self.root  # check for reusable (equivalent) object
@@ -243,22 +243,22 @@ class AnyTimeSeries(BaseResqpy):
     def create_time_index(self, time_index, root = None, check_valid_index = True):
         """Create a time index node, including time series reference, optionally add to root.
 
-      arguments:
-         time_index (int): non-negative integer index into the time series, identifying the datetime
-            being referenced by the new node
-         root (optional): if present, the newly created time index xml node is added
-            as a child to this node
-         check_valid_index (boolean, default True): if True, an assertion error is raised
-            if the time index is out of range for this time series
+        arguments:
+           time_index (int): non-negative integer index into the time series, identifying the datetime
+              being referenced by the new node
+           root (optional): if present, the newly created time index xml node is added
+              as a child to this node
+           check_valid_index (boolean, default True): if True, an assertion error is raised
+              if the time index is out of range for this time series
 
-      returns:
-         the newly created time index xml node
+        returns:
+           the newly created time index xml node
 
-      note:
-         a time index node is typically part of a recurrent property object; it identifies
-         the datetime relevant to the property array (or other data) by indexing into a time series
-         object
-      """
+        note:
+           a time index node is typically part of a recurrent property object; it identifies
+           the datetime relevant to the property array (or other data) by indexing into a time series
+           object
+        """
 
         assert self.uuid is not None
         if check_valid_index:
@@ -282,10 +282,10 @@ class AnyTimeSeries(BaseResqpy):
 class TimeSeries(AnyTimeSeries):
     """Class for RESQML Time Series without year offsets.
 
-   notes:
-      use this class for time series on a human timeframe; use the resqpy GeologicTimeSeries class
-      instead if the time series is on a geological timeframe
-   """
+    notes:
+       use this class for time series on a human timeframe; use the resqpy GeologicTimeSeries class
+       instead if the time series is on a geological timeframe
+    """
 
     def __init__(self,
                  parent_model,
@@ -301,35 +301,35 @@ class TimeSeries(AnyTimeSeries):
                  extra_metadata = None):
         """Create a TimeSeries object, either from a time series node in parent model, or from given data.
 
-      arguments:
-         parent_model (model.Model): the resqpy model to which the time series will belong
-         uuid (uuid.UUID, optional): the uuid of a TimeSeries object to be loaded from xml
-         time_series_root (xml node, DEPRECATED): the xml root node; use uuid instead
-         first_time_stamp (str, optional): the first timestamp (in RESQML format) if not loading from xml;
-            this and the remaining arguments are ignored if loading from xml
-         daily (non-negative int, optional): the number of one day interval timesteps to start the series
-         monthly (non-negative int, optional): the number of 30 day interval timesteps to follow the daily
-            timesteps
-         quarterly (non-negative int, optional): the number of 90 day interval timesteps to follow the
-            monthly timesteps
-         yearly (non-negative int, optional): the number of 365 day interval timesteps to follow the
-            quarterly timesteps
-         title (str, optional): the citation title to use for a new time series;
-            ignored if uuid or time_series_root is not None
-         originator (str, optional): the name of the person creating the time series, defaults to login id;
-            ignored if uuid or time_series_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the time series;
-            ignored if uuid or time_series_root is not None
+        arguments:
+           parent_model (model.Model): the resqpy model to which the time series will belong
+           uuid (uuid.UUID, optional): the uuid of a TimeSeries object to be loaded from xml
+           time_series_root (xml node, DEPRECATED): the xml root node; use uuid instead
+           first_time_stamp (str, optional): the first timestamp (in RESQML format) if not loading from xml;
+              this and the remaining arguments are ignored if loading from xml
+           daily (non-negative int, optional): the number of one day interval timesteps to start the series
+           monthly (non-negative int, optional): the number of 30 day interval timesteps to follow the daily
+              timesteps
+           quarterly (non-negative int, optional): the number of 90 day interval timesteps to follow the
+              monthly timesteps
+           yearly (non-negative int, optional): the number of 365 day interval timesteps to follow the
+              quarterly timesteps
+           title (str, optional): the citation title to use for a new time series;
+              ignored if uuid or time_series_root is not None
+           originator (str, optional): the name of the person creating the time series, defaults to login id;
+              ignored if uuid or time_series_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the time series;
+              ignored if uuid or time_series_root is not None
 
-      returns:
-         newly instantiated TimeSeries object
+        returns:
+           newly instantiated TimeSeries object
 
-      note:
-         a new bespoke time series can be populated by passing the first timestamp here and using the
-         add_timestamp() and/or extend_by...() methods
+        note:
+           a new bespoke time series can be populated by passing the first timestamp here and using the
+           add_timestamp() and/or extend_by...() methods
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         self.timeframe = 'human'
         self.timestamps = []  # ordered list of timestamp strings in resqml/iso format
@@ -373,8 +373,8 @@ class TimeSeries(AnyTimeSeries):
     def index_for_timestamp_not_later_than(self, timestamp):
         """Returns the index of the latest timestamp that is not later than the specified date.
 
-      :meta common:
-      """
+        :meta common:
+        """
         index = len(self.timestamps) - 1
         while (index >= 0) and (self.timestamps[index] > timestamp):
             index -= 1
@@ -385,8 +385,8 @@ class TimeSeries(AnyTimeSeries):
     def index_for_timestamp_not_earlier_than(self, timestamp):
         """Returns the index of the earliest timestamp that is not earlier than the specified date.
 
-      :meta common:
-      """
+        :meta common:
+        """
         index = 0
         while (index < len(self.timestamps)) and (self.timestamps[index] < timestamp):
             index += 1
@@ -397,8 +397,8 @@ class TimeSeries(AnyTimeSeries):
     def index_for_timestamp_closest_to(self, timestamp):
         """Returns the index of the timestamp that is closest to the specified date.
 
-      :meta common:
-      """
+        :meta common:
+        """
         if not self.timestamps:
             return None
         before = self.index_for_timestamp_not_later_than(self, timestamp)
@@ -414,8 +414,8 @@ class TimeSeries(AnyTimeSeries):
     def duration_between_timestamps(self, earlier_index, later_index):
         """Returns the duration between a pair of timestamps.
 
-      :meta common:
-      """
+        :meta common:
+        """
         if earlier_index < 0 or later_index >= len(self.timestamps) or later_index < earlier_index:
             return None
         return TimeDuration(earlier_timestamp = self.timestamps[earlier_index],
@@ -431,8 +431,8 @@ class TimeSeries(AnyTimeSeries):
     def duration_since_start(self, index):
         """Returns the duration between the start of the time series and the indexed timestamp.
 
-      :meta common:
-      """
+        :meta common:
+        """
         if index < 0 or index >= len(self.timestamps):
             return None
         return self.duration_between_timestamps(0, index)
@@ -444,8 +444,8 @@ class TimeSeries(AnyTimeSeries):
     def step_duration(self, index):
         """Returns the duration of the time step between the indexed timestamp and preceeding one.
 
-      :meta common:
-      """
+        :meta common:
+        """
         if index < 1 or index >= len(self.timestamps):
             return None
         return self.duration_between_timestamps(index - 1, index)
@@ -493,7 +493,10 @@ class TimeSeries(AnyTimeSeries):
 
     @property
     def time_series_root(self):
-        """DEPRECATED. Alias for root"""
+        """DEPRECATED.
+
+        Alias for root
+        """
         warnings.warn("Attribute 'time_series_root' is deprecated. Use 'root'", DeprecationWarning)
         return self.root
 
@@ -510,25 +513,25 @@ class GeologicTimeSeries(AnyTimeSeries):
                  extra_metadata = None):
         """Create a GeologicTimeSeries object, either from a time series node in parent model, or empty.
 
-      arguments:
-         parent_model (model.Model): the resqpy model to which the time series will belong
-         uuid (uuid.UUID, optional): the uuid of a TimeSeries object to be loaded from xml
-         title (str, optional): the citation title to use for a new time series;
-            ignored if uuid or time_series_root is not None
-         originator (str, optional): the name of the person creating the time series, defaults to login id;
-            ignored if uuid or time_series_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the time series;
-            ignored if uuid or time_series_root is not None
+        arguments:
+           parent_model (model.Model): the resqpy model to which the time series will belong
+           uuid (uuid.UUID, optional): the uuid of a TimeSeries object to be loaded from xml
+           title (str, optional): the citation title to use for a new time series;
+              ignored if uuid or time_series_root is not None
+           originator (str, optional): the name of the person creating the time series, defaults to login id;
+              ignored if uuid or time_series_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the time series;
+              ignored if uuid or time_series_root is not None
 
-      returns:
-         newly instantiated GeologicTimeSeries object
+        returns:
+           newly instantiated GeologicTimeSeries object
 
-      note:
-         if instantiating from an existing RESQML time series, its Time entries must all have YearOffset data
-         which should be large negative integers
+        note:
+           if instantiating from an existing RESQML time series, its Time entries must all have YearOffset data
+           which should be large negative integers
 
-      :meta common:
-      """
+        :meta common:
+        """
         self.timeframe = 'geologic'
         self.timestamps = []  # ordered list of (large negative) ints being year offsets from present
         super().__init__(model = parent_model,
@@ -544,12 +547,12 @@ class GeologicTimeSeries(AnyTimeSeries):
     def from_year_list(cls, parent_model, year_list, title = None, originator = None, extra_metadata = {}):
         """Creates a new GeologicTimeSeries from a list of large integers representing years before present.
 
-      note:
-         the years will be converted to negative numbers if positive, and sorted from oldest (most negative)
-         to youngest (least negative)
+        note:
+           the years will be converted to negative numbers if positive, and sorted from oldest (most negative)
+           to youngest (least negative)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert isinstance(year_list, list) and len(year_list) > 0
         negative_list = []
@@ -576,7 +579,8 @@ class GeologicTimeSeries(AnyTimeSeries):
 
 
 def selected_time_series(full_series, indices_list, title = None):
-    """Returns a new TimeSeries or GeologicTimeSeries object with timestamps selected from the full series by a list of indices."""
+    """Returns a new TimeSeries or GeologicTimeSeries object with timestamps selected from the full series by a list of
+    indices."""
 
     if isinstance(full_series, TimeSeries):
         selected_ts = TimeSeries(full_series.model, title = title)
@@ -616,10 +620,10 @@ def cleaned_timestamp(timestamp):
 def time_series_from_list(timestamp_list, parent_model = None, title = None):
     """Create a TimeSeries object from a list of timestamps (model and node set to None).
 
-   note:
-      timestamps in the list should be in the correct string format for human timeframe series,
-      or large negative integers for geologic timeframe series
-   """
+    note:
+       timestamps in the list should be in the correct string format for human timeframe series,
+       or large negative integers for geologic timeframe series
+    """
 
     assert (len(timestamp_list) > 0)
     sorted_timestamps = sorted(timestamp_list)
@@ -639,7 +643,12 @@ def time_series_from_list(timestamp_list, parent_model = None, title = None):
 
 
 def merge_timeseries_from_uuid(model, timeseries_uuid_iter):
-    """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries. iterable can be a list, array, or iteratable generator (model must be provided). The new timeseries is sorted in ascending order. Returns the new time series, the new time series uuid, and the list of timeseries objects used to generate the list"""
+    """Create a TimeSeries object from an iteratable object of existing timeseries UUIDs of timeseries.
+
+    iterable can be a list, array, or iteratable generator (model must be provided). The new timeseries is sorted in
+    ascending order. Returns the new time series, the new time series uuid, and the list of timeseries objects used to
+    generate the list
+    """
 
     reverse = False
 

--- a/resqpy/unstructured.py
+++ b/resqpy/unstructured.py
@@ -48,36 +48,36 @@ class UnstructuredGrid(BaseResqpy):
                  extra_metadata = {}):
         """Create an Unstructured Grid object and optionally populate from xml tree.
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
-         find_properties (boolean, default True): if True and uuid is present, a
-            grid property collection is instantiated as an attribute, holding properties for which
-            this grid is the supporting representation
-         geometry_required (boolean, default True): if True and no geometry node exists in the xml,
-            an assertion error is raised; ignored if uuid is None
-         cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
-            are loaded into attributes of the new grid object
-         cell_shape (str, optional): one of 'polyhedral', 'tetrahedral', 'pyramidal', 'prism', 'hexahedral';
-            ignored if uuid is present
-         title (str, optional): citation title for new grid; ignored if uuid is present
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if uuid is present
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if uuid is present
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
+           find_properties (boolean, default True): if True and uuid is present, a
+              grid property collection is instantiated as an attribute, holding properties for which
+              this grid is the supporting representation
+           geometry_required (boolean, default True): if True and no geometry node exists in the xml,
+              an assertion error is raised; ignored if uuid is None
+           cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
+              are loaded into attributes of the new grid object
+           cell_shape (str, optional): one of 'polyhedral', 'tetrahedral', 'pyramidal', 'prism', 'hexahedral';
+              ignored if uuid is present
+           title (str, optional): citation title for new grid; ignored if uuid is present
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if uuid is present
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if uuid is present
 
-      returns:
-         a newly created Unstructured Grid object
+        returns:
+           a newly created Unstructured Grid object
 
-      notes:
-         if not instantiating from an existing RESQML object, then pass a cell_shape here (if geometry is
-         going to be used), then set the cell count and, for geometry, build the points array and other
-         arrays before writing to the hdf5 file and creating the xml;
-         hinge node faces and subnode topology not yet supported at all;
-         setting cache_geometry True is equivalent to calling the cache_all_geometry_arrays() method
+        notes:
+           if not instantiating from an existing RESQML object, then pass a cell_shape here (if geometry is
+           going to be used), then set the cell count and, for geometry, build the points array and other
+           arrays before writing to the hdf5 file and creating the xml;
+           hinge node faces and subnode topology not yet supported at all;
+           setting cache_geometry True is equivalent to calling the cache_all_geometry_arrays() method
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if cell_shape is not None:
             assert cell_shape in valid_cell_shapes, f'invalid cell shape {cell_shape} for unstructured grid'
@@ -143,12 +143,12 @@ class UnstructuredGrid(BaseResqpy):
     def set_cell_count(self, n: int):
         """Set the number of cells in the grid.
 
-      arguments:
-         n (int): the number of cells in the unstructured grid
+        arguments:
+           n (int): the number of cells in the unstructured grid
 
-      note:
-         only call this method when creating a new grid, not when working from an existing RESQML grid
-      """
+        note:
+           only call this method when creating a new grid, not when working from an existing RESQML grid
+        """
         assert self.cell_count is None or self.cell_count == n
         self.cell_count = n
 
@@ -161,17 +161,17 @@ class UnstructuredGrid(BaseResqpy):
     def cache_all_geometry_arrays(self):
         """Loads from hdf5 into memory all the arrays defining the grid geometry.
 
-      returns:
-         None
+        returns:
+           None
 
-      notes:
-         call this method if much grid geometry processing is coming up;
-         the arrays are cached as direct attributes to this grid object;
-         the node and face indices make use of 'jagged' arrays (effectively an array of lists represented as
-         a linear array and a 'cumulative length' index array)
+        notes:
+           call this method if much grid geometry processing is coming up;
+           the arrays are cached as direct attributes to this grid object;
+           the node and face indices make use of 'jagged' arrays (effectively an array of lists represented as
+           a linear array and a 'cumulative length' index array)
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert self.node_count is not None and self.face_count is not None
 
@@ -223,9 +223,9 @@ class UnstructuredGrid(BaseResqpy):
     def extract_crs_uuid(self):
         """Returns uuid for coordinate reference system, as stored in geometry xml tree.
 
-      returns:
-         uuid.UUID object
-      """
+        returns:
+           uuid.UUID object
+        """
 
         if self.crs_uuid is not None:
             return self.crs_uuid
@@ -240,14 +240,14 @@ class UnstructuredGrid(BaseResqpy):
     def extract_inactive_mask(self):
         """Returns boolean numpy array indicating which cells are inactive, if (in)active property found for this grid.
 
-      returns:
-         numpy array of booleans, of shape (cell_count,) being True for cells which are inactive; False for active
+        returns:
+           numpy array of booleans, of shape (cell_count,) being True for cells which are inactive; False for active
 
-      note:
-         RESQML does not have a built-in concept of inactive (dead) cells, though the usage guide advises to use a
-         discrete property with a local property kind of 'active'; this resqpy code can maintain an 'inactive'
-         attribute for the grid object, which is a boolean numpy array indicating which cells are inactive
-      """
+        note:
+           RESQML does not have a built-in concept of inactive (dead) cells, though the usage guide advises to use a
+           discrete property with a local property kind of 'active'; this resqpy code can maintain an 'inactive'
+           attribute for the grid object, which is a boolean numpy array indicating which cells are inactive
+        """
 
         if self.inactive is not None:
             return self.inactive
@@ -276,14 +276,14 @@ class UnstructuredGrid(BaseResqpy):
     def extract_property_collection(self):
         """Load grid property collection object holding lists of all properties in model that relate to this grid.
 
-      returns:
-         resqml_property.PropertyCollection object
+        returns:
+           resqml_property.PropertyCollection object
 
-      note:
-         a reference to the grid property collection is cached in this grid object; if the properties change,
-         for example by generating some new properties, the property_collection attribute of the grid object
-         would need to be reset to None elsewhere before calling this method again
-      """
+        note:
+           a reference to the grid property collection is cached in this grid object; if the properties change,
+           for example by generating some new properties, the property_collection attribute of the grid object
+           would need to be reset to None elsewhere before calling this method again
+        """
 
         if self.property_collection is not None:
             return self.property_collection
@@ -293,14 +293,14 @@ class UnstructuredGrid(BaseResqpy):
     def set_cells_per_face(self, check_all_faces_used = True):
         """Sets and returns the cells_per_face array showing which cells are using each face.
 
-      arguments:
-         check_all_faces_used (boolean, default True): if True, an assertion error is raised if there are any
-            faces which do not appear in any cells
+        arguments:
+           check_all_faces_used (boolean, default True): if True, an assertion error is raised if there are any
+              faces which do not appear in any cells
 
-      returns:
-         numpy int array of shape (face_count, 2) showing upto 2 cell indices for each face index; -1 is a
-         null value; if only one cell uses a face, its index is always in position 0 of the second axis
-      """
+        returns:
+           numpy int array of shape (face_count, 2) showing upto 2 cell indices for each face index; -1 is a
+           null value; if only one cell uses a face, its index is always in position 0 of the second axis
+        """
 
         if self.cells_per_face is not None:
             return self.cells_per_face
@@ -320,17 +320,17 @@ class UnstructuredGrid(BaseResqpy):
     def masked_cells_per_face(self, exclude_cell_mask):
         """Sets and returns the cells_per_face array showing which cells are using each face.
 
-      arguments:
-         exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
-         are excluded when populating the result
+        arguments:
+           exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
+           are excluded when populating the result
 
-      returns:
-         numpy int array of shape (face_count, 2) showing upto 2 cell indices for each face index; -1 is a
-         null value; if only one cell uses a face, its index is always in position 0 of the second axis
+        returns:
+           numpy int array of shape (face_count, 2) showing upto 2 cell indices for each face index; -1 is a
+           null value; if only one cell uses a face, its index is always in position 0 of the second axis
 
-      note:
-         this method recomputes the result on every call - nothing extra is cached in the grid
-      """
+        note:
+           this method recomputes the result on every call - nothing extra is cached in the grid
+        """
 
         assert self.face_count is not None
         result = -np.ones((self.face_count, 2), dtype = int)  # -1 is used here as a null value
@@ -348,9 +348,9 @@ class UnstructuredGrid(BaseResqpy):
     def external_face_indices(self):
         """Returns a numpy int vector listing the indices of faces which are only used by one cell.
 
-      note:
-         resulting array is ordered by face index
-      """
+        note:
+           resulting array is ordered by face index
+        """
 
         self.set_cells_per_face()
         return np.where(self.cells_per_face[:, 1] == -1)[0]
@@ -358,13 +358,13 @@ class UnstructuredGrid(BaseResqpy):
     def external_face_indices_for_masked_cells(self, exclude_cell_mask):
         """Returns a numpy int vector listing the indices of faces which are used by exactly one of masked cells.
 
-      arguments:
-         exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
-         are excluded when populating the result
+        arguments:
+           exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
+           are excluded when populating the result
 
-      note:
-         resulting array is ordered by face index
-      """
+        note:
+           resulting array is ordered by face index
+        """
 
         cpf = self.masked_cells_per_face(exclude_cell_mask)
         return np.where(np.logical_and(cpf[:, 0] >= 0, cpf[:, 1] == -1))[0]
@@ -372,13 +372,13 @@ class UnstructuredGrid(BaseResqpy):
     def internal_face_indices_for_masked_cells(self, exclude_cell_mask):
         """Returns a numpy int vector listing the indices of faces which are used by two of masked cells.
 
-      arguments:
-         exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
-         are excluded when populating the result
+        arguments:
+           exclude_cell_mask (numpy bool array of shape (cell_count,)): cells with a value True in this array
+           are excluded when populating the result
 
-      note:
-         resulting array is ordered by face index
-      """
+        note:
+           resulting array is ordered by face index
+        """
 
         cpf = self.masked_cells_per_face(exclude_cell_mask)
         return np.where(np.logical_and(cpf[:, 0] >= 0, cpf[:, 1] >= 0))[0]
@@ -386,15 +386,15 @@ class UnstructuredGrid(BaseResqpy):
     def points_ref(self):
         """Returns an in-memory numpy array containing the xyz data for points used in the grid geometry.
 
-      returns:
-         numpy array of shape (node_count, 3)
+        returns:
+           numpy array of shape (node_count, 3)
 
-      notes:
-         this is the usual way to get at the actual grid geometry points data in the native RESQML layout;
-         the array is cached as an attribute of the grid object
+        notes:
+           this is the usual way to get at the actual grid geometry points data in the native RESQML layout;
+           the array is cached as an attribute of the grid object
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.points_cached is None:
 
@@ -422,11 +422,11 @@ class UnstructuredGrid(BaseResqpy):
     def xyz_box(self):
         """Returns the minimum and maximum xyz for the grid geometry.
 
-      returns:
-         numpy array of float of shape (2, 3); the first axis is minimum, maximum; the second axis is x, y, z
+        returns:
+           numpy array of float of shape (2, 3); the first axis is minimum, maximum; the second axis is x, y, z
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if self.xyz_box_cached is None:
             self.xyz_box_cached = np.empty((2, 3), dtype = float)
@@ -439,16 +439,16 @@ class UnstructuredGrid(BaseResqpy):
     def face_centre_point(self, face_index):
         """Returns a nominal centre point for a single face calculated as the mean position of its nodes.
 
-      arguments:
-         face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
+        arguments:
+           face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
 
-      returns:
-         numpy float array of shape (3,) being the xyz location of the centre point of the face
+        returns:
+           numpy float array of shape (3,) being the xyz location of the centre point of the face
 
-      note:
-         this returns a nominal centre point for a face - the mean position of its nodes - which is not generally
-         its barycentre
-      """
+        note:
+           this returns a nominal centre point for a face - the mean position of its nodes - which is not generally
+           its barycentre
+        """
 
         return np.mean(self.points_cached[self.node_indices_for_face(face_index)], axis = 0)
 
@@ -481,17 +481,17 @@ class UnstructuredGrid(BaseResqpy):
     def node_indices_for_face(self, face_index):
         """Returns numpy list of node indices for a single face.
 
-      arguments:
-         face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
+        arguments:
+           face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
 
-      returns:
-         numpy int array of shape (N,) being the node indices identifying the vertices of the face
+        returns:
+           numpy int array of shape (N,) being the node indices identifying the vertices of the face
 
-      note:
-         the node indices are used to index the points data (points_cached attribute);
-         ordering of returned nodes is clockwise or anticlockwise when viewed from within the cell,
-         as indicated by the entry in the cell_face_is_right_handed array
-      """
+        note:
+           the node indices are used to index the points data (points_cached attribute);
+           ordering of returned nodes is clockwise or anticlockwise when viewed from within the cell,
+           as indicated by the entry in the cell_face_is_right_handed array
+        """
 
         self.cache_all_geometry_arrays()
         start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
@@ -500,15 +500,15 @@ class UnstructuredGrid(BaseResqpy):
     def distinct_node_indices_for_cell(self, cell):
         """Returns a numpy list of distinct node indices used by the faces of a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which distinct node indices are required
+        arguments:
+           cell (int): the index of the cell for which distinct node indices are required
 
-      returns:
-         numpy int array of shape (N, ) being the indices of N distinct nodes used by the cell's faces
+        returns:
+           numpy int array of shape (N, ) being the indices of N distinct nodes used by the cell's faces
 
-      note:
-         the returned array is sorted by increasing node index
-      """
+        note:
+           the returned array is sorted by increasing node index
+        """
 
         face_indices = self.face_indices_for_cell(cell)
         node_set = self.node_indices_for_face(face_indices[0])
@@ -519,16 +519,16 @@ class UnstructuredGrid(BaseResqpy):
     def face_indices_for_cell(self, cell):
         """Returns numpy list of face indices for a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which face indices are required
+        arguments:
+           cell (int): the index of the cell for which face indices are required
 
-      returns:
-         numpy int array of shape (F,) being the face indices of each of the F faces for the cell
+        returns:
+           numpy int array of shape (F,) being the face indices of each of the F faces for the cell
 
-      note:
-         the face indices are used when accessing the nodes per face data and can also be used to identify
-         shared faces
-      """
+        note:
+           the face indices are used when accessing the nodes per face data and can also be used to identify
+           shared faces
+        """
 
         self.cache_all_geometry_arrays()
         start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
@@ -537,19 +537,19 @@ class UnstructuredGrid(BaseResqpy):
     def face_indices_and_handedness_for_cell(self, cell):
         """Returns numpy list of face indices for a single cell, and numpy boolean list of face right handedness.
 
-      arguments:
-         cell (int): the index of the cell for which face indices are required
+        arguments:
+           cell (int): the index of the cell for which face indices are required
 
-      returns:
-         numpy int array of shape (F,), numpy boolean array of shape (F, ):
-         being the face indices of each of the F faces for the cell, and the right handedness (clockwise order)
-         of the face nodes when viewed from within the cell
+        returns:
+           numpy int array of shape (F,), numpy boolean array of shape (F, ):
+           being the face indices of each of the F faces for the cell, and the right handedness (clockwise order)
+           of the face nodes when viewed from within the cell
 
-      note:
-         the face indices are used when accessing the nodes per face data and can also be used to identify
-         shared faces; the handedness (clockwise or anti-clockwise ordering of nodes) is significant for
-         some processing of geometry such as volume calculations
-      """
+        note:
+           the face indices are used when accessing the nodes per face data and can also be used to identify
+           shared faces; the handedness (clockwise or anti-clockwise ordering of nodes) is significant for
+           some processing of geometry such as volume calculations
+        """
 
         self.cache_all_geometry_arrays()
         start = 0 if cell == 0 else self.faces_per_cell_cl[cell - 1]
@@ -559,16 +559,16 @@ class UnstructuredGrid(BaseResqpy):
     def edges_for_face(self, face_index):
         """Returns numpy list of pairs of node indices, each pair being one edge of the face.
 
-      arguments:
-         face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
+        arguments:
+           face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
 
-      returns:
-         numpy int array of shape (N, 2) being the node indices identifying the N edges of the face
+        returns:
+           numpy int array of shape (N, 2) being the node indices identifying the N edges of the face
 
-      notes:
-         the order of the pairs follows the order of the nodes for the face; within each pair, the
-         order of the two node indices also follows the order of the nodes for the face
-      """
+        notes:
+           the order of the pairs follows the order of the nodes for the face; within each pair, the
+           order of the two node indices also follows the order of the nodes for the face
+        """
 
         face_nodes = self.node_indices_for_face(face_index)
         return np.array([(face_nodes[i - 1], face_nodes[i]) for i in range(len(face_nodes))], dtype = int)
@@ -576,16 +576,16 @@ class UnstructuredGrid(BaseResqpy):
     def edges_for_face_with_node_indices_ordered_within_pairs(self, face_index):
         """Returns numpy list of pairs of node indices, each pair being one edge of the face.
 
-      arguments:
-         face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
+        arguments:
+           face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
 
-      returns:
-         numpy int array of shape (N, 2) being the node indices identifying the N edges of the face
+        returns:
+           numpy int array of shape (N, 2) being the node indices identifying the N edges of the face
 
-      notes:
-         the order of the pairs follows the order of the nodes for the face; within each pair, the
-         two node indices are ordered with the lower index first
-      """
+        notes:
+           the order of the pairs follows the order of the nodes for the face; within each pair, the
+           two node indices are ordered with the lower index first
+        """
 
         edges = self.edges_for_face(face_index)
         for i in range(len(edges)):
@@ -597,15 +597,15 @@ class UnstructuredGrid(BaseResqpy):
     def distinct_edges_for_cell(self, cell):
         """Returns numpy list of pairs of node indices, each pair being one distinct edge of the cell.
 
-      arguments:
-         cell (int): the index of the cell
+        arguments:
+           cell (int): the index of the cell
 
-      returns:
-         numpy int array of shape (E, 2) being the node indices identifying the E edges of the cell
+        returns:
+           numpy int array of shape (E, 2) being the node indices identifying the E edges of the cell
 
-      note:
-         within each pair, the two node indices are ordered with the lower index first
-      """
+        note:
+           within each pair, the two node indices are ordered with the lower index first
+        """
 
         edge_list = []
         for face_index in self.face_indices_for_cell(cell):
@@ -619,17 +619,17 @@ class UnstructuredGrid(BaseResqpy):
     def cell_face_centre_points(self, cell):
         """Returns a numpy array of centre points of the faces for a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which face centre points are required
+        arguments:
+           cell (int): the index of the cell for which face centre points are required
 
-      returns:
-         numpy array of shape (F, 3) being the xyz location of each of the F faces for the cell
+        returns:
+           numpy array of shape (F, 3) being the xyz location of each of the F faces for the cell
 
-      notes:
-         the order of the returned face centre points matches the faces_per_cell for the cell;
-         the returned values are nominal centre points for the faces - the mean position of their nodes - which
-         are not generally their barycentres
-      """
+        notes:
+           the order of the returned face centre points matches the faces_per_cell for the cell;
+           the returned values are nominal centre points for the faces - the mean position of their nodes - which
+           are not generally their barycentres
+        """
 
         face_indices = self.face_indices_for_cell(cell)
         face_centres = np.empty((len(face_indices), 3))
@@ -640,17 +640,17 @@ class UnstructuredGrid(BaseResqpy):
     def face_normal(self, face_index):
         """Returns a unit vector normal to a planar approximation of the face.
 
-      arguments:
-         face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
+        arguments:
+           face_index (int): the index of the face (as used in faces_per_cell and implicitly in nodes_per_face)
 
-      returns:
-         numpy float array of shape (3,) being the xyz components of a unit length vector normal to the face
+        returns:
+           numpy float array of shape (3,) being the xyz components of a unit length vector normal to the face
 
-      note:
-         in the case of a degenerate face, a zero length vector is returned;
-         the direction of the normal will be into or out of the cell depending on the handedness of the
-         cell face
-      """
+        note:
+           in the case of a degenerate face, a zero length vector is returned;
+           the direction of the normal will be into or out of the cell depending on the handedness of the
+           cell face
+        """
 
         self.cache_all_geometry_arrays()
         vertices = self.points_cached[self.node_indices_for_face(face_index)]
@@ -671,16 +671,16 @@ class UnstructuredGrid(BaseResqpy):
     def planar_face_points(self, face_index, xy_plane = False):
         """Returns points for a planar approximation of a face.
 
-      arguments:
-         face_index (int): the index of the face for which a planar approximation is required
-         xy_plane (boolean, default False): if True, the returned points lie in a horizontal plane with z = 0.0;
-            if False, the plane is located approximately in the position of the original face, with the same
-            normal direction
+        arguments:
+           face_index (int): the index of the face for which a planar approximation is required
+           xy_plane (boolean, default False): if True, the returned points lie in a horizontal plane with z = 0.0;
+              if False, the plane is located approximately in the position of the original face, with the same
+              normal direction
 
-      returns:
-         numpy float array of shape (N, 3) being the xyz points of the planar face nodes corresponding to the
-         N nodes of the original face, in the same order
-      """
+        returns:
+           numpy float array of shape (N, 3) being the xyz points of the planar face nodes corresponding to the
+           N nodes of the original face, in the same order
+        """
 
         self.cache_all_geometry_arrays()
         face_centre = self.face_centre_point(face_index)
@@ -701,16 +701,16 @@ class UnstructuredGrid(BaseResqpy):
     def face_triangulation(self, face_index, local_nodes = False):
         """Returns a Delauney triangulation of (a planar approximation of) a face.
 
-      arguments:
-         face_index (int): the index of the face for which a triangulation is required
-         local_nodes (boolean, default False): if True, the returned node indices are local to the face nodes,
-            ie. can index into node_indices_for_face(); if False, the returned node indices are the global
-            node indices in use by the grid
+        arguments:
+           face_index (int): the index of the face for which a triangulation is required
+           local_nodes (boolean, default False): if True, the returned node indices are local to the face nodes,
+              ie. can index into node_indices_for_face(); if False, the returned node indices are the global
+              node indices in use by the grid
 
-      returns:
-         numpy int array of shape (N - 2, 3) being the node indices of the triangulation, where N is the number
-         of nodes defining the face
-      """
+        returns:
+           numpy int array of shape (N - 2, 3) being the node indices of the triangulation, where N is the number
+           of nodes defining the face
+        """
 
         face_points = self.planar_face_points(face_index, xy_plane = True)
         local_triangulation = tri.dt(face_points)  # returns int array of shape (M, 3)
@@ -723,18 +723,18 @@ class UnstructuredGrid(BaseResqpy):
     def area_of_face(self, face_index, in_plane = False):
         """Returns the area of a face.
 
-      arguments:
-         face_index (int): the index of the face for which the area is required
-         in_plane (boolean, default False): if True, the area returned is the area of the planar approximation
-            of the face; if False, the area is the sum of the areas of the triangulation of the face, which
-            need not be planar
+        arguments:
+           face_index (int): the index of the face for which the area is required
+           in_plane (boolean, default False): if True, the area returned is the area of the planar approximation
+              of the face; if False, the area is the sum of the areas of the triangulation of the face, which
+              need not be planar
 
-      returns:
-         float being the area of the face
+        returns:
+           float being the area of the face
 
-      notes:
-         units of measure of the area is implied by the units of the crs in use by the grid
-      """
+        notes:
+           units of measure of the area is implied by the units of the crs in use by the grid
+        """
 
         if in_plane:
             face_points = self.planar_face_points(face_index, xy_plane = True)
@@ -752,39 +752,40 @@ class UnstructuredGrid(BaseResqpy):
     def cell_centre_point(self, cell):
         """Returns centre point of a single cell calculated as the mean position of the centre points of its faces.
 
-      arguments:
-         cell (int): the index of the cell for which the centre point is required
+        arguments:
+           cell (int): the index of the cell for which the centre point is required
 
-      returns:
-         numpy float array of shape (3,) being the xyz location of the centre point of the cell
+        returns:
+           numpy float array of shape (3,) being the xyz location of the centre point of the cell
 
-      note:
-         this is a nominal centre point - the mean of the nominal face centres - which is not generally
-         the barycentre of the cell
-      """
+        note:
+           this is a nominal centre point - the mean of the nominal face centres - which is not generally
+           the barycentre of the cell
+        """
 
         return np.mean(self.cell_face_centre_points(cell), axis = 0)
 
     def centre_point(self, cell = None, cache_centre_array = False):
-        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all cells.
+        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all
+        cells.
 
-      arguments:
-         cell (optional): if present, the cell number of the individual cell for which the
-            centre point is required; zero based indexing
-         cache_centre_array (boolean, default False): If True, or cell is None, an array of centre points
-            is generated and added as an attribute of the grid, with attribute name array_centre_point
+        arguments:
+           cell (optional): if present, the cell number of the individual cell for which the
+              centre point is required; zero based indexing
+           cache_centre_array (boolean, default False): If True, or cell is None, an array of centre points
+              is generated and added as an attribute of the grid, with attribute name array_centre_point
 
-      returns:
-         (x, y, z) 3 element numpy array of floats holding centre point of a single cell;
-         or numpy 2D array of shape (cell_count, 3) if cell is None
+        returns:
+           (x, y, z) 3 element numpy array of floats holding centre point of a single cell;
+           or numpy 2D array of shape (cell_count, 3) if cell is None
 
-      notes:
-         a simple mean of the nominal centres of the faces is used to calculate the centre point of a cell;
-         this is not generally the barycentre of the cell;
-         resulting coordinates are in the same (local) crs as the grid points
+        notes:
+           a simple mean of the nominal centres of the faces is used to calculate the centre point of a cell;
+           this is not generally the barycentre of the cell;
+           resulting coordinates are in the same (local) crs as the grid points
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if cell is None:
             cache_centre_array = True
@@ -812,15 +813,15 @@ class UnstructuredGrid(BaseResqpy):
     def volume(self, cell):
         """Returns the volume of a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which the volume is required
+        arguments:
+           cell (int): the index of the cell for which the volume is required
 
-      returns:
-         float being the volume of the cell; units of measure is implied by crs units
+        returns:
+           float being the volume of the cell; units of measure is implied by crs units
 
-      note:
-         this is a computationally expensive method
-      """
+        note:
+           this is a computationally expensive method
+        """
 
         tetra = TetraGrid.from_unstructured_cell(self, cell, set_handedness = False)
         assert tetra is not None
@@ -845,24 +846,24 @@ class UnstructuredGrid(BaseResqpy):
     def xy_units(self):
         """Returns the projected view (x, y) units of measure of the coordinate reference system for the grid.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return rqet.find_tag(self._crs_root(), 'ProjectedUom').text
 
     def z_units(self):
         """Returns the vertical (z) units of measure of the coordinate reference system for the grid.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         return rqet.find_tag(self._crs_root(), 'VerticalUom').text
 
     def write_hdf5(self, file = None, geometry = True, imported_properties = None, write_active = None):
         """Write to an hdf5 file the datasets for the grid geometry and optionally properties from cached arrays.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
         # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
@@ -932,33 +933,33 @@ class UnstructuredGrid(BaseResqpy):
                    extra_metadata = {}):
         """Creates an unstructured grid node and optionally adds as a part in the model.
 
-      arguments:
-         ext_uuid (uuid.UUID, optional): the uuid of the hdf5 external part holding the array data for the grid geometry
-         add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-            in the model
-         add_relationships (boolean, default True): if True, relationship xml parts are created relating the
-            new grid part to: the crs, and the hdf5 external part
-         title (string): used as the citation title text; careful consideration should be given
-            to this argument when dealing with multiple grids in one model, as it is the means by which a
-            human will distinguish them
-         originator (string, optional): the name of the human being who created the unstructured grid part;
-            default is to use the login name
-         write_active (boolean, default True): if True, xml for an active cell property is also generated, but
-            only if the active_property_uuid is set and no part exists in the model for that uuid
-         write_geometry (boolean, default True): if False, the geometry node is omitted from the xml
-         extra_metadata (dict): any key value pairs in this dictionary are added as extra metadata xml nodes
+        arguments:
+           ext_uuid (uuid.UUID, optional): the uuid of the hdf5 external part holding the array data for the grid geometry
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in the model
+           add_relationships (boolean, default True): if True, relationship xml parts are created relating the
+              new grid part to: the crs, and the hdf5 external part
+           title (string): used as the citation title text; careful consideration should be given
+              to this argument when dealing with multiple grids in one model, as it is the means by which a
+              human will distinguish them
+           originator (string, optional): the name of the human being who created the unstructured grid part;
+              default is to use the login name
+           write_active (boolean, default True): if True, xml for an active cell property is also generated, but
+              only if the active_property_uuid is set and no part exists in the model for that uuid
+           write_geometry (boolean, default True): if False, the geometry node is omitted from the xml
+           extra_metadata (dict): any key value pairs in this dictionary are added as extra metadata xml nodes
 
-      returns:
-         the newly created unstructured grid xml node
+        returns:
+           the newly created unstructured grid xml node
 
-      notes:
-         the write_active argument should generally be set to the same value as that passed to the write_hdf5... method;
-         the RESQML standard allows the geometry to be omitted for a grid, controlled here by the write_geometry argument;
-         the explicit geometry may be omitted for unstructured grids, in which case the arrays should not be written to
-         the hdf5 file either
+        notes:
+           the write_active argument should generally be set to the same value as that passed to the write_hdf5... method;
+           the RESQML standard allows the geometry to be omitted for a grid, controlled here by the write_geometry argument;
+           the explicit geometry may be omitted for unstructured grids, in which case the arrays should not be written to
+           the hdf5 file either
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if ext_uuid is None:
             ext_uuid = self.model.h5_uuid()
@@ -1113,23 +1114,23 @@ class TetraGrid(UnstructuredGrid):
                  extra_metadata = {}):
         """Creates a new resqpy TetraGrid object (RESQML UnstructuredGrid with cell shape tetrahedral)
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
-         find_properties (boolean, default True): if True and uuid is present, a
-            grid property collection is instantiated as an attribute, holding properties for which
-            this grid is the supporting representation
-         cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
-            are loaded into attributes of the new grid object
-         title (str, optional): citation title for new grid; ignored if uuid is present
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if uuid is present
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if uuid is present
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
+           find_properties (boolean, default True): if True and uuid is present, a
+              grid property collection is instantiated as an attribute, holding properties for which
+              this grid is the supporting representation
+           cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
+              are loaded into attributes of the new grid object
+           title (str, optional): citation title for new grid; ignored if uuid is present
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if uuid is present
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if uuid is present
 
-      returns:
-         a newly created TetraGrid object
-      """
+        returns:
+           a newly created TetraGrid object
+        """
 
         super().__init__(parent_model = parent_model,
                          uuid = uuid,
@@ -1159,9 +1160,9 @@ class TetraGrid(UnstructuredGrid):
     def face_centre_point(self, face_index):
         """Returns a nominal centre point for a single face calculated as the mean position of its nodes.
 
-      note:
-         this is a nominal centre point for a face and not generally its barycentre
-      """
+        note:
+           this is a nominal centre point for a face and not generally its barycentre
+        """
 
         self.cache_all_geometry_arrays()
         start = 0 if face_index == 0 else self.nodes_per_face_cl[face_index - 1]
@@ -1170,12 +1171,12 @@ class TetraGrid(UnstructuredGrid):
     def volume(self, cell):
         """Returns the volume of a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which the volume is required
+        arguments:
+           cell (int): the index of the cell for which the volume is required
 
-      returns:
-         float being the volume of the tetrahedral cell; units of measure is implied by crs units
-      """
+        returns:
+           float being the volume of the tetrahedral cell; units of measure is implied by crs units
+        """
 
         self.cache_all_geometry_arrays()
         abcd = self.points_cached[self.distinct_node_indices_for_cell(cell)]
@@ -1185,9 +1186,9 @@ class TetraGrid(UnstructuredGrid):
     def grid_volume(self):
         """Returns the sum of the volumes of all the cells in the grid.
 
-      returns:
-         float being the total volume of the grid; units of measure is implied by crs units
-      """
+        returns:
+           float being the total volume of the grid; units of measure is implied by crs units
+        """
 
         v = 0.0
         for cell in range(self.cell_count):
@@ -1317,23 +1318,23 @@ class PyramidGrid(UnstructuredGrid):
                  extra_metadata = {}):
         """Creates a new resqpy PyramidGrid object (RESQML UnstructuredGrid with cell shape pyramidal)
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
-         find_properties (boolean, default True): if True and uuid is present, a
-            grid property collection is instantiated as an attribute, holding properties for which
-            this grid is the supporting representation
-         cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
-            are loaded into attributes of the new grid object
-         title (str, optional): citation title for new grid; ignored if uuid is present
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if uuid is present
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if uuid is present
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
+           find_properties (boolean, default True): if True and uuid is present, a
+              grid property collection is instantiated as an attribute, holding properties for which
+              this grid is the supporting representation
+           cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
+              are loaded into attributes of the new grid object
+           title (str, optional): citation title for new grid; ignored if uuid is present
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if uuid is present
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if uuid is present
 
-      returns:
-         a newly created PyramidGrid object
-      """
+        returns:
+           a newly created PyramidGrid object
+        """
 
         super().__init__(parent_model = parent_model,
                          uuid = uuid,
@@ -1354,10 +1355,10 @@ class PyramidGrid(UnstructuredGrid):
     def check_pyramidal(self):
         """Checks that each cell has 5 faces and each face has 3 or 4 nodes.
 
-      note:
-         currently only performs a cursory check, without checking nodes are shared or that there is exactly one
-         quadrilateral face
-      """
+        note:
+           currently only performs a cursory check, without checking nodes are shared or that there is exactly one
+           quadrilateral face
+        """
 
         assert self.cell_shape == 'pyramidal'
         self.cache_all_geometry_arrays()
@@ -1371,17 +1372,17 @@ class PyramidGrid(UnstructuredGrid):
     def face_indices_for_cell(self, cell):
         """Returns numpy list of face indices for a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which face indices are required
+        arguments:
+           cell (int): the index of the cell for which face indices are required
 
-      returns:
-         numpy int array of shape (5,) being the face indices of each of the 5 faces for the cell; the first
-         index in the array is for the quadrilateral face
+        returns:
+           numpy int array of shape (5,) being the face indices of each of the 5 faces for the cell; the first
+           index in the array is for the quadrilateral face
 
-      note:
-         the face indices are used when accessing the nodes per face data and can also be used to identify
-         shared faces
-      """
+        note:
+           the face indices are used when accessing the nodes per face data and can also be used to identify
+           shared faces
+        """
 
         faces = super().face_indices_for_cell(cell)
         assert len(faces) == 5
@@ -1402,20 +1403,20 @@ class PyramidGrid(UnstructuredGrid):
     def face_indices_and_handedness_for_cell(self, cell):
         """Returns numpy list of face indices for a single cell, and numpy boolean list of face right handedness.
 
-      arguments:
-         cell (int): the index of the cell for which face indices are required
+        arguments:
+           cell (int): the index of the cell for which face indices are required
 
-      returns:
-         numpy int array of shape (5,), numpy boolean array of shape (5, ):
-         being the face indices of each of the 5 faces for the cell, and the right handedness (clockwise order)
-         of the face nodes when viewed from within the cell; the first entry in each list is for the
-         quadrilateral face
+        returns:
+           numpy int array of shape (5,), numpy boolean array of shape (5, ):
+           being the face indices of each of the 5 faces for the cell, and the right handedness (clockwise order)
+           of the face nodes when viewed from within the cell; the first entry in each list is for the
+           quadrilateral face
 
-      note:
-         the face indices are used when accessing the nodes per face data and can also be used to identify
-         shared faces; the handedness (clockwise or anti-clockwise ordering of nodes) is significant for
-         some processing of geometry such as volume calculations
-      """
+        note:
+           the face indices are used when accessing the nodes per face data and can also be used to identify
+           shared faces; the handedness (clockwise or anti-clockwise ordering of nodes) is significant for
+           some processing of geometry such as volume calculations
+        """
 
         faces, handednesses = super().face_indices_and_handedness_for_cell(cell)
         assert len(faces) == 5 and len(handednesses) == 5
@@ -1439,12 +1440,12 @@ class PyramidGrid(UnstructuredGrid):
     def volume(self, cell):
         """Returns the volume of a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which the volume is required
+        arguments:
+           cell (int): the index of the cell for which the volume is required
 
-      returns:
-         float being the volume of the pyramidal cell; units of measure is implied by crs units
-      """
+        returns:
+           float being the volume of the pyramidal cell; units of measure is implied by crs units
+        """
 
         self._set_crs_handedness()
         self.cache_all_geometry_arrays()
@@ -1473,9 +1474,9 @@ class PyramidGrid(UnstructuredGrid):
 class PrismGrid(UnstructuredGrid):
     """Class for unstructured grids where every cell is a triangular prism.
 
-   note:
-      prism cells are not constrained to have a fixed cross-section, though in practice they often will
-   """
+    note:
+       prism cells are not constrained to have a fixed cross-section, though in practice they often will
+    """
 
     def __init__(self,
                  parent_model,
@@ -1487,23 +1488,23 @@ class PrismGrid(UnstructuredGrid):
                  extra_metadata = {}):
         """Creates a new resqpy PrismGrid object (RESQML UnstructuredGrid with cell shape trisngular prism)
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
-         find_properties (boolean, default True): if True and uuid is present, a
-            grid property collection is instantiated as an attribute, holding properties for which
-            this grid is the supporting representation
-         cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
-            are loaded into attributes of the new grid object
-         title (str, optional): citation title for new grid; ignored if uuid is present
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if uuid is present
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if uuid is present
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
+           find_properties (boolean, default True): if True and uuid is present, a
+              grid property collection is instantiated as an attribute, holding properties for which
+              this grid is the supporting representation
+           cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
+              are loaded into attributes of the new grid object
+           title (str, optional): citation title for new grid; ignored if uuid is present
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if uuid is present
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if uuid is present
 
-      returns:
-         a newly created PrismGrid object
-      """
+        returns:
+           a newly created PrismGrid object
+        """
 
         super().__init__(parent_model = parent_model,
                          uuid = uuid,
@@ -1524,10 +1525,10 @@ class PrismGrid(UnstructuredGrid):
     def check_prism(self):
         """Checks that each cell has 5 faces and each face has 3 or 4 nodes.
 
-      note:
-         currently only performs a cursory check, without checking nodes are shared or that there are exactly two
-         triangular faces without shared nodes
-      """
+        note:
+           currently only performs a cursory check, without checking nodes are shared or that there are exactly two
+           triangular faces without shared nodes
+        """
 
         assert self.cell_shape == 'prism'
         self.cache_all_geometry_arrays()
@@ -1544,14 +1545,14 @@ class PrismGrid(UnstructuredGrid):
 class VerticalPrismGrid(PrismGrid):
     """Class for unstructured grids where every cell is a vertical triangular prism.
 
-   notes:
-      vertical prism cells are constrained to have a fixed triangular horzontal cross-section, though top and base
-      triangular faces need not be horizontal; edges not involved in the triangular faces must be vertical;
-      this is not a native RESQML sub-class but is a resqpy concoction to allow optimisation of some methods;
-      face ordering within a cell is also constrained to be top, base, then the three vertical planar quadrilateral
-      faces; node ordering within triangular faces is constrained to ensure correspondence of nodes in triangles
-      within a column
-   """
+    notes:
+       vertical prism cells are constrained to have a fixed triangular horzontal cross-section, though top and base
+       triangular faces need not be horizontal; edges not involved in the triangular faces must be vertical;
+       this is not a native RESQML sub-class but is a resqpy concoction to allow optimisation of some methods;
+       face ordering within a cell is also constrained to be top, base, then the three vertical planar quadrilateral
+       faces; node ordering within triangular faces is constrained to ensure correspondence of nodes in triangles
+       within a column
+    """
 
     def __init__(self,
                  parent_model,
@@ -1563,23 +1564,23 @@ class VerticalPrismGrid(PrismGrid):
                  extra_metadata = {}):
         """Creates a new resqpy VerticalPrismGrid object.
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
-         find_properties (boolean, default True): if True and uuid is present, a
-            grid property collection is instantiated as an attribute, holding properties for which
-            this grid is the supporting representation
-         cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
-            are loaded into attributes of the new grid object
-         title (str, optional): citation title for new grid; ignored if uuid is present
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if uuid is present
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if uuid is present
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
+           find_properties (boolean, default True): if True and uuid is present, a
+              grid property collection is instantiated as an attribute, holding properties for which
+              this grid is the supporting representation
+           cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
+              are loaded into attributes of the new grid object
+           title (str, optional): citation title for new grid; ignored if uuid is present
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if uuid is present
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if uuid is present
 
-      returns:
-         a newly created VerticalPrismGrid object
-      """
+        returns:
+           a newly created VerticalPrismGrid object
+        """
 
         self.nk = None  #: number of layers when constructed as a layered grid
 
@@ -1611,36 +1612,36 @@ class VerticalPrismGrid(PrismGrid):
                       set_handedness = False):
         """Create a layered vertical prism grid from an ordered list of untorn surfaces.
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         surfaces (list of surface.Surface): list of two or more untorn surfaces ordered from
-            shallowest to deepest; see notes
-         column_points (2D numpy float array, optional): if present, the xy points to use for
-            the grid's triangulation; see notes
-         column_triangles (numpy int array of shape (M, 3), optional): if present, indices into the
-            first dimension of column_points giving the xy triangulation to use for the grid; see notes
-         title (str, optional): citation title for the new grid
-         originator (str, optional): name of person creating the grid; defaults to login id
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           surfaces (list of surface.Surface): list of two or more untorn surfaces ordered from
+              shallowest to deepest; see notes
+           column_points (2D numpy float array, optional): if present, the xy points to use for
+              the grid's triangulation; see notes
+           column_triangles (numpy int array of shape (M, 3), optional): if present, indices into the
+              first dimension of column_points giving the xy triangulation to use for the grid; see notes
+           title (str, optional): citation title for the new grid
+           originator (str, optional): name of person creating the grid; defaults to login id
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid
 
-      returns:
-         a newly created VerticalPrismGrid object
+        returns:
+           a newly created VerticalPrismGrid object
 
-      notes:
-         this method will not work for torn (faulted) surfaces, nor for surfaces with recumbent folds;
-         the surfaces may not cross each other, ie. the depth ordering must be consistent over the area;
-         the triangular pattern of the columns (in the xy plane) can be specified with the column_points
-         and column_triangles arguments;
-         if those arguments are None, the first, shallowest, surface is used as a master and determines
-         the triangular pattern of the columns;
-         where a gravity vector from a node above does not intersect a surface, the point is inherited
-         as a copy of the node above and will be NaNs if no surface above has an intersection;
-         the Surface class has methods for creating a Surface from a PointSet or a Mesh (RESQML
-         Grid2dRepresentation), or for a horizontal plane;
-         this class is represented in RESQML as an UnstructuredGridRepresentation – when a resqpy
-         class is written for ColumnLayerGridRepresentation, a method will be added to that class to
-         convert from a resqpy VerticalPrismGrid
-      """
+        notes:
+           this method will not work for torn (faulted) surfaces, nor for surfaces with recumbent folds;
+           the surfaces may not cross each other, ie. the depth ordering must be consistent over the area;
+           the triangular pattern of the columns (in the xy plane) can be specified with the column_points
+           and column_triangles arguments;
+           if those arguments are None, the first, shallowest, surface is used as a master and determines
+           the triangular pattern of the columns;
+           where a gravity vector from a node above does not intersect a surface, the point is inherited
+           as a copy of the node above and will be NaNs if no surface above has an intersection;
+           the Surface class has methods for creating a Surface from a PointSet or a Mesh (RESQML
+           Grid2dRepresentation), or for a horizontal plane;
+           this class is represented in RESQML as an UnstructuredGridRepresentation – when a resqpy
+           class is written for ColumnLayerGridRepresentation, a method will be added to that class to
+           convert from a resqpy VerticalPrismGrid
+        """
 
         def find_pair(a, pair):
             # for sorted array a of shape (N, 2) returns index in first axis of a pair
@@ -1808,31 +1809,31 @@ class VerticalPrismGrid(PrismGrid):
                                       set_handedness = False):
         """Create a layered vertical prism grid from seed points and an ordered list of untorn surfaces.
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         seed_xy (numpy float array of shape (N, 2 or 3)): the xy locations of seed points
-         surfaces (list of surface.Surface): list of two or more untorn surfaces ordered from
-            shallowest to deepest; see notes
-         area_of_interest (closed convex Polyline): the frontier polygon in the xy plane
-         title (str, optional): citation title for the new grid
-         originator (str, optional): name of person creating the grid; defaults to login id
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           seed_xy (numpy float array of shape (N, 2 or 3)): the xy locations of seed points
+           surfaces (list of surface.Surface): list of two or more untorn surfaces ordered from
+              shallowest to deepest; see notes
+           area_of_interest (closed convex Polyline): the frontier polygon in the xy plane
+           title (str, optional): citation title for the new grid
+           originator (str, optional): name of person creating the grid; defaults to login id
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid
 
-      returns:
-         a newly created VerticalPrismGrid object
+        returns:
+           a newly created VerticalPrismGrid object
 
-      notes:
-         the triangular pattern of the columns (in the xy plane) is constructed as a re-triangulation
-         of the Voronoi diagram of the Delauney triangulation of the seed points;
-         the seed points may be xy or xyz data but z is ignored;
-         this method will not work for torn (faulted) surfaces, nor for surfaces with recumbent folds;
-         the surfaces may not cross each other, ie. the depth ordering must be consistent over the area;
-         all the seed points must lie wholly within the area of interest;
-         where a gravity vector from a node above does not intersect a surface, the point is inherited
-         as a copy of the node above (the topmost surface must cover the entire area of interest);
-         the Surface class has methods for creating a Surface from a PointSet or a Mesh (RESQML
-         Grid2dRepresentation), or for a horizontal plane
-      """
+        notes:
+           the triangular pattern of the columns (in the xy plane) is constructed as a re-triangulation
+           of the Voronoi diagram of the Delauney triangulation of the seed points;
+           the seed points may be xy or xyz data but z is ignored;
+           this method will not work for torn (faulted) surfaces, nor for surfaces with recumbent folds;
+           the surfaces may not cross each other, ie. the depth ordering must be consistent over the area;
+           all the seed points must lie wholly within the area of interest;
+           where a gravity vector from a node above does not intersect a surface, the point is inherited
+           as a copy of the node above (the topmost surface must cover the entire area of interest);
+           the Surface class has methods for creating a Surface from a PointSet or a Mesh (RESQML
+           Grid2dRepresentation), or for a horizontal plane
+        """
 
         assert seed_xy.ndim == 2 and seed_xy.shape[1] in [2, 3]
         assert area_of_interest.isclosed and area_of_interest.is_convex()
@@ -1870,12 +1871,12 @@ class VerticalPrismGrid(PrismGrid):
     def cell_centre_point(self, cell = None):
         """Returns centre point of a single cell (or all cells) calculated as the mean position of its 6 nodes.
 
-      arguments:
-         cell (int): the index of the cell for which the centre point is required
+        arguments:
+           cell (int): the index of the cell for which the centre point is required
 
-      returns:
-         numpy float array of shape (3,) being the xyz location of the centre point of the cell
-      """
+        returns:
+           numpy float array of shape (3,) being the xyz location of the centre point of the cell
+        """
 
         cp = self.corner_points(cell = cell)
         return np.mean(cp.reshape((-1, 6, 3)), axis = (1))
@@ -1883,14 +1884,14 @@ class VerticalPrismGrid(PrismGrid):
     def corner_points(self, cell = None):
         """Returns corner points for all cells or for a single cell.
 
-      arguments:
-         cell (int, optional): cell index of single cell for which corner points are required;
-            if None, corner points are returned for all cells
+        arguments:
+           cell (int, optional): cell index of single cell for which corner points are required;
+              if None, corner points are returned for all cells
 
-      returns:
-         numpy float array of shape (2, 3, 3) being xyz points for top & base points for one cell, or
-         numpy float array of shape (N, 2, 3, 3) being xyz points for top & base points for all cells
-      """
+        returns:
+           numpy float array of shape (2, 3, 3) being xyz points for top & base points for one cell, or
+           numpy float array of shape (N, 2, 3, 3) being xyz points for top & base points for all cells
+        """
 
         if hasattr(self, 'array_corner_points'):
             if cell is None:
@@ -1923,9 +1924,9 @@ class VerticalPrismGrid(PrismGrid):
     def thickness(self, cell = None):
         """Returns array of thicknesses of all cells or a single cell.
 
-      note:
-         units are z units of crs used by this grid
-      """
+        note:
+           units are z units of crs used by this grid
+        """
 
         if hasattr(self, 'array_thickness'):
             if cell is None:
@@ -1950,15 +1951,15 @@ class VerticalPrismGrid(PrismGrid):
     def triangulation(self):
         """Returns triangulation used by this vertical prism grid.
 
-      returns:
-         numpy int array of shape (M, 3) being the indices into the grid points of the triangles forming
-         the top faces of the top layer of cells of the grid
+        returns:
+           numpy int array of shape (M, 3) being the indices into the grid points of the triangles forming
+           the top faces of the top layer of cells of the grid
 
-      notes:
-         use points_ref() to access the full points data;
-         the order of the first axis of the returned values will match the order of the columns
-         within cell related data
-      """
+        notes:
+           use points_ref() to access the full points data;
+           the order of the first axis of the returned values will match the order of the columns
+           within cell related data
+        """
 
         n_col = self.column_count()
         top_face_indices = self.top_faces()
@@ -1968,26 +1969,26 @@ class VerticalPrismGrid(PrismGrid):
         return top_nodes
 
     def triple_horizontal_permeability(self, primary_k, orthogonal_k, primary_azimuth = 0.0):
-        """Returns array of triple horizontal permeabilities derived from a pair of permeability properties
+        """Returns array of triple horizontal permeabilities derived from a pair of permeability properties.
 
-      arguments:
-         primary_k (numpy float array of shape (N,) being the primary horizontal permeability for each cell
-         orthogonal_k (numpy float array of shape (N,) being the horizontal permeability for each cell in a
-            direction orthogonal to the primary permeability
-         primary_azimuth (float or numpy float array of shape (N,), default 0.0): the azimuth(s) of the
-            primary permeability, in degrees compass bearing
+        arguments:
+           primary_k (numpy float array of shape (N,) being the primary horizontal permeability for each cell
+           orthogonal_k (numpy float array of shape (N,) being the horizontal permeability for each cell in a
+              direction orthogonal to the primary permeability
+           primary_azimuth (float or numpy float array of shape (N,), default 0.0): the azimuth(s) of the
+              primary permeability, in degrees compass bearing
 
-      returns:
-         numpy float array of shape (N, 3) being the triple horizontal permeabilities applicable to half
-         cell horizontal transmissibilities
+        returns:
+           numpy float array of shape (N, 3) being the triple horizontal permeabilities applicable to half
+           cell horizontal transmissibilities
 
-      notes:
-         this method should be used to generate horizontal permeabilities for use in transmissibility
-         calculations if starting from an anisotropic permeability defined by a pair of locally
-         orthogonal values; resulting values will be locally bounded by the pair of source values;
-         the order of the 3 values per cell follows the node indices for the top triangle, for the
-         opposing vertical face; no net to gross ratio modification is applied here;
-      """
+        notes:
+           this method should be used to generate horizontal permeabilities for use in transmissibility
+           calculations if starting from an anisotropic permeability defined by a pair of locally
+           orthogonal values; resulting values will be locally bounded by the pair of source values;
+           the order of the 3 values per cell follows the node indices for the top triangle, for the
+           opposing vertical face; no net to gross ratio modification is applied here;
+        """
 
         assert primary_k.size == self.cell_count and orthogonal_k.size == self.cell_count
         azimuth_is_constant = isinstance(primary_azimuth, float) or isinstance(primary_azimuth, int)
@@ -2031,25 +2032,25 @@ class VerticalPrismGrid(PrismGrid):
     def half_cell_transmissibility(self, use_property = True, realization = None, tolerance = 1.0e-6):
         """Returns (and caches if realization is None) half cell transmissibilities for this vertical prism grid.
 
-      arguments:
-         use_property (boolean, default True): if True, the grid's property collection is inspected for
-            a possible half cell transmissibility array and if found, it is used instead of calculation
-         realization (int, optional) if present, only a property with this realization number will be used
-         tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
-            will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
-            units are implicitly those of the grid's crs length units
+        arguments:
+           use_property (boolean, default True): if True, the grid's property collection is inspected for
+              a possible half cell transmissibility array and if found, it is used instead of calculation
+           realization (int, optional) if present, only a property with this realization number will be used
+           tolerance (float, default 1.0e-6): minimum half axis length below which the transmissibility
+              will be deemed uncomputable (for the axis in question); NaN values will be returned (not Inf);
+              units are implicitly those of the grid's crs length units
 
-      returns:
-         numpy float array of shape (N, 5) where N is the number of cells in the grid and the 5 covers
-         the faces of a cell in the order of the faces_per_cell data;
-         units will depend on the length units of the coordinate reference system for the grid;
-         the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft respectively
+        returns:
+           numpy float array of shape (N, 5) where N is the number of cells in the grid and the 5 covers
+           the faces of a cell in the order of the faces_per_cell data;
+           units will depend on the length units of the coordinate reference system for the grid;
+           the units will be m3.cP/(kPa.d) or bbl.cP/(psi.d) for grid length units of m and ft respectively
 
-      notes:
-         this method does not write to hdf5, nor create a new property or xml;
-         if realization is None, a grid attribute cached array will be used;
-         tolerance will only be used if the half cell transmissibilities are actually computed
-      """
+        notes:
+           this method does not write to hdf5, nor create a new property or xml;
+           if realization is None, a grid attribute cached array will be used;
+           tolerance will only be used if the half cell transmissibilities are actually computed
+        """
 
         if realization is None and hasattr(self, 'array_half_cell_t'):
             return self.array_half_cell_t
@@ -2156,23 +2157,23 @@ class HexaGrid(UnstructuredGrid):
                  extra_metadata = {}):
         """Creates a new resqpy HexaGrid object (RESQML UnstructuredGrid with cell shape hexahedral)
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
-         find_properties (boolean, default True): if True and uuid is present, a
-            grid property collection is instantiated as an attribute, holding properties for which
-            this grid is the supporting representation
-         cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
-            are loaded into attributes of the new grid object
-         title (str, optional): citation title for new grid; ignored if uuid is present
-         originator (str, optional): name of person creating the grid; defaults to login id;
-            ignored if uuid is present
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
-            ignored if uuid is present
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           uuid (uuid.UUID, optional): if present, the new grid object is populated from the RESQML object
+           find_properties (boolean, default True): if True and uuid is present, a
+              grid property collection is instantiated as an attribute, holding properties for which
+              this grid is the supporting representation
+           cache_geometry (boolean, default False): if True and uuid is present, all the geometry arrays
+              are loaded into attributes of the new grid object
+           title (str, optional): citation title for new grid; ignored if uuid is present
+           originator (str, optional): name of person creating the grid; defaults to login id;
+              ignored if uuid is present
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid;
+              ignored if uuid is present
 
-      returns:
-         a newly created HexaGrid object
-      """
+        returns:
+           a newly created HexaGrid object
+        """
 
         super().__init__(parent_model = parent_model,
                          uuid = uuid,
@@ -2200,21 +2201,21 @@ class HexaGrid(UnstructuredGrid):
                           write_active = None):
         """Creates a new (unstructured) HexaGrid from an existing resqpy unsplit (IJK) Grid without K gaps.
 
-      arguments:
-         parent_model (model.Model object): the model which this grid is part of
-         grid_uuid (uuid.UUID): the uuid of an IjkGridRepresentation from which the hexa grid will be created
-         inherit_properties (boolean, default True): if True, properties will be created for the new grid
-         title (str, optional): citation title for the new grid
-         extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid
-         write_active (boolean, optional): if True (or None and inactive property is established) then an
-            active cell property is created (in addition to any inherited properties)
+        arguments:
+           parent_model (model.Model object): the model which this grid is part of
+           grid_uuid (uuid.UUID): the uuid of an IjkGridRepresentation from which the hexa grid will be created
+           inherit_properties (boolean, default True): if True, properties will be created for the new grid
+           title (str, optional): citation title for the new grid
+           extra_metadata (dict, optional): dictionary of extra metadata items to add to the grid
+           write_active (boolean, optional): if True (or None and inactive property is established) then an
+              active cell property is created (in addition to any inherited properties)
 
-      returns:
-         a newly created HexaGrid object
+        returns:
+           a newly created HexaGrid object
 
-      note:
-         this method includes the writing of hdf5 data, creation of xml for the new grid and adding it as a part
-      """
+        note:
+           this method includes the writing of hdf5 data, creation of xml for the new grid and adding it as a part
+        """
 
         import resqpy.grid as grr
 
@@ -2364,10 +2365,10 @@ class HexaGrid(UnstructuredGrid):
     def check_hexahedral(self):
         """Checks that each cell has 6 faces and each face has 4 nodes.
 
-      notes:
-         currently only performs a cursory check, without checking nodes are shared;
-         assumes that degenerate faces still have four nodes identified
-      """
+        notes:
+           currently only performs a cursory check, without checking nodes are shared;
+           assumes that degenerate faces still have four nodes identified
+        """
 
         assert self.cell_shape == 'hexahedral'
         self.cache_all_geometry_arrays()
@@ -2378,16 +2379,16 @@ class HexaGrid(UnstructuredGrid):
     def corner_points(self, cell):
         """Returns corner points (nodes) of a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which the corner points are required
+        arguments:
+           cell (int): the index of the cell for which the corner points are required
 
-      returns:
-         numpy float array of shape (8, 3) being the xyz points of 8 nodes defining a single hexahedral cell
+        returns:
+           numpy float array of shape (8, 3) being the xyz points of 8 nodes defining a single hexahedral cell
 
-      note:
-         if this hexa grid has been created using the from_unsplit_grid class method, then the result can be
-         reshaped to (2, 2, 2, 3) for corner points compatible with those used by the Grid class
-      """
+        note:
+           if this hexa grid has been created using the from_unsplit_grid class method, then the result can be
+           reshaped to (2, 2, 2, 3) for corner points compatible with those used by the Grid class
+        """
 
         self.cache_all_geometry_arrays()
         return self.points_cached[self.distinct_node_indices_for_cell(cell)]
@@ -2395,12 +2396,12 @@ class HexaGrid(UnstructuredGrid):
     def volume(self, cell):
         """Returns the volume of a single cell.
 
-      arguments:
-         cell (int): the index of the cell for which the volume is required
+        arguments:
+           cell (int): the index of the cell for which the volume is required
 
-      returns:
-         float being the volume of the hexahedral cell; units of measure is implied by crs units
-      """
+        returns:
+           float being the volume of the hexahedral cell; units of measure is implied by crs units
+        """
 
         self._set_crs_handedness()
         apex = self.cell_centre_point(cell)

--- a/resqpy/weights_and_measures.py
+++ b/resqpy/weights_and_measures.py
@@ -86,19 +86,19 @@ CASE_INSENSITIVE_UOMS = {'m', 'ft', 'm3', 'ft3', 'm3/m3', 'ft3/ft3', 'bbl', 'bar
 
 @lru_cache(None)
 def rq_uom(units, quantity = None):
-    """Returns RESQML uom string equivalent to units
-   
-   Args:
-      units (str): unit to coerce
-      quantity (str, optional): if given, raise an exception if the uom is not supported
-         for this quantity
+    """Returns RESQML uom string equivalent to units.
 
-   Returns:
-      str: unit of measure
+    Args:
+       units (str): unit to coerce
+       quantity (str, optional): if given, raise an exception if the uom is not supported
+          for this quantity
 
-   Raises:
-      InvalidUnitError: if units cannot be coerced into RESQML units for the given quantity
-   """
+    Returns:
+       str: unit of measure
+
+    Raises:
+       InvalidUnitError: if units cannot be coerced into RESQML units for the given quantity
+    """
     if not units:
         raise InvalidUnitError("Must provide non-empty unit")
 
@@ -116,23 +116,23 @@ def rq_uom(units, quantity = None):
 
 
 def convert(x, unit_from, unit_to, quantity = None, inplace = False):
-    """Convert value between two compatible units
+    """Convert value between two compatible units.
 
-   Args:
-      x (numeric or np.array): value(s) to convert
-      unit_from (str): resqml uom
-      unit_to (str): resqml uom
-      quantity (str, optional): If provided, raise an exception if units are not supported
-         by this quantity
-      inplace (bool): if True, convert arrays in-place. Else, return new value
+    Args:
+       x (numeric or np.array): value(s) to convert
+       unit_from (str): resqml uom
+       unit_to (str): resqml uom
+       quantity (str, optional): If provided, raise an exception if units are not supported
+          by this quantity
+       inplace (bool): if True, convert arrays in-place. Else, return new value
 
-   Returns:
-      Converted value(s)
+    Returns:
+       Converted value(s)
 
-   Raises:
-      InvalidUnitError: if units cannot be coerced into RESQML units
-      IncompatibleUnitsError: if units do not have compatible base units
-   """
+    Raises:
+       InvalidUnitError: if units cannot be coerced into RESQML units
+       IncompatibleUnitsError: if units do not have compatible base units
+    """
 
     # conversion data assume the formula "y=(A + Bx)/(C + Dx)" where "y" represents a value in the base unit.
     # Backwards formula: x=(A-Cy)/(Dy-B)
@@ -172,17 +172,17 @@ def convert(x, unit_from, unit_to, quantity = None, inplace = False):
 
 @lru_cache(None)
 def valid_uoms(quantity = None, return_attributes = False):
-    """Return set of valid RESQML units of measure
-   
-   Args:
-      quantity (str): If given, filter to uoms supported by this quanitity.
-      return_attributes (bool): If True, return a dict of all uoms and their
-         attributes, such as the full name and dimension. Else, simply return
-         the set of valid uoms.
+    """Return set of valid RESQML units of measure.
 
-   Returns
-      set or dict
-   """
+    Args:
+       quantity (str): If given, filter to uoms supported by this quanitity.
+       return_attributes (bool): If True, return a dict of all uoms and their
+          attributes, such as the full name and dimension. Else, simply return
+          the set of valid uoms.
+
+    Returns
+       set or dict
+    """
     uoms = _properties_data()['units']
     if quantity:
         all_quantities = _properties_data()['quantities']
@@ -196,16 +196,16 @@ def valid_uoms(quantity = None, return_attributes = False):
 
 @lru_cache(None)
 def valid_quantities(return_attributes = False):
-    """Return set of valid RESQML quantities
-   
-   Args:
-      return_attributes (bool): If True, return a dict of all quantities and their
-         attributes, such as the supported units of measure. Else, simply return
-         the set of valid properties.
-   
-   Returns
-      set or dict
-   """
+    """Return set of valid RESQML quantities.
+
+    Args:
+       return_attributes (bool): If True, return a dict of all quantities and their
+          attributes, such as the supported units of measure. Else, simply return
+          the set of valid properties.
+
+    Returns
+       set or dict
+    """
     quantities = _properties_data()['quantities']
     if return_attributes:
         return quantities
@@ -214,7 +214,7 @@ def valid_quantities(return_attributes = False):
 
 
 def valid_property_kinds():
-    """Return set of valid property kinds"""
+    """Return set of valid property kinds."""
 
     return set(_properties_data()['property_kinds'].keys())
 
@@ -239,10 +239,10 @@ def rq_time_unit(units):
 
 def convert_times(a, from_units, to_units, invert = False):
     """Converts values in numpy array (or a scalar) from one time unit to another, in situ if array.
-   
-   note:
-      To see supported units, use: `valid_uoms(quantity='time')`
-   """
+
+    note:
+       To see supported units, use: `valid_uoms(quantity='time')`
+    """
 
     if invert:
         from_units, to_units = to_units, from_units
@@ -253,17 +253,17 @@ def convert_times(a, from_units, to_units, invert = False):
 def convert_lengths(a, from_units, to_units):
     """Converts values in numpy array (or a scalar) from one length unit to another, in situ if array.
 
-   arguments:
-      a (numpy float array, or float): array of length values to undergo unit conversion in situ, or a scalar
-      from_units (string): the units of the data before conversion
-      to_units (string): the required units
+    arguments:
+       a (numpy float array, or float): array of length values to undergo unit conversion in situ, or a scalar
+       from_units (string): the units of the data before conversion
+       to_units (string): the required units
 
-   returns:
-      a after unit conversion
+    returns:
+       a after unit conversion
 
-   note:
-      To see supported units, use: `valid_uoms(quantity='length')`
-   """
+    note:
+       To see supported units, use: `valid_uoms(quantity='length')`
+    """
 
     return convert(a, from_units, to_units, quantity = 'length', inplace = True)
 
@@ -271,67 +271,66 @@ def convert_lengths(a, from_units, to_units):
 def convert_pressures(a, from_units, to_units):
     """Converts values in numpy array (or a scalar) from one pressure unit to another, in situ if array.
 
-   arguments:
-      a (numpy float array, or float): array of pressure values to undergo unit conversion in situ, or a scalar
-      from_units (string): the units of the data before conversion
-      to_units (string): the required units
+    arguments:
+       a (numpy float array, or float): array of pressure values to undergo unit conversion in situ, or a scalar
+       from_units (string): the units of the data before conversion
+       to_units (string): the required units
 
-   returns:
-      a after unit conversion
+    returns:
+       a after unit conversion
 
-   note:
-      To see supported units, use: `valid_uoms(quantity='pressure')`
-   """
+    note:
+       To see supported units, use: `valid_uoms(quantity='pressure')`
+    """
     return convert(a, from_units, to_units, quantity = 'pressure', inplace = True)
 
 
 def convert_volumes(a, from_units, to_units):
     """Converts values in numpy array (or a scalar) from one volume unit to another, in situ if array.
 
-   arguments:
-      a (numpy float array, or float): array of volume values to undergo unit conversion in situ, or a scalar
-      from_units (string): units of the data before conversion; see note for accepted units
-      to_units (string): the required units; see note for accepted units
+    arguments:
+       a (numpy float array, or float): array of volume values to undergo unit conversion in situ, or a scalar
+       from_units (string): units of the data before conversion; see note for accepted units
+       to_units (string): the required units; see note for accepted units
 
-   returns:
-      a after unit conversion
+    returns:
+       a after unit conversion
 
-   note:
-      To see supported units, use: `valid_uoms(quantity='volume')`
-
-   """
+    note:
+       To see supported units, use: `valid_uoms(quantity='volume')`
+    """
     return convert(a, from_units, to_units, quantity = 'volume', inplace = True)
 
 
 def convert_flow_rates(a, from_units, to_units):
     """Converts values in numpy array (or a scalar) from one volume flow rate unit to another, in situ if array.
 
-   arguments:
-      a (numpy float array, or float): array of volume flow rate values to undergo unit conversion in situ, or a scalar
-      from_units (string): units of the data before conversion, eg. 'm3/d'; see notes for acceptable units
-      to_units (string): required units of the data after conversion, eg. 'ft3/d'; see notes for acceptable units
+    arguments:
+       a (numpy float array, or float): array of volume flow rate values to undergo unit conversion in situ, or a scalar
+       from_units (string): units of the data before conversion, eg. 'm3/d'; see notes for acceptable units
+       to_units (string): required units of the data after conversion, eg. 'ft3/d'; see notes for acceptable units
 
-   returns:
-      a after unit conversion
+    returns:
+       a after unit conversion
 
-   note:
-      To see supported units, use: `valid_uoms(quantity='volume per time')`
-   """
+    note:
+       To see supported units, use: `valid_uoms(quantity='volume per time')`
+    """
     return convert(a, from_units, to_units, quantity = 'volume per time', inplace = True)
 
 
 @lru_cache(None)
 def get_conversion_factors(uom):
     """Return base unit and conversion factors (A, B, C, D) for a given uom.
-   
-   The formula "y=(A + Bx)/(C + Dx)" where "y" represents a value in the base unit.
 
-   Returns:
-      3-tuple of (base_unit, dimension, factors). Factors is a 4-tuple of conversion factors
+    The formula "y=(A + Bx)/(C + Dx)" where "y" represents a value in the base unit.
 
-   Raises:
-      ValueError if either uom is not a valid resqml uom
-   """
+    Returns:
+       3-tuple of (base_unit, dimension, factors). Factors is a 4-tuple of conversion factors
+
+    Raises:
+       ValueError if either uom is not a valid resqml uom
+    """
     if uom not in valid_uoms():
         raise ValueError(f"{uom} is not a valid uom")
     uoms_data = _properties_data()["units"][uom]
@@ -351,21 +350,20 @@ def get_conversion_factors(uom):
 
 @lru_cache(None)
 def _properties_data():
-    """ Return a data structure that represents resqml unit system.
+    """Return a data structure that represents resqml unit system.
 
-   The dict is loaded directly from a JSON file which is bundled with resqpy.
-   The unit system is represented as a dict with the following keys:
+    The dict is loaded directly from a JSON file which is bundled with resqpy.
+    The unit system is represented as a dict with the following keys:
 
-   - dimensions
-   - quantities
-   - units
-   - prefixes
-   - property_kinds
+    - dimensions
+    - quantities
+    - units
+    - prefixes
+    - property_kinds
 
-   Returns:
-      dict: resqml unit system
-      
-   """
+    Returns:
+       dict: resqml unit system
+    """
     json_path = Path(__file__).parent / 'olio/data/properties.json'
     with open(json_path) as f:
         data = json.load(f)
@@ -373,7 +371,7 @@ def _properties_data():
 
 
 def _try_parse_unit(units):
-    """Try to match unit against known uoms and aliases, else return None"""
+    """Try to match unit against known uoms and aliases, else return None."""
 
     uom_list = valid_uoms()
     ul = units.casefold()

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -88,35 +88,35 @@ class MdDatum(BaseResqpy):
             extra_metadata = None):
         """Initialises a new MdDatum object.
 
-      arguments:
-         parent_model (model.Model object): the model which the new md datum belongs to
-         uuid: If not None, load from existing object. Else, create new.
-         md_datum_root (optional): DEPRECATED: the root node of the xml tree representing the md datum;
-            if not None, the new md datum object is initialised based on data in the tree;
-            if None, the new object is initialised from the remaining arguments
-         crs_uuid (uuid.UUID): required if initialising from values
-         crs_root: DEPRECATED, use crs_uuid instead; the root node of the coordinate reference system
-            xml tree; ignored if uuid or md_datum_root is not None or crs_uuid is not None
-         location: (triple float): the x, y, z location of the new measured depth datum;
-            ignored if uuid or md_datum_root is not None
-         md_reference (string): human readable resqml standard string indicating the real
-            world nature of the datum, eg. 'kelly bushing'; the full list of options is
-            available as the global variable valid_md_reference_list in this module;
-            ignored if uuid or md_datum_root is not None
-         title (str, optional): the citation title to use for a new datum;
-            ignored if uuid or md_datum_root is not None
-         originator (str, optional): the name of the person creating the datum, defaults to login id;
-            ignored if uuid or md_datum_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the datum;
-            ignored if uuid or md_datum_root is not None
+        arguments:
+           parent_model (model.Model object): the model which the new md datum belongs to
+           uuid: If not None, load from existing object. Else, create new.
+           md_datum_root (optional): DEPRECATED: the root node of the xml tree representing the md datum;
+              if not None, the new md datum object is initialised based on data in the tree;
+              if None, the new object is initialised from the remaining arguments
+           crs_uuid (uuid.UUID): required if initialising from values
+           crs_root: DEPRECATED, use crs_uuid instead; the root node of the coordinate reference system
+              xml tree; ignored if uuid or md_datum_root is not None or crs_uuid is not None
+           location: (triple float): the x, y, z location of the new measured depth datum;
+              ignored if uuid or md_datum_root is not None
+           md_reference (string): human readable resqml standard string indicating the real
+              world nature of the datum, eg. 'kelly bushing'; the full list of options is
+              available as the global variable valid_md_reference_list in this module;
+              ignored if uuid or md_datum_root is not None
+           title (str, optional): the citation title to use for a new datum;
+              ignored if uuid or md_datum_root is not None
+           originator (str, optional): the name of the person creating the datum, defaults to login id;
+              ignored if uuid or md_datum_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the datum;
+              ignored if uuid or md_datum_root is not None
 
-      returns:
-         the newly instantiated measured depth datum object
+        returns:
+           the newly instantiated measured depth datum object
 
-      note:
-         this function does not create an xml node for the md datum; call the create_xml() method afterwards
-         if initialising from data other than an existing RESQML object
-      """
+        note:
+           this function does not create an xml node for the md datum; call the create_xml() method afterwards
+           if initialising from data other than an existing RESQML object
+        """
 
         if crs_root is not None:
             warnings.warn("Attribute 'crs_root' is deprecated. Use 'crs_uuid'", DeprecationWarning)
@@ -156,7 +156,7 @@ class MdDatum(BaseResqpy):
 
     @property
     def crs_root(self):
-        """XML node corresponding to self.crs_uuid"""
+        """XML node corresponding to self.crs_uuid."""
 
         return self.model.root_for_uuid(self.crs_uuid)
 
@@ -190,18 +190,18 @@ class MdDatum(BaseResqpy):
     def create_xml(self, add_as_part = True, add_relationships = True, title = None, originator = None):
         """Creates xml for a measured depth datum element; crs node must already exist; optionally adds as part.
 
-         arguments:
-            add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-               in the model
-            add_relationships (boolean, default True): if True, a relationship xml part is created relating the
-               new md datum part to the crs
-            title (string): used as the citation Title text for the new md datum node
-            originator (string, optional): the name of the human being who created the md datum part;
-               default is to use the login name
+        arguments:
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in the model
+           add_relationships (boolean, default True): if True, a relationship xml part is created relating the
+              new md datum part to the crs
+           title (string): used as the citation Title text for the new md datum node
+           originator (string, optional): the name of the human being who created the md datum part;
+              default is to use the login name
 
-         returns:
-            the newly created measured depth datum xml node
-      """
+        returns:
+           the newly created measured depth datum xml node
+        """
 
         md_reference = self.md_reference.lower()
         assert md_reference in valid_md_reference_list, 'invalid measured depth reference: ' + md_reference
@@ -244,22 +244,22 @@ class MdDatum(BaseResqpy):
 class DeviationSurvey(BaseResqpy):
     """Class for RESQML wellbore deviation survey.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      Specifies the station data from a deviation survey.
+       Specifies the station data from a deviation survey.
 
-      The deviation survey does not provide a complete specification of the
-      geometry of a wellbore trajectory. Although a minimum-curvature
-      algorithm is used in most cases, the implementation varies sufficiently
-      that no single algorithmic specification is available as a data transfer
-      standard.
+       The deviation survey does not provide a complete specification of the
+       geometry of a wellbore trajectory. Although a minimum-curvature
+       algorithm is used in most cases, the implementation varies sufficiently
+       that no single algorithmic specification is available as a data transfer
+       standard.
 
-      Instead, the geometry of a RESQML wellbore trajectory is represented by
-      a parametric line, parameterized by the MD.
+       Instead, the geometry of a RESQML wellbore trajectory is represented by
+       a parametric line, parameterized by the MD.
 
-      CRS and units of measure do not need to be consistent with the CRS and
-      units of measure for wellbore trajectory representation.
-   """
+       CRS and units of measure do not need to be consistent with the CRS and
+       units of measure for wellbore trajectory representation.
+    """
 
     resqml_type = 'DeviationSurveyRepresentation'
 
@@ -282,35 +282,35 @@ class DeviationSurvey(BaseResqpy):
                  extra_metadata = None):
         """Load or create a DeviationSurvey object.
 
-      If uuid is given, loads from XML. Else, create new. If loading from disk, other
-      parameters will be overwritten.
+        If uuid is given, loads from XML. Else, create new. If loading from disk, other
+        parameters will be overwritten.
 
-      Args:
-         parent_model (model.Model): the model which the new survey belongs to
-         uuid (uuid.UUID): If given, loads from disk. Else, creates new.
-         title (str): Citation title
-         deviation_survey_root: DEPCRECATED. If given, load from disk.
-         represented_interp (wellbore interpretation): if present, is noted as the wellbore
-            interpretation object which this deviation survey relates to
-         md_datum (MdDatum): the datum that the depths for this survey are measured from
-         md_uom (string, default 'm'): a resqml length unit of measure applicable to the
-            measured depths; should be 'm' or 'ft'
-         angle_uom (string): a resqml angle unit; should be 'dega' or 'rad'
-         measured_depths (np.array): 1d array
-         azimuths (np.array): 1d array
-         inclindations (np.array): 1d array
-         station_count (int): length of measured_depths, azimuths & inclinations
-         first_station (tuple): (x, y, z) of first point in survey, in crs for md datum
-         is_final (bool): whether survey is a finalised deviation survey
-         originator (str): name of author
-         extra_metadata (dict, optional): extra metadata key, value pairs
+        Args:
+           parent_model (model.Model): the model which the new survey belongs to
+           uuid (uuid.UUID): If given, loads from disk. Else, creates new.
+           title (str): Citation title
+           deviation_survey_root: DEPCRECATED. If given, load from disk.
+           represented_interp (wellbore interpretation): if present, is noted as the wellbore
+              interpretation object which this deviation survey relates to
+           md_datum (MdDatum): the datum that the depths for this survey are measured from
+           md_uom (string, default 'm'): a resqml length unit of measure applicable to the
+              measured depths; should be 'm' or 'ft'
+           angle_uom (string): a resqml angle unit; should be 'dega' or 'rad'
+           measured_depths (np.array): 1d array
+           azimuths (np.array): 1d array
+           inclindations (np.array): 1d array
+           station_count (int): length of measured_depths, azimuths & inclinations
+           first_station (tuple): (x, y, z) of first point in survey, in crs for md datum
+           is_final (bool): whether survey is a finalised deviation survey
+           originator (str): name of author
+           extra_metadata (dict, optional): extra metadata key, value pairs
 
-      Returns:
-         DeviationSurvey
+        Returns:
+           DeviationSurvey
 
-      Notes:
-         this method does not create an xml node, nor write hdf5 arrays
-      """
+        Notes:
+           this method does not create an xml node, nor write hdf5 arrays
+        """
 
         self.is_final = is_final
         self.md_uom = bwam.rq_length_unit(md_uom)
@@ -356,28 +356,28 @@ class DeviationSurvey(BaseResqpy):
                         angle_uom = 'dega'):
         """Load MD, aximuth & inclination data from a pandas data frame.
 
-      Args:
-         parent_model (model.Model): the parent resqml model
-         data_frame: a pandas dataframe holding the deviation survey data
-         md_datum (MdDatum object): the datum that the depths for this survey are measured from
-         md_col (string, default 'MD'): the name of the column holding measured depth values
-         azimuth_col (string, default 'AZIM_GN'): the name of the column holding azimuth values relative
-            to the north direction (+ve y axis) of the coordinate reference system
-         inclination_col (string, default 'INCL'): the name of the column holding inclination values
-         x_col (string, default 'X'): the name of the column holding an x value in the first row
-         y_col (string, default 'Y'): the name of the column holding an Y value in the first row
-         z_col (string, default 'Z'): the name of the column holding an z value in the first row
-         md_uom (string, default 'm'): a resqml length unit of measure applicable to the
-            measured depths; should be 'm' or 'ft'
-         angle_uom (string, default 'dega'): a resqml angle unit of measure applicable to both
-            the azimuth and inclination data
+        Args:
+           parent_model (model.Model): the parent resqml model
+           data_frame: a pandas dataframe holding the deviation survey data
+           md_datum (MdDatum object): the datum that the depths for this survey are measured from
+           md_col (string, default 'MD'): the name of the column holding measured depth values
+           azimuth_col (string, default 'AZIM_GN'): the name of the column holding azimuth values relative
+              to the north direction (+ve y axis) of the coordinate reference system
+           inclination_col (string, default 'INCL'): the name of the column holding inclination values
+           x_col (string, default 'X'): the name of the column holding an x value in the first row
+           y_col (string, default 'Y'): the name of the column holding an Y value in the first row
+           z_col (string, default 'Z'): the name of the column holding an z value in the first row
+           md_uom (string, default 'm'): a resqml length unit of measure applicable to the
+              measured depths; should be 'm' or 'ft'
+           angle_uom (string, default 'dega'): a resqml angle unit of measure applicable to both
+              the azimuth and inclination data
 
-      Returns:
-         DeviationSurvey
+        Returns:
+           DeviationSurvey
 
-      Note:
-         The X, Y & Z columns are only used to set the first station location (from the first row)
-      """
+        Note:
+           The X, Y & Z columns are only used to set the first station location (from the first row)
+        """
 
         for col in [md_col, azimuth_col, inclination_col, x_col, y_col, z_col]:
             assert col in data_frame.columns
@@ -415,31 +415,31 @@ class DeviationSurvey(BaseResqpy):
                         md_datum = None):
         """Load MD, aximuth & inclination data from an ascii deviation survey file.
 
-      Arguments:
-         parent_model (model.Model): the parent resqml model
-         deviation_survey_file (string): the filename of an ascii file holding the deviation survey data
-         comment_character (string): the character to be treated as introducing comments
-         space_separated_instead_of_csv (boolea, default False): if False, csv format expected;
-            if True, columns are expected to be seperated by white space
-         md_col (string, default 'MD'): the name of the column holding measured depth values
-         azimuth_col (string, default 'AZIM_GN'): the name of the column holding azimuth values relative
-            to the north direction (+ve y axis) of the coordinate reference system
-         inclination_col (string, default 'INCL'): the name of the column holding inclination values
-         x_col (string, default 'X'): the name of the column holding an x value in the first row
-         y_col (string, default 'Y'): the name of the column holding an Y value in the first row
-         z_col (string, default 'Z'): the name of the column holding an z value in the first row
-         md_uom (string, default 'm'): a resqml length unit of measure applicable to the
-            measured depths; should be 'm' or 'ft'
-         angle_uom (string, default 'dega'): a resqml angle unit of measure applicable to both
-            the azimuth and inclination data
-         md_datum (MdDatum object): the datum that the depths for this survey are measured from
+        Arguments:
+           parent_model (model.Model): the parent resqml model
+           deviation_survey_file (string): the filename of an ascii file holding the deviation survey data
+           comment_character (string): the character to be treated as introducing comments
+           space_separated_instead_of_csv (boolea, default False): if False, csv format expected;
+              if True, columns are expected to be seperated by white space
+           md_col (string, default 'MD'): the name of the column holding measured depth values
+           azimuth_col (string, default 'AZIM_GN'): the name of the column holding azimuth values relative
+              to the north direction (+ve y axis) of the coordinate reference system
+           inclination_col (string, default 'INCL'): the name of the column holding inclination values
+           x_col (string, default 'X'): the name of the column holding an x value in the first row
+           y_col (string, default 'Y'): the name of the column holding an Y value in the first row
+           z_col (string, default 'Z'): the name of the column holding an z value in the first row
+           md_uom (string, default 'm'): a resqml length unit of measure applicable to the
+              measured depths; should be 'm' or 'ft'
+           angle_uom (string, default 'dega'): a resqml angle unit of measure applicable to both
+              the azimuth and inclination data
+           md_datum (MdDatum object): the datum that the depths for this survey are measured from
 
-      Returns:
-         DeviationSurvey
+        Returns:
+           DeviationSurvey
 
-      Note:
-         The X, Y & Z columns are only used to set the first station location (from the first row)
-      """
+        Note:
+           The X, Y & Z columns are only used to set the first station location (from the first row)
+        """
 
         try:
             df = pd.read_csv(deviation_survey_file,
@@ -466,11 +466,11 @@ class DeviationSurvey(BaseResqpy):
     def _load_from_xml(self):
         """Load attributes from xml and associated hdf5 data.
 
-      This is invoked as part of the init method when an existing uuid is given.
-      
-      Returns:
-         [bool]: True if sucessful
-      """
+        This is invoked as part of the init method when an existing uuid is given.
+
+        Returns:
+           [bool]: True if sucessful
+        """
 
         # Get node from self.uuid
         node = self.root
@@ -511,23 +511,23 @@ class DeviationSurvey(BaseResqpy):
                    originator = None):
         """Creates a deviation survey representation xml element from this DeviationSurvey object.
 
-      arguments:
-         ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the deviation survey arrays
-         md_datum_root: the root xml node for the measured depth datum that the deviation survey depths
-            are based on
-         md_datum_xyz: TODO: document this
-         add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-            in the model
-         add_relationships (boolean, default True): if True, a relationship xml part is created relating the
-            new deviation survey part to the measured depth datum part
-         title (string): used as the citation Title text; should usually refer to the well name in a
-            human readable way
-         originator (string, optional): the name of the human being who created the deviation survey part;
-            default is to use the login name
+        arguments:
+           ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the deviation survey arrays
+           md_datum_root: the root xml node for the measured depth datum that the deviation survey depths
+              are based on
+           md_datum_xyz: TODO: document this
+           add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+              in the model
+           add_relationships (boolean, default True): if True, a relationship xml part is created relating the
+              new deviation survey part to the measured depth datum part
+           title (string): used as the citation Title text; should usually refer to the well name in a
+              human readable way
+           originator (string, optional): the name of the human being who created the deviation survey part;
+              default is to use the login name
 
-      returns:
-         the newly created deviation survey xml node
-      """
+        returns:
+           the newly created deviation survey xml node
+        """
 
         assert self.station_count > 0
 
@@ -635,7 +635,7 @@ class DeviationSurvey(BaseResqpy):
         h5_reg.write(file = file_name, mode = mode)
 
     def _load_related_datum(self):
-        """Return related MdDatum object from XML if present"""
+        """Return related MdDatum object from XML if present."""
 
         md_datum_uuid = bu.uuid_from_string(rqet.find_tag(rqet.find_tag(self.root, 'MdDatum'), 'UUID'))
         if md_datum_uuid is not None:
@@ -646,7 +646,7 @@ class DeviationSurvey(BaseResqpy):
         return md_datum
 
     def _load_related_wellbore_interp(self):
-        """Return related wellbore interp object from XML if present"""
+        """Return related wellbore interp object from XML if present."""
 
         interp_uuid = rqet.find_nested_tags_text(self.root, ['RepresentedInterpretation', 'UUID'])
         if interp_uuid is None:
@@ -659,10 +659,10 @@ class DeviationSurvey(BaseResqpy):
 class Trajectory(BaseResqpy):
     """Class for RESQML Wellbore Trajectory Representation (Geometry).
 
-   note:
-      resqml allows trajectory to have different crs to the measured depth datum crs;
-      however, this code requires the trajectory to be in the same crs as the md datum
-   """
+    note:
+       resqml allows trajectory to have different crs to the measured depth datum crs;
+       however, this code requires the trajectory to be in the same crs as the md datum
+    """
 
     resqml_type = 'WellboreTrajectoryRepresentation'
     well_name = rqo._alias_for_attribute("title")
@@ -689,60 +689,61 @@ class Trajectory(BaseResqpy):
             hdf5_source_model = None,
             originator = None,
             extra_metadata = None):
-        """Creates a new trajectory object and optionally loads it from xml, deviation survey, pandas dataframe, or ascii file.
+        """Creates a new trajectory object and optionally loads it from xml, deviation survey, pandas dataframe, or
+        ascii file.
 
-      arguments:
-         parent_model (model.Model object): the model which the new trajectory belongs to
-         trajectory_root (DEPRECATED): use uuid instead; the root node of an xml tree representing the trajectory;
-            if not None, the new trajectory object is initialised based on the data in the tree;
-            if None, one of the other arguments is used
-         md_datum (MdDatum object): the datum that the depths for this trajectory are measured from;
-            not used if uuid or trajectory_root is not None
-         deviation_survey (DeviationSurvey object, optional): if present and uuid and trajectory_root are None
-            then the trajectory is derived from the deviation survey based on minimum curvature
-         data_frame (optional): a pandas dataframe with columns 'MD', 'X', 'Y' and 'Z', holding
-            the measured depths, and corresponding node locations; ignored if uuid or trajectory_root is not None
-         grid (grid.Grid object, optional): only required if initialising from a list of cell indices;
-            ignored otherwise
-         cell_kji0_list (numpy int array of shape (N, 3)): ordered list of cell indices to be visited by
-            the trajectory; ignored if uuid or trajectory_root is not None
-         wellspec_file (string, optional): name of an ascii file containing Nexus WELLSPEC data; well_name
-            and length_uom arguments must be passed
-         spline_mode (string, default 'cube'): one of 'none', 'linear', 'square', or 'cube'; affects spline
-            tangent generation; only relevant if initialising from list of cells
-         deviation_survey_file (string): filename of an ascii file holding the trajectory
-            in a tabular form; ignored if uuid or trajectory_root is not None
-         survey_file_space_separated (boolean, default False): if True, deviation survey file is
-            space separated; if False, comma separated (csv); ignored unless loading from survey file
-         length_uom (string, default 'm'): a resqml length unit of measure applicable to the
-            measured depths; should be 'm' or 'ft'
-         md_domain (string, optional): if present, must be 'logger' or 'driller'; the source of the original
-            deviation data; ignored if uuid or trajectory_root is not None
-         represented_interp (wellbore interpretation object, optional): if present, is noted as the wellbore
-            interpretation object which this trajectory relates to; ignored if uuid or trajectory_root is not None
-         well_name (string, optional): used as citation title
-         set_tangent_vectors (boolean, default False): if True and tangent vectors are not loaded then they will
-            be computed from the control points
-         hdf5_source_model (model.Model, optional): if present this model is used to determine the hdf5 file
-            name from which to load the trajectory's array data; if None, the parent_model is used as usual
-         originator (str, optional): the name of the person creating the trajectory, defaults to login id;
-            ignored if uuid or trajectory_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the trajectory;
-            ignored if uuid or trajectory_root is not None
+        arguments:
+           parent_model (model.Model object): the model which the new trajectory belongs to
+           trajectory_root (DEPRECATED): use uuid instead; the root node of an xml tree representing the trajectory;
+              if not None, the new trajectory object is initialised based on the data in the tree;
+              if None, one of the other arguments is used
+           md_datum (MdDatum object): the datum that the depths for this trajectory are measured from;
+              not used if uuid or trajectory_root is not None
+           deviation_survey (DeviationSurvey object, optional): if present and uuid and trajectory_root are None
+              then the trajectory is derived from the deviation survey based on minimum curvature
+           data_frame (optional): a pandas dataframe with columns 'MD', 'X', 'Y' and 'Z', holding
+              the measured depths, and corresponding node locations; ignored if uuid or trajectory_root is not None
+           grid (grid.Grid object, optional): only required if initialising from a list of cell indices;
+              ignored otherwise
+           cell_kji0_list (numpy int array of shape (N, 3)): ordered list of cell indices to be visited by
+              the trajectory; ignored if uuid or trajectory_root is not None
+           wellspec_file (string, optional): name of an ascii file containing Nexus WELLSPEC data; well_name
+              and length_uom arguments must be passed
+           spline_mode (string, default 'cube'): one of 'none', 'linear', 'square', or 'cube'; affects spline
+              tangent generation; only relevant if initialising from list of cells
+           deviation_survey_file (string): filename of an ascii file holding the trajectory
+              in a tabular form; ignored if uuid or trajectory_root is not None
+           survey_file_space_separated (boolean, default False): if True, deviation survey file is
+              space separated; if False, comma separated (csv); ignored unless loading from survey file
+           length_uom (string, default 'm'): a resqml length unit of measure applicable to the
+              measured depths; should be 'm' or 'ft'
+           md_domain (string, optional): if present, must be 'logger' or 'driller'; the source of the original
+              deviation data; ignored if uuid or trajectory_root is not None
+           represented_interp (wellbore interpretation object, optional): if present, is noted as the wellbore
+              interpretation object which this trajectory relates to; ignored if uuid or trajectory_root is not None
+           well_name (string, optional): used as citation title
+           set_tangent_vectors (boolean, default False): if True and tangent vectors are not loaded then they will
+              be computed from the control points
+           hdf5_source_model (model.Model, optional): if present this model is used to determine the hdf5 file
+              name from which to load the trajectory's array data; if None, the parent_model is used as usual
+           originator (str, optional): the name of the person creating the trajectory, defaults to login id;
+              ignored if uuid or trajectory_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the trajectory;
+              ignored if uuid or trajectory_root is not None
 
-      returns:
-         the newly created wellbore trajectory object
+        returns:
+           the newly created wellbore trajectory object
 
-      notes:
-         if starting from a deviation survey file, there are two routes: create a deviation survey object first,
-         using the azimuth and inclination data, then generate a trajectory from that based on minimum curvature;
-         or, create a trajectory directly using X, Y, Z data from the deviation survey file (ie. minimum
-         curvature or other algorithm already applied externally);
-         if not loading from xml, then the crs is set to that used by the measured depth datum, or if that is not
-         available then the default crs for the model
+        notes:
+           if starting from a deviation survey file, there are two routes: create a deviation survey object first,
+           using the azimuth and inclination data, then generate a trajectory from that based on minimum curvature;
+           or, create a trajectory directly using X, Y, Z data from the deviation survey file (ie. minimum
+           curvature or other algorithm already applied externally);
+           if not loading from xml, then the crs is set to that used by the measured depth datum, or if that is not
+           available then the default crs for the model
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         self.crs_uuid = None
         self.title = well_name
@@ -817,18 +818,18 @@ class Trajectory(BaseResqpy):
 
     @property
     def crs_root(self):
-        """XML node corresponding to self.crs_uuid"""
+        """XML node corresponding to self.crs_uuid."""
 
         return self.model.root_for_uuid(self.crs_uuid)
 
     def iter_wellbore_frames(self):
-        """ Iterable of all WellboreFrames associated with a trajectory
+        """Iterable of all WellboreFrames associated with a trajectory.
 
-      Yields:
-         frame: instance of :class:`resqpy.organize.WellboreFrame`
+        Yields:
+           frame: instance of :class:`resqpy.organize.WellboreFrame`
 
-      :meta common:
-      """
+        :meta common:
+        """
         uuids = self.model.uuids(obj_type = "WellboreFrameRepresentation", related_uuid = self.uuid)
         for uuid in uuids:
             yield WellboreFrame(self.model, uuid = uuid)
@@ -1080,23 +1081,23 @@ class Trajectory(BaseResqpy):
     def set_tangents(self, force = False, write_hdf5 = False, weight = 'cube'):
         """Calculates tangent vectors based on control points.
 
-      arguments:
-         force (boolean, default False): if False and tangent vectors already exist then the existing ones are used;
-            if True or no tangents vectors exist then they are computed
-         write_hdf5 (boolean, default False): if True and new tangent vectors are computed then the array is also written
-            directly to the hdf5 file
-         weight (string, default 'linear'): one of 'linear', 'square', 'cube'; if linear, each tangent is the mean of the
-            direction vectors of the two trjectory segments which meet at the knot; the square and cube options give
-            increased weight to the direction vector of shorter segments (usually better)
+        arguments:
+           force (boolean, default False): if False and tangent vectors already exist then the existing ones are used;
+              if True or no tangents vectors exist then they are computed
+           write_hdf5 (boolean, default False): if True and new tangent vectors are computed then the array is also written
+              directly to the hdf5 file
+           weight (string, default 'linear'): one of 'linear', 'square', 'cube'; if linear, each tangent is the mean of the
+              direction vectors of the two trjectory segments which meet at the knot; the square and cube options give
+              increased weight to the direction vector of shorter segments (usually better)
 
-      returns:
-         numpy float array of shape (knot_count, 3) being the tangents in xyz, 'pointing' in the direction of increased
-         knot index; the tangents are also stored as an attribute of the object
+        returns:
+           numpy float array of shape (knot_count, 3) being the tangents in xyz, 'pointing' in the direction of increased
+           knot index; the tangents are also stored as an attribute of the object
 
-      note:
-         the write_hdf5() method writes all the array data for the trajectory, including the tangent vectors; only set
-         the write_hdf5 argument to this method to True if the other arrays for the trajectory already exist in the hdf5 file
-      """
+        note:
+           the write_hdf5() method writes all the array data for the trajectory, including the tangent vectors; only set
+           the write_hdf5 argument to this method to True if the other arrays for the trajectory already exist in the hdf5 file
+        """
 
         if self.tangent_vectors is not None and not force:
             return self.tangent_vectors
@@ -1115,11 +1116,11 @@ class Trajectory(BaseResqpy):
     def dataframe(self, md_col = 'MD', x_col = 'X', y_col = 'Y', z_col = 'Z'):
         """Returns a pandas data frame containing MD and control points (xyz) data.
 
-      note:
-         set md_col to None for a dataframe containing only X, Y & Z data
+        note:
+           set md_col to None for a dataframe containing only X, Y & Z data
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if md_col:
             column_list = [md_col, x_col, y_col, z_col]
@@ -1144,30 +1145,31 @@ class Trajectory(BaseResqpy):
                             z_col = 'Z'):
         """Writes trajectory to an ascii file.
 
-      note:
-         set md_col to None for a dataframe containing only X, Y & Z data
-      """
+        note:
+           set md_col to None for a dataframe containing only X, Y & Z data
+        """
 
         df = self.dataframe(md_col = md_col, x_col = x_col, y_col = y_col, z_col = z_col)
         sep = ' ' if space_separated_instead_of_csv else ','
         df.to_csv(trajectory_file, sep = sep, index = False, mode = mode)
 
     def xyz_for_md(self, md):
-        """Returns an xyz triplet corresponding to the given measured depth; uses simple linear interpolation between knots.
+        """Returns an xyz triplet corresponding to the given measured depth; uses simple linear interpolation between
+        knots.
 
-      args:
-         md (float): measured depth for which xyz location is required; units must be those of self.md_uom
+        args:
+           md (float): measured depth for which xyz location is required; units must be those of self.md_uom
 
-      returns:
-         triple float being x, y, z coordinates of point on trajectory corresponding to given measured depth
+        returns:
+           triple float being x, y, z coordinates of point on trajectory corresponding to given measured depth
 
-      note:
-         the algorithm uses a simple linear interpolation between neighbouring knots (control points) on the trajectory;
-         if the measured depth is less than zero or greater than the finish md, a single None is returned; if the md is
-         less than the start md then a linear interpolation between the md datum location and the first knot is returned
+        note:
+           the algorithm uses a simple linear interpolation between neighbouring knots (control points) on the trajectory;
+           if the measured depth is less than zero or greater than the finish md, a single None is returned; if the md is
+           less than the start md then a linear interpolation between the md datum location and the first knot is returned
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         def interpolate(p1, p2, f):
             return f * p2 + (1.0 - f) * p1
@@ -1201,38 +1203,38 @@ class Trajectory(BaseResqpy):
                            store_tangents_if_calculated = True):
         """Creates and returns a new Trajectory derived as a cubic spline of this trajectory.
 
-      arguments:
-         well_name (string): the name to use as the citation title for the new trajectory
-         min_subdivisions (+ve integer, default 1): the minimum number of segments in the trajectory for each
-            segment in this trajectory
-         max_segment_length (float, optional): if present, each segment of this trajectory is subdivided so
-            that the naive subdivided length is not greater than the specified length
-         max_degrees_per_knot (float, default 5.0): the maximum number of degrees
-         use_tangents_if_present (boolean, default False): if True, any tangent vectors in this trajectory
-            are used during splining
-         store_tangents_if_calculated (boolean, default True): if True any tangents calculated by the method
-            are stored in the object (causing any previous tangents to be discarded); however, the new tangents
-            are not written to the hdf5 file by this method
+        arguments:
+           well_name (string): the name to use as the citation title for the new trajectory
+           min_subdivisions (+ve integer, default 1): the minimum number of segments in the trajectory for each
+              segment in this trajectory
+           max_segment_length (float, optional): if present, each segment of this trajectory is subdivided so
+              that the naive subdivided length is not greater than the specified length
+           max_degrees_per_knot (float, default 5.0): the maximum number of degrees
+           use_tangents_if_present (boolean, default False): if True, any tangent vectors in this trajectory
+              are used during splining
+           store_tangents_if_calculated (boolean, default True): if True any tangents calculated by the method
+              are stored in the object (causing any previous tangents to be discarded); however, the new tangents
+              are not written to the hdf5 file by this method
 
-      returns:
-         Trajectory object with control points lying on a cubic spline of the points of this trajectory
+        returns:
+           Trajectory object with control points lying on a cubic spline of the points of this trajectory
 
-      notes:
-         this method is typically used to smoothe an artificial or simulator trajectory;
-         measured depths are re-calculated and will differ from those in this trajectory;
-         unexpected behaviour may occur if the z units are different from the xy units in the crs;
-         if tangent vectors for neighbouring points in this trajectory are pointing in opposite directions,
-         the resulting spline is likely to be bad;
-         the max_segment_length is applied when deciding how many subdivisions to make for a segment in this
-         trajectory, based on the stright line segment length; segments in the resulting spline may exceed this
-         length;
-         similarly max_degrees_per_knot assumes a simply bend between neighbouring knots; if the position of the
-         control points results in a loop, the value may be exceeded in the spline;
-         the hdf5 data for the splined trajectory is not written by this method, neither is the xml created;
-         no interpretation object is created by this method
-         NB: direction of tangent vectors affects results, set use_tangents_if_present = False to
-         ensure locally calculated tangent vectors are used
-      """
+        notes:
+           this method is typically used to smoothe an artificial or simulator trajectory;
+           measured depths are re-calculated and will differ from those in this trajectory;
+           unexpected behaviour may occur if the z units are different from the xy units in the crs;
+           if tangent vectors for neighbouring points in this trajectory are pointing in opposite directions,
+           the resulting spline is likely to be bad;
+           the max_segment_length is applied when deciding how many subdivisions to make for a segment in this
+           trajectory, based on the stright line segment length; segments in the resulting spline may exceed this
+           length;
+           similarly max_degrees_per_knot assumes a simply bend between neighbouring knots; if the position of the
+           control points results in a loop, the value may be exceeded in the spline;
+           the hdf5 data for the splined trajectory is not written by this method, neither is the xml created;
+           no interpretation object is created by this method
+           NB: direction of tangent vectors affects results, set use_tangents_if_present = False to
+           ensure locally calculated tangent vectors are used
+        """
 
         assert self.knot_count > 1 and self.control_points is not None
         assert min_subdivisions >= 1
@@ -1281,10 +1283,11 @@ class Trajectory(BaseResqpy):
         return self.measured_depths
 
     def create_feature_and_interpretation(self):
-        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does not already exist.
-      
-      Uses the trajectory citation title as the well name
-      """
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does
+        not already exist.
+
+        Uses the trajectory citation title as the well name
+        """
 
         log.debug("Creating a new WellboreInterpretation..")
         log.debug(f"WellboreFeature exists: {self.wellbore_feature is not None}")
@@ -1310,14 +1313,14 @@ class Trajectory(BaseResqpy):
                    originator = None):
         """Create a wellbore trajectory representation node from a Trajectory object, optionally add as part.
 
-         notes:
-            measured depth datum xml node must be in place before calling this function;
-            branching well structures (multi-laterals) are supported by the resqml standard but not yet by
-            this code;
-            optional witsml trajectory reference not yet supported here
+           notes:
+              measured depth datum xml node must be in place before calling this function;
+              branching well structures (multi-laterals) are supported by the resqml standard but not yet by
+              this code;
+              optional witsml trajectory reference not yet supported here
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if title:
             self.title = title
@@ -1459,10 +1462,11 @@ class Trajectory(BaseResqpy):
         return wbt_node
 
     def write_hdf5(self, file_name = None, mode = 'a'):
-        """Create or append to an hdf5 file, writing datasets for the measured depths, control points and tangent vectors.
+        """Create or append to an hdf5 file, writing datasets for the measured depths, control points and tangent
+        vectors.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # NB: array data must all have been set up prior to calling this function
         if self.uuid is None:
@@ -1476,7 +1480,10 @@ class Trajectory(BaseResqpy):
         h5_reg.write(file = file_name, mode = mode)
 
     def __eq__(self, other):
-        """Implements equals operator. Compares class type and uuid"""
+        """Implements equals operator.
+
+        Compares class type and uuid
+        """
 
         # TODO: more detailed equality comparison
         other_uuid = getattr(other, "uuid", None)
@@ -1486,17 +1493,16 @@ class Trajectory(BaseResqpy):
 class WellboreFrame(BaseResqpy):
     """Class for RESQML WellboreFrameRepresentation objects (supporting well log Properties)
 
-   RESQML documentation:
+    RESQML documentation:
 
-      Representation of a wellbore that is organized along a wellbore trajectory by its MD values.
-      RESQML uses MD values to associate properties on points and to organize association of
-      properties on intervals between MD points.
+       Representation of a wellbore that is organized along a wellbore trajectory by its MD values.
+       RESQML uses MD values to associate properties on points and to organize association of
+       properties on intervals between MD points.
 
-   Roughly equivalent to a Techlog "dataset" object with a given depth reference.
+    Roughly equivalent to a Techlog "dataset" object with a given depth reference.
 
-   The `logs` attribute is a :class:`resqpy.property.WellLogCollection` of all logs in the frame.
-
-   """
+    The `logs` attribute is a :class:`resqpy.property.WellLogCollection` of all logs in the frame.
+    """
 
     resqml_type = 'WellboreFrameRepresentation'
 
@@ -1512,30 +1518,30 @@ class WellboreFrame(BaseResqpy):
                  extra_metadata = None):
         """Creates a new wellbore frame object and optionally loads it from xml or list of measured depths.
 
-      arguments:
-         parent_model (model.Model object): the model which the new wellbore frame belongs to
-         frame_root (optional): DEPRECATED. the root node of an xml tree representing the wellbore frame;
-            if not None, the new wellbore frame object is initialised based on the data in the tree;
-            if None, an empty wellbore frame object is returned
-         trajectory (Trajectory object, optional): the trajectory of the well; required if loading from
-            list of measured depths
-         mds (optional numpy 1D array, tuple or list of floats): ordered list of measured depths which
-            will constitute the frame; ignored if frame_root is not None
-         represented_interp (wellbore interpretation object, optional): if present, is noted as the wellbore
-            interpretation object which this frame relates to; ignored if frame_root is not None
-         title (str, optional): the citation title to use for a new wellbore frame;
-            ignored if uuid or frame_root is not None
-         originator (str, optional): the name of the person creating the wellbore frame, defaults to login id;
-            ignored if uuid or frame_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the wellbore frame;
-            ignored if uuid or frame_root is not None
+        arguments:
+           parent_model (model.Model object): the model which the new wellbore frame belongs to
+           frame_root (optional): DEPRECATED. the root node of an xml tree representing the wellbore frame;
+              if not None, the new wellbore frame object is initialised based on the data in the tree;
+              if None, an empty wellbore frame object is returned
+           trajectory (Trajectory object, optional): the trajectory of the well; required if loading from
+              list of measured depths
+           mds (optional numpy 1D array, tuple or list of floats): ordered list of measured depths which
+              will constitute the frame; ignored if frame_root is not None
+           represented_interp (wellbore interpretation object, optional): if present, is noted as the wellbore
+              interpretation object which this frame relates to; ignored if frame_root is not None
+           title (str, optional): the citation title to use for a new wellbore frame;
+              ignored if uuid or frame_root is not None
+           originator (str, optional): the name of the person creating the wellbore frame, defaults to login id;
+              ignored if uuid or frame_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the wellbore frame;
+              ignored if uuid or frame_root is not None
 
-      returns:
-         the newly created wellbore frame object
+        returns:
+           the newly created wellbore frame object
 
-      note:
-         if initialising from a list of measured depths, the wellbore trajectory object must already exist
-      """
+        note:
+           if initialising from a list of measured depths, the wellbore trajectory object must already exist
+        """
 
         #: Associated wellbore trajectory, an instance of :class:`resqpy.well.Trajectory`.
         self.trajectory = trajectory
@@ -1613,10 +1619,11 @@ class WellboreFrame(BaseResqpy):
         return self.trajectory.crs_root
 
     def create_feature_and_interpretation(self):
-        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does not already exist.
-      
-      Uses the wellboreframe citation title as the well name
-      """
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does
+        not already exist.
+
+        Uses the wellboreframe citation title as the well name
+        """
         if self.wellbore_interpretation is not None:
             log.info(f"Creating WellboreInterpretation and WellboreFeature with name {self.title}")
             self.wellbore_feature = rqo.WellboreFeature(parent_model = self.model, feature_name = self.title)
@@ -1646,9 +1653,9 @@ class WellboreFrame(BaseResqpy):
                    originator = None):
         """Create a wellbore frame representation node from this WellboreFrame object, optionally add as part.
 
-      note:
-         trajectory xml node must be in place before calling this function
-      """
+        note:
+           trajectory xml node must be in place before calling this function
+        """
 
         assert self.trajectory is not None, 'trajectory object missing'
         assert self.trajectory.root is not None, 'trajectory xml not established'
@@ -1722,15 +1729,15 @@ class WellboreFrame(BaseResqpy):
 class BlockedWell(BaseResqpy):
     """Class for RESQML Blocked Wellbore Representation (Wells), ie cells visited by wellbore.
 
-   RESQML documentation:
+    RESQML documentation:
 
-      The information that allows you to locate, on one or several grids (existing or planned),
-      the intersection of volume (cells) and surface (faces) elements with a wellbore trajectory
-      (existing or planned).
+       The information that allows you to locate, on one or several grids (existing or planned),
+       the intersection of volume (cells) and surface (faces) elements with a wellbore trajectory
+       (existing or planned).
 
-   note:
-      measured depth data must be in same crs as those for the related trajectory
-   """
+    note:
+       measured depth data must be in same crs as those for the related trajectory
+    """
 
     resqml_type = 'BlockedWellboreRepresentation'
     well_name = rqo._alias_for_attribute("title")
@@ -1753,57 +1760,57 @@ class BlockedWell(BaseResqpy):
                  add_wellspec_properties = False):
         """Creates a new blocked well object and optionally loads it from xml, or trajectory, or Nexus wellspec file.
 
-      arguments:
-         parent_model (model.Model object): the model which the new blocked well belongs to
-         blocked_well_root (DEPRECATED): the root node of an xml tree representing the blocked well;
-            if not None, the new blocked well object is initialised based on the data in the tree;
-            if None, the other arguments are used
-         grid (optional, grid.Grid object): required if intialising from a trajectory or wellspec file;
-            not used if blocked_well_root is not None
-         trajectory (optional, Trajectory object): the trajectory of the well, to be intersected with the grid;
-            not used if blocked_well_root is not None
-         wellspec_file (optional, string): filename of an ascii file holding the Nexus wellspec data;
-            ignored if blocked_well_root is not None or trajectory is not None
-         cellio_file (optional, string): filename of an ascii file holding the RMS exported blocked well data;
-            ignored if blocked_well_root is not None or trajectory is not None or wellspec_file is not None
-         column_ji0 (optional, pair of ints): column indices (j0, i0) for a 'vertical' well; ignored if
-            blocked_well_root is not None or trajectory is not None or wellspec_file is not None or
-            cellio_file is not None
-         well_name (string): the well name as given in the wellspec or cellio file; required if loading from
-            one of those files; or the name to be used as citation title for a column well
-         check_grid_name (boolean, default False): if True, the GRID column of the wellspec data will be checked
-            for a match with the citation title of the grid object; perforations for other grids will be skipped;
-            if False, all wellspec data is assumed to relate to the grid; only relevant when loading from wellspec
-         use_face_centres (boolean, default False): if True, cell face centre points are used for the entry and
-            exit points when constructing the simulation trajectory; if False and ANGLA & ANGLV data are available
-            then entry and exit points are constructed based on a straight line at those angles passing through
-            the centre of the cell; only relevant when loading from wellspec
-         represented_interp (wellbore interpretation object, optional): if present, is noted as the wellbore
-            interpretation object which this frame relates to; ignored if blocked_well_root is not None
-         originator (str, optional): the name of the person creating the blocked well, defaults to login id;
-            ignored if uuid or blocked_well_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the blocked well;
-            ignored if uuid or blocked_well_root is not None
-         add_wellspec_properties (boolean or list of str, default False): if not False, and initialising from
-            a wellspec file, the blocked well has its hdf5 data written and xml created and properties are
-            fully created; if a list is provided the elements must be numerical wellspec column names;
-            if True, all numerical columns other than the cell indices are added as properties
+        arguments:
+           parent_model (model.Model object): the model which the new blocked well belongs to
+           blocked_well_root (DEPRECATED): the root node of an xml tree representing the blocked well;
+              if not None, the new blocked well object is initialised based on the data in the tree;
+              if None, the other arguments are used
+           grid (optional, grid.Grid object): required if intialising from a trajectory or wellspec file;
+              not used if blocked_well_root is not None
+           trajectory (optional, Trajectory object): the trajectory of the well, to be intersected with the grid;
+              not used if blocked_well_root is not None
+           wellspec_file (optional, string): filename of an ascii file holding the Nexus wellspec data;
+              ignored if blocked_well_root is not None or trajectory is not None
+           cellio_file (optional, string): filename of an ascii file holding the RMS exported blocked well data;
+              ignored if blocked_well_root is not None or trajectory is not None or wellspec_file is not None
+           column_ji0 (optional, pair of ints): column indices (j0, i0) for a 'vertical' well; ignored if
+              blocked_well_root is not None or trajectory is not None or wellspec_file is not None or
+              cellio_file is not None
+           well_name (string): the well name as given in the wellspec or cellio file; required if loading from
+              one of those files; or the name to be used as citation title for a column well
+           check_grid_name (boolean, default False): if True, the GRID column of the wellspec data will be checked
+              for a match with the citation title of the grid object; perforations for other grids will be skipped;
+              if False, all wellspec data is assumed to relate to the grid; only relevant when loading from wellspec
+           use_face_centres (boolean, default False): if True, cell face centre points are used for the entry and
+              exit points when constructing the simulation trajectory; if False and ANGLA & ANGLV data are available
+              then entry and exit points are constructed based on a straight line at those angles passing through
+              the centre of the cell; only relevant when loading from wellspec
+           represented_interp (wellbore interpretation object, optional): if present, is noted as the wellbore
+              interpretation object which this frame relates to; ignored if blocked_well_root is not None
+           originator (str, optional): the name of the person creating the blocked well, defaults to login id;
+              ignored if uuid or blocked_well_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the blocked well;
+              ignored if uuid or blocked_well_root is not None
+           add_wellspec_properties (boolean or list of str, default False): if not False, and initialising from
+              a wellspec file, the blocked well has its hdf5 data written and xml created and properties are
+              fully created; if a list is provided the elements must be numerical wellspec column names;
+              if True, all numerical columns other than the cell indices are added as properties
 
-      returns:
-         the newly created blocked well object
+        returns:
+           the newly created blocked well object
 
-      notes:
-         if starting from a wellspec file or column indices, a 'simulation' trajectory and md datum objects are
-         constructed to go with the blocked well;
-         column wells might not be truly vertical - the trajectory will consist of linear segments joining the
-         centres of the k faces in the column;
-         optional RESQML attributes are not handled by this code (WITSML log reference, interval stratigraphic units,
-         cell fluid phase units);
-         mysterious RESQML WellboreFrameIndexableElements is not used in any other RESQML classes and is therefore
-         not used here
+        notes:
+           if starting from a wellspec file or column indices, a 'simulation' trajectory and md datum objects are
+           constructed to go with the blocked well;
+           column wells might not be truly vertical - the trajectory will consist of linear segments joining the
+           centres of the k faces in the column;
+           optional RESQML attributes are not handled by this code (WITSML log reference, interval stratigraphic units,
+           cell fluid phase units);
+           mysterious RESQML WellboreFrameIndexableElements is not used in any other RESQML classes and is therefore
+           not used here
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         self.trajectory = trajectory  #: trajectory object associated with the wellbore
         self.trajectory_to_be_written = False
@@ -1969,9 +1976,9 @@ class BlockedWell(BaseResqpy):
     def map_cell_and_grid_indices(self):
         """Returns a list of index values linking the grid_indices to cell_indices.
 
-      note:
-         length will match grid_indices, and will show -1 where cell is unblocked
-      """
+        note:
+           length will match grid_indices, and will show -1 where cell is unblocked
+        """
 
         indexmap = []
         j = 0
@@ -1986,9 +1993,9 @@ class BlockedWell(BaseResqpy):
     def compressed_grid_indices(self):
         """Returns a list of grid indices excluding the -1 elements (unblocked intervals).
 
-      note:
-         length will match that of cell_indices
-      """
+        note:
+           length will match that of cell_indices
+        """
 
         compressed = []
         for i in self.grid_indices:
@@ -2013,8 +2020,8 @@ class BlockedWell(BaseResqpy):
     def grid_uuid_list(self):
         """Returns a list of the uuids of the grids referenced by the blocked well object.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         uuid_list = []
         if self.grid_list is None:
@@ -2026,8 +2033,8 @@ class BlockedWell(BaseResqpy):
     def cell_indices_kji0(self):
         """Returns a numpy int array of shape (N, 3) of cells visited by well, for a single grid situation.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         grid = self.single_grid()
         return grid.denaturalized_cell_indices(self.cell_indices)
@@ -2035,8 +2042,8 @@ class BlockedWell(BaseResqpy):
     def cell_indices_and_grid_list(self):
         """Returns a numpy int array of shape (N, 3) of cells visited by well, and a list of grid objects of length N.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         grid_for_cell_list = []
         grid_indices = self.compressed_grid_indices()
@@ -2051,8 +2058,8 @@ class BlockedWell(BaseResqpy):
     def cell_indices_for_grid_uuid(self, grid_uuid):
         """Returns a numpy int array of shape (N, 3) of cells visited by well in specified grid.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         if isinstance(grid_uuid, str):
             grid_uuid = bu.uuid_from_string(grid_uuid)
@@ -2079,18 +2086,19 @@ class BlockedWell(BaseResqpy):
         return well_box
 
     def face_pair_array(self):
-        """Returns numpy int array of shape (N, 2, 2) being pairs of face (axis, polarity) pairs, to go with cell_kji0_array().
+        """Returns numpy int array of shape (N, 2, 2) being pairs of face (axis, polarity) pairs, to go with
+        cell_kji0_array().
 
-      note:
+        note:
 
-         each of the N rows in the returned array is of the form:
+           each of the N rows in the returned array is of the form:
 
-            ((entry_face_axis, entry_face_polarity), (exit_face_axis, exit_face_polarity))
+              ((entry_face_axis, entry_face_polarity), (exit_face_axis, exit_face_polarity))
 
-         where the axis values are in the range 0 to 2 for k, j & i respectively, and
-         the polarity values are zero for the 'negative' face and 1 for the 'positive' face;
-         exit values may be -1 to indicate TD within the cell (ie. no exit point)
-      """
+           where the axis values are in the range 0 to 2 for k, j & i respectively, and
+           the polarity values are zero for the 'negative' face and 1 for the 'positive' face;
+           exit values may be -1 to indicate TD within the cell (ie. no exit point)
+        """
         return self.face_pair_indices
 
     def compute_from_trajectory(self,
@@ -2101,23 +2109,23 @@ class BlockedWell(BaseResqpy):
                                 use_single_layer_tactics = True):
         """Populate this blocked wellbore object based on intersection of trajectory with cells of grid.
 
-      arguments:
-         trajectory (Trajectory object): the trajectory to intersect with the grid; control_points and crs_root attributes must
-            be populated
-         grid (grid.Grid object): the grid with which to intersect the trajectory
-         active_only (boolean, default False): if True, only active cells are included as blocked intervals
-         quad_triangles (boolean, default True): if True, 4 triangles per cell face are used for the intersection calculations;
-            if False, only 2 triangles per face are used
-         use_single_layer_tactics (boolean, default True): if True and the grid does not have k gaps, initial intersection
-            calculations with fault planes or the outer IK & JK skin of the grid are calculated as if the grid is a single
-            layer (and only after an intersection is thus found is the actual layer identified); this significantly speeds up
-            computation but may cause failure in the presence of significantly non-straight pillars and could (rarely) cause
-            problems where a fault plane is significantly skewed (non-planar) even if individual pillars are straight
+        arguments:
+           trajectory (Trajectory object): the trajectory to intersect with the grid; control_points and crs_root attributes must
+              be populated
+           grid (grid.Grid object): the grid with which to intersect the trajectory
+           active_only (boolean, default False): if True, only active cells are included as blocked intervals
+           quad_triangles (boolean, default True): if True, 4 triangles per cell face are used for the intersection calculations;
+              if False, only 2 triangles per face are used
+           use_single_layer_tactics (boolean, default True): if True and the grid does not have k gaps, initial intersection
+              calculations with fault planes or the outer IK & JK skin of the grid are calculated as if the grid is a single
+              layer (and only after an intersection is thus found is the actual layer identified); this significantly speeds up
+              computation but may cause failure in the presence of significantly non-straight pillars and could (rarely) cause
+              problems where a fault plane is significantly skewed (non-planar) even if individual pillars are straight
 
-      note:
-         this method is computationally intensive and might take ~30 seconds for a tyipical grid and trajectory; large grids,
-         grids with k gaps, or setting use_single_layer_tactics False will typically result in significantly longer processing time
-      """
+        note:
+           this method is computationally intensive and might take ~30 seconds for a tyipical grid and trajectory; large grids,
+           grids with k gaps, or setting use_single_layer_tactics False will typically result in significantly longer processing time
+        """
 
         import resqpy.grid_surface as rgs  # was causing circular import issue when at global level
 
@@ -2150,7 +2158,8 @@ class BlockedWell(BaseResqpy):
         assert bw is self
 
     def set_for_column(self, well_name, grid, col_ji0, skip_inactive = True):
-        """Populates empty blocked well for a 'vertical' well in given column; creates simulation trajectory and md datum."""
+        """Populates empty blocked well for a 'vertical' well in given column; creates simulation trajectory and md
+        datum."""
 
         if well_name:
             self.well_name = well_name
@@ -2179,28 +2188,28 @@ class BlockedWell(BaseResqpy):
                              add_properties = True):
         """Populates empty blocked well from Nexus WELLSPEC data; creates simulation trajectory and md datum.
 
-      args:
-         wellspec_file (string): path of Nexus ascii file holding WELLSPEC keyword
-         well_name (string): the name of the well as used in the wellspec data
-         grid (grid.Grid object): the grid object which the cell indices in the wellspec data relate to
-         check_grid_name (boolean, default False): if True, the GRID column of the wellspec data will be checked
-            for a match with the citation title of the grid object; perforations for other grids will be skipped;
-            if False, all wellspec data is assumed to relate to the grid
-         use_face_centres (boolean, default False): if True, cell face centre points are used for the entry and
-            exit points when constructing the simulation trajectory; if False and ANGLA & ANGLV data are available
-            then entry and exit points are constructed based on a straight line at those angles passing through
-            the centre of the cell
-         add_properties (bool or list of str, default True): if True, WELLSPEC columns (other than IW, JW, L & GRID)
-            are added as property parts for the blocked well; if a list is passed, it must contain a subset of the
-            columns in the WELLSPEC data
+        args:
+           wellspec_file (string): path of Nexus ascii file holding WELLSPEC keyword
+           well_name (string): the name of the well as used in the wellspec data
+           grid (grid.Grid object): the grid object which the cell indices in the wellspec data relate to
+           check_grid_name (boolean, default False): if True, the GRID column of the wellspec data will be checked
+              for a match with the citation title of the grid object; perforations for other grids will be skipped;
+              if False, all wellspec data is assumed to relate to the grid
+           use_face_centres (boolean, default False): if True, cell face centre points are used for the entry and
+              exit points when constructing the simulation trajectory; if False and ANGLA & ANGLV data are available
+              then entry and exit points are constructed based on a straight line at those angles passing through
+              the centre of the cell
+           add_properties (bool or list of str, default True): if True, WELLSPEC columns (other than IW, JW, L & GRID)
+              are added as property parts for the blocked well; if a list is passed, it must contain a subset of the
+              columns in the WELLSPEC data
 
-      returns:
-         self if successful; None otherwise
+        returns:
+           self if successful; None otherwise
 
-      note:
-         if add_properties is True or present as a list, this method will write the hdf5, create the xml and add
-         parts to the model for this blocked well and the properties
-      """
+        note:
+           if add_properties is True or present as a list, this method will write the hdf5, create the xml and add
+           parts to the model for this blocked well and the properties
+        """
 
         if well_name:
             self.well_name = well_name
@@ -2255,10 +2264,10 @@ class BlockedWell(BaseResqpy):
                               add_as_properties = False):
         """Populate empty blocked well from WELLSPEC-like dataframe; first columns must be IW, JW, L (i, j, k).
 
-      note:
-         if add_as_properties is True or present as a list of wellspec column names, both the blocked well and
-         the properties will have their hdf5 data written, xml created and be added as parts to the model
-      """
+        note:
+           if add_as_properties is True or present as a list of wellspec column names, both the blocked well and
+           the properties will have their hdf5 data written, xml created and be added as parts to the model
+        """
 
         def cell_kji0_from_df(df, df_row):
             row = df.iloc[df_row]
@@ -2456,15 +2465,15 @@ class BlockedWell(BaseResqpy):
     def import_from_rms_cellio(self, cellio_file, well_name, grid, include_overburden_unblocked_interval = False):
         """Populates empty blocked well from RMS cell I/O data; creates simulation trajectory and md datum.
 
-      args:
-         cellio_file (string): path of RMS ascii export file holding blocked well cell I/O data; cell entry and
-            exit points are expected
-         well_name (string): the name of the well as used in the cell I/O file
-         grid (grid.Grid object): the grid object which the cell indices in the cell I/O data relate to
+        args:
+           cellio_file (string): path of RMS ascii export file holding blocked well cell I/O data; cell entry and
+              exit points are expected
+           well_name (string): the name of the well as used in the cell I/O file
+           grid (grid.Grid object): the grid object which the cell indices in the cell I/O data relate to
 
-      returns:
-         self if successful; None otherwise
-      """
+        returns:
+           self if successful; None otherwise
+        """
 
         if well_name:
             self.well_name = well_name
@@ -2632,114 +2641,114 @@ class BlockedWell(BaseResqpy):
                   use_properties = False):
         """Returns a pandas data frame containing WELLSPEC style data.
 
-      arguments:
-         i_col (string, default 'IW'): the column name to use for cell I index values
-         j_col (string, default 'JW'): the column name to use for cell J index values
-         k_col (string, default 'L'): the column name to use for cell K index values
-         one_based (boolean, default True): if True, simulator protocol i, j & k values are placed in I, J & K columns;
-            if False, resqml zero based values; this does not affect the interpretation of min_k0 & max_k0 arguments
-         extra_columns_list (list of string, optional): list of WELLSPEC column names to include in the dataframe, from currently
-            recognised values: 'GRID', 'ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'RADW', 'SKIN', 'PPERF', 'RADB', 'WI', 'WBC'
-         ntg_uuid (uuid.UUID, optional): the uuid of the net to gross ratio property; if present is used to downgrade the i & j
-            permeabilities in the calculation of KH; ignored if 'KH' not in the extra column list and min_kh is not specified;
-            the argument may also be a dictionary mapping from grid uuid to ntg uuid; if no net to gross data is provided, it
-            is effectively assumed to be one (or, equivalently, the I & J permeability data is applicable to the gross rock); see
-            also preferential_perforation argument which can cause adjustment of effective ntg in partially perforated cells
-         perm_i_uuid (uuid.UUID or dictionary, optional): the uuid of the permeability property in the I direction;
-            required if 'KH' is included in the extra columns list and min_kh is not specified; ignored otherwise;
-            the argument may also be a dictionary mapping from grid uuid to perm I uuid
-         perm_j_uuid (uuid.UUID, optional): the uuid (or dict) of the permeability property in the J direction;
-            defaults to perm_i_uuid
-         perm_k_uuid (uuid.UUID, optional): the uuid (or dict) of the permeability property in the K direction;
-            defaults to perm_i_uuid
-         satw_uuid (uuid.UUID, optional): the uuid of a water saturation property; required if max_satw is specified; may also
-            be a dictionary mapping from grid uuid to satw uuid; ignored if max_satw is None
-         sato_uuid (uuid.UUID, optional): the uuid of an oil saturation property; required if min_sato is specified; may also
-            be a dictionary mapping from grid uuid to sato uuid; ignored if min_sato is None
-         satg_uuid (uuid.UUID, optional): the uuid of a gas saturation property; required if max_satg is specified; may also
-            be a dictionary mapping from grid uuid to satg uuid; ignored if max_satg is None
-         region_uuid (uuid.UUID, optional): the uuid of a discrete or categorical property, required if region_list is not None;
-            may also be a dictionary mapping from grid uuid to region uuid; ignored if region_list is None
-         radw (float, optional): if present, the wellbore radius used for all perforations; must be in correct units for intended
-            use of the WELLSPEC style dataframe; will default to 0.25 if 'RADW' is included in the extra column list
-         skin (float, optional): if present, a skin column is included with values set to this constant
-         stat (string, optional): if present, should be 'ON' or 'OFF' and is used for all perforations; will default to 'ON' if
-            'STAT' is included in the extra column list
-         active_only (boolean, default False): if True, only cells that are flagged in the grid object as active are included;
-            if False, cells are included whether active or not
-         min_k0 (int, optional): if present, perforations in layers above this are excluded (layer number will be applied
-            naively to all grids – not recommended when working with more than one grid with different layering)
-         max_k0 (int, optional): if present, perforations in layers below this are excluded (layer number will be applied
-            naively to all grids – not recommended when working with more than one grid with different layering)
-         k0_list (list of int, optional): if present, only perforations in cells in these layers are included (layer numbers
-            will be applied naively to all grids – not recommended when working with more than one grid with different layering)
-         min_length (float, optional): if present, a minimum length for an individual perforation interval to be included;
-            units are the length units of the trajectory object unless length_uom argument is set
-         min_kh (float, optional): if present, the minimum permeability x length value for which an individual interval is
-            included; permeabilty uuid(s) must be supplied for the kh calculation; units of the length component are those
-            of the trajectory object unless length_uom argument is set
-         max_depth (float, optional): if present, rows are excluded for cells with a centre point depth greater than this value;
-            max_depth should be positive downwards, with units of measure those of the grid z coordinates
-         max_satw (float, optional): if present, perforations in cells where the water saturation exceeds this value will
-            be excluded; satw_uuid must be supplied if this argument is present
-         min_sato (float, optional): if present, perforations in cells where the oil saturation is less than this value will
-            be excluded; sato_uuid must be supplied if this argument is present
-         max_satg (float, optional): if present, perforations in cells where the gas saturation exceeds this value will
-            be excluded; satg_uuid must be supplied if this argument is present
-         perforation_list (list of (float, float), optional): if present, a list of perforated intervals; each entry is the
-            start and end measured depths for a perforation; these do not need to align with cell boundaries
-         region_list (list of int, optional): if present, a list of region numbers for which rows are to be included; the
-            property holding the region data is identified by the region_uuid argument
-         depth_inc_down (boolean, optional): if present and True, the depth values will increase with depth; if False or None,
-            the direction of the depth values will be determined by the z increasing downwards indicator in the trajectory crs
-         set_k_face_intervals_vertical (boolean, default False): if True, intervals with entry through K- and exit through K+
-            will have angla and anglv set to 0.0 (vertical); if False angles will be computed depending on geometry
-         anglv_ref (string, default 'normal ij down'): either 'gravity', 'z down' (same as gravity), 'z+', 'k down', 'k+',
-            'normal ij', or 'normal ij down';
-            the ANGLV angles are relative to a local (per cell) reference vector selected by this keyword
-         angla_plane_ref (string, optional): string indicating normal vector defining plane onto which trajectory and I axis are
-            projected for the calculation of ANGLA; options as for anglv_ref, or 'normal well i+' which results in no projection;
-            defaults to the same as anglv_ref
-         length_mode (string, default 'MD'): 'MD' or 'straight' indicating which length to use; 'md' takes measured depth
-            difference between exit and entry; 'straight' uses a naive straight line length between entry and exit;
-            this will affect values for LENGTH, KH, DEPTH, X & Y
-         length_uom (string, optional): if present, either 'm' or 'ft': the length units to use for the LENGTH, KH, MD, DEPTH,
-            X & Y columns if they are present in extra_columns_list; also used to interpret min_length and min_kh; if None, the
-            length units of the trajectory attribute are used LENGTH, KH & MD and those of the grid are used for DEPTH, X & Y;
-            RADW value, if present, is assumed to be in the correct units and is not changed; also used implicitly to determine
-            conversion constant used in calculation of wellbore constant (WBC)
-         use_face_centres (boolean, default False): if True, the centre points of the entry and exit faces will determine the
-            vector used as the basis of ANGLA and ANGLV calculations; if False, the trajectory locations for the entry and exit
-            measured depths will be used
-         preferential_perforation (boolean, default True): if perforation_list is given, and KH is requested or a min_kh given,
-            the perforated intervals are assumed to penetrate pay rock preferentially: an effective ntg weighting is computed
-            to account for any residual non-pay perforated interval; ignored if perforation_list is None or kh values are not
-            being computed
-         add_as_properties (boolean or list of str, default False): if True, each column in the extra_columns_list (excluding
-            GRID and STAT) is added as a property with the blocked well as supporting representation and 'cells' as the
-            indexable element; any cell that is excluded from the dataframe will have corresponding entries of NaN in all the
-            properties; if a list is provided it must be a subset of extra_columns_list
-         use_properties (boolean or list of str, default False): if True, each column in the extra_columns_list (excluding
-            GRID and STAT) is populated from a property with citation title matching the column name, if it exists
+        arguments:
+           i_col (string, default 'IW'): the column name to use for cell I index values
+           j_col (string, default 'JW'): the column name to use for cell J index values
+           k_col (string, default 'L'): the column name to use for cell K index values
+           one_based (boolean, default True): if True, simulator protocol i, j & k values are placed in I, J & K columns;
+              if False, resqml zero based values; this does not affect the interpretation of min_k0 & max_k0 arguments
+           extra_columns_list (list of string, optional): list of WELLSPEC column names to include in the dataframe, from currently
+              recognised values: 'GRID', 'ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'RADW', 'SKIN', 'PPERF', 'RADB', 'WI', 'WBC'
+           ntg_uuid (uuid.UUID, optional): the uuid of the net to gross ratio property; if present is used to downgrade the i & j
+              permeabilities in the calculation of KH; ignored if 'KH' not in the extra column list and min_kh is not specified;
+              the argument may also be a dictionary mapping from grid uuid to ntg uuid; if no net to gross data is provided, it
+              is effectively assumed to be one (or, equivalently, the I & J permeability data is applicable to the gross rock); see
+              also preferential_perforation argument which can cause adjustment of effective ntg in partially perforated cells
+           perm_i_uuid (uuid.UUID or dictionary, optional): the uuid of the permeability property in the I direction;
+              required if 'KH' is included in the extra columns list and min_kh is not specified; ignored otherwise;
+              the argument may also be a dictionary mapping from grid uuid to perm I uuid
+           perm_j_uuid (uuid.UUID, optional): the uuid (or dict) of the permeability property in the J direction;
+              defaults to perm_i_uuid
+           perm_k_uuid (uuid.UUID, optional): the uuid (or dict) of the permeability property in the K direction;
+              defaults to perm_i_uuid
+           satw_uuid (uuid.UUID, optional): the uuid of a water saturation property; required if max_satw is specified; may also
+              be a dictionary mapping from grid uuid to satw uuid; ignored if max_satw is None
+           sato_uuid (uuid.UUID, optional): the uuid of an oil saturation property; required if min_sato is specified; may also
+              be a dictionary mapping from grid uuid to sato uuid; ignored if min_sato is None
+           satg_uuid (uuid.UUID, optional): the uuid of a gas saturation property; required if max_satg is specified; may also
+              be a dictionary mapping from grid uuid to satg uuid; ignored if max_satg is None
+           region_uuid (uuid.UUID, optional): the uuid of a discrete or categorical property, required if region_list is not None;
+              may also be a dictionary mapping from grid uuid to region uuid; ignored if region_list is None
+           radw (float, optional): if present, the wellbore radius used for all perforations; must be in correct units for intended
+              use of the WELLSPEC style dataframe; will default to 0.25 if 'RADW' is included in the extra column list
+           skin (float, optional): if present, a skin column is included with values set to this constant
+           stat (string, optional): if present, should be 'ON' or 'OFF' and is used for all perforations; will default to 'ON' if
+              'STAT' is included in the extra column list
+           active_only (boolean, default False): if True, only cells that are flagged in the grid object as active are included;
+              if False, cells are included whether active or not
+           min_k0 (int, optional): if present, perforations in layers above this are excluded (layer number will be applied
+              naively to all grids – not recommended when working with more than one grid with different layering)
+           max_k0 (int, optional): if present, perforations in layers below this are excluded (layer number will be applied
+              naively to all grids – not recommended when working with more than one grid with different layering)
+           k0_list (list of int, optional): if present, only perforations in cells in these layers are included (layer numbers
+              will be applied naively to all grids – not recommended when working with more than one grid with different layering)
+           min_length (float, optional): if present, a minimum length for an individual perforation interval to be included;
+              units are the length units of the trajectory object unless length_uom argument is set
+           min_kh (float, optional): if present, the minimum permeability x length value for which an individual interval is
+              included; permeabilty uuid(s) must be supplied for the kh calculation; units of the length component are those
+              of the trajectory object unless length_uom argument is set
+           max_depth (float, optional): if present, rows are excluded for cells with a centre point depth greater than this value;
+              max_depth should be positive downwards, with units of measure those of the grid z coordinates
+           max_satw (float, optional): if present, perforations in cells where the water saturation exceeds this value will
+              be excluded; satw_uuid must be supplied if this argument is present
+           min_sato (float, optional): if present, perforations in cells where the oil saturation is less than this value will
+              be excluded; sato_uuid must be supplied if this argument is present
+           max_satg (float, optional): if present, perforations in cells where the gas saturation exceeds this value will
+              be excluded; satg_uuid must be supplied if this argument is present
+           perforation_list (list of (float, float), optional): if present, a list of perforated intervals; each entry is the
+              start and end measured depths for a perforation; these do not need to align with cell boundaries
+           region_list (list of int, optional): if present, a list of region numbers for which rows are to be included; the
+              property holding the region data is identified by the region_uuid argument
+           depth_inc_down (boolean, optional): if present and True, the depth values will increase with depth; if False or None,
+              the direction of the depth values will be determined by the z increasing downwards indicator in the trajectory crs
+           set_k_face_intervals_vertical (boolean, default False): if True, intervals with entry through K- and exit through K+
+              will have angla and anglv set to 0.0 (vertical); if False angles will be computed depending on geometry
+           anglv_ref (string, default 'normal ij down'): either 'gravity', 'z down' (same as gravity), 'z+', 'k down', 'k+',
+              'normal ij', or 'normal ij down';
+              the ANGLV angles are relative to a local (per cell) reference vector selected by this keyword
+           angla_plane_ref (string, optional): string indicating normal vector defining plane onto which trajectory and I axis are
+              projected for the calculation of ANGLA; options as for anglv_ref, or 'normal well i+' which results in no projection;
+              defaults to the same as anglv_ref
+           length_mode (string, default 'MD'): 'MD' or 'straight' indicating which length to use; 'md' takes measured depth
+              difference between exit and entry; 'straight' uses a naive straight line length between entry and exit;
+              this will affect values for LENGTH, KH, DEPTH, X & Y
+           length_uom (string, optional): if present, either 'm' or 'ft': the length units to use for the LENGTH, KH, MD, DEPTH,
+              X & Y columns if they are present in extra_columns_list; also used to interpret min_length and min_kh; if None, the
+              length units of the trajectory attribute are used LENGTH, KH & MD and those of the grid are used for DEPTH, X & Y;
+              RADW value, if present, is assumed to be in the correct units and is not changed; also used implicitly to determine
+              conversion constant used in calculation of wellbore constant (WBC)
+           use_face_centres (boolean, default False): if True, the centre points of the entry and exit faces will determine the
+              vector used as the basis of ANGLA and ANGLV calculations; if False, the trajectory locations for the entry and exit
+              measured depths will be used
+           preferential_perforation (boolean, default True): if perforation_list is given, and KH is requested or a min_kh given,
+              the perforated intervals are assumed to penetrate pay rock preferentially: an effective ntg weighting is computed
+              to account for any residual non-pay perforated interval; ignored if perforation_list is None or kh values are not
+              being computed
+           add_as_properties (boolean or list of str, default False): if True, each column in the extra_columns_list (excluding
+              GRID and STAT) is added as a property with the blocked well as supporting representation and 'cells' as the
+              indexable element; any cell that is excluded from the dataframe will have corresponding entries of NaN in all the
+              properties; if a list is provided it must be a subset of extra_columns_list
+           use_properties (boolean or list of str, default False): if True, each column in the extra_columns_list (excluding
+              GRID and STAT) is populated from a property with citation title matching the column name, if it exists
 
-      notes:
-         units of length along wellbore will be those of the trajectory's length_uom (also applies to K.H values) unless
-         the length_uom argument is used;
-         the constraints are applied independently for each row and a row is excluded if it fails any constraint;
-         the min_k0 and max_k0 arguments do not stop later rows within the layer range from being included;
-         the min_length and min_kh limits apply to individual cell intervals and thus depend on cell size;
-         the water and oil saturation limits are for saturations at a single time and affect whether the interval
-         is included in the dataframe – there is no functionality to support turning perforations off and on over time;
-         the saturation limits do not stop deeper intervals with qualifying saturations from being included;
-         the k0_list, perforation_list and region_list arguments should be set to None to disable the corresponding functionality,
-         if set to an empty list, no rows will be included in the dataframe;
-         if add_as_properties is True, the blocked well must already have been added as a part to the model;
-         at add_as_properties and use_properties cannot both be True;
-         add_as_properties and use_properties are only currently functional for single grid blocked wells;
-         at present, unit conversion is not handled when using properties
+        notes:
+           units of length along wellbore will be those of the trajectory's length_uom (also applies to K.H values) unless
+           the length_uom argument is used;
+           the constraints are applied independently for each row and a row is excluded if it fails any constraint;
+           the min_k0 and max_k0 arguments do not stop later rows within the layer range from being included;
+           the min_length and min_kh limits apply to individual cell intervals and thus depend on cell size;
+           the water and oil saturation limits are for saturations at a single time and affect whether the interval
+           is included in the dataframe – there is no functionality to support turning perforations off and on over time;
+           the saturation limits do not stop deeper intervals with qualifying saturations from being included;
+           the k0_list, perforation_list and region_list arguments should be set to None to disable the corresponding functionality,
+           if set to an empty list, no rows will be included in the dataframe;
+           if add_as_properties is True, the blocked well must already have been added as a part to the model;
+           at add_as_properties and use_properties cannot both be True;
+           add_as_properties and use_properties are only currently functional for single grid blocked wells;
+           at present, unit conversion is not handled when using properties
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         def prop_array(uuid_or_dict, grid):
             assert uuid_or_dict is not None and grid is not None
@@ -3343,11 +3352,12 @@ class BlockedWell(BaseResqpy):
                   length_uom = None,
                   use_face_centres = False,
                   preferential_perforation = True):
-        """Returns the total static K.H (permeability x height); length units are those of trajectory md_uom unless length_upm is set.
+        """Returns the total static K.H (permeability x height); length units are those of trajectory md_uom unless
+        length_upm is set.
 
-      note:
-         see doc string for dataframe() method for argument descriptions; perm_i_uuid required
-      """
+        note:
+           see doc string for dataframe() method for argument descriptions; perm_i_uuid required
+        """
 
         df = self.dataframe(i_col = 'I',
                             j_col = 'J',
@@ -3428,13 +3438,13 @@ class BlockedWell(BaseResqpy):
                        float_format = '5.3'):
         """Writes Nexus WELLSPEC keyword to an ascii file.
 
-      returns:
-         pandas DataFrame containing data that has been written to the wellspec file
+        returns:
+           pandas DataFrame containing data that has been written to the wellspec file
 
-      note:
-         see doc string for dataframe() method for most of the argument descriptions;
-         align_columns and float_format arguments are deprecated and no longer used
-      """
+        note:
+           see doc string for dataframe() method for most of the argument descriptions;
+           align_columns and float_format arguments are deprecated and no longer used
+        """
 
         def tidy_well_name(well_name):
             nexus_friendly = ''
@@ -3585,10 +3595,10 @@ class BlockedWell(BaseResqpy):
     def xyz_marker(self, active_only = True):
         """Convenience method returning (x, y, z), crs_uuid of perforation in first blocked interval.
 
-      notes:
-         active_only argument not yet in use;
-         returns None, None if no blocked interval found
-      """
+        notes:
+           active_only argument not yet in use;
+           returns None, None if no blocked interval found
+        """
 
         cells, grids = self.cell_indices_and_grid_list()
         if cells is None or grids is None or len(grids) == 0:
@@ -3603,10 +3613,10 @@ class BlockedWell(BaseResqpy):
         return xyz, rqet.uuid_for_part_root(self.trajectory.crs_root)
 
     def create_feature_and_interpretation(self, shared_interpretation = True):
-        """Instantiate new empty WellboreFeature and WellboreInterpretation objects
-      
-      Uses the Blocked well citation title as the well name
-      """
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects.
+
+        Uses the Blocked well citation title as the well name
+        """
         if self.trajectory is not None:
             traj_interp_uuid = self.model.uuid(obj_type = 'WellboreInterpretation', related_uuid = self.trajectory.uuid)
             if traj_interp_uuid is not None:
@@ -3637,9 +3647,9 @@ class BlockedWell(BaseResqpy):
                                        create_feature_and_interp = True):
         """Creates an Md Datum object and a (simulation) Trajectory object for this blocked well.
 
-      note:
-         not usually called directly; used by import methods
-      """
+        note:
+           not usually called directly; used by import methods
+        """
 
         # create md datum node for synthetic trajectory, using crs for grid
         datum_location = trajectory_points[0].copy()
@@ -3679,12 +3689,12 @@ class BlockedWell(BaseResqpy):
                    originator = None):
         """Create a blocked wellbore representation node from this BlockedWell object, optionally add as part.
 
-      note:
-         trajectory xml node must be in place before calling this function;
-         witsml log reference, interval stratigraphic units, and cell fluid phase units not yet supported
+        note:
+           trajectory xml node must be in place before calling this function;
+           witsml log reference, interval stratigraphic units, and cell fluid phase units not yet supported
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         assert self.trajectory is not None, 'trajectory object missing'
 
@@ -3833,8 +3843,8 @@ class BlockedWell(BaseResqpy):
     def write_hdf5(self, file_name = None, mode = 'a', create_for_trajectory_if_needed = True):
         """Create or append to an hdf5 file, writing datasets for the measured depths, grid, cell & face indices.
 
-      :meta common:
-      """
+        :meta common:
+        """
 
         # NB: array data must all have been set up prior to calling this function
 
@@ -3867,9 +3877,9 @@ class BlockedWell(BaseResqpy):
 class WellboreMarkerFrame(BaseResqpy):
     """Class to handle RESQML WellBoreMarkerFrameRepresentation objects.
 
-   note:
-      measured depth data must be in same crs as those for the related trajectory
-   """
+    note:
+       measured depth data must be in same crs as those for the related trajectory
+    """
 
     resqml_type = 'WellboreMarkerFrameRepresentation'
 
@@ -3883,21 +3893,21 @@ class WellboreMarkerFrame(BaseResqpy):
                  extra_metadata = None):
         """Creates a new wellbore marker object and optionally loads it from xml, or trajectory, or Nexus wellspec file.
 
-      arguments:
-         parent_model (model.Model object): the model which the new blocked well belongs to
-         wellbore_marker_root (DEPRECATED): the root node of an xml tree representing the wellbore marker;
-         trajectory (optional, Trajectory object): the trajectory of the well, to be intersected with the grid;
-            not used if wellbore_marker_root is not None;
-         title (str, optional): the citation title to use for a new wellbore marker frame;
-            ignored if uuid or wellbore_marker_frame_root is not None
-         originator (str, optional): the name of the person creating the wellbore marker frame, defaults to login id;
-            ignored if uuid or wellbore_marker_frame_root is not None
-         extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the wellbore marker frame;
-            ignored if uuid or wellbore_marker_frame_root is not None
+        arguments:
+           parent_model (model.Model object): the model which the new blocked well belongs to
+           wellbore_marker_root (DEPRECATED): the root node of an xml tree representing the wellbore marker;
+           trajectory (optional, Trajectory object): the trajectory of the well, to be intersected with the grid;
+              not used if wellbore_marker_root is not None;
+           title (str, optional): the citation title to use for a new wellbore marker frame;
+              ignored if uuid or wellbore_marker_frame_root is not None
+           originator (str, optional): the name of the person creating the wellbore marker frame, defaults to login id;
+              ignored if uuid or wellbore_marker_frame_root is not None
+           extra_metadata (dict, optional): string key, value pairs to add as extra metadata for the wellbore marker frame;
+              ignored if uuid or wellbore_marker_frame_root is not None
 
-      returns:
-         the newly created wellbore framework marker object
-      """
+        returns:
+           the newly created wellbore framework marker object
+        """
 
         self.trajectory = None
         self.node_count = None  # number of measured depth nodes, each being for a marker
@@ -3917,15 +3927,15 @@ class WellboreMarkerFrame(BaseResqpy):
     def get_trajectory_obj(self, trajectory_uuid):
         """Returns a trajectory object.
 
-      arguments:
-         trajectory_uuid (string or uuid.UUID): the uuid of the trajectory for which a Trajectory object is required
+        arguments:
+           trajectory_uuid (string or uuid.UUID): the uuid of the trajectory for which a Trajectory object is required
 
-      returns:
-         well.Trajectory object
+        returns:
+           well.Trajectory object
 
-      note:
-         this method is not usually called directly
-      """
+        note:
+           this method is not usually called directly
+        """
 
         if trajectory_uuid is None:
             log.error('no trajectory was found')
@@ -3939,17 +3949,17 @@ class WellboreMarkerFrame(BaseResqpy):
     def get_interpretation_obj(self, interpretation_uuid, interp_type = None):
         """Creates an interpretation object; returns a horizon or fault interpretation object.
 
-      arguments:
-         interpretation_uiud (string or uuid.UUID): the uuid of the required interpretation object
-         interp_type (string, optional): 'HorizonInterpretation' or 'FaultInterpretation' (optionally
-            prefixed with `obj_`); if None, the type is inferred from the xml for the given uuid
+        arguments:
+           interpretation_uiud (string or uuid.UUID): the uuid of the required interpretation object
+           interp_type (string, optional): 'HorizonInterpretation' or 'FaultInterpretation' (optionally
+              prefixed with `obj_`); if None, the type is inferred from the xml for the given uuid
 
-      returns:
-         organization.HorizonInterpretation or organization.FaultInterpretation object
+        returns:
+           organization.HorizonInterpretation or organization.FaultInterpretation object
 
-      note:
-         this method is not usually called directly
-      """
+        note:
+           this method is not usually called directly
+        """
 
         assert interpretation_uuid is not None, 'interpretation uuid argument missing'
 
@@ -3980,9 +3990,9 @@ class WellboreMarkerFrame(BaseResqpy):
     def _load_from_xml(self):
         """Loads the wellbore marker frame object from an xml node (and associated hdf5 data).
 
-      note:
-         this method is not usually called directly
-      """
+        note:
+           this method is not usually called directly
+        """
 
         wellbore_marker_frame_root = self.root
         assert wellbore_marker_frame_root is not None
@@ -4144,10 +4154,10 @@ class WellboreMarkerFrame(BaseResqpy):
     def write_hdf5(self, file_name = None, mode = 'a'):
         """Writes the hdf5 array associated with this object (the measured depth data).
 
-      arguments:
-         file_name (string): the name of the hdf5 file, or None, in which case the model's default will be used
-         mode (string, default 'a'): the write mode for the hdf5, either 'w' or 'a'
-      """
+        arguments:
+           file_name (string): the name of the hdf5 file, or None, in which case the model's default will be used
+           mode (string, default 'a'): the write mode for the hdf5, either 'w' or 'a'
+        """
 
         h5_reg = rwh5.H5Register(self.model)
         h5_reg.register_dataset(self.uuid, 'Mds', self.node_mds)
@@ -4156,19 +4166,19 @@ class WellboreMarkerFrame(BaseResqpy):
     def find_marker_from_interp(self, interpetation_obj = None, uuid = None):
         """Find wellbore marker by interpretation; can pass object or uuid.
 
-      arguments:
-         interpretation_obj (organize.HorizonInterpretation or organize.FaultInterpretation object, optional):
-            if present, the first (smallest md) marker relating to this interpretation object is returned
-         uuid (string or uuid.UUID): if present, the uuid of the interpretation object of interest; ignored if
-            interpretation_obj is not None
+        arguments:
+           interpretation_obj (organize.HorizonInterpretation or organize.FaultInterpretation object, optional):
+              if present, the first (smallest md) marker relating to this interpretation object is returned
+           uuid (string or uuid.UUID): if present, the uuid of the interpretation object of interest; ignored if
+              interpretation_obj is not None
 
-      returns:
-         tuple, list of tuples or None; tuple is (marker UUID, geologic boundary, marker citation title, interp. object)
+        returns:
+           tuple, list of tuples or None; tuple is (marker UUID, geologic boundary, marker citation title, interp. object)
 
-      note:
-         if no arguments are passed, then a list of wellbore markers is returned;
-         if no marker is found for the interpretation object, None is returned
-      """
+        note:
+           if no arguments are passed, then a list of wellbore markers is returned;
+           if no marker is found for the interpretation object, None is returned
+        """
 
         if interpetation_obj is None and uuid is None:
             return self.wellbore_marker_list
@@ -4183,12 +4193,12 @@ class WellboreMarkerFrame(BaseResqpy):
         return None
 
     def get_marker_count(self):
-        '''Retruns number of wellbore markers'''
+        """Retruns number of wellbore markers."""
 
         return len(self.wellbore_marker_list)
 
     def find_marker_from_index(self, idx):
-        '''Returns wellbore marker by index'''
+        """Returns wellbore marker by index."""
 
         return self.wellbore_marker_list[idx - 1]
 
@@ -4196,23 +4206,22 @@ class WellboreMarkerFrame(BaseResqpy):
 def add_las_to_trajectory(las: lasio.LASFile, trajectory, realization = None, check_well_name = False):
     """Creates a WellLogCollection and WellboreFrame from a LAS file.
 
-   Note:
-      In this current implementation, the first curve in the las object must be
-      Measured Depths, not e.g. TVDSS.
+    Note:
+       In this current implementation, the first curve in the las object must be
+       Measured Depths, not e.g. TVDSS.
 
-   Arguments:
-      las: an lasio.LASFile object
-      trajectory: an instance of :class:`resqpy.well.Trajectory` .
-      realization (integer): if present, the single realisation (within an ensemble)
-         that this collection is for
-      check_well_name (bool): if True, raise warning if LAS well name does not match
-         existing wellborefeature citation title
+    Arguments:
+       las: an lasio.LASFile object
+       trajectory: an instance of :class:`resqpy.well.Trajectory` .
+       realization (integer): if present, the single realisation (within an ensemble)
+          that this collection is for
+       check_well_name (bool): if True, raise warning if LAS well name does not match
+          existing wellborefeature citation title
 
-   Returns:
-      collection, well_frame: instances of :class:`resqpy.property.WellLogCollection`
-         and :class:`resqpy.well.WellboreFrame`
-
-   """
+    Returns:
+       collection, well_frame: instances of :class:`resqpy.property.WellLogCollection`
+          and :class:`resqpy.well.WellboreFrame`
+    """
 
     # Lookup relevant related resqml parts
     model = trajectory.model
@@ -4262,10 +4271,10 @@ def add_las_to_trajectory(las: lasio.LASFile, trajectory, realization = None, ch
 def add_logs_from_cellio(blockedwell, cellio):
     """Creates a WellIntervalPropertyCollection for a given BlockedWell, using a given cell I/O file.
 
-   Arguments:
-      blockedwell: a resqml blockedwell object
-      cellio: an ascii file exported from RMS containing blocked well geometry and logs. Must contain columns i_index, j_index and k_index, plus additional columns for logs to be imported.
-   """
+    Arguments:
+       blockedwell: a resqml blockedwell object
+       cellio: an ascii file exported from RMS containing blocked well geometry and logs. Must contain columns i_index, j_index and k_index, plus additional columns for logs to be imported.
+    """
     # Get the initial variables from the blocked well
     assert isinstance(blockedwell, BlockedWell), 'Not a blocked wellbore object'
     collection = rqp.WellIntervalPropertyCollection(frame = blockedwell)
@@ -4356,12 +4365,13 @@ def add_logs_from_cellio(blockedwell, cellio):
 
 def lookup_from_cellio(line, model):
     """Create a StringLookup Object from a cell I/O row containing a categorical column name and details.
-   Arguments:
-      line: a string from a cell I/O file, containing the column (log) name, type and categorical information
-      model: the model to add the StringTableLookup to
-   Returns:
-      uuid: the uuid of a StringTableLookup, either for a newly created table, or for an existing table if an identical one exists
-   """
+
+    Arguments:
+       line: a string from a cell I/O file, containing the column (log) name, type and categorical information
+       model: the model to add the StringTableLookup to
+    Returns:
+       uuid: the uuid of a StringTableLookup, either for a newly created table, or for an existing table if an identical one exists
+    """
     lookup_dict = {}
     value, string = None, None
     # Generate a dictionary of values and strings
@@ -4408,35 +4418,35 @@ def add_wells_from_ascii_file(model,
                               drilled = False):
     """Creates new md datum, trajectory, interpretation and feature objects for each well in an ascii file.
 
-   arguments:
-      crs_uuid (uuid.UUID): the unique identifier of the coordinate reference system applicable to the x,y,z data;
-         if None, a default crs will be created, making use of the length_uom and z_inc_down arguments
-      trajectory_file (string): the path of the ascii file holding the well trajectory data to be loaded
-      comment_character (string, default '#'): character deemed to introduce a comment in the trajectory file
-      space_separated_instead_of_csv (boolean, default False): if True, the columns in the trajectory file are space
-         separated; if False, comma separated
-      well_col (string, default 'WELL'): the heading for the column containing well names
-      md_col (string, default 'MD'): the heading for the column containing measured depths
-      x_col (string, default 'X'): the heading for the column containing X (usually easting) data
-      y_col (string, default 'Y'): the heading for the column containing Y (usually northing) data
-      z_col (string, default 'Z'): the heading for the column containing Z (depth or elevation) data
-      length_uom (string, default 'm'): the units of measure for the measured depths; should be 'm' or 'ft'
-      md_domain (string, optional): the source of the original deviation data; may be 'logger' or 'driller'
-      drilled (boolean, default False): True should be used for wells that have been drilled; False otherwise (planned,
-         proposed, or a location being studied)
-      z_inc_down (boolean, default True): indicates whether z values increase with depth; only used in the creation
-         of a default coordinate reference system; ignored if crs_uuid is not None
+    arguments:
+       crs_uuid (uuid.UUID): the unique identifier of the coordinate reference system applicable to the x,y,z data;
+          if None, a default crs will be created, making use of the length_uom and z_inc_down arguments
+       trajectory_file (string): the path of the ascii file holding the well trajectory data to be loaded
+       comment_character (string, default '#'): character deemed to introduce a comment in the trajectory file
+       space_separated_instead_of_csv (boolean, default False): if True, the columns in the trajectory file are space
+          separated; if False, comma separated
+       well_col (string, default 'WELL'): the heading for the column containing well names
+       md_col (string, default 'MD'): the heading for the column containing measured depths
+       x_col (string, default 'X'): the heading for the column containing X (usually easting) data
+       y_col (string, default 'Y'): the heading for the column containing Y (usually northing) data
+       z_col (string, default 'Z'): the heading for the column containing Z (depth or elevation) data
+       length_uom (string, default 'm'): the units of measure for the measured depths; should be 'm' or 'ft'
+       md_domain (string, optional): the source of the original deviation data; may be 'logger' or 'driller'
+       drilled (boolean, default False): True should be used for wells that have been drilled; False otherwise (planned,
+          proposed, or a location being studied)
+       z_inc_down (boolean, default True): indicates whether z values increase with depth; only used in the creation
+          of a default coordinate reference system; ignored if crs_uuid is not None
 
-   returns:
-      tuple of lists of objects: (feature_list, interpretation_list, trajectory_list, md_datum_list),
+    returns:
+       tuple of lists of objects: (feature_list, interpretation_list, trajectory_list, md_datum_list),
 
-   notes:
-      ascii file must be table with first line being column headers, with columns for WELL, MD, X, Y & Z;
-      actual column names can be set with optional arguments;
-      all the objects are added to the model, with array data being written to the hdf5 file for the trajectories;
-      the md_domain and drilled values are stored in the RESQML metadata but are only for human information and do not
-      generally affect computations
-   """
+    notes:
+       ascii file must be table with first line being column headers, with columns for WELL, MD, X, Y & Z;
+       actual column names can be set with optional arguments;
+       all the objects are added to the model, with array data being written to the hdf5 file for the trajectories;
+       the md_domain and drilled values are stored in the RESQML metadata but are only for human information and do not
+       generally affect computations
+    """
 
     assert md_col and x_col and y_col and z_col
     md_col = str(md_col)
@@ -4522,18 +4532,18 @@ def add_wells_from_ascii_file(model,
 def well_name(well_object, model = None):
     """Returns the 'best' citation title from the object or related well objects.
 
-   arguments:
-      well_object (object, uuid or root): Object for which a well name is required. Can be a
-         Trajectory, WellboreInterpretation, WellboreFeature, BlockedWell, WellboreMarkerFrame,
-         WellboreFrame, DeviationSurvey or MdDatum object
-      model (model.Model, optional): required if passing a uuid or root; not recommended otherwise
+    arguments:
+       well_object (object, uuid or root): Object for which a well name is required. Can be a
+          Trajectory, WellboreInterpretation, WellboreFeature, BlockedWell, WellboreMarkerFrame,
+          WellboreFrame, DeviationSurvey or MdDatum object
+       model (model.Model, optional): required if passing a uuid or root; not recommended otherwise
 
-   returns:
-      string being the 'best' citation title to serve as a well name, form the object or some related objects
+    returns:
+       string being the 'best' citation title to serve as a well name, form the object or some related objects
 
-   note:
-      xml and relationships must be established for this function to work
-   """
+    note:
+       xml and relationships must be established for this function to work
+    """
 
     def better_root(model, root_a, root_b):
         a = rqet.citation_title_for_node(root_a)
@@ -4672,18 +4682,18 @@ def well_name(well_object, model = None):
 def add_blocked_wells_from_wellspec(model, grid, wellspec_file):
     """Add a blocked well for each well in a Nexus WELLSPEC file.
 
-   arguments:
-      model (model.Model object): model to which blocked wells are added
-      grid (grid.Grid object): grid against which wellspec data will be interpreted
-      wellspec_file (string): path of ascii file holding Nexus WELLSPEC keyword and data
+    arguments:
+       model (model.Model object): model to which blocked wells are added
+       grid (grid.Grid object): grid against which wellspec data will be interpreted
+       wellspec_file (string): path of ascii file holding Nexus WELLSPEC keyword and data
 
-   returns:
-      int: count of number of blocked wells created
+    returns:
+       int: count of number of blocked wells created
 
-   notes:
-      this function appends to the hdf5 file and creates xml for the blocked wells (but does not store epc);
-      'simulation' trajectory and measured depth datum objects will also be created
-   """
+    notes:
+       this function appends to the hdf5 file and creates xml for the blocked wells (but does not store epc);
+       'simulation' trajectory and measured depth datum objects will also be created
+    """
 
     well_list_dict = wsk.load_wellspecs(wellspec_file, column_list = None)
 
@@ -4709,12 +4719,12 @@ def add_blocked_wells_from_wellspec(model, grid, wellspec_file):
 def extract_xyz(xyz_node):
     """Extracts an x,y,z coordinate from a solitary point xml node.
 
-      argument:
-         xyz_node: the xml node representing the solitary point (in 3D space)
+    argument:
+       xyz_node: the xml node representing the solitary point (in 3D space)
 
-      returns:
-         triple float: (x, y, z) coordinates as a tuple
-   """
+    returns:
+       triple float: (x, y, z) coordinates as a tuple
+    """
 
     if xyz_node is None:
         return None
@@ -4749,8 +4759,8 @@ def well_names_in_cellio_file(cellio_file):
 def load_hdf5_array(object, node, array_attribute, tag = 'Values', dtype = 'float', model = None):
     """Loads the property array data as an attribute of object, from the hdf5 referenced in xml node.
 
-      :meta private:
-   """
+    :meta private:
+    """
 
     assert (rqet.node_type(node) in ['DoubleHdf5Array', 'IntegerHdf5Array', 'Point3dHdf5Array'])
     if model is None:
@@ -4769,8 +4779,8 @@ def load_hdf5_array(object, node, array_attribute, tag = 'Values', dtype = 'floa
 def find_entry_and_exit(cp, entry_vector, exit_vector, well_name):
     """Returns (entry_axis, entry_polarity, entry_xyz, exit_axis, exit_polarity, exit_xyz).
 
-      :meta private:
-   """
+    :meta private:
+    """
 
     cell_centre = np.mean(cp, axis = (0, 1, 2))
     face_triangles = gf.triangles_for_cell_faces(cp).reshape(-1, 3, 3)  # flattened first index 4 values per face
@@ -4799,9 +4809,9 @@ def find_entry_and_exit(cp, entry_vector, exit_vector, well_name):
 def _as_optional_array(arr):
     """If not None, cast as numpy array.
 
-   Casting directly to an array can be problematic:
-   np.array(None) creates an unsized array, which is potentially confusing.
-   """
+    Casting directly to an array can be problematic: np.array(None) creates an unsized array, which is potentially
+    confusing.
+    """
     if arr is None:
         return None
     else:


### PR DESCRIPTION
Closes #247 

Changes are almost entirely whitespace changes, to indent multi-line docstrings to a consistent level.

Uses the `docformatter` tool which aims to make code adhere to [PEP 257](https://www.python.org/dev/peps/pep-0257/):

```bash
docformatter -i --wrap-summaries 120 --wrap-descriptions 120 -r .\resqpy
```

Does not automatically re-indent nested blocks like `args:` or `returns:` within the docstsrings; but this gets 80% of the way there at least.

A few minor side-effects:

- Full stops added to end of some docstrings
- Some very long lines rewrapped (although far fewer than if default line length were left)