### PR TITLE
Test against older versions of dependencies

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,6 +1,6 @@
 ---
 
-name: Python CI
+name: Tests
 
 on:
   push:
@@ -63,8 +63,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run pytest
-        run: |
-          poetry run pytest --cov=resqpy --junitxml=pytest.xml
+        run: poetry run pytest --cov=resqpy --junitxml=pytest.xml
 
       - name: Upload pytest artifacts
         if: ${{ always() }}
@@ -80,8 +79,26 @@ jobs:
           files: pytest.xml
           fail_ci_if_error: true
 
-      # - name: Publish Unit Test Results
-      #   if: always()
-      #   uses: EnricoMi/publish-unit-test-result-action@v1
-        # with:
-        #   files: *.xml
+  legacy-dependencies:
+    # Test against older versions of numpy and pandas,
+    # To ensure resqpy works with the lower bounds of our published constraints
+
+    name: Unit tests (older dependencies)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        uses: ./.github/actions/prepare-poetry
+        with:
+          python-version: 3.7
+
+      - name: Downgrade numpy and pandas
+        # Use caret-style requirements (~) to fix minor version but allow patches
+        run: |
+          poetry add numpy@~1.19 pandas@~1.1
+          poetry show
+
+      - name: Run pytest
+        run: poetry run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,17 @@ classifiers = [
 include = ["data/*.json"]
 
 [tool.poetry.dependencies]
+# Aim to follow NEP29 deprecation policy:
+#   - Support all minor versions of Python released in the prior 42 months
+#   - Support all minor versions of NumPy/Pandas released in the prior 24 months
+#   - https://numpy.org/neps/nep-0029-deprecation_policy.html
+# See here for meaning of Semantic Version numbers:
+#   - https://semver.org/
+# See here for "caret" style dependency specifications:
+#   - https://python-poetry.org/docs/dependency-specification/
 python = ">= 3.7.1, < 3.10"
 numpy = "^1.19"
-pandas = "^1.3"
+pandas = "^1.1"
 h5py = "^3.2"
 lxml = "^4.6"
 lasio = "^0.29"


### PR DESCRIPTION
Closes #432 

Adds a CI job that runs the unit tests against some older versions of our 3rd party libraries. 

Steps in the job:

1. Installs the usual dependencies, using the reusable "prepare poetry" action implemented in #431
2. Downgrades numpy to 1.19 and pandas to 1.1 (the lowest versions we claim to support in our `pyproject.toml` metadata
3. Runs pytest

I note that for some even older versions of pandas, the "downgrade" step takes ages (10+ minutes) then fails, as pip tries to build pandas from source rather than use a pre-built wheel. However, for the minimum versions we have now, the installation step works reasonably smoothly (~30 seconds). 