### PR TITLE
Fix D2xx error codes

### DIFF
--- a/resqpy/derived_model/_dm_drape_to_surface.py
+++ b/resqpy/derived_model/_dm_drape_to_surface.py
@@ -31,7 +31,9 @@ def drape_to_surface(epc_file,
                      inherit_all_realizations = False,
                      new_grid_title = None,
                      new_epc_file = None):
-    """Extends a resqml model with a new grid where the reference layer boundary of the source grid has been re-draped
+    """Return a new grid with geometry draped to a surface.
+    
+    Extend a resqml model with a new grid where the reference layer boundary of the source grid has been re-draped
     to a surface.
 
     arguments:

--- a/resqpy/fault.py
+++ b/resqpy/fault.py
@@ -49,8 +49,9 @@ class GridConnectionSet(BaseResqpy):
                  title = None,
                  originator = None,
                  extra_metadata = None):
-        """Initializes a new GridConnectionSet and optionally loads it from xml or a list of simulator format ascii
-        files.
+        """Initializes a new GridConnectionSet.
+        
+        Optionally loads it from xml or a list of simulator format ascii files.
 
         arguments:
            parent_model (model.Model object): the resqml model that this grid connection set will be part of
@@ -229,9 +230,10 @@ class GridConnectionSet(BaseResqpy):
         return self.property_collection
 
     def set_pairs_from_kelp(self, kelp_0, kelp_1, feature_name, create_organizing_objects_where_needed, axis = 'K'):
-        """Sets cell_index_pairs and face_index_pairs based on j and i face kelp strands, using simple no throw
-        pairing."""
-
+        """Set cell_index_pairs and face_index_pairs based on j and i face kelp strands.
+        
+        Uses simple no throw pairing.
+        """
         # note: this method has been reworked to allow 'kelp' to be 'horizontal' strands when working in cross section
 
         if axis == 'K':
@@ -1093,8 +1095,9 @@ class GridConnectionSet(BaseResqpy):
                    write_new_properties = True,
                    title = None,
                    originator = None):
-        """Creates a Grid Connection Set (fault faces) xml node and optionally adds as child of root and/or to parts
-        forest.
+        """Creates a Grid Connection Set (fault faces) xml node.
+        
+        Optionally adds as child of root and/or to parts forest.
 
         :meta common:
         """
@@ -1433,8 +1436,7 @@ class GridConnectionSet(BaseResqpy):
                                                 property_name = 'Transmissibility multiplier',
                                                 gridindex = 0,
                                                 ref_k = None):
-        """Generate a float value aray defining the property values for different column edges present for a given
-        feature.
+        """Generate a float value aray defining the property values for different column edges present for a given feature.
 
         Args:
            feature - feature index
@@ -1516,8 +1518,7 @@ class GridConnectionSet(BaseResqpy):
                                                    property_name = 'Transmissibility multiplier',
                                                    feature_list = None,
                                                    ref_k = None):
-        """Generate a combined mask, index and value arrays for all column edges across a k-layer range, for a defined
-        feature_list.
+        """Generate combined mask, index and value arrays for all column edges across a k-layer range, for a defined feature_list.
 
         Args:
            gridindex - index of grid to be used in grid connection set gridlist, default 0

--- a/resqpy/grid.py
+++ b/resqpy/grid.py
@@ -41,9 +41,6 @@ always_write_cell_geometry_is_defined_array = False
 
 
 def _add_to_kelp_list(extent_kji, kelp_list, face_axis, ji):
-    """
-      :meta private:
-   """
     if isinstance(face_axis, bool):
         face_axis = 'J' if face_axis else 'I'
     # ignore external faces
@@ -321,8 +318,7 @@ class Grid(BaseResqpy):
         return (k0, j0, i0)
 
     def denaturalized_cell_indices(self, c0s):
-        """Returns an integer numpy array of shape (..., 3) holding kji0 indices for the cells with given natural
-        indices.
+        """Returns an integer array holding kji0 indices for the cells with given natural indices.
 
         argument:
            c0s: numpy integer array of shape (...,) being natural cell indices (for a flattened array)
@@ -897,8 +893,9 @@ class Grid(BaseResqpy):
         return self.inactive
 
     def cell_geometry_is_defined(self, cell_kji0 = None, cell_geometry_is_defined_root = None, cache_array = True):
-        """Returns True if the geometry of the specified cell is defined; can also be used to cache (load) the boolean
-        array.
+        """Returns True if the geometry of the specified cell is defined.
+        
+        Can also be used to cache (load) the boolean array.
 
         arguments:
            cell_kji0 (triplet of integer, optional): if present, the index of the cell of interest, in kji0 protocol;
@@ -955,8 +952,9 @@ class Grid(BaseResqpy):
             return result
 
     def pillar_geometry_is_defined(self, pillar_ji0 = None, pillar_geometry_is_defined_root = None, cache_array = True):
-        """Returns True if the geometry of the specified pillar is defined; False otherwise; can also be used to cache
-        (load) the boolean array.
+        """Returns True if the geometry of the specified pillar is defined; False otherwise.
+        
+        Can also be used to cache (load) the boolean array.
 
         arguments:
            pillar_ji0 (pair of integers, optional): if present, the index of the pillar of interest, in ji0 protocol;
@@ -1111,8 +1109,7 @@ class Grid(BaseResqpy):
                                 complete_partial_pillars = False,
                                 nullify_partial_pillars = False,
                                 complete_all = False):
-        """Sets cached flags and/or arrays indicating which primary pillars have any points defined and which cells all
-        points.
+        """Set cached flags and/or arrays indicating which primary pillars have any points defined and which cells all points.
 
         arguments:
            treat_as_nan (float, optional): if present, any point with this value as x, y or z is changed
@@ -1762,8 +1759,7 @@ class Grid(BaseResqpy):
         return self.pillars_for_column
 
     def pillar_foursome(self, ji0, none_if_unsplit = False):
-        """Returns a numpy int array of shape (2, 2) being the natural pillar indices applicable to each column around
-        primary.
+        """Returns an int array of the natural pillar indices applicable to each column around primary.
 
         arguments:
            ji0 (pair of ints): the pillar indices (j0, i0) of the primary pillar of interest
@@ -1996,8 +1992,7 @@ class Grid(BaseResqpy):
         return (self.fault_throw_j, self.fault_throw_i)
 
     def fault_throws_per_edge_per_column(self, mode = 'maximum', simple_z = False, axis_polarity_mode = True):
-        """Returns numpy array of shape (nj, ni, 2, 2) or (nj, ni, 4) holding max, mean or min throw based on split node
-        separations.
+        """Return array holding max, mean or min throw based on split node separations.
 
         arguments:
            mode (string, default 'maximum'): one of 'minimum', 'mean', 'maximum'; determines how to resolve variation in throw for
@@ -2303,9 +2298,12 @@ class Grid(BaseResqpy):
         return local_face_set_dict, full_pillar_list_dict
 
     def check_top_and_base_cell_edge_directions(self):
-        """checks grid top face I & J edge vectors (in x,y) against basal equivalents: max 90 degree angle tolerated.
+        """Check grid top face I & J edge vectors (in x,y) against basal equivalents.
+        
+        Max 90 degree angle tolerated.
 
-        returns: boolean: True if all checks pass; False if one or more checks fail
+        returns:
+            boolean: True if all checks pass; False if one or more checks fail
 
         notes:
            similarly checks cell edge directions in neighbouring cells in top (and separately in base)
@@ -2775,8 +2773,7 @@ class Grid(BaseResqpy):
             return points[:, cpm[ref_slice0, :, ij_p, :], :]
 
     def split_gap_x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
-        """Returns an array of points representing cell corners from an I or J interface slice for a faulted grid with k
-        gaps.
+        """Return array of points representing cell corners from an I or J interface slice for a faulted grid.
 
         arguments:
            axis (string): 'I' or 'J' being the axis of the cross-sectional slice (ie. dimension being dropped)
@@ -2854,7 +2851,7 @@ class Grid(BaseResqpy):
             return points[:, ref_slice0, :, :]
 
     def x_section_points(self, axis, ref_slice0 = 0, plus_face = False, masked = False):
-        """Deprecated: please use unsplit_x_section_points() instead."""
+        """Deprecated: please use `unsplit_x_section_points` instead."""
 
         return self.unsplit_x_section_points(axis, ref_slice0 = ref_slice0, plus_face = plus_face, masked = masked)
 
@@ -3344,15 +3341,17 @@ class Grid(BaseResqpy):
         return cp
 
     def invalidate_corner_points(self):
-        """Deletes cached copy of corner points, if present; use if any pillar geometry changes, or to reclaim
-        memory."""
-
+        """Deletes cached copy of corner points, if present.
+        
+        Use if any pillar geometry changes, or to reclaim memory.
+        """
         if hasattr(self, 'array_corner_points'):
             delattr(self, 'array_corner_points')
 
     def centre_point(self, cell_kji0 = None, cache_centre_array = False):
-        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all
-        cells.
+        """Returns centre point of a cell or array of centre points of all cells.
+        
+        Optionally cache centre points for all cells.
 
         arguments:
            cell_kji0 (optional): if present, the (k, j, i) indices of the individual cell for which the
