### PR TITLE
appending realisation number to Nexus grid property file names

### DIFF
--- a/resqpy/grid/grid.py
+++ b/resqpy/grid/grid.py
@@ -519,17 +519,17 @@ class Grid(BaseResqpy):
 
         write_nexus_corp(self,
                          file_name,
-                         local_coords = False,
-                         global_xy_units = None,
-                         global_z_units = None,
-                         global_z_increasing_downward = True,
-                         write_nx_ny_nz = False,
-                         write_units_keyword = False,
-                         write_rh_keyword_if_needed = False,
-                         write_corp_keyword = False,
-                         use_binary = False,
-                         binary_only = False,
-                         nan_substitute_value = None)
+                         local_coords = local_coords,
+                         global_xy_units = global_xy_units,
+                         global_z_units = global_z_units,
+                         global_z_increasing_downward = global_z_increasing_downward,
+                         write_nx_ny_nz = write_nx_ny_nz,
+                         write_units_keyword = write_units_keyword,
+                         write_rh_keyword_if_needed = write_rh_keyword_if_needed,
+                         write_corp_keyword = write_corp_keyword,
+                         use_binary = use_binary,
+                         binary_only = binary_only,
+                         nan_substitute_value = nan_substitute_value)
 
     def xy_units(self):
         """Returns the projected view (x, y) units of measure of the coordinate reference system for the grid.

--- a/resqpy/grid/write_nexus_corp.py
+++ b/resqpy/grid/write_nexus_corp.py
@@ -78,7 +78,7 @@ def write_nexus_corp(grid,
                 elif global_xy_units in ['ft', 'feet', 'foot']:
                     header.write('ENGLISH\n\n')
                 else:
-                    header.write('! globsl coordinates not recognized\n\n')
+                    header.write('! global coordinates not recognized\n\n')
             else:
                 header.write('! global units unknown or mixed\n\n')
         if write_nx_ny_nz:

--- a/resqpy/property/grid_property_collection.py
+++ b/resqpy/property/grid_property_collection.py
@@ -678,9 +678,11 @@ class GridPropertyCollection(PropertyCollection):
            for other arguments, see the docstring for the write_nexus_property() function
 
         note:
-           the generated filename consists of the citation title (with spaces replaced with underscores);
-           the facet type and facet, if present;
-           _t_ and the time_index, if the part has a time index
+           the generated filename consists of:
+              the citation title (with spaces replaced with underscores);
+              the facet type and facet, if present;
+              _t_ and the time_index, if the part has a time index
+              _r_ and the realisation number, if the part has a realisation number
         """
 
         title = self.citation_title_for_part(part).replace(' ', '_')
@@ -695,6 +697,9 @@ class GridPropertyCollection(PropertyCollection):
         time_index = self.time_index_for_part(part)
         if time_index is not None:
             fname += '_t_' + str(time_index)
+        realisation = self.realization_for_part(part)
+        if realisation is not None:
+            fname += '_r_' + str(realisation)
         # could add .dat extension
         self.write_nexus_property(part,
                                   os.path.join(directory, fname),


### PR DESCRIPTION
When exporting grid properties to Nexus ascii files, the filenames need to include a realisation number if the property collection includes multiple realisations.