### PR TITLE
scipy Delaunay triangulation now using an xy projection

### DIFF
--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -236,6 +236,7 @@ class Surface(BaseSurface):
         self.triangles = None  # clear cached arrays for surface
         self.points = None
         self.uuid = bu.new_uuid()  # hope this doesn't cause problems
+        assert self.root is None
 
     def set_to_trimmed_surface(self, large_surface, xyz_box = None, xy_polygon = None):
         """Populate this (empty) surface with triangles and points which overlap with a trimming volume.
@@ -398,7 +399,7 @@ class Surface(BaseSurface):
         log.debug('number of points going into dt: ' + str(len(p_xy_e)))
         success = False
         try:
-            t = triangulate.dt(p_xy_e[:, :2], container_size_factor = convexity_parameter, algorithm = "simple")
+            t = triangulate.dt(p_xy_e[:, :2], container_size_factor = convexity_parameter, algorithm = "scipy")
             success = True
         except AssertionError:
             pass

--- a/resqpy/unstructured/_prism_grid.py
+++ b/resqpy/unstructured/_prism_grid.py
@@ -389,7 +389,7 @@ class VerticalPrismGrid(PrismGrid):
         assert area_of_interest.isclosed and area_of_interest.is_convex()
 
         # compute Delauney triangulation
-        delauney_t, hull_indices = tri.dt(seed_xy, return_hull = True, algorithm = "simple")
+        delauney_t, hull_indices = tri.dt(seed_xy, return_hull = True, algorithm = 'scipy')
 
         # construct Voronoi graph
         voronoi_points, voronoi_indices = tri.voronoi(seed_xy, delauney_t, hull_indices, area_of_interest)

--- a/resqpy/unstructured/_unstructured_grid.py
+++ b/resqpy/unstructured/_unstructured_grid.py
@@ -703,7 +703,7 @@ class UnstructuredGrid(BaseResqpy):
         """
 
         face_points = self.planar_face_points(face_index, xy_plane = True)
-        local_triangulation = tri.dt(face_points, algorithm = "simple")  # returns int array of shape (M, 3)
+        local_triangulation = tri.dt(face_points, algorithm = 'scipy')  # returns int array of shape (M, 3)
         assert len(
             local_triangulation) == len(face_points) - 2, 'face triangulation failure (concave edges when planar?)'
         if local_nodes:

--- a/tests/unit_tests/unstructured/test_unstructured.py
+++ b/tests/unit_tests/unstructured/test_unstructured.py
@@ -344,7 +344,8 @@ def test_vertical_prism_grid_from_surfaces(tmp_path):
     # create a very similar grid using explicit triangulation arguments
 
     # make the same Delauney triangulation
-    triangles = triangulation.dt(pentagon_points, algorithm = "simple")
+    triangles = triangulation.dt(pentagon_points, algorithm = "scipy")
+    assert triangles.ndim == 2 and triangles.shape[1] == 3
 
     # slightly shrink pentagon points to be within area of surfaces
     for i in range(len(pentagon_points)):
@@ -373,8 +374,16 @@ def test_vertical_prism_grid_from_surfaces(tmp_path):
     # check similarity
     for attr in ('cell_shape', 'nk', 'cell_count', 'node_count', 'face_count'):
         assert getattr(grid, attr) == getattr(similar, attr)
-    for index_attr in ('nodes_per_face', 'nodes_per_face_cl', 'faces_per_cell', 'faces_per_cell_cl'):
-        assert np.all(getattr(grid, index_attr) == getattr(similar, index_attr))
+    # for index_attr in ('nodes_per_face', 'nodes_per_face_cl', 'faces_per_cell', 'faces_per_cell_cl'):
+    for i, (index_attr, index_attr_cl) in enumerate([('nodes_per_face', 'nodes_per_face_cl'),
+                                                     ('faces_per_cell', 'faces_per_cell_cl')]):
+        ga_cl = getattr(grid, index_attr_cl)
+        sa_cl = getattr(similar, index_attr_cl)
+        assert np.all(ga_cl == sa_cl)
+        ga = getattr(grid, index_attr)
+        sa = getattr(similar, index_attr)
+        ip = 0 if i == 0 else ga_cl[i - 1]
+        assert set(ga[ip:ga_cl[i]]) == set(sa[ip:ga_cl[i]])
     assert_allclose(grid.points_ref(), similar.points_ref(), atol = 2.0)
 
     # check that isotropic horizontal permeability is preserved


### PR DESCRIPTION
This change enforces an xy projection when points are in 3D space, when using the 'scipy' algorithm for triangulation.
The scipy option is now used wherever resqpy code uses the triangulation functionality.