### PR TITLE
fix for missing crs_uuid in a grid method

### DIFF
--- a/resqpy/grid/_grid.py
+++ b/resqpy/grid/_grid.py
@@ -47,7 +47,7 @@ from ._cell_properties import thickness, volume, pinched_out, cell_inactive, int
     interface_lengths_kji, interface_vectors_kji, poly_line_for_cell
 from ._connection_sets import fault_connection_set, pinchout_connection_set, k_gap_connection_set
 from ._xyz import xyz_box, xyz_box_centre, bounding_box, composite_bounding_box, z_inc_down, \
-    check_top_and_base_cell_edge_directions, local_to_global_crs, global_to_local_crs
+    check_top_and_base_cell_edge_directions, _local_to_global_crs, _global_to_local_crs
 from ._pixel_maps import pixel_maps, pixel_map_for_split_horizon_points
 
 import warnings
@@ -1951,12 +1951,12 @@ class Grid(BaseResqpy):
         """Converts array of points in situ from global coordinate system to established local one."""
         assert crs_uuid is not None
         # todo: change function name to be different from method name
-        return global_to_local_crs(self,
-                                   a,
-                                   crs_uuid = crs_uuid,
-                                   global_xy_units = global_xy_units,
-                                   global_z_units = global_z_units,
-                                   global_z_increasing_downward = global_z_increasing_downward)
+        return _global_to_local_crs(self,
+                                    a,
+                                    crs_uuid = crs_uuid,
+                                    global_xy_units = global_xy_units,
+                                    global_z_units = global_z_units,
+                                    global_z_increasing_downward = global_z_increasing_downward)
 
     def z_inc_down(self):
         """Return True if z increases downwards in the coordinate reference system used by the grid geometry
@@ -1974,12 +1974,12 @@ class Grid(BaseResqpy):
         """Converts array of points in situ from local coordinate system to global one."""
         assert crs_uuid is not None
         # todo: change function name to be different from method name
-        return local_to_global_crs(self,
-                                   a,
-                                   crs_uuid = crs_uuid,
-                                   global_xy_units = global_xy_units,
-                                   global_z_units = global_z_units,
-                                   global_z_increasing_downward = global_z_increasing_downward)
+        return _local_to_global_crs(self,
+                                    a,
+                                    crs_uuid = crs_uuid,
+                                    global_xy_units = global_xy_units,
+                                    global_z_units = global_z_units,
+                                    global_z_increasing_downward = global_z_increasing_downward)
 
     def composite_bounding_box(self, bounding_box_list):
         """Returns the xyz box which envelopes all the boxes in the list, as a numpy array of shape (2, 3)."""

--- a/resqpy/grid/_points_functions.py
+++ b/resqpy/grid/_points_functions.py
@@ -1062,7 +1062,7 @@ def find_cell_for_point_xy(grid, x, y, k0 = 0, vertical_ref = 'top', local_coord
     # then check the four cells around that corner point
     a = np.array([[x, y, 0.0]])  # extra axis needed to keep global_to_local_crs happy
     if not local_coords:
-        grid.global_to_local_crs(a)
+        grid.global_to_local_crs(a, crs_uuid = grid.crs_uuid)
     if a is None:
         return (None, None)
     a[0, 2] = 0.0  # discard z

--- a/resqpy/grid/_xyz.py
+++ b/resqpy/grid/_xyz.py
@@ -104,12 +104,12 @@ def composite_bounding_box(grid, bounding_box_list):
     return result
 
 
-def local_to_global_crs(grid,
-                        a,
-                        crs_uuid = None,
-                        global_xy_units = None,
-                        global_z_units = None,
-                        global_z_increasing_downward = None):
+def _local_to_global_crs(grid,
+                         a,
+                         crs_uuid = None,
+                         global_xy_units = None,
+                         global_z_units = None,
+                         global_z_increasing_downward = None):
     """Converts array of points in situ from local coordinate system to global one."""
 
     if crs_uuid is None:
@@ -155,12 +155,12 @@ def z_inc_down(grid):
     return grid.crs.z_inc_down
 
 
-def global_to_local_crs(grid,
-                        a,
-                        crs_uuid = None,
-                        global_xy_units = None,
-                        global_z_units = None,
-                        global_z_increasing_downward = None):
+def _global_to_local_crs(grid,
+                         a,
+                         crs_uuid = None,
+                         global_xy_units = None,
+                         global_z_units = None,
+                         global_z_increasing_downward = None):
     """Converts array of points in situ from global coordinate system to established local one."""
 
     if crs_uuid is None:

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -2156,6 +2156,7 @@ class PropertyCollection():
             return None, min_value, max_value
 
         n_prop = p_array.astype(float)
+        # todo: for discrete p_array, set n_prop to nan where p_array == null value
         if use_logarithm:
             n_prop, min_value, max_value = pcga._normalized_part_array_use_logarithm(min_value, n_prop, masked)
             if min_value == np.nan or max_value == np.nan:
@@ -2166,10 +2167,11 @@ class PropertyCollection():
                                                                                    fix_zero_at)
 
         if max_value == min_value:
-            n_prop[:] = 0.5
+            n_prop[:] = np.where(np.isnan(p_array), np.nan, 0.5)
             return n_prop, min_value, max_value
 
-        return (n_prop - min_value) / (max_value - min_value), min_value, max_value
+        n_prop[:] = np.where(np.isnan(p_array), np.nan, (n_prop - min_value) / (max_value - min_value))
+        return n_prop, min_value, max_value
 
     def uncache_part_array(self, part):
         """Removes the cached copy of the array of data for the named property part.


### PR DESCRIPTION
In one of the _points functions, the crs_uuid argument was missing in the call to Grid.global_to_local_crs()