### PR TITLE
Add test for correct version string

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -69,7 +69,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -e ".[tests]"
-
+      
+      - name: Debug git info
+        run: git describe --tags --always
+        
       - name: Run pytest
         run: |
           pytest --cov=resqpy --junitxml=pytest.xml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -59,6 +59,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Ensure tags are fetched, for creating version string
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -69,10 +72,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -e ".[tests]"
-      
-      - name: Debug git info
-        run: git describe --tags --always
-        
+
       - name: Run pytest
         run: |
           pytest --cov=resqpy --junitxml=pytest.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ tests =
     mypy
     yapf
     setuptools_scm[toml]
+    packaging
 docs = 
     sphinx
     sphinx_rtd_theme<1.0.0

--- a/tests/test_resqpy.py
+++ b/tests/test_resqpy.py
@@ -1,3 +1,6 @@
+from packaging.version import Version
+
+import resqpy
 from resqpy import model
 
 
@@ -16,3 +19,15 @@ def test_all_imports():
 
     #    from resqpy.olio import *
     return
+
+
+def test_version():
+
+    # This is dynamically created when package is built
+    # If this fails when running tests locally, ensure you have installed the dev dependencies specified in setup.cfg
+    # In particular, try:  pip install setuptools_scm
+    version_string = resqpy.__version__
+
+    # Ensure version string is a PEP-440 compliant version
+    version = Version(version_string)
+    assert version >= Version("1.1.1")


### PR DESCRIPTION
Adds a unit test to ensure version is being picked up correctly, and is PEP 440-compliant.

The `packaging` lib can be used to validate version strings. It's a small library already in our dependencies indirectly though `setuptools_scm`, but I've added it here explicitly to our dev dependencies.