@@ -3576,8 +3575,10 @@ class Grid(BaseResqpy):
         return abs(np.mean(cp[1, :, :, 2]) - np.mean(cp[0, :, :, 2]))
 
     def point_areally(self, tolerance = 0.001):
-        """Returns a numpy boolean array of shape extent_kji indicating which cells are reduced to a point in both I & J
-        axes.
+        """Returns array indicating which cells are reduced to a point in both I & J axes.
+
+        Returns:
+            numopy bool array of shape extent_kji
 
         Note:
            Any NaN point values will yield True for a cell
@@ -3722,8 +3723,9 @@ class Grid(BaseResqpy):
                     cache_cp_array = False,
                     cache_thickness_array = False,
                     cache_pinchout_array = None):
-        """Returns boolean or boolean array indicating whether cell is pinched out; ie. has a thickness less than
-        tolerance.
+        """Returns boolean or boolean array indicating whether cell is pinched out.
+        
+        Pinched out means cell has a thickness less than tolerance.
 
         :meta common:
         """
@@ -4316,9 +4318,10 @@ class Grid(BaseResqpy):
                            points_root = None,
                            cache_resqml_array = True,
                            cache_cp_array = False):
-        """Returns xyz point interpolated from corners of cell depending on 3 interpolation fractions in range 0 to
-        1."""
-
+        """Returns xyz point interpolated from corners of cell.
+        
+        Depends on 3 interpolation fractions in range 0 to 1.
+        """
         # todo: think about best ordering of axes operations given high aspect ratio of cells (for best accuracy)
         fp = np.empty(3)
         fm = np.empty(3)
@@ -4344,8 +4347,9 @@ class Grid(BaseResqpy):
                             points_root = None,
                             cache_resqml_array = True,
                             cache_cp_array = False):
-        """Returns xyz points interpolated from corners of cell depending on 3 interpolation fraction numpy vectors,
-        each value in range 0 to 1.
+        """Returns xyz points interpolated from corners of cell.
+        
+        Depending on 3 interpolation fraction numpy vectors, each value in range 0 to 1.
 
         arguments:
            cell_kji0 (triple int): indices of individual cell whose corner points are to be interpolated
@@ -4533,8 +4537,7 @@ class Grid(BaseResqpy):
                 bwam.convert_lengths(flat_a[:, 2], crs_z_units_text, global_z_units)  # z
 
     def z_inc_down(self):
-        """Returns True if z increases downwards in the coordinate reference system used by the grid geometry, False
-        otherwise.
+        """Return True if z increases downwards in the coordinate reference system used by the grid geometry
 
         :meta common:
         """
@@ -4591,9 +4594,10 @@ class Grid(BaseResqpy):
                                write_active = None,
                                stratigraphy = True,
                                expand_const_arrays = False):
-        """Create or append to an hdf5 file, writing datasets for the grid geometry (and parent grid mapping) and
-        properties from cached arrays."""
-
+        """Create or append to an hdf5 file.
+        
+        Writes datasets for the grid geometry (and parent grid mapping) and properties from cached arrays.
+        """
         # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
         # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
         # xml is not created here for property objects
@@ -4857,9 +4861,10 @@ class Grid(BaseResqpy):
         return rqet.find_tag(crs_root, 'VerticalUom').text
 
     def poly_line_for_cell(self, cell_kji0, vertical_ref = 'top'):
-        """Returns a numpy array of shape (4, 3) being the 4 corners in order J-I-, J-I+, J+I+, J+I-; from the top or
-        base face."""
-
+        """Returns a numpy array of shape (4, 3) being the 4 corners.
+        
+        Corners are in order J-I-, J-I+, J+I+, J+I-; from the top or base face.
+        """
         if vertical_ref == 'top':
             kp = 0
         elif vertical_ref == 'base':
@@ -4916,7 +4921,8 @@ class Grid(BaseResqpy):
 
         arguments:
            x_sect (numpy float array of shape (nk, nj or ni, 2, 2, 2 or 3): the cross section x,z or x,y,z data
-           x, z (floats): the point of interest in the cross section space
+           x (float) x-coordinate of point of interest in the cross section space
+           z (float): y-coordinate of  point of interest in the cross section space
 
         note:
            the x_sect data is in the form returned by x_section_corner_points() or split_gap_x_section_points();
@@ -5615,8 +5621,9 @@ class RegularGrid(Grid):
     # override of Grid methods
 
     def point_raw(self, index = None, points_root = None, cache_array = True):
-        """Returns element from points data, indexed as corner point (k0, j0, i0); can optionally be used to cache
-        points data.
+        """Returns element from points data, indexed as corner point (k0, j0, i0).
+        
+        Can optionally be used to cache points data.
 
         arguments:
            index (3 integers, optional): if not None, the index into the raw points data for the point of interest

--- a/resqpy/grid_surface.py
+++ b/resqpy/grid_surface.py
@@ -192,8 +192,9 @@ class GridSkin:
                                               start_xyz = None,
                                               nudge = None,
                                               exclude_kji0 = None):
-        """Returns the x,y,z and K,J,I and axis, polarity & segment of the first intersection of the trajectory with the
-        torn skin.
+        """Returns the first intersection of the trajectory with the torn skin.
+
+        Returns the x,y,z and K,J,I and axis, polarity & segment.
 
         arguments:
            trajectory (well.Trajectory object): the trajectory to be intersected with the skin
@@ -205,10 +206,13 @@ class GridSkin:
            exclude_kji0 (triple int, optional): if present, the indices of a cell to exclude as a possible result
 
         returns:
-           5-tuple (triple float, triple int, int, int, int): the first element is the xyz coordinates of the intersection point
-           in the crs of the grid; second element is the kji0 of the cell that is intersected, which might be a pinched out
-           or otherwise inactive cell; 3rd element is 0, 1 or 2 for K, J or I axis of cell face; 4th element is 0 for -ve
-           face, 1 for +ve face; 5th element is the trajectory knot prior to the intersection (also the segment number)
+           5-tuple of:
+
+           - (triple float): xyz coordinates of the intersection point in the crs of the grid
+           - (triple int): kji0 of the cell that is intersected, which might be a pinched out or otherwise inactive cell
+           - (int): 0, 1 or 2 for K, J or I axis of cell face
+           - (int): 0 for -ve face, 1 for +ve face
+           - (int): trajectory knot prior to the intersection (also the segment number)
 
         note:
            if the GridSkin object has been initialised using single layer tactics, then the k0 value will be zero for any
