### PR TITLE
Check for presence of deviation survey when initialising trajectory

### DIFF
--- a/resqpy/well/_trajectory.py
+++ b/resqpy/well/_trajectory.py
@@ -276,7 +276,7 @@ class Trajectory(BaseResqpy):
             ds_uuid = self.model.uuid(obj_type = 'DeviationSurveyRepresentation',
                                       uuid = ds_uuid)  # check part is present
             if ds_uuid is not None:
-                self.deviation_survey = DeviationSurvey(self.model, uuid = ds_uuid, md_datum = self.md_datum)
+                self.deviation_survey = DeviationSurvey(self.model, uuid = ds_uuid)
         interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
         if interp_uuid is None:
             self.wellbore_interpretation = None

--- a/resqpy/well/_trajectory.py
+++ b/resqpy/well/_trajectory.py
@@ -273,10 +273,10 @@ class Trajectory(BaseResqpy):
         self.md_datum = MdDatum(self.model, uuid = relatives_model.uuid_for_part(md_datum_part))
         ds_uuid = bu.uuid_from_string(rqet.find_nested_tags_text(node, ['DeviationSurvey', 'UUID']))
         if ds_uuid is not None:  # this will probably not work when relatives model is different from self.model
-            ds_part = rqet.part_name_for_object('obj_DeviationSurveyRepresentation_', ds_uuid)
-            self.deviation_survey = DeviationSurvey(self.model,
-                                                    uuid = relatives_model.uuid_for_part(ds_part, is_rels = False),
-                                                    md_datum = self.md_datum)
+            ds_uuid = self.model.uuid(obj_type = 'DeviationSurveyRepresentation',
+                                      uuid = ds_uuid)  # check part is present
+            if ds_uuid is not None:
+                self.deviation_survey = DeviationSurvey(self.model, uuid = ds_uuid, md_datum = self.md_datum)
         interp_uuid = rqet.find_nested_tags_text(node, ['RepresentedInterpretation', 'UUID'])
         if interp_uuid is None:
             self.wellbore_interpretation = None


### PR DESCRIPTION
This change checks that a referenced deviation survey is actually present before attempting to add it as an attribute of a resqpy Trajectory object, when initialising from xml.