### PR TITLE
Ensure dev version number works when cwd is not repository root

### DIFF
--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -26,21 +26,31 @@
 """
 
 import logging
+import warnings
 
-# Dynamically get true resqpy version
-try:
-    # Prod setup: Look for resqpy/version.py
-    # This file is created by setuptools_scm when package is pip-installed
-    from .version import version as __version__  # type: ignore
-except ImportError:
-    # Dev setup: Dynamically get version from local git history
+_DEFAULT_VERSION = "0.0.0-version-not-available"
+
+
+def _get_dev_version():
+    """Lookup version from local git history (dev setup only)"""
     try:
         from setuptools_scm import get_version
-        __version__ = get_version(root = '..', relative_to = __file__)
+        return get_version(root = '..', relative_to = __file__)
+    except ImportError:
+        warnings.warn("Missing dev dependency 'setuptools_scm'")
+        return _DEFAULT_VERSION
     except Exception:
-        __version__ = "0.0.0-version-not-available"
+        return _DEFAULT_VERSION
+
+
+try:
+    # Prod setup: Look for hard-coded file resqpy/version.py , created when lib is packaged.
+    from .version import version as __version__  # type: ignore
+except ImportError:
+    # Dev setup: Use local git history
+    __version__ = _get_dev_version()
 except Exception:
-    __version__ = "0.0.0-version-not-available"
+    __version__ = _DEFAULT_VERSION
 
 log = logging.getLogger(__name__)
 log.info(f"Imported resqpy version {__version__}")

--- a/resqpy/__init__.py
+++ b/resqpy/__init__.py
@@ -36,7 +36,7 @@ except ImportError:
     # Dev setup: Dynamically get version from local git history
     try:
         from setuptools_scm import get_version
-        __version__ = get_version()
+        __version__ = get_version(root = '..', relative_to = __file__)
     except Exception:
         __version__ = "0.0.0-version-not-available"
 except Exception:

--- a/tests/test_resqpy.py
+++ b/tests/test_resqpy.py
@@ -22,7 +22,6 @@ def test_all_imports():
     return
 
 
-@pytest.mark.skip("Disabling until the build tools have been fixed.")
 def test_version():
     # This is dynamically created when package is built
     # If this fails when running tests locally, ensure you have installed the dev dependencies specified in setup.cfg


### PR DESCRIPTION
Previous implementation implicitly assumed that the calling code's current working directory was resqpy root, which is obviously not always the case.