@@ -767,8 +771,7 @@ def find_first_intersection_of_trajectory_with_layer_interface(trajectory,
                                                                start = 0,
                                                                heal_faults = False,
                                                                quad_triangles = True):
-    """Returns xyz and other info of the first intersection of well trajectory (or list of trajectories) with layer
-    interface.
+    """Returns info about the first intersection of well trajectory(s) with layer interface.
 
     arguments:
        trajectory (well.Trajectory object; or list thereof): the wellbore trajectory object(s) to find the intersection for;
@@ -839,8 +842,7 @@ def find_first_intersection_of_trajectory_with_cell_surface(trajectory,
                                                             start_xyz = None,
                                                             nudge = 0.001,
                                                             quad_triangles = True):
-    """Searches along the trajectory from a starting point until the first intersection with the cell's surface is
-    encountered."""
+    """Return first intersection with cell's surface found along a trajectory."""
 
     cp = grid.corner_points(kji0)
     cell_surface = rqs.Surface(grid.model)

--- a/resqpy/lines/_polyline.py
+++ b/resqpy/lines/_polyline.py
@@ -261,8 +261,7 @@ class Polyline(_BasePolyline):
         return 0.5 * (self.coordinates[segment_index] + self.coordinates[successor])
 
     def segment_normal(self, segment_index):
-        """For a closed polyline returns a unit vector giving the 2D (xy) direction of an outward facing normal to a
-        segment."""
+        """For a closed polyline return a unit vector giving the 2D (xy) direction of an outward facing normal to a segment."""
 
         successor = self._successor(segment_index)
         segment_vector = self.coordinates[successor, :2] - self.coordinates[segment_index, :2]
@@ -359,7 +358,6 @@ class Polyline(_BasePolyline):
            segment number & x, y of first intersection of (half) bounded line x,y 1 to 2 with polyline,
            or None, None, None if no intersection found
         """
-
         seg_count = len(self.coordinates) - 1
         if self.isclosed:
             seg_count += 1

--- a/resqpy/model.py
+++ b/resqpy/model.py
@@ -43,7 +43,6 @@ class Model():
     """Class for RESQML (v2) based models.
 
     Examples:
-
           To open an existing dataset::
 
              Model(epc_file = 'filename.epc')
@@ -2537,26 +2536,26 @@ class Model():
                    z_inc_down = True):
         """DEPRECATED: Creates a Coordinate Reference System node and optionally adds as child of root and/or to parts forest.
 
-      arguments:
-         add_as_part (boolean, default True): if True the newly created crs node is added to the model
+        arguments:
+            add_as_part (boolean, default True): if True the newly created crs node is added to the model
             as a part
-         title (string): used as the Title text in the citation node
-         epsg_code (integer): EPSG code of the parent coordinate reference system that this crs sits within;
+            title (string): used as the Title text in the citation node
+            epsg_code (integer): EPSG code of the parent coordinate reference system that this crs sits within;
             used for both projected and vertical frames of reference; if None then unknown settings are used
-         originator (string, optional): the name of the human being who created the crs object;
+            originator (string, optional): the name of the human being who created the crs object;
             default is to use the login name
-         x_offset, y_offset, z_offset (floats, default 0.0): the local origin within the parent coordinate
+            x_offset, y_offset, z_offset (floats, default 0.0): the local origin within the parent coordinate
             reference system space
-         areal_rotation_radians (float, default 0.0): the areal rotation of the xy axes of this crs relative
+            areal_rotation_radians (float, default 0.0): the areal rotation of the xy axes of this crs relative
             to the parent coordinate reference system
-         xy_units (string, default 'm'): the length units of x & y values in this crs; 'm' or 'ft'
-         z_units (string, default 'm'): the length units of z values in this crs; 'm' or 'ft'
-         z_inc_down (boolean, default True): if True, z values increase with depth; if False, z values increase
+            xy_units (string, default 'm'): the length units of x & y values in this crs; 'm' or 'ft'
+            z_units (string, default 'm'): the length units of z values in this crs; 'm' or 'ft'
+            z_inc_down (boolean, default True): if True, z values increase with depth; if False, z values increase
             with elevation
 
-      returns:
-         newly created coordinate reference system xml node
-      """
+        returns:
+            newly created coordinate reference system xml node
+        """
 
         warnings.warn("model.create_crs is Deprecated, will be removed", DeprecationWarning)
         crs = rqc.Crs(self,
@@ -3039,8 +3038,7 @@ class Model():
         return new_node
 
     def force_consolidation_uuid_equivalence(self, immigrant_uuid, resident_uuid):
-        """Forces object identified by immigrant uuid to be teated as equivalent to that with resident uuid during
-        consolidation."""
+        """Force immigrant object to be teated as equivalent to resident during consolidation."""
 
         if self.consolidation is None:
             self.consolidation = cons.Consolidation(self)
@@ -3471,7 +3469,6 @@ class ModelContext:
             print(model.uuids())
 
     Note:
-
         The "write_hdf5" and "create_xml" methods of individual resqpy objects
         still need to be invoked as usual.
     """
@@ -3505,7 +3502,7 @@ class ModelContext:
         self._model: Optional[Model] = None
 
     def __enter__(self) -> Model:
-        # Enter the runtime context, return a model
+        """Enter the runtime context, return a model."""
 
         if self.mode in ["read", "read/write"]:
             if not os.path.exists(self.epc_file):
@@ -3523,7 +3520,7 @@ class ModelContext:
         return self._model
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        # Exit the runtime context, close the model
+        """Exit the runtime context, close the model."""
 
         # Only write to disk if no exception has occured
         if self.mode in ["read/write", "create"] and exc_type is None:

--- a/resqpy/olio/box_utilities.py
+++ b/resqpy/olio/box_utilities.py
@@ -403,9 +403,10 @@ def trim_box_by_box_returning_new_mask(box_to_be_trimmed, trim_box, mask_kji0):
 
 
 def trim_box_to_mask_returning_new_mask(bounding_box_kji0, mask_kji0):
