### PR TITLE
optional absolute radius argument for flange ring

### DIFF
--- a/resqpy/olio/triangulation.py
+++ b/resqpy/olio/triangulation.py
@@ -1,6 +1,6 @@
 """triangulation.py: functions for finding Delaunay triangulation and Voronoi graph from a set of points."""
 
-version = '5th October 2021'
+version = '21st June 2022'
 
 import logging
 
@@ -814,7 +814,7 @@ def make_all_clockwise_xy(t, p):
     return t
 
 
-def surrounding_xy_ring(p, count = 12, radial_factor = 10.0):
+def surrounding_xy_ring(p, count = 12, radial_factor = 10.0, radial_distance = None):
     """Creates a set of points surrounding the point set p, in the xy plane.
 
     arguments:
@@ -822,6 +822,8 @@ def surrounding_xy_ring(p, count = 12, radial_factor = 10.0):
        count (int): the number of points to generate in the surrounding ring
        radial_factor (float): a distance factor roughly determining the radius of the ring relative to
           the 'radius' of the outermost points in p
+       radial_distance (float): if present, the radius of the ring of points, unless radial_factor
+          results in a greater distance in which case that is used
 
     returns:
        numpy float array of shape (count, 3) being xyz points in surrounding ring; z is set constant to
@@ -834,6 +836,8 @@ def surrounding_xy_ring(p, count = 12, radial_factor = 10.0):
     p_radius_v = np.nanmax(np.abs(p.reshape((-1, 3)) - np.expand_dims(centre, axis = 0)), axis = 0)[:2]
     p_radius = maths.sqrt(np.sum(p_radius_v * p_radius_v))
     radius = p_radius * radial_factor
+    if radial_distance is not None and radial_distance > radius:
+        radius = radial_distance
     delta_theta = 2.0 * maths.pi / float(count)
     ring = np.zeros((count, 3))
     for i in range(count):

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -361,6 +361,7 @@ class Surface(BaseSurface):
                            extend_with_flange = False,
                            flange_point_count = 11,
                            flange_radial_factor = 10.0,
+                           flange_radial_distance = None,
                            make_clockwise = False):
         """Populate this (empty) Surface object with a Delaunay triangulation of points in a PointSet object.
 
@@ -379,6 +380,8 @@ class Surface(BaseSurface):
               extend_with_flange is False
            flange_radial_factor (float, default 10.0): distance of flange points from centre of points, as a
               factor of the maximum radial distance of the points themselves; ignored if extend_with_flange is False
+           flange_radial_distance (float, optional): if present, the minimum absolute distance of flange points from
+              centre of points; units are those of the crs
            make_clockwise (bool, default False): if True, the returned triangles will all be clockwise when
               viewed in the direction -ve to +ve z axis; if reorient is also True, the clockwise aspect is
               enforced in the reoriented space
@@ -387,10 +390,12 @@ class Surface(BaseSurface):
            if extend_with_flange is True, numpy bool array with a value per triange indicating flange trianges;
            if extent_with_flange is False, None
 
-        note:
+        notes:
            if extend_with_flange is True, then a boolean array is created for the surface, with a value per triangle,
            set to False (zero) for non-flange triangles and True (one) for flange triangles; this array is
-           suitable for adding as a property for the surface, with indexable element 'faces'
+           suitable for adding as a property for the surface, with indexable element 'faces';
+           when flange extension occurs, the radius is the greater of the values determined from the radial factor
+           and radial distance arguments
         """
 
         p = point_set.full_array_ref()
@@ -399,7 +404,10 @@ class Surface(BaseSurface):
         else:
             p_xy = p
         if extend_with_flange:
-            flange_points = triangulate.surrounding_xy_ring(p_xy, flange_point_count, flange_radial_factor)
+            flange_points = triangulate.surrounding_xy_ring(p_xy,
+                                                            count = flange_point_count,
+                                                            radial_factor = flange_radial_factor,
+                                                            radial_distance = flange_radial_distance)
             p_xy_e = np.concatenate((p_xy, flange_points), axis = 0)
             if reorient:
                 # reorient back extenstion points into original p space


### PR DESCRIPTION
when extending a point set with a flange ring of points, the previous radius factor argument is augmented with an optional absolute radius argument; the greater of the two radii values is used