### PR TITLE
Blocked well dateformat

### DIFF
--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -237,6 +237,7 @@ def load_wellspecs(
     keep_duplicate_cells: bool = False,
     keep_null_columns: bool = True,
     last_data_only: bool = True,
+    usa_date_format: bool = False,
 ) -> Dict[str, Union[pd.DataFrame, None]]:
     """Reads the Nexus wellspec file returning a dictionary of well name to pandas dataframe.
 
@@ -255,6 +256,8 @@ def load_wellspecs(
             otherwise they are removed.
         last_data_only (bool): If True, only the last entry of well data in the file are used in the
             dataframe, otherwise all of the well data are used at different times.
+        usa_date_format (bool): If True, wellspec file is expected to contain date formats in MM/DD/YYYY.
+            if False, DD/MM/YYYY.
 
     Returns:
        well_dict (Dict[str, Union[pd.DataFrame, None]]): mapping each well name found in the

--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -271,7 +271,7 @@ def load_wellspecs(
     selecting = bool(column_list)
 
     well_dict = {}
-    well_pointers = get_well_pointers(wellspec_file)
+    well_pointers = get_well_pointers(wellspec_file, usa_date_format = usa_date_format)
 
     if column_list is None:
         well_dict = dict.fromkeys(well_pointers, None)

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -604,7 +604,10 @@ class BlockedWell(BaseResqpy):
                                                                          grid = grid,
                                                                          col_list = col_list)
 
-        wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list, usa_date_format = usa_date_format)
+        wellspec_dict = wsk.load_wellspecs(wellspec_file,
+                                           well = well_name,
+                                           column_list = col_list,
+                                           usa_date_format = usa_date_format)
 
         assert len(wellspec_dict) == 1, 'no wellspec data found in file ' + wellspec_file + ' for well ' + well_name
 

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -63,7 +63,8 @@ class BlockedWell(BaseResqpy):
                  represented_interp = None,
                  originator = None,
                  extra_metadata = None,
-                 add_wellspec_properties = False):
+                 add_wellspec_properties = False,
+                 usa_date_format = False):
         """Creates a new blocked well object and optionally loads it from xml, or trajectory, or Nexus wellspec file.
 
         arguments:
@@ -100,6 +101,8 @@ class BlockedWell(BaseResqpy):
               a wellspec file, the blocked well has its hdf5 data written and xml created and properties are
               fully created; if a list is provided the elements must be numerical wellspec column names;
               if True, all numerical columns other than the cell indices are added as properties
+           usa_date_format (boolean, optional): specifies whether MM/DD/YYYY (True) or DD/MM/YYYY (False) is used 
+              in wellspec file
 
         returns:
            the newly created blocked well object
@@ -174,7 +177,8 @@ class BlockedWell(BaseResqpy):
                             grid,
                             check_grid_name = check_grid_name,
                             use_face_centres = use_face_centres,
-                            add_properties = add_wellspec_properties),
+                            add_properties = add_wellspec_properties,
+                            usa_date_format = usa_date_format),
                 'cellio_file':
                     partial(self.__check_cellio_init_okay,
                             cellio_file = cellio_file,
@@ -565,7 +569,8 @@ class BlockedWell(BaseResqpy):
                              grid,
                              check_grid_name = False,
                              use_face_centres = False,
-                             add_properties = True):
+                             add_properties = True,
+                             usa_date_format = False):
         """Populates empty blocked well from Nexus WELLSPEC data; creates simulation trajectory and md datum.
 
         args:
@@ -599,7 +604,7 @@ class BlockedWell(BaseResqpy):
                                                                          grid = grid,
                                                                          col_list = col_list)
 
-        wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list)
+        wellspec_dict = wsk.load_wellspecs(wellspec_file, well = well_name, column_list = col_list, usa_date_format = usa_date_format)
 
         assert len(wellspec_dict) == 1, 'no wellspec data found in file ' + wellspec_file + ' for well ' + well_name
 

--- a/resqpy/well/well_object_funcs.py
+++ b/resqpy/well/well_object_funcs.py
@@ -371,13 +371,14 @@ def add_las_to_trajectory(las: lasio.LASFile, trajectory, realization = None, ch
     return collection, well_frame
 
 
-def add_blocked_wells_from_wellspec(model, grid, wellspec_file):
+def add_blocked_wells_from_wellspec(model, grid, wellspec_file, usa_date_format = False):
     """Add a blocked well for each well in a Nexus WELLSPEC file.
 
     arguments:
        model (model.Model object): model to which blocked wells are added
        grid (grid.Grid object): grid against which wellspec data will be interpreted
        wellspec_file (string): path of ascii file holding Nexus WELLSPEC keyword and data
+       usa_date_format (bool): mm/dd/yyyy (True) vs. dd/mm/yyyy (False)
 
     returns:
        int: count of number of blocked wells created
@@ -387,10 +388,11 @@ def add_blocked_wells_from_wellspec(model, grid, wellspec_file):
        'simulation' trajectory and measured depth datum objects will also be created
     """
 
-    well_list_dict = wsk.load_wellspecs(wellspec_file, column_list = None)
+    well_list_dict = wsk.load_wellspecs(wellspec_file, column_list = None, usa_date_format = usa_date_format)
 
     count = 0
     for well in well_list_dict:
+        print('add_blocked_wells_from_wellspec',well,usa_date_format)
         log.info('processing well: ' + str(well))
         bw = BlockedWell(model,
                          grid = grid,

--- a/resqpy/well/well_object_funcs.py
+++ b/resqpy/well/well_object_funcs.py
@@ -392,14 +392,14 @@ def add_blocked_wells_from_wellspec(model, grid, wellspec_file, usa_date_format 
 
     count = 0
     for well in well_list_dict:
-        print('add_blocked_wells_from_wellspec',well,usa_date_format)
         log.info('processing well: ' + str(well))
         bw = BlockedWell(model,
                          grid = grid,
                          wellspec_file = wellspec_file,
                          well_name = well,
                          check_grid_name = True,
-                         use_face_centres = True)
+                         use_face_centres = True,
+			 usa_date_format = usa_date_format)
         if not bw.node_count:  # failed to load from wellspec, eg. because of no perforations in grid
             log.warning('no wellspec data loaded for well: ' + str(well))
             continue

--- a/resqpy/well/well_object_funcs.py
+++ b/resqpy/well/well_object_funcs.py
@@ -399,7 +399,7 @@ def add_blocked_wells_from_wellspec(model, grid, wellspec_file, usa_date_format 
                          well_name = well,
                          check_grid_name = True,
                          use_face_centres = True,
-			 usa_date_format = usa_date_format)
+                         usa_date_format = usa_date_format)
         if not bw.node_count:  # failed to load from wellspec, eg. because of no perforations in grid
             log.warning('no wellspec data loaded for well: ' + str(well))
             continue


### PR DESCRIPTION
When creating a BlockedWell object from a wellspec file, the user must specify whether the usa_date_format is True (MM/DD/YYYY) or False (DD/MM/YYYY). Currently the usa_date_format variable defaults to False and there's no way to specify otherwise when creating a BlockedWell object. This PR adds the usa_date_format arg to the BlockedWell constructor as well as several supporting functions within resqpy/well/well_object_funcs.py.