### PR TITLE
always writing PillarGeometryIsDefined xml for grids

### DIFF
--- a/resqpy/grid/_create_grid_xml.py
+++ b/resqpy/grid/_create_grid_xml.py
@@ -8,6 +8,7 @@ import resqpy.olio.xml_et as rqet
 import resqpy.property as rprop
 from resqpy.olio.xml_namespaces import curly_namespace as ns
 
+# these booleans control expansion of constant arrays
 always_write_pillar_geometry_is_defined_array = False
 always_write_cell_geometry_is_defined_array = False
 

--- a/resqpy/grid/_regular_grid.py
+++ b/resqpy/grid/_regular_grid.py
@@ -20,7 +20,7 @@ from ._grid_types import is_regular_grid
 from ._create_grid_xml import _add_constant_pillar_geometry_is_defined, _add_constant_cell_geometry_is_defined
 
 # for a regular grid, the ...is_defined xml is created as a constant bool array, if the following set True
-always_write_pillar_geometry_is_defined = False
+always_write_pillar_geometry_is_defined = True  # required True for Fesapi interoperability (xsd compliance)
 always_write_cell_geometry_is_defined = False
 
 


### PR DESCRIPTION
This change ensures that the PillarGeometryIsDefined xml is written for RegularGrids with lattice geometry.  Required for inter-operability with Fesapi and for RESQML schema compliance.