### PR TITLE
cleans up extra metadata when storing a RegularGrid with a geometry

### DIFF
--- a/resqpy/grid/_regular_grid.py
+++ b/resqpy/grid/_regular_grid.py
@@ -20,7 +20,7 @@ always_write_cell_geometry_is_defined_array = False
 
 
 class RegularGrid(Grid):
-    """Class for completely regular block grids aligned with xyz axes."""
+    """Class for completely regular block grids, usually aligned with xyz axes."""
 
     # todo: use RESQML lattice like geometry specification
 

--- a/resqpy/grid/_regular_grid.py
+++ b/resqpy/grid/_regular_grid.py
@@ -561,13 +561,20 @@ class RegularGrid(Grid):
         :meta common:
         """
 
-        if extra_metadata is None:
-            extra_metadata = {}
-        if self.crs_uuid is not None:
-            extra_metadata['crs uuid'] = str(self.crs_uuid)
-
         if write_geometry is None:
             write_geometry = (self.grid_representation == 'IjkGrid')
+
+        if extra_metadata is None:
+            extra_metadata = {}
+        else:
+            extra_metadata = extra_metadata.copy()
+
+        if write_geometry:
+            extra_metadata['grid_flavour'] = 'IjkGrid'
+            if 'crs uuid' in extra_metadata:
+                extra_metadata.pop('crs uuid')
+        elif self.crs_uuid is not None:
+            extra_metadata['crs uuid'] = str(self.crs_uuid)
 
         node = super().create_xml(ext_uuid = ext_uuid,
                                   add_as_part = add_as_part,


### PR DESCRIPTION
This sets the extra metadata as for a normal Ijk grid when creating xml for a RegularGrid and including geometry.