### PR TITLE
Fix D4xx error codes and most D1 codes

### DIFF
--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -207,7 +207,7 @@ class BaseResqpy(metaclass = ABCMeta):
         return f"{self.__class__.__name__}(uuid={self.uuid}, title={self.title})"
 
     def _repr_html_(self):
-        """IPython / Jupyter representation."""
+        """Return HTML for IPython / Jupyter representation."""
 
         keys_to_display = ('uuid', 'title', 'originator')
         html = f"<h3>{self.__class__.__name__}</h3>\n"

--- a/resqpy/olio/box_utilities.py
+++ b/resqpy/olio/box_utilities.py
@@ -279,14 +279,14 @@ def boxes_overlap(box_a, box_b):
 
 def overlapping_boxes(established_box, new_box, trim_box):
     """Checks for 3D overlap of two boxes; returns True and sets trim_box if there is overlap, otherwise False.
+    
+    trim_box is modified in place.
 
     Arguments:
        established_box: numpy int array of shape (2, 3)
        new_box: numpy int array of shape (2, 3)
           each is lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
           protocol of indices for the two boxes must be the same
-
-    output argument (modified):
        trim_box: numpy int array of shape (2, 3)
           set to lower & upper indices in 3 dimensions defining a logical cuboid subset of a 3D cartesian grid
           a subset of new_box such that if removed from new_box, a valid box would remain with no overlap with established_box
@@ -294,7 +294,6 @@ def overlapping_boxes(established_box, new_box, trim_box):
           if there is no overlap (return value False), all elements of trim_box are set to 0
 
     note:
-
        when there is overlap between the boxes, there can be more than one way to trim the new_box,
        with trim_box fully covering either ij, jk or ik planes of new_box
        the function selects the trim_box containing the minimum number of cells (minimum 'loss' to trimming)

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ select =
     # Deprecation
     W60,
     # Docstrings (pydocstyle)
-    D100, D104, D2
+    D100, D101, D104, D105, D106, D107, D2, D4
     # Other checks to be progressively enabled in future
     # D
 ignore =
@@ -94,7 +94,7 @@ ignore =
     D202, D210, D402, D405, D415, D417
 per-file-ignores =
     # Do not check docstrings in the [t]ests or [d]ocs directories
-    [td]*/*: D100, D104, D2
+    [td]*/*: D100, D101, D104, D105, D106, D107, D2, D4
     resqpy/version.py: D100
 
 [mypy]


### PR DESCRIPTION
Supports #290. Enables checks for below error codes, and includes fixes to existing broken docstrings.

```
 D101: Missing docstring in public class
 D105: Missing docstring in magic method
 D106: Missing docstring in public nested class
 D107: Missing docstring in init

 D401: First line should be in imperative mood; try rephrasing
 D403: First word of the first line should be properly capitalized
 D410: Missing blank line after section
 D411: Missing blank line before section
 D412: No blank lines allowed between a section header and its content
 D414: Section has no content
 D415: First line should end with a period, question mark, or exclamation point
 D416: Section name should end with a colon
 D418: Function/ Method decorated with @overload shouldn’t contain a docstring
```

Once this is merged, the only two left to fix would be missing docstrings for functions and methods.