### PR TITLE
Enable logging of true resqpy version

### DIFF
--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -25,9 +25,19 @@
     olio
 """
 
-try:
-    # Version dynamically extracted from git tags when package is built
-    from .version import version as __version__  # type: ignore
+import logging
 
+# Dynamically get true resqpy version
+try:
+    # Prod setup: Look for resqpy/version.py
+    # This file is created by setuptools_scm when package is pip-installed
+    from .version import version as __version__  # type: ignore
 except ImportError:
+    # Dev setup: Dynamically get version from local git history
+    from setuptools_scm import get_version
+    __version__ = get_version()
+except Exception:
     __version__ = "0.0.0-version-not-available"
+
+log = logging.getLogger(__name__)
+log.info(f"Imported resqpy version {__version__}")

--- a/resqpy/model/_model.py
+++ b/resqpy/model/_model.py
@@ -16,8 +16,9 @@ import resqpy.model._forestry as m_f
 import resqpy.model._grids as m_g
 import resqpy.model._hdf5 as m_h
 import resqpy.model._xml as m_x
+from resqpy import __version__
 
-log.debug('resqpy Model class version: ' + version + '; xml citation format: ' + m_x.citation_format)
+log.debug('resqpy Model class version: ' + __version__ + '; xml citation format: ' + m_x.citation_format)
 
 
 class Model():

--- a/resqpy/model/_xml.py
+++ b/resqpy/model/_xml.py
@@ -1,9 +1,5 @@
 """_xml.py: functions to support xml creation methods in the Model class."""
 
-# following should be kept in line with major.minor tag values in repository
-citation_format = 'bp:resqpy:1.6'
-use_version_string = False
-
 import logging
 
 log = logging.getLogger(__name__)
@@ -18,6 +14,11 @@ import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 from resqpy.olio.xml_namespaces import curly_namespace as ns
 from resqpy.olio.xml_namespaces import namespace as ns_url
+from resqpy import __version__
+
+# following should be kept in line with major.minor tag values in repository
+citation_format = f'bp:resqpy:v{__version__}'
+use_version_string = False
 
 
 def _create_tree_if_none(model):

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ tests =
     flake8
     mypy
     yapf
+    setuptools_scm[toml]
 docs = 
     sphinx
     sphinx_rtd_theme<1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-lxml.*]
 ignore_missing_imports = True
+[mypy-setuptools_scm.*]
+ignore_missing_imports = True
 
 [yapf]
 based_on_style = google


### PR DESCRIPTION
Closes #342 

Adds a log message with the auto-generated `__version__` attribute. Also improves it slightly to ensure the version tag is picked up in a development setting even when the package was not properly pip-installed.

The package `setuptools_scm[toml]` is already a dependency under `setup_resquires`, but I propose adding it to the dev dependencies too.

This is what happens when the version is fetched for a development version (working from a local clone, rather than an installed release):
![image](https://user-images.githubusercontent.com/71127464/146761310-fdaf5095-84d5-4be3-bb0e-30f2aa384d60.png)
