### PR TITLE
Ignore further unimportant pydocstyle error codes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ select =
     E9,
     # Deprecation
     W60,
-    # flake8-docstrings (pydocstyle)
+    # Docstrings (pydocstyle)
     D100, D104
     # Other checks to be progressively enabled in future
     # D1
@@ -91,6 +91,8 @@ ignore =
     # pydocstyle exceptions for Google-style docstrings
     # See http://www.pydocstyle.org/en/latest/error_codes.html#default-conventions
     D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
+    # Further pydocstyle exceptions for relatively unimportant issues
+    D202, D405
 per-file-ignores =
     # Do not check docstrings for the tests directory
     tests/*: D100, D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ ignore =
     # See http://www.pydocstyle.org/en/latest/error_codes.html#default-conventions
     D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
     # Further pydocstyle exceptions for relatively unimportant issues
-    D202, D405
+    D202, D405, D415
 per-file-ignores =
     # Do not check docstrings for the tests directory
     tests/*: D100, D104


### PR DESCRIPTION
I suggest always ignoring these two flake8 errors:

- `D202: No blank lines allowed after function docstring` : does not affect HTML docs.
- `D405: Section name should be properly capitalized` : docs will render fine either way.

Nb. These errors are not actually enabled at the moment in the CI suite; however, including the codes in the "ignore" list will ensure these checks aren't included when flake8 is run on the command line with `flake8 --select=D path/to/file.py`

See #290