### PR TITLE
Refactor poetry CI

### DIFF
--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -1,0 +1,29 @@
+---
+
+name: Prepare Poetry Env
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Install Poetry Plugins
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry-dynamic-versioning
+      
+      # - name: Load cached venv
+      #   id: cached-poetry-dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .venv
+      #     key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+     
+    - name: Install missing cached dependencies
+      # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction

--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -16,6 +16,7 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry-dynamic-versioning
+      shell: bash
       
       # - name: Load cached venv
       #   id: cached-poetry-dependencies
@@ -27,3 +28,5 @@ runs:
     - name: Install missing cached dependencies
       # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction
+      shell: bash
+  

--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -1,10 +1,27 @@
 ---
 
-name: Prepare Poetry Env
+name: Prepare Python and Poetry
+Description: Install Python, Poetry and dev dependencies, cached for speed
+
+inputs:
+  python-version:  
+    description: 'Python version to use'
+    required: true
+    default: '3.x'
 
 runs:
   using: "composite"
   steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    # - name: Load cached Poetry installation
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ~/.local  # the path depends on the OS
+    #     key: poetry-0  # increment to reset cache
 
     - name: Install Poetry
       uses: snok/install-poetry@v1

--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -35,12 +35,12 @@ runs:
         pip install poetry-dynamic-versioning
       shell: bash
       
-      # - name: Load cached venv
-      #   id: cached-poetry-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: .venv
-      #     key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
      
     - name: Install missing cached dependencies
       # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'

--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -35,14 +35,14 @@ runs:
         pip install poetry-dynamic-versioning
       shell: bash
       
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
      
-    - name: Install missing cached dependencies
+    - name: Install dependencies and library
       # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction
       shell: bash

--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -17,11 +17,11 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    # - name: Load cached Poetry installation
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: ~/.local  # the path depends on the OS
-    #     key: poetry-0  # increment to reset cache
+    - name: Load cached Poetry installation
+      uses: actions/cache@v2
+      with:
+        path: ~/.local  # the path depends on the OS
+        key: poetry-0  # increment to reset cache
 
     - name: Install Poetry
       uses: snok/install-poetry@v1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -56,9 +56,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          # Ensure tags are fetched, for creating version string
-          fetch-depth: 0
 
       - name: Install dependencies
         uses: ./.github/actions/prepare-poetry

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,16 +13,18 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
-      # Post in-line comments for any issues found
-      # Do not run if coming from a forked repo
-      # See https://github.com/marketplace/actions/lint-action
-
+    
       - name: Checkout code
         uses: actions/checkout@v2
        
       - name: Install dependencies
         uses: ./.github/actions/prepare-poetry
+        with:
+          python-version: 3.9
 
+      # Post in-line comments for any issues found
+      # Do not run if coming from a forked repo
+      # See https://github.com/marketplace/actions/lint-action
       - name: Run linters (with annotations)
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: wearerequired/lint-action@v1
@@ -58,32 +60,10 @@ jobs:
           # Ensure tags are fetched, for creating version string
           fetch-depth: 0
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Install dependencies
+        uses: ./.github/actions/prepare-poetry
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Install Poetry Plugins
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry-dynamic-versioning
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install missing cached dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction
 
       - name: Run pytest
         run: |
@@ -96,7 +76,7 @@ jobs:
           name: Unit Test Results (Python ${{ matrix.python-version }})
           path: pytest.xml
 
-      - name: "Upload coverage to Codecov"
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -19,13 +19,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
        
-      - name: Prepare Poetry
+      - name: Install dependencies
         uses: ./.github/actions/prepare-poetry
 
       - name: Run linters (with annotations)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,28 +24,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Install Poetry Plugins
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry-dynamic-versioning
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install missing cached dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction
+       
+      - name: Prepare Poetry
+        uses: ./.github/actions/prepare-poetry
 
       - name: Run linters (with annotations)
         if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Refactors the Poetry CI steps that install Python, Poetry and dependencies.

Separates jobs as a separate GitHub "action", that is re-used between the linting and unit test jobs to avoid duplication. Added further caching for speed.

The installation steps can be triggered from within a CI job with:

```yaml
- name: Install dependencies
  uses: ./.github/actions/prepare-poetry
  with:
    python-version: 3.9
```