-    """Reduces the coverage of bounding box to the minimum needed to contain True elements of mask; returns trimmed
-    mask."""
-
+    """Reduce the coverage of bounding box to the minimum needed to contain True elements of mask.
+    
+    Returns trimmed mask.
+    """
     # NB: bounding box is modified by this function
     assert bounding_box_kji0.ndim == 2 and bounding_box_kji0.shape == (2, 3) and bounding_box_kji0.dtype == 'int'
     assert (mask_kji0.ndim == 3 and

--- a/resqpy/olio/fine_coarse.py
+++ b/resqpy/olio/fine_coarse.py
@@ -158,8 +158,11 @@ class FineCoarse:
         return tuple(base)
 
     def fine_box_for_coarse(self, c_kji0):
-        """Returns a numpy int array of shape (2, 3) being the min, max for k, j, i0 in fine grid for given coarse
-        cell."""
+        """Return the min, max for k, j, i0 in fine grid for given coarse cell.
+        
+        Returns:
+            Numpy int array of shape (2, 3) being the min, max for k, j, i0
+        """
 
         box = np.empty((2, 3), dtype = int)
         box[0] = self.fine_base_for_coarse(c_kji0)
@@ -167,8 +170,11 @@ class FineCoarse:
         return box
 
     def proportion(self, axis, c0):
-        """Return a numpy vector of floats (summing to one) being the axial relative proportions of fine within
-        coarse."""
+        """Return the axial relative proportions of fine within coarse.
+        
+        Returns:
+            numpy vector of floats, summing to one
+        """
 
         if self.equal_proportions[axis]:
             count = self.ratio(axis, c0)
@@ -177,8 +183,7 @@ class FineCoarse:
         return self.vector_proportions[axis][c0]
 
     def proportions_for_axis(self, axis):
-        """Return a numpy vector of floats for fine (summing to one for each coarse slice) being the axial relative
-        proportions."""
+        """Return the axial relative proportions as array of floats summing to one."""
 
         if self.equal_proportions[axis]:
             count = self.constant_ratios[axis]
@@ -187,9 +192,10 @@ class FineCoarse:
         return np.concatenate(self.vector_proportions[axis])
 
     def interpolation(self, axis, c0):
-        """Return a numpy vector of floats starting at zero and increasing monotonically to less than one, ready for
-        interpolation."""
-
+        """Return a float array ready for interpoltion.
+        
+        Returns floats starting at zero and increasing monotonically to less than one.
+        """
         count = self.ratio(axis, c0)
         fractions = np.zeros((count,))
         proport = self.proportion(axis, c0)

--- a/resqpy/olio/grid_functions.py
+++ b/resqpy/olio/grid_functions.py
@@ -468,8 +468,11 @@ def triangles_for_cell_faces(cp):
 
 
 def actual_pillar_shape(pillar_points, tolerance = 0.001):
-    """Returns 'curved', 'straight' or 'vertical' for shape of fully defined points array of shape (nk + k_gaps + 1,
-    ..., 3)."""
+    """Returns 'curved', 'straight' or 'vertical' for shape of pillar points.
+    
+    Args:
+        pillar_points: fully defined points array of shape (nk + k_gaps + 1,..., 3).
+    """
 
     assert pillar_points.ndim >= 3 and pillar_points.shape[-1] == 3
 
@@ -501,9 +504,10 @@ def actual_pillar_shape(pillar_points, tolerance = 0.001):
 
 
 def columns_to_nearest_split_face(grid):
-    """Returns a numpy integer array of shape (NJ, NI) being number of cells to nearest split edge (Manhattan
-    distance)."""
-
+    """Return an int array of shape (NJ, NI) being number of cells to nearest split edge.
+    
+    Uses Manhattan distance.
+    """
     if not grid.has_split_coordinate_lines:
         return None
 

--- a/resqpy/olio/intersection.py
+++ b/resqpy/olio/intersection.py
@@ -207,8 +207,8 @@ def distilled_intersects(line_set_intersections):
           this array is as returned by the line_set_triangles_intersects() function or the
           poly_line_triangles_intersects() function
 
-       returns:
-          (numpy int array of shape (N,), numpy int array of shape (N,), numpy float array of shape (N, 3)):
+    returns:
+       (numpy int array of shape (N,), numpy int array of shape (N,), numpy float array of shape (N, 3)):
           for N intersections, first array is list of line indices, second is list of triangle indices, the
           third array contains the (x, y, z) coordinates of the intersection points
     """

--- a/resqpy/olio/point_inclusion.py
+++ b/resqpy/olio/point_inclusion.py
@@ -85,8 +85,9 @@ def pip_wn(p, poly):
 
 
 def pip_array_cn(p_a, poly):
-    """array of 2D points inclusion: returns bool array True where point is inside polygon (uses crossing number
-    algorithm).
+    """Return bool array of 2D points inclusion, True where point is inside polygon.
+    
+    Uses crossing number algorithm.
 
     arguments:
        p_a (2D numpy float array): set of xy points to test for inclusion in polygon

--- a/resqpy/olio/relperm.py
+++ b/resqpy/olio/relperm.py
@@ -247,8 +247,7 @@ class RelPerm(DataFrame):
                 print(f'Appended to DAT file: {filename} at {filepath}')
 
     def write_hdf5_and_create_xml(self):
-        """Write relative permeability table data to hdf5 file and create xml for RESQML objects to represent
-        dataframe."""
+        """Write relative permeability table data to hdf5 file and create xml for dataframe objects."""
         super().write_hdf5_and_create_xml()
         mesh_root = self.mesh.root
         # create an xml of extra metadata to indicate that this is a relative permeability table
@@ -256,8 +255,7 @@ class RelPerm(DataFrame):
 
 
 def text_to_relperm_dict(relperm_data, is_file = True):
-    """Returns a dictionary that contains dataframes with relative permeability and capillary pressure data and phase
-    combinations.
+    """Return dict of dataframes with relative permeability and capillary pressure data and phase combinations.
 
     arguments:
        relperm_data (str): relative or full path of the text file to be processed or string of relative permeability data

--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -167,32 +167,42 @@ def find_nested_tags_cast(root, tag_list, dtype = None):
 
 
 def find_nested_tags_text(root, tag_list):
-    """Follows a list of tags in a nested xml hierarchy, returning the stripped text of the node at the deepest
-    level."""
+    """Return stripped text of node at deepest level of xml hierarchy.
+    
+    Args:
+        tag_list: list of tags in a nested xml hierarchy
+    """
 
     node = find_nested_tags(root, tag_list)
     return node_text(node)
 
 
 def find_nested_tags_bool(root, tag_list):
-    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as
-    bool."""
-
+    """Return stripped text of node at deepest level of xml hierarchy as a bool.
+    
+    Args:
+        tag_list: list of tags in a nested xml hierarchy
+    """
     node = find_nested_tags(root, tag_list)
     return node_bool(node)
 
 
 def find_nested_tags_int(root, tag_list):
-    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as int."""
-
+    """Return stripped text of node at deepest level of xml hierarchy as an int.
+    
+    Args:
+        tag_list: list of tags in a nested xml hierarchy
+    """
     node = find_nested_tags(root, tag_list)
     return node_int(node)
 
 
 def find_nested_tags_float(root, tag_list):
-    """Follows a list of tags in a nested xml hierarchy, returning the text of the node at the deepest level, as
-    float."""
-
+    """Return stripped text of node at deepest level of xml hierarchy as a float.
+    
+    Args:
+        tag_list: list of tags in a nested xml hierarchy
+    """
     node = find_nested_tags(root, tag_list)
     return node_float(node)
 
@@ -583,9 +593,8 @@ def time_units_from_node(node):
         return node.text.strip()
 
 
-def xyz_handedness(xy_axes, z_inc_down):
-    """Returns xyz true handedness as 'left', 'right' or 'unknown', based on xy_axes (string) and z_inc_down
-    (boolean)."""
+def xyz_handedness(xy_axes: str, z_inc_down: bool):
+    """Return xyz true handedness as 'left', 'right' or 'unknown'."""
 
     if xy_axes is None or z_inc_down is None:
         return 'unknown'
@@ -611,8 +620,11 @@ def xyz_handedness(xy_axes, z_inc_down):
 
 
 def ijk_handedness(geom_node):
-    """Returns ijk true handedness as 'left', 'right' or 'unknown', based on GridIsRightHanded node in grid geometry
-    node."""
+    """Returns ijk true handedness as 'left', 'right' or 'unknown'.
+    
+    Args:
+        GridIsRightHanded node in grid geometry node.
+    """
 
     if geom_node is None:
         return 'unknown'

--- a/resqpy/organize/__init__.py
+++ b/resqpy/organize/__init__.py
@@ -1,6 +1,4 @@
-"""
-resqpy.organize: Package for RESQML organizational objects.
-"""
+""" Package for RESQML organizational objects """
 
 __all__ = [
     'OrganizationFeature',

--- a/resqpy/organize/geobody_boundary_interpretation.py
+++ b/resqpy/organize/geobody_boundary_interpretation.py
@@ -27,7 +27,8 @@ class GeobodyBoundaryInterpretation(BaseResqpy):
                  domain = 'depth',
                  boundary_relation_list = None,
                  extra_metadata = None):
-        """
+        """ Instantiate a GeobodyBoundaryInterpretation object.
+
         Args:
             parent_model(model.Model): Model to which the feature belongs
             root_node(DEPRECATED)
@@ -106,8 +107,7 @@ class GeobodyBoundaryInterpretation(BaseResqpy):
                    originator = None,
                    title_suffix = None,
                    reuse = True):
-        """Creates a geobody boundary interpretation organisational xml node from a geobody boundary interpretation
-        object."""
+        """Create a organisational xml node from a geobody boundary interpretation object."""
 
         if not self.title:
             self.title = self.genetic_boundary_feature.feature_name

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -606,7 +606,7 @@ class PropertyCollection():
 
         arguments:
            other: another PropertyCollection object with some imported arrays
-           copy_cached_array (boolean, default True): if True, arrays cached with the other
+           copy_cached_arrays (boolean, default True): if True, arrays cached with the other
               collection are copied and cached with this collection
            exclude_inactive (boolean, default False): if True, any item in the other imported list
               which has INACTIVE or ACTIVE as the keyword is excluded from the inheritance
@@ -739,7 +739,6 @@ class PropertyCollection():
         to be inherited.
 
         note:
-
            the grid argument is maintained for backward compatibility; it is treated synonymously with support
            which takes precendence; the categorical boolean argument can be used to filter only Categorical
            (or non-Categorical) properties

--- a/resqpy/property.py
+++ b/resqpy/property.py
@@ -123,8 +123,7 @@ class PropertyCollection():
     """
 
     def __init__(self, support = None, property_set_root = None, realization = None):
-        """Initialise an empty Property Collection; if support is not None, populate with properties for that
-        representation.
+        """Initialise an empty Property Collection, optionally populate properties from a supporting representation.
 
         arguments:
            support (optional): a grid.Grid object or a well.WellboreFrame object which belongs to a resqpy.Model which includes
@@ -200,8 +199,9 @@ class PropertyCollection():
                 self.populate_from_property_set(property_set_root)
 
     def set_support(self, support_uuid = None, support = None, model = None, modify_parts = True):
-        """Sets the supporting object associated with this collection, without loading props, if not done so at
-        initialisation.
+        """Sets the supporting object associated with this collection if not done so at initialisation.
+
+        Does not load properties.
 
         Arguments:
            support_uuid: the uuid of the supporting representation which the properties in this collection are for
@@ -286,8 +286,7 @@ class PropertyCollection():
                         self.dict[part] = tuple(modified)
 
     def supporting_shape(self, indexable_element = None, direction = None):
-        """Returns the shape of the supporting representation with respect to the given indexable element, as a list of
-        ints.
+        """Return the shape of the supporting representation with respect to the given indexable element
 
         arguments:
            indexable_element (string, optional): if None, a hard-coded default depending on the supporting representation class
@@ -904,8 +903,7 @@ class PropertyCollection():
                                                                      example_part,
                                                                      citation_title_match_starts_with = False,
                                                                      ignore_clashes = False):
