### PR TITLE
Enable full set of docstring error codes

### DIFF
--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -67,6 +67,7 @@ class Grid(BaseResqpy):
 
     @property
     def nk_plus_k_gaps(self):
+        """Returns the number of layers including any K gaps."""
         if self.nk is None:
             return None
         if self.k_gaps is None:
@@ -792,6 +793,7 @@ class Grid(BaseResqpy):
             self.is_refinement = self_is_refinement
 
     def extract_children(self):
+        """Looks for LGRs related to this grid and sets the local_grid_uuid_list attribute."""
         assert self.uuid is not None
         if self.local_grid_uuid_list is not None:
             return self.local_grid_uuid_list

--- a/resqpy/property/property.py
+++ b/resqpy/property/property.py
@@ -21,6 +21,7 @@ class Property(BaseResqpy):
 
     @property
     def resqml_type(self):
+        """Returns the RESQML object class string for this Property."""
         root_node = self.root
         if root_node is not None:
             return rqet.node_type(root_node, strip_obj = True)

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -1057,6 +1057,11 @@ class PropertyCollection():
     # the main dictionary maps from part name to a tuple of information
     # this function simply extracts one element of the tuple in a way that returns None if the part is awol
     def element_for_part(self, part, index):
+        """Returns a particular element by index from the tuple of metadata for the specified part.
+
+        :meta private:
+        """
+
         if part not in self.dict:
             return None
         return self.dict[part][index]
@@ -1064,6 +1069,11 @@ class PropertyCollection():
     # 'private' function for returning a list of unique values for an element from the tuples within the collection
     # excludes None from list
     def unique_element_list(self, index, sort_list = True):
+        """Returns an optionally sorted list of unique values (excluding None) of an element identified by index.
+
+        :meta private:
+        """
+
         s = set()
         for _, t in self.dict.items():
             e = t[index]

--- a/resqpy/property/property_common.py
+++ b/resqpy/property/property_common.py
@@ -612,6 +612,8 @@ def dtype_flavour(continuous, use_32_bit):
 
 
 def return_cell_indices(i, cell_indices):
+    """Returns the i'th entry in the cell_indices array, or NaN if i has null value of -1."""
+
     if i == -1:
         return np.nan
     else:

--- a/resqpy/property/string_lookup.py
+++ b/resqpy/property/string_lookup.py
@@ -73,6 +73,8 @@ class StringLookup(BaseResqpy):
                 self.max_index = key
 
     def load_from_dict(self, int_to_str_dict):
+        """Sets the contents of this string lookup based on a dict mapping int to str."""
+
         if int_to_str_dict is None:
             return
         assert len(int_to_str_dict), 'empty dictionary passed to string lookup initialisation'

--- a/resqpy/property/well_interval_property_collection.py
+++ b/resqpy/property/well_interval_property_collection.py
@@ -25,9 +25,12 @@ class WellIntervalPropertyCollection(PropertyCollection):
 
     def logs(self):
         """Generator that yields component Interval log or Blocked well log objects."""
+
         return (WellIntervalProperty(collection = self, part = part) for part in self.parts())
 
     def to_pandas(self, include_units = False):
+        """Returns a dataframe with a column for each well log included in the collection."""
+
         cell_indices = [return_cell_indices(i, self.support.cell_indices) for i in self.support.cell_grid_link]
         data = {}
         for log in self.logs():

--- a/resqpy/surface/surface.py
+++ b/resqpy/surface/surface.py
@@ -131,6 +131,8 @@ class Surface(BaseSurface):
 
     @property
     def represented_interpretation_uuid(self):
+        """Returns the uuid of the represented surface interpretation, or None."""
+
         return rqet.uuid_for_part_root(self.represented_interpretation_root)
 
     def set_represented_interpretation_root(self, interp_root):

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -1005,6 +1005,7 @@ class Trajectory(BaseResqpy):
         self.set_measured_depths()
 
     def load_from_wellspec(self, grid, wellspec_file, well_name, spline_mode = 'cube', md_uom = 'm'):
+        """Sets the trajectory data based on visiting the cells identified in a Nexus wellspec keyword."""
 
         col_list = ['IW', 'JW', 'L']
         wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list)
@@ -4077,6 +4078,7 @@ class WellboreMarkerFrame(BaseResqpy):
                    wellbore_marker_list = None,
                    title = 'wellbore marker framework',
                    originator = None):
+        """Creates the xml tree for this wellbore marker frame and optionally adds as a part to the model."""
 
         assert type(add_as_part) is bool
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,9 +79,7 @@ select =
     # Deprecation
     W60,
     # Docstrings (pydocstyle)
-    D100, D101, D104, D105, D106, D107, D2, D4
-    # Other checks to be progressively enabled in future
-    # D
+    D
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority
     F401,
@@ -93,9 +91,10 @@ ignore =
     # Further pydocstyle exceptions for relatively unimportant issues
     D202, D210, D402, D405, D415, D417
 per-file-ignores =
-    # Do not check docstrings in the [t]ests or [d]ocs directories
-    [td]*/*: D100, D101, D104, D105, D106, D107, D2, D4
-    resqpy/version.py: D100
+    # Do not check docstrings for the tests or docs directories
+    tests/*: D
+    docs/*: D
+    resqpy/version.py: D
 
 [mypy]
 # Ignoring missing types in 3rd party libs


### PR DESCRIPTION
Closes #290

Updates our linter to include all "D" error codes, other than those in the "ignore" list. Expected to fail until all docstrings for public functions are written.