### PR TITLE
Add basic docstring checks to static analysis tests

### DIFF
--- a/resqpy/derived_model/__init__.py
+++ b/resqpy/derived_model/__init__.py
@@ -1,3 +1,5 @@
+"""Creating a derived resqml model from an existing one; mostly grid manipulations."""
+
 __all__ = [
     'add_edges_per_column_property_array', 'add_faults', 'add_one_blocked_well_property', 'add_one_grid_property_array',
     'add_single_cell_grid', 'add_wells_from_ascii_file', 'add_zone_by_layer_property', 'coarsened_grid', 'copy_grid',

--- a/resqpy/olio/ab_toolbox.py
+++ b/resqpy/olio/ab_toolbox.py
@@ -1,5 +1,4 @@
-# ab_toolbox module
-# contains small utility functions related to use of pure binary files
+""" Small utility functions related to use of pure binary files """
 
 version = '4th September 2020'
 

--- a/resqpy/olio/box_utilities.py
+++ b/resqpy/olio/box_utilities.py
@@ -1,4 +1,11 @@
-# box_utilities module
+"""Simple functions relating to cartesian grid boxes
+
+A box is a logical cuboid subset of the cells of a cartesian grid.
+A box is defined by a small numpy array: [[min_k, min_j, min_i], [max_k, max_j, max_i]].
+The cells identified by the max indices are included in the box (not following the python convention)
+The ordering of the i,j & k indices might be reversed - identifier names then have a suffix of _ijk instead of _kji.
+The indices can be in simulator convention, starting at 1, or python convention, starting at 0, indicated by suffix of 0 or 1
+"""
 
 version = '13th July 2021'
 
@@ -6,32 +13,6 @@ import logging
 
 log = logging.getLogger(__name__)
 log.debug('box_utilities.py version %s', version)
-
-# simple functions relating to cartesian grid boxes
-# a box is a logical cuboid subset of the cells of a cartesian grid
-# a box is defined by a small numpy array: [[min_k, min_j, min_i], [max_k, max_j, max_i]]
-# the cells identified by the max indices are included in the box (not following the python convention)
-# the ordering of the i,j & k indices might be reversed - identifier names then have a suffix of _ijk instead of _kji
-# the indices can be in simulator convention, starting at 1, or python convention, starting at 0, indicated by suffix of 0 or 1
-
-# functions defined here:
-#    def extent_of_box(box):     # returns 3 element extent of box (box can be kji or ijk, 0 or 1 based)
-#    def volume_of_box(box):
-#    def central_cell(box):
-#    def string_iijjkk1_for_box_kji0(box_kji0):
-#    def spaced_string_iijjkk1_for_box_kji0(box_kji0, colon_separator = ' '):
-#    def box_kji0_from_words_iijjkk1(words):
-#    def cell_in_box(cell, box):
-#    def valid_box(box0, host_extent):
-#    def single_cell_box(cell):
-#    def full_extent_box0(extent):
-#    def union(box_1, box_2):
-#    def parent_cell_from_local_box_cell(box, box_cell, based_0_or_1 = 0):
-#    def local_box_cell_from_parent_cell(box, parent_cell, based_0_or_1 = 0):
-#    def boxes_overlap(box_a, box_b):
-#    def overlapping_boxes(established_box, new_box, trim_box):
-#    def trim_box_by_box_returning_new_mask(box_to_be_trimmed, trim_box, mask_kji0):
-#    def trim_box_to_mask_returning_new_mask(bounding_box_kji0, mask_kji0):
 
 import numpy as np
 

--- a/resqpy/olio/dataframe.py
+++ b/resqpy/olio/dataframe.py
@@ -1,8 +1,8 @@
 """dataframe.py: classes for storing and retrieving dataframes as RESQML objects.
 
-   note that this module uses the obj_Grid2dRepresentation class in a way that was not envisaged
-   when the RESQML standard was defined; software that does not use resqpy is unlikely to be
-   able to do much with data stored in this way
+Note that this module uses the obj_Grid2dRepresentation class in a way that was not envisaged
+when the RESQML standard was defined; software that does not use resqpy is unlikely to be
+able to do much with data stored in this way
 """
 
 version = '6th May 2021'

--- a/resqpy/olio/factors.py
+++ b/resqpy/olio/factors.py
@@ -1,5 +1,4 @@
-# factors.py
-"""Module providing factorization and functions supporting grid extent determination from corner points."""
+"""Factorization and functions supporting grid extent determination from corner points."""
 
 version = '24th December 2019'
 

--- a/resqpy/olio/grid_functions.py
+++ b/resqpy/olio/grid_functions.py
@@ -1,4 +1,4 @@
-# grid functions module
+"""Miscellaneous functions relating to grids"""
 
 version = '29th April 2021'
 

--- a/resqpy/olio/keyword_files.py
+++ b/resqpy/olio/keyword_files.py
@@ -1,6 +1,7 @@
-# keyword_files module
-# provides basic functions for searching for keywords in an ascii control file such as a nexus deck
-# ascii file must already have been opened for reading before calling any of these functions
+"""Basic functions for searching for keywords in an ascii control file such as a nexus deck.
+
+Ascii file must already have been opened for reading before calling any of these functions.
+"""
 
 version = '4th September 2020'
 

--- a/resqpy/olio/load_data.py
+++ b/resqpy/olio/load_data.py
@@ -1,5 +1,4 @@
-# load_data module
-# contains functions to load data from various formats of file
+""" Functions to load data from various ASCII simulator file formats"""
 
 version = '29th April 2021'
 

--- a/resqpy/olio/relperm.py
+++ b/resqpy/olio/relperm.py
@@ -1,12 +1,12 @@
-"""relperm.py: class for storing and retrieving dataframes of relative permeability
-data as RESQML objects.
+"""relperm.py: class for dataframes of relative permeability data as RESQML objects.
 
-   note that this module uses the obj_Grid2dRepresentation class in a way that was not envisaged
-   when the RESQML standard was defined; software that does not use resqpy is unlikely to be
-   able to do much with data stored in this way
-
-   Nexus is a registered trademark of Halliburton
+Note that this module uses the obj_Grid2dRepresentation class in a way that was not envisaged
+when the RESQML standard was defined; software that does not use resqpy is unlikely to be
+able to do much with data stored in this way.
 """
+
+# Nexus is a registered trademark of Halliburton
+
 import logging
 import os
 

--- a/resqpy/olio/trademark.py
+++ b/resqpy/olio/trademark.py
@@ -1,4 +1,4 @@
-# trademark.py module for mentioning trademarks in diagnostic log
+""" trademark.py module for mentioning trademarks in diagnostic log """
 
 version = '9th April 2021'
 

--- a/resqpy/olio/transmission.py
+++ b/resqpy/olio/transmission.py
@@ -1,4 +1,4 @@
-# transmission.py
+"""Transmissibility functions for grids"""
 
 version = '14th October 2021'
 

--- a/resqpy/olio/utility.py
+++ b/resqpy/olio/utility.py
@@ -1,4 +1,4 @@
-# utility.py
+"""Generic small utility functions"""
 
 version = '29th April 2021'
 

--- a/resqpy/olio/uuid.py
+++ b/resqpy/olio/uuid.py
@@ -1,4 +1,4 @@
-"""uuid.py: Thin bifrost wrapper around python uuid (universally unique identifier) module."""
+"""uuid.py: Thin wrapper around python uuid (universally unique identifier) module."""
 
 # NB: at present the code does not enforce multiprocessor safe generation of unique identifiers
 # it calls uuid.uuid1() to generate new uuids, ie. using version 1 of the iso standard options

--- a/resqpy/olio/vector_utilities.py
+++ b/resqpy/olio/vector_utilities.py
@@ -1,5 +1,10 @@
-# vector_utilities module
-# note: many of these functions are redundant as they are provided by built-in numpy operations
+""" Utilities for working with 3D vectors in cartesian space.
+
+note: some of these functions are redundant as they are provided by built-in numpy operations.
+
+a vector is a one dimensional numpy array with 3 elements: x, y, z.
+some functions accept a tuple or list of 3 elements as an alternative to a numpy array.
+"""
 
 version = '15th November 2021'
 
@@ -7,10 +12,6 @@ import logging
 
 log = logging.getLogger(__name__)
 log.debug('vector_utilities.py version %s', version)
-
-# works with 3D vectors in a cartesian space
-# a vector is a one dimensional numpy array with 3 elements: x, y, z
-# some functions accept a tuple or list of 3 elements as an alternative to a numpy array
 
 import math as maths
 

--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -1,4 +1,4 @@
-# module defining dictionary of nexus WELLSPEC column keywords
+"""Module defining dictionary of nexus WELLSPEC column keywords"""
 
 version = '29th April 2021'
 

--- a/resqpy/olio/write_data.py
+++ b/resqpy/olio/write_data.py
@@ -1,4 +1,4 @@
-# module containing array writing functions
+"""Array writing functions"""
 
 version = '29th April 2021'
 

--- a/resqpy/olio/write_faults.py
+++ b/resqpy/olio/write_faults.py
@@ -1,4 +1,4 @@
-#  write_faults.py
+"""Writing faults in NEXUS format"""
 
 version = '29th April 2021'
 
@@ -41,7 +41,6 @@ def write_faults_nexus(filename, df, grid_name = 'ROOT'):
     assert df is not None and len(df) > 0, 'no data in faults dataframe'
 
     with open(filename, 'w') as fp:
-        fp.write('! Exported from Bifrost resqml_baffle notebook\n\n')
         fault_names = pd.unique(df.name)
         for fault_name in fault_names:
             fdf = df[df.name == fault_name]

--- a/resqpy/olio/zmap_reader.py
+++ b/resqpy/olio/zmap_reader.py
@@ -1,4 +1,4 @@
-# function for reading a zmap file
+""" Functions for reading a zmap file"""
 
 version = '13th May 2021'
 

--- a/resqpy/surface/__init__.py
+++ b/resqpy/surface/__init__.py
@@ -1,3 +1,5 @@
+"""Classes for RESQML objects related to surfaces"""
+
 __all__ = ['base_surface', 'combined_surface', 'mesh', 'triangulated_patch', 'pointset', 'surface']
 
 from .base_surface import BaseSurface

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ select =
     # Deprecation
     W60,
     # flake8-docstrings (pydocstyle)
-    D100
+    D100, D104
     # Other checks to be progressively enabled in future
     # D1
     # D200, D201, D205, D206, D207, D208, D209, D211, D212, D214
@@ -93,7 +93,7 @@ ignore =
     D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
 per-file-ignores =
     # Do not check docstrings for the tests directory
-    tests/*: D100
+    tests/*: D100, D104
     docs/*: D100
     resqpy/version.py: D100
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ tests =
     pytest
     pytest-cov
     pytest-mock
+    flake8-docstrings
     flake8
     mypy
     yapf
@@ -63,6 +64,7 @@ filterwarnings =
 # count = True
 # statistics = True
 show_source = True
+docstring-convention = google
 exclude =  .git, __pycache__, .ipynb_checkpoints
 # error code reference: https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3
 select =

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,8 +91,10 @@ ignore =
     # pydocstyle exceptions for Google-style docstrings
     # See http://www.pydocstyle.org/en/latest/error_codes.html#default-conventions
     D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
-per-file-ignores = 
-    tests/*: D
+per-file-ignores =
+    # Do not check docstrings for the tests directory
+    tests/*: D100
+    docs/*: D100
 
 [mypy]
 # Ignoring missing types in 3rd party libs

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,11 @@ select =
     # Deprecation
     W60,
     # flake8-docstrings (pydocstyle)
-    D1,
-    D200, D201, D205, D206, D207, D208, D209, D211, D212, D214
+    D100
+
+    # Other checks to be progressively enabled in future
+    # D1
+    # D200, D201, D205, D206, D207, D208, D209, D211, D212, D214
 
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,11 +80,9 @@ select =
     W60,
     # flake8-docstrings (pydocstyle)
     D100
-
     # Other checks to be progressively enabled in future
     # D1
     # D200, D201, D205, D206, D207, D208, D209, D211, D212, D214
-
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority
     F401,
@@ -93,6 +91,8 @@ ignore =
     # pydocstyle exceptions for Google-style docstrings
     # See http://www.pydocstyle.org/en/latest/error_codes.html#default-conventions
     D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
+per-file-ignores = 
+    tests/*: D
 
 [mypy]
 # Ignoring missing types in 3rd party libs

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,13 +71,15 @@ select =
     # Logical errors
     F,
     # Indentation
-    E101, E112, E113, W19
+    E101, E112, E113, W19,
     # Statements
-    E71, E72, E73, E74
+    E71, E72, E73, E74,
     # Runtime
-    E9
+    E9,
     # Deprecation
-    W60
+    W60,
+    # Missing docstrings
+    D1
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority
     F401,

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ per-file-ignores =
     # Do not check docstrings for the tests directory
     tests/*: D100
     docs/*: D100
+    resqpy/version.py: D100
 
 [mypy]
 # Ignoring missing types in 3rd party libs

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,13 +78,18 @@ select =
     E9,
     # Deprecation
     W60,
-    # Missing docstrings
-    D1
+    # flake8-docstrings (pydocstyle)
+    D1,
+    D200, D201, D205, D206, D207, D208, D209, D211, D212, D214
+
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority
     F401,
     # F841: "local variable is assigned to but never used". Ignoring as sometimes deliberate
-    F841
+    F841,
+    # pydocstyle exceptions for Google-style docstrings
+    # See http://www.pydocstyle.org/en/latest/error_codes.html#default-conventions
+    D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
 
 [mypy]
 # Ignoring missing types in 3rd party libs


### PR DESCRIPTION
Supports progress towards #290 .

Changes `setup.cgf` to include a new flake8 plugin and error code.