-        """Adds the example part from other collection and any other parts for same property with different
-        realizations.
+        """Add the example part from other collection and any other parts for same property with different realizations.
 
         arguments:
            other: another PropertyCollection object related to the same support as this collection, from which to inherit
@@ -1735,8 +1733,7 @@ class PropertyCollection():
         return self.unique_element_list(15, sort_list = sort_list)
 
     def string_lookup_uuid_for_part(self, part):
-        """If the property has an associated string lookup (is categorical), returns the uuid for the string table
-        lookup.
+        """If the property has an associated string lookup (is categorical), return the uuid.
 
         arguments:
            part (string): the part name for which the string lookup uuid is required
@@ -1804,9 +1801,10 @@ class PropertyCollection():
         self.dict[part] = tuple(property_part)
 
     def establish_time_set_kind(self):
-        """Re-evaulates the time set kind attribute based on all properties having same time index in the same time
-        series."""
-
+        """Re-evaulate the time set kind attribute.
+        
+        Based on all properties having same time index in the same time series.
+        """
         self.time_set_kind_attr = 'single time'
         #  note: other option of 'equivalent times' not catered for in this code
         common_time_index = None
@@ -1833,17 +1831,19 @@ class PropertyCollection():
         return self.time_set_kind_attr
 
     def time_set_kind(self):
-        """Returns the time set kind attribute based on all properties having same time index in the same time
-        series."""
-
+        """Returns the time set kind attribute.
+        
+        Based on all properties having same time index in the same time series.
+        """
         if self.time_set_kind_attr is None:
             self.establish_time_set_kind()
         return self.time_set_kind_attr
 
     def establish_has_single_property_kind(self):
-        """Re-evaluates the has single property kind attribute depending on whether all properties are of the same
-        kind."""
-
+        """Re-evaluates the has single property kind attribute
+        
+        Depends on whether all properties are of the same kind.
+        """
         self.has_single_property_kind_flag = True
         common_property_kind = None
         for part in self.parts():
@@ -1856,15 +1856,17 @@ class PropertyCollection():
         return self.has_single_property_kind_flag
 
     def has_single_property_kind(self):
-        """Returns the has single property kind flag depending on whether all properties are of the same kind."""
+        """Return the has single property kind flag depending on whether all properties are of the same kind."""
 
         if self.has_single_property_kind_flag is None:
             self.establish_has_single_property_kind()
         return self.has_single_property_kind_flag
 
     def establish_has_single_indexable_element(self):
-        """Re-evaluates the has single indexable element attribute depending on whether all properties have the same."""
-
+        """Re-evaluate the has single indexable element attribute.
+        
+        Depends on whether all properties have the same.
+        """
         self.has_single_indexable_element_flag = True
         common_ie = None
         for part in self.parts():
@@ -1884,9 +1886,10 @@ class PropertyCollection():
         return self.has_single_indexable_element_flag
 
     def establish_has_multiple_realizations(self):
-        """Re-evaluates the has multiple realizations attribute based on whether properties belong to more than one
-        realization."""
-
+        """Re-evaluates the has multiple realizations attribute.
+        
+        Based on whether properties belong to more than one realization.
+        """
         self.has_multiple_realizations_flag = False
         common_realization = None
         for part in self.parts():
@@ -1915,8 +1918,7 @@ class PropertyCollection():
         return self.has_multiple_realizations_flag
 
     def establish_has_single_uom(self):
-        """Re-evaluates the has single uom attribute depending on whether all properties have the same units of
-        measure."""
+        """Re-evaluates the has single uom attribute depending on whether all properties have the same units of measure."""
 
         self.has_single_uom_flag = True
         common_uom = None
@@ -1963,8 +1965,7 @@ class PropertyCollection():
         self.has_multiple_realizations_flag = (realization > 1)
 
     def masked_array(self, simple_array, exclude_inactive = True, exclude_value = None, points = False):
-        """Returns a masked version of simple_array, using inactive mask associated with support for this property
-        collection.
+        """Returns a masked version of simple_array, using inactive mask associated with support for this property collection.
 
         arguments:
            simple_array (numpy array): an unmasked numpy array with the same shape as property arrays for the support
@@ -2468,8 +2469,7 @@ class PropertyCollection():
         return resqpy_a
 
     def discombobulated_face_array(self, resqpy_a):
-        """Returns a RESQML format copy of logical face property array a, re-ordered and reshaped regarding the six
-        facial directions.
+        """Return logical face property array a, re-ordered and reshaped regarding the six facial directions.
 
         argument:
            resqpy_a (numpy array of shape (..., 3, 2)): the penultimate array axis represents K,J,I and the final axis is -/+ face
@@ -2518,8 +2518,7 @@ class PropertyCollection():
                               discrete_cycle = None,
                               trust_min_max = False,
                               fix_zero_at = None):
-        """Returns a triplet of: a numpy float array containing the data normalized between 0.0 and 1.0, the min value,
-        the max value.
+        """Return data normalised to between 0 and 1, along with min and max value.
 
         arguments:
            part (string): the part name for which the normalized array reference is required
@@ -2818,8 +2817,9 @@ class PropertyCollection():
                                                             find_local_property_kinds = True,
                                                             expand_const_arrays = False,
                                                             extra_metadata = {}):
