### PR TITLE
FineCoarse bug fix

### DIFF
--- a/resqpy/olio/fine_coarse.py
+++ b/resqpy/olio/fine_coarse.py
@@ -183,9 +183,18 @@ class FineCoarse:
         return self.vector_proportions[axis][c0]
 
     def proportions_for_axis(self, axis):
-        """Return the axial relative proportions as array of floats summing to one."""
+        """Return the axial relative proportions as array of floats summing to one for each coarse slice."""
 
         if self.equal_proportions[axis]:
+            if self.constant_ratios[axis] is None:
+                assert self.vector_ratios[axis] is not None and len(self.vector_ratios[axis]) == self.coarse_extent_kji[axis]
+                fractions = 1.0 / self.vector_ratios[axis].astype(float)
+                proportions = np.zeros((self.fine_extent_kji[axis],), dtype = float)
+                fi = 0
+                for ci in range(self.coarse_extent_kji[axis]):
+                    proportions[fi : fi + self.vector_ratios[axis][ci]] = fractions[ci]
+                    fi += self.vector_ratios[axis][ci]
+                return proportions
             count = self.constant_ratios[axis]
             fraction = 1.0 / float(count)
             return np.full((self.fine_extent_kji[axis],), fraction)

--- a/resqpy/olio/fine_coarse.py
+++ b/resqpy/olio/fine_coarse.py
@@ -187,12 +187,13 @@ class FineCoarse:
 
         if self.equal_proportions[axis]:
             if self.constant_ratios[axis] is None:
-                assert self.vector_ratios[axis] is not None and len(self.vector_ratios[axis]) == self.coarse_extent_kji[axis]
+                assert self.vector_ratios[axis] is not None and len(
+                    self.vector_ratios[axis]) == self.coarse_extent_kji[axis]
                 fractions = 1.0 / self.vector_ratios[axis].astype(float)
                 proportions = np.zeros((self.fine_extent_kji[axis],), dtype = float)
                 fi = 0
                 for ci in range(self.coarse_extent_kji[axis]):
-                    proportions[fi : fi + self.vector_ratios[axis][ci]] = fractions[ci]
+                    proportions[fi:fi + self.vector_ratios[axis][ci]] = fractions[ci]
                     fi += self.vector_ratios[axis][ci]
                 return proportions
             count = self.constant_ratios[axis]

--- a/tests/unit_tests/olio/test_fine_coarse.py
+++ b/tests/unit_tests/olio/test_fine_coarse.py
@@ -57,12 +57,14 @@ def test_fine_coarse_functions():
         assert const is None
     assert np.all(fct.vector_ratios[1] == (1, 2, 3, 3, 3, 2, 1))
     assert np.all(fct.vector_ratios[2] == (2, 3, 4, 4, 4, 3, 2))
-    ep = np.array((1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 0.5, 0.5, 1, 1), dtype = float)
+    ep = np.array((1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 0.5, 0.5, 1, 1), dtype = float)
     assert_array_almost_equal(fct.proportions_for_axis(0), ep)
-    ep = np.array((1.0, 0.5, 0.5, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3,
-                   1.0/3, 1.0/3, 0.5, 0.5, 1.0), dtype = float)
+    ep = np.array(
+        (1.0, 0.5, 0.5, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 0.5, 0.5, 1.0),
+        dtype = float)
     assert_array_almost_equal(fct.proportions_for_axis(1), ep)
-    ep = np.array((0.5, 0.5, 1.0/3, 1.0/3, 1.0/3, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25,
-                   0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 1.0/3, 1.0/3, 1.0/3, 0.5, 0.5), dtype = float)
+    ep = np.array((0.5, 0.5, 1.0 / 3, 1.0 / 3, 1.0 / 3, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25,
+                   0.25, 0.25, 1.0 / 3, 1.0 / 3, 1.0 / 3, 0.5, 0.5),
+                  dtype = float)
     assert_array_almost_equal(fct.proportions_for_axis(2), ep)
     # todo: add test of tartan refinement in exponential mode

--- a/tests/unit_tests/olio/test_fine_coarse.py
+++ b/tests/unit_tests/olio/test_fine_coarse.py
@@ -57,5 +57,12 @@ def test_fine_coarse_functions():
         assert const is None
     assert np.all(fct.vector_ratios[1] == (1, 2, 3, 3, 3, 2, 1))
     assert np.all(fct.vector_ratios[2] == (2, 3, 4, 4, 4, 3, 2))
-
+    ep = np.array((1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 0.5, 0.5, 1, 1), dtype = float)
+    assert_array_almost_equal(fct.proportions_for_axis(0), ep)
+    ep = np.array((1.0, 0.5, 0.5, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3, 1.0/3,
+                   1.0/3, 1.0/3, 0.5, 0.5, 1.0), dtype = float)
+    assert_array_almost_equal(fct.proportions_for_axis(1), ep)
+    ep = np.array((0.5, 0.5, 1.0/3, 1.0/3, 1.0/3, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25,
+                   0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 1.0/3, 1.0/3, 1.0/3, 0.5, 0.5), dtype = float)
+    assert_array_almost_equal(fct.proportions_for_axis(2), ep)
     # todo: add test of tartan refinement in exponential mode


### PR DESCRIPTION
This change fixes a bug in the FineCoarse class proportions_for_axis() method when equal proportions is True for the axis and constant ratios is None for the axis.