### PR TITLE
read_nexus_fault bug fixes

### DIFF
--- a/resqpy/olio/read_nexus_fault.py
+++ b/resqpy/olio/read_nexus_fault.py
@@ -49,7 +49,8 @@ def load_nexus_fault_mult_table(file_name):
     num_tables = 0
     ISTABLE = False
     ISRECORD = False
-    grid = name = face = None
+    name = face = None
+    grid = 'ROOT' ## nexus default grid
 
     face_dict = {'TX': 'I', 'TY': 'J', 'TZ': 'K', 'TI': 'I', 'TJ': 'J', 'TK': 'K'}
 
@@ -80,9 +81,9 @@ def load_nexus_fault_mult_table(file_name):
                                 for column in df.columns:
                                     df[column] = pd.to_numeric(df[column], errors = 'ignore')
                                 df.columns = ['i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult']
-                                grids.append(grid)
-                                names.append(name)
-                                faces.append(face)
+                                df['grid'] = grid
+                                df['name'] = name
+                                df['face'] = face
                                 dfs.append(df)
                                 num_tables += 1
 
@@ -130,10 +131,9 @@ def load_nexus_fault_mult_table(file_name):
                         for column in df.columns:
                             df[column] = pd.to_numeric(df[column], errors = 'ignore')
                         df.columns = ['i1', 'i2', 'j1', 'j2', 'k1', 'k2', 'mult']
-
-                        grids.append(grid)
-                        names.append(name)
-                        faces.append(face)
+                        df['grid'] = grid
+                        df['name'] = name
+                        df['face'] = face
                         dfs.append(df)
                         num_tables += 1
 
@@ -141,22 +141,23 @@ def load_nexus_fault_mult_table(file_name):
                         ISRECORD = False
                         chunks = []
 
-    data = {
-        'grid': grids,
-        'name': names,
-        'face': faces,
-        'i1': [],
-        'i2': [],
-        'j1': [],
-        'j2': [],
-        'k1': [],
-        'k2': [],
-        'mult': []
-    }
-    for df in dfs:
-        for col in df.columns:
-            data[col].extend(df[col])
-    fault_df = pd.DataFrame(data)
+#     data = {
+#         'grid': grids,
+#         'name': names,
+#         'face': faces,
+#         'i1': [],
+#         'i2': [],
+#         'j1': [],
+#         'j2': [],
+#         'k1': [],
+#         'k2': [],
+#         'mult': []
+#     }
+#     for df in dfs:
+#         for col in df.columns:
+#             data[col].extend(df[col])
+    fault_df = pd.concat(dfs).reset_index(drop=True)
+#     fault_df = pd.DataFrame(data)
 
     convert_dict = {'i1': int, 'i2': int, 'j1': int, 'j2': int, 'k1': int, 'k2': int, 'mult': float}
     fault_df = fault_df.astype(convert_dict)

--- a/resqpy/olio/read_nexus_fault.py
+++ b/resqpy/olio/read_nexus_fault.py
@@ -41,9 +41,6 @@ def load_nexus_fault_mult_table(file_name):
 
         return False
 
-    names = []
-    grids = []
-    faces = []
     dfs = []
 
     num_tables = 0
@@ -141,29 +138,12 @@ def load_nexus_fault_mult_table(file_name):
                         ISRECORD = False
                         chunks = []
 
-#     data = {
-#         'grid': grids,
-#         'name': names,
-#         'face': faces,
-#         'i1': [],
-#         'i2': [],
-#         'j1': [],
-#         'j2': [],
-#         'k1': [],
-#         'k2': [],
-#         'mult': []
-#     }
-#     for df in dfs:
-#         for col in df.columns:
-#             data[col].extend(df[col])
     fault_df = pd.concat(dfs).reset_index(drop=True)
-#     fault_df = pd.DataFrame(data)
 
     convert_dict = {'i1': int, 'i2': int, 'j1': int, 'j2': int, 'k1': int, 'k2': int, 'mult': float}
     fault_df = fault_df.astype(convert_dict)
 
     return fault_df
-
 
 def load_nexus_fault_mult_table_new(file_name):
     """Reads a Nexus (!) format file containing one or more MULT keywords and returns a dataframe with the MULT rows."""

--- a/resqpy/olio/read_nexus_fault.py
+++ b/resqpy/olio/read_nexus_fault.py
@@ -47,7 +47,7 @@ def load_nexus_fault_mult_table(file_name):
     ISTABLE = False
     ISRECORD = False
     name = face = None
-    grid = 'ROOT' ## nexus default grid
+    grid = 'ROOT'  ## nexus default grid
 
     face_dict = {'TX': 'I', 'TY': 'J', 'TZ': 'K', 'TI': 'I', 'TJ': 'J', 'TK': 'K'}
 
@@ -138,12 +138,13 @@ def load_nexus_fault_mult_table(file_name):
                         ISRECORD = False
                         chunks = []
 
-    fault_df = pd.concat(dfs).reset_index(drop=True)
+    fault_df = pd.concat(dfs).reset_index(drop = True)
 
     convert_dict = {'i1': int, 'i2': int, 'j1': int, 'j2': int, 'k1': int, 'k2': int, 'mult': float}
     fault_df = fault_df.astype(convert_dict)
 
     return fault_df
+
 
 def load_nexus_fault_mult_table_new(file_name):
     """Reads a Nexus (!) format file containing one or more MULT keywords and returns a dataframe with the MULT rows."""


### PR DESCRIPTION
This pull request addresses two issues:
-In nexus deck, user doesn't need to specify what grid faults are associated with - default is ROOT. This pull request sets the default to 'ROOT' instead of None. 
-Current process of creating fault_df can potentially have mismatched series lengths, throwing an "All arrays must be of the same length" error.  Creating fault_df with a pd.concat() of all the individual fault df's is more robust and avoids this error. 