-        """Add imported or generated grid property arrays as parts in parent model, creating xml; hdf5 should already
-        have been written.
+        """Add imported or generated grid property arrays as parts in parent model, creating xml.
+        
+        hdf5 should already have been written.
 
         arguments:
            ext_uuid: uuid for the hdf5 external part, which must be known to the model's hdf5 dictionary
@@ -4118,8 +4118,9 @@ class GridPropertyCollection(PropertyCollection):
                                                                            realization = None,
                                                                            copy_all_realizations = False,
                                                                            uncache_other_arrays = True):
-        """Extends this collection's imported list with properties from other collection, optionally extracting for a
-        box.
+        """Extend this collection's imported list with properties from other collection.
+        
+        Optionally extract for a box.
 
         arguments:
            other: another GridPropertyCollection object which might relate to a different grid object
@@ -4469,8 +4470,9 @@ class GridPropertyCollection(PropertyCollection):
                                        facet = None,
                                        realization = None,
                                        use_binary = True):
-        """Reads a property array from an ascii (or pure binary) file, caches and adds to imported list (but not
-        collection dict).
+        """Reads a property array from an ascii (or pure binary) file, caches and adds to imported list.
+        
+        Does not add to collection dict.
 
         arguments:
            file_name (string): the name of the file to read the array data from; should contain data for one array only, without
@@ -4595,8 +4597,9 @@ class GridPropertyCollection(PropertyCollection):
                                                time_index = None,
                                                uom = None,
                                                realization = None):
-        """Reads a vdb recurrent property array for one timestep, caches and adds to imported list (but not collection
-        dict).
+        """Reads a vdb recurrent property array for one timestep, caches and adds to imported list.
+        
+        Does not add to collection dict.
 
         arguments:
            vdbase: an object of class vdb.VDB, already initialised with the path of the vdb
@@ -5553,8 +5556,10 @@ class PropertyKind(BaseResqpy):
 
 
 class WellIntervalProperty:
-    """Thin wrapper class around interval properties for a Wellbore Frame or Blocked Wellbore (ie interval or cell well
-    logss)."""
+    """Thin wrapper class around interval properties for a Wellbore Frame or Blocked Wellbore.
+    
+    ie, interval or cell well logs.
+    """
 
     def __init__(self, collection, part):
         """Create an interval log or blocked well log from a part name."""
@@ -5576,8 +5581,7 @@ class WellIntervalProperty:
 
 
 class WellIntervalPropertyCollection(PropertyCollection):
-    """Class for RESQML property collection for a WellboreFrame for interval or blocked well logs, inheriting from
-    PropertyCollection."""
+    """Class for RESQML property collection for a WellboreFrame for interval or blocked well logs"""
 
     def __init__(self, frame = None, property_set_root = None, realization = None):
         """Creates a new property collection related to interval or blocked well logs and a wellbore frame."""

--- a/resqpy/rq_import.py
+++ b/resqpy/rq_import.py
@@ -75,12 +75,14 @@ def import_nexus(
         grid_title = 'ROOT',
         mode = 'w',
         progress_fn = None):
-    """Read a simulation grid geometry and optionally grid properties and return a resqml model in memory & written to
-    disc.
+    """Read a simulation grid geometry and optionally grid properties.
 
     Input may be from nexus ascii input files, or nexus vdb output.
-    """
 
+    Returns:
+        resqml model in memory & written to disc
+    
+    """
     if resqml_file_root.endswith('.epc'):
         resqml_file_root = resqml_file_root[:-4]
     assert mode in ['w', 'a']
@@ -638,8 +640,9 @@ def import_vdb_ensemble(
         split_pillars = True,
         split_tolerance = 0.01,  # applies to each of x, y, z differences
         progress_fn = None):
-    """Adds properties from all vdb's within an ensemble directory tree to a single RESQML dataset, referencing a shared
-    grid.
+    """Adds properties from all vdbs within an ensemble directory tree to a single RESQML dataset.
+    
+    Referencing a shared grid.
 
     args:
        epc_file (string): filename of epc file to be extended with ensemble properties
@@ -955,9 +958,10 @@ def add_ab_properties(
     ab_property_list = None
 ):  # list of (file_name, keyword, property_kind, facet_type, facet, uom, time_index, null_value,
     #          discrete, realization)
-    """Process a list of pure binary property array files, adding as parts of model, related to grid (hdf5 file is
-    appended to)."""
-
+    """Process a list of pure binary property array files.
+    
+    Adds as parts of model, related to grid (hdf5 file is appended to).
+    """
     assert ab_property_list, 'property list is empty or missing'
 
     model = rq.Model(epc_file = epc_file)

--- a/resqpy/strata/_binary_contact_interpretation.py
+++ b/resqpy/strata/_binary_contact_interpretation.py
@@ -111,8 +111,7 @@ class BinaryContactInterpretation:
            f'missing or invalid contact verb {self.verb} in xml for binary contact interpretation'
 
     def create_xml(self, parent_node = None):
-        """Generates xml sub-tree for this contact interpretation, for inclusion as element of high level
-        interpretation.
+        """Generates xml sub-tree for this contact interpretation, for inclusion as element of high level interpretation.
 
         arguments:
            parent_node (lxml.etree._Element, optional): if present, the created sub-tree is added as a child to this node

--- a/resqpy/surface/combined_surface.py
+++ b/resqpy/surface/combined_surface.py
@@ -14,8 +14,10 @@ import numpy as np
 
 
 class CombinedSurface:
-    """Class allowing a collection of Surface objects to be treated as a single surface (not a RESQML class in its own
-    right)."""
+    """Class allowing a collection of Surface objects to be treated as a single surface.
+    
+    Not a RESQML class in its own right.
+    """
 
     def __init__(self, surface_list, crs_uuid = None):
         """Initialise a CombinedSurface object from a list of Surface (and/or CombinedSurface) objects.
@@ -53,9 +55,11 @@ class CombinedSurface:
             self.points_count_list.append(len(p))
 
     def surface_index_for_triangle_index(self, tri_index):
-        """For a triangle index in the combined surface, returns the index of the surface containing rhe triangle and
-        local triangle index."""
-
+        """Return the index of the surface containing the triangle and local triangle index.
+        
+        Arguments:
+            tri_index: triangle index in the combined surface
+        """
         for s_i in range(len(self.surface_list)):
             if tri_index < self.triangle_count_list[s_i]:
                 return s_i, tri_index

--- a/resqpy/surface/pointset.py
+++ b/resqpy/surface/pointset.py
@@ -141,7 +141,8 @@ class PointSet(BaseSurface):
         # note: load of patches handled elsewhere
 
     def from_charisma(self, charisma_file):
-        """Instantiates a pointset using points from an input charisma file
+        """Instantiate a pointset using points from an input charisma file
+
         arguments:
             charisma_file: a charisma 3d interpretation file
         """
@@ -158,7 +159,8 @@ class PointSet(BaseSurface):
             self.title = charisma_file
 
     def from_irap(self, irap_file):
-        """Instantiates a pointset using points from an input irap file
+        """Instantiate a pointset using points from an input irap file.
+
         arguments:
             irap_file: a IRAP classic points format file
         """
@@ -183,7 +185,8 @@ class PointSet(BaseSurface):
               the (closed, convex) polyline
            random_point_count (int, optional): if present then the number of random
               points to generate within the (closed) polyline in the xy plane, with z set to 0.0
-            """
+
+        """
         if random_point_count:
             assert polyline.is_convex()
             points = np.zeros((random_point_count, 3))
@@ -333,20 +336,20 @@ class PointSet(BaseSurface):
                    originator = None):
         """Creates a point set representation xml node from this point set object and optionally adds as part of model.
 
