### PR TITLE
Add depandabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Enable version updates for pip
+  - package-ecosystem: "pip"
+    # Look for `poetry.lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We could try using Dependabot to flag updates to the lockfile. As I understand, this should raise PRs when new versions are available, and the CI will check these against the test suite.

In practice we might want a less frequent update (e.g. monthly), but I proposed it daily to check it works as expected. 