-           arguments:
-              ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the points array(s)
-              add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-                 in the model
-              add_relationships (boolean, default True): if True, a relationship xml part is created relating the
-                 new point set part to the crs part (and optional interpretation part)
-              root (optional, usually None): if not None, the newly created point set representation node is appended
-                 as a child to this node
-              title (string): used as the citation Title text; should be meaningful to a human
-              originator (string, optional): the name of the human being who created the point set representation part;
-                 default is to use the login name
+        arguments:
+            ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the points array(s)
+            add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+                in the model
+            add_relationships (boolean, default True): if True, a relationship xml part is created relating the
+                new point set part to the crs part (and optional interpretation part)
+            root (optional, usually None): if not None, the newly created point set representation node is appended
+                as a child to this node
+            title (string): used as the citation Title text; should be meaningful to a human
+            originator (string, optional): the name of the human being who created the point set representation part;
+                default is to use the login name
 
-           returns:
-              the newly created point set representation xml node
+        returns:
+            the newly created point set representation xml node
 
         :meta common:
         """

--- a/resqpy/surface/surface.py
+++ b/resqpy/surface/surface.py
@@ -42,8 +42,9 @@ class Surface(BaseSurface):
                  crs_uuid = None,
                  originator = None,
                  extra_metadata = {}):
-        """Create an empty Surface object (RESQML TriangulatedSetRepresentation) and optionally populates from xml,
-        point set or mesh.
+        """Create an empty Surface object (RESQML TriangulatedSetRepresentation).
+        
+        Optionally populates from xml, point set or mesh.
 
         arguments:
            parent_model (model.Model object): the model to which this surface belongs
@@ -325,9 +326,10 @@ class Surface(BaseSurface):
         self.uuid = bu.new_uuid()
 
     def set_to_multi_cell_faces_from_corner_points(self, cp, quad_triangles = True):
-        """Populates this (empty) surface to represent faces of a set of cells, from corner points of shape (N, 2, 2, 2,
-        3)."""
-
+        """Populates this (empty) surface to represent faces of a set of cells.
+        
+        From corner points of shape (N, 2, 2, 2, 3).
+        """
         assert cp.size % 24 == 0
         cp = cp.reshape((-1, 2, 2, 2, 3))
         self.patch_list = []
@@ -340,10 +342,9 @@ class Surface(BaseSurface):
         self.uuid = bu.new_uuid()
 
     def cell_axis_and_polarity_from_triangle_index(self, triangle_index):
-        """For surface freshly built for cell faces, returns (cell_number, face_axis, polarity) for given triangle
-        index.
+        """For surface freshly built for cell faces, returns (cell_number, face_axis, polarity).
 
-        argument:
+        arguments:
            triangle_index (int or numpy int array): the triangle index (or array of indices) for which cell face
               information is required
 
@@ -361,13 +362,14 @@ class Surface(BaseSurface):
         return cell_number, axis, polarity
 
     def set_to_horizontal_plane(self, depth, box_xyz, border = 0.0):
-        """Populate this (empty) surface with a patch of two triangles defining a flat, horizontal plane at a given
-        depth.
+        """Populate this (empty) surface with a patch of two triangles.
+        
+        Triangles define a flat, horizontal plane at a given depth.
 
-           arguments:
-              depth (float): z value to use in all points in the triangulated patch
-              box_xyz (float[2, 3]): the min, max values of x, y (&z) giving the area to be covered (z ignored)
-              border (float): an optional border width added around the x,y area defined by box_xyz
+        arguments:
+            depth (float): z value to use in all points in the triangulated patch
+            box_xyz (float[2, 3]): the min, max values of x, y (&z) giving the area to be covered (z ignored)
+            border (float): an optional border width added around the x,y area defined by box_xyz
 
         :meta common:
         """
@@ -438,9 +440,10 @@ class Surface(BaseSurface):
         self.set_from_mesh_file(filename, 'rms', quad_triangles = quad_triangles)
 
     def vertical_rescale_points(self, ref_depth = None, scaling_factor = 1.0):
-        """Modify the z values of points for this surface by stretching the distance from reference depth by scaling
-        factor."""
-
+        """Modify the z values of points by rescaling.
+        
+        Stretches the distance from reference depth by scaling factor.
+        """
         if scaling_factor == 1.0:
             return
         if ref_depth is None:
@@ -480,20 +483,20 @@ class Surface(BaseSurface):
                    originator = None):
         """Creates a triangulated surface xml node from this surface object and optionally adds as part of model.
 
-           arguments:
-              ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the surface arrays
-              add_as_part (boolean, default True): if True, the newly created xml node is added as a part
-                 in the model
-              add_relationships (boolean, default True): if True, a relationship xml part is created relating the
-                 new triangulated representation part to the crs part (and optional interpretation part)
-              crs_uuid (optional): the uuid of the coordinate reference system applicable to the surface points data;
-                 if None, the main crs for the model is assumed to apply
-              title (string): used as the citation Title text; should be meaningful to a human
-              originator (string, optional): the name of the human being who created the triangulated representation part;
-                 default is to use the login name
+        arguments:
+            ext_uuid (uuid.UUID): the uuid of the hdf5 external part holding the surface arrays
+            add_as_part (boolean, default True): if True, the newly created xml node is added as a part
+                in the model
+            add_relationships (boolean, default True): if True, a relationship xml part is created relating the
+                new triangulated representation part to the crs part (and optional interpretation part)
+            crs_uuid (optional): the uuid of the coordinate reference system applicable to the surface points data;
+                if None, the main crs for the model is assumed to apply
+            title (string): used as the citation Title text; should be meaningful to a human
+            originator (string, optional): the name of the human being who created the triangulated representation part;
+                default is to use the login name
 
-           returns:
-              the newly created triangulated representation (surface) xml node
+        returns:
+            the newly created triangulated representation (surface) xml node
 
         :meta common:
         """

--- a/resqpy/surface/triangulated_patch.py
+++ b/resqpy/surface/triangulated_patch.py
@@ -299,9 +299,10 @@ class TriangulatedPatch:
         self.triangle_count = nt
 
     def get_indices_from_sparse_meshxyz(self, mesh_xyz):
-        """Updates self.points and self.node_count with non-nan points in a given mesh_xyz array,
-            and returns the indices of these non_nan points"""
+        """Update self.points and self.node_count with non-nan points in a given mesh_xyz array.
 
+        Returns the indices of these non_nan points.
+        """
         points = np.zeros(mesh_xyz.shape).reshape((-1, 3))
         indices = np.zeros(mesh_xyz.shape[:2], dtype = int) - 1
 
@@ -473,9 +474,11 @@ class TriangulatedPatch:
         return axis, polarity
 
     def vertical_rescale_points(self, ref_depth, scaling_factor):
-        """Modify the z values of points for this patch by stretching the distance from reference depth by scaling
-        factor."""
-
+        """Rescale points along vertical direction.
+        
+        Modifies the z values of points for this patch by stretching the distance
+        from reference depth by scaling factor.
+        """
         _, _ = self.triangles_and_points()  # ensure points are loaded
         z_values = self.points[:, 2].copy()
         self.points[:, 2] = ref_depth + scaling_factor * (z_values - ref_depth)

--- a/resqpy/time_series.py
+++ b/resqpy/time_series.py
@@ -579,9 +579,10 @@ class GeologicTimeSeries(AnyTimeSeries):
 
 
 def selected_time_series(full_series, indices_list, title = None):
-    """Returns a new TimeSeries or GeologicTimeSeries object with timestamps selected from the full series by a list of
-    indices."""
-
+    """Return a new TimeSeries or GeologicTimeSeries object with timestamps.
+    
+    Timestamps are selected from the full series by a list of indices.
+    """
     if isinstance(full_series, TimeSeries):
         selected_ts = TimeSeries(full_series.model, title = title)
     else:

--- a/resqpy/unstructured/_unstructured_grid.py
+++ b/resqpy/unstructured/_unstructured_grid.py
@@ -757,8 +757,9 @@ class UnstructuredGrid(BaseResqpy):
         return np.mean(self.cell_face_centre_points(cell), axis = 0)
 
     def centre_point(self, cell = None, cache_centre_array = False):
-        """Returns centre point of a cell or array of centre points of all cells; optionally cache centre points for all
-        cells.
+        """Returns centre point of a cell or array of centre points of all cells.
+        
+        Optionally cache centre points for all cells.
 
         arguments:
            cell (optional): if present, the cell number of the individual cell for which the

--- a/resqpy/well.py
+++ b/resqpy/well.py
@@ -687,8 +687,9 @@ class Trajectory(BaseResqpy):
             hdf5_source_model = None,
             originator = None,
             extra_metadata = None):
-        """Creates a new trajectory object and optionally loads it from xml, deviation survey, pandas dataframe, or
-        ascii file.
+        """Creates a new trajectory object.
+        
+        Optionally loads it from xml, deviation survey, pandas dataframe, or ascii file.
 
         arguments:
            parent_model (model.Model object): the model which the new trajectory belongs to
@@ -1152,8 +1153,9 @@ class Trajectory(BaseResqpy):
         df.to_csv(trajectory_file, sep = sep, index = False, mode = mode)
 
     def xyz_for_md(self, md):
-        """Returns an xyz triplet corresponding to the given measured depth; uses simple linear interpolation between
-        knots.
+        """Returns an xyz triplet corresponding to the given measured depth.
+        
+        Uses simple linear interpolation between knots.
 
         args:
            md (float): measured depth for which xyz location is required; units must be those of self.md_uom
@@ -1281,8 +1283,7 @@ class Trajectory(BaseResqpy):
         return self.measured_depths
 
     def create_feature_and_interpretation(self):
-        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does
-        not already exist.
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects.
 
         Uses the trajectory citation title as the well name
         """
@@ -1311,11 +1312,11 @@ class Trajectory(BaseResqpy):
                    originator = None):
         """Create a wellbore trajectory representation node from a Trajectory object, optionally add as part.
 
-           notes:
-              measured depth datum xml node must be in place before calling this function;
-              branching well structures (multi-laterals) are supported by the resqml standard but not yet by
-              this code;
-              optional witsml trajectory reference not yet supported here
+        notes:
+            measured depth datum xml node must be in place before calling this function;
+            branching well structures (multi-laterals) are supported by the resqml standard but not yet by
+            this code;
+            optional witsml trajectory reference not yet supported here
 
         :meta common:
         """
@@ -1460,8 +1461,9 @@ class Trajectory(BaseResqpy):
         return wbt_node
 
     def write_hdf5(self, file_name = None, mode = 'a'):
-        """Create or append to an hdf5 file, writing datasets for the measured depths, control points and tangent
-        vectors.
+        """Create or append to an hdf5 file.
+        
+        Writes datasets for the measured depths, control points and tangent vectors.
 
         :meta common:
         """
@@ -1617,10 +1619,10 @@ class WellboreFrame(BaseResqpy):
         return self.trajectory.crs_root
 
     def create_feature_and_interpretation(self):
-        """Instantiate new empty WellboreFeature and WellboreInterpretation objects, if a wellboreinterpretation does
-        not already exist.
+        """Instantiate new empty WellboreFeature and WellboreInterpretation objects.
 
-        Uses the wellboreframe citation title as the well name
+        Does nothing if WellboreInterpretation already exists.
+        Uses the wellboreframe citation title as the well name.
         """
         if self.wellbore_interpretation is not None:
             log.info(f"Creating WellboreInterpretation and WellboreFeature with name {self.title}")
@@ -2084,11 +2086,12 @@ class BlockedWell(BaseResqpy):
         return well_box
 
     def face_pair_array(self):
-        """Returns numpy int array of shape (N, 2, 2) being pairs of face (axis, polarity) pairs, to go with
-        cell_kji0_array().
+        """Return pairs of face (axis, polarity) pairs, to go with cell_kji0_array.
+
+        Returns:
+            int array of shape (N, 2, 2)
 
         note:
-
            each of the N rows in the returned array is of the form:
 
               ((entry_face_axis, entry_face_polarity), (exit_face_axis, exit_face_polarity))
@@ -2156,9 +2159,10 @@ class BlockedWell(BaseResqpy):
         assert bw is self
 
     def set_for_column(self, well_name, grid, col_ji0, skip_inactive = True):
-        """Populates empty blocked well for a 'vertical' well in given column; creates simulation trajectory and md
-        datum."""
-
+        """Populates empty blocked well for a 'vertical' well in given column.
+        
+        Creates simulation trajectory and md datum.
+        """
         if well_name:
             self.well_name = well_name
         col_list = ['IW', 'JW', 'L', 'ANGLA', 'ANGLV']  # NB: L is Layer, ie. k
@@ -3350,8 +3354,9 @@ class BlockedWell(BaseResqpy):
                   length_uom = None,
                   use_face_centres = False,
                   preferential_perforation = True):
-        """Returns the total static K.H (permeability x height); length units are those of trajectory md_uom unless
-        length_upm is set.
+        """Returns the total static K.H (permeability x height).
+        
+        Length units are those of trajectory md_uom unless length_upm is set.
 
         note:
            see doc string for dataframe() method for argument descriptions; perm_i_uuid required

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,10 +79,9 @@ select =
     # Deprecation
     W60,
     # Docstrings (pydocstyle)
-    D100, D104
+    D100, D104, D2
     # Other checks to be progressively enabled in future
-    # D1
-    # D200, D201, D205, D206, D207, D208, D209, D211, D212, D214
+    # D
 ignore =
     # F401: "module imported but unused". Ignoring as low-priority
     F401,
@@ -94,9 +93,8 @@ ignore =
     # Further pydocstyle exceptions for relatively unimportant issues
     D202, D405, D415
 per-file-ignores =
-    # Do not check docstrings for the tests directory
-    tests/*: D100, D104
-    docs/*: D100
+    # Do not check docstrings in the [t]ests or [d]ocs directories
+    [td]*/*: D100, D104, D2
     resqpy/version.py: D100
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ ignore =
     # See http://www.pydocstyle.org/en/latest/error_codes.html#default-conventions
     D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
     # Further pydocstyle exceptions for relatively unimportant issues
-    D202, D405, D415
+    D202, D210, D405, D415
 per-file-ignores =
     # Do not check docstrings in the [t]ests or [d]ocs directories
     [td]*/*: D100, D104, D2

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ ignore =
     # See http://www.pydocstyle.org/en/latest/error_codes.html#default-conventions
     D203, D204, D213, D215, D400, D401, D404, D406, D407, D408, D409, D413
     # Further pydocstyle exceptions for relatively unimportant issues
-    D202, D210, D405, D415
+    D202, D210, D402, D405, D415, D417
 per-file-ignores =
     # Do not check docstrings in the [t]ests or [d]ocs directories
     [td]*/*: D100, D104, D2


### PR DESCRIPTION
This change supports #290 by fixing docstring issues for the set of error codes starting with "D2".

Inevitably this required manually editing a large number of files, glad to say that's now done.

Three main changes:

-  `setup.py`: Includes the below error codes to the "include list"
-  `setup.py`: Adds D210, D402 and D417 to the "ignore list" (mostly false positives or unimportant)
- Many files: relevant fixes for existing broken docstrings.

Errors fixed:

```
 D200: One-line docstring should fit on one line with quotes
 D201: No blank lines allowed before function docstring
 D205: 1 blank line required between summary line and description
 D206: Docstring should be indented with spaces, not tabs
 D207: Docstring is under-indented
 D208: Docstring is over-indented
 D209: Multi-line docstring closing quotes should be on a separate line
 D211: No blank lines allowed before class docstring
 D212: Multi-line docstring summary should start at the first line
 D214: Section is over-indented
```