### PR TITLE
Normal vectors to point upwards

### DIFF
--- a/resqpy/olio/vector_utilities.py
+++ b/resqpy/olio/vector_utilities.py
@@ -290,7 +290,7 @@ def degrees_difference(a, b):
 
 
 def rotation_matrix_3d_axial(axis, angle):
-    """Returns a rotation matrix which will rotate points about axis (0, 1, or 2) by angle in degrees."""
+    """Returns a rotation matrix which will rotate points about axis (0: x, 1: y, or 2: z) by angle in degrees."""
 
     axis_a = (axis + 1) % 3
     axis_b = (axis_a + 1) % 3

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -742,13 +742,14 @@ class Surface(BaseSurface):
         Returns:
             normal_vectors_array (np.ndarray): the normal vectors corresponding to each triangle in the surface.
         """
+        crs = rqc.Crs(self.model, uuid = self.crs_uuid)
         triangles, points = self.triangles_and_points()
         n_triangles = len(triangles)
         normal_vectors_array = np.empty((n_triangles, 3))
         for triangle_num in range(n_triangles):
             normal_vector = vec.triangle_normal_vector_numba(points[triangles[triangle_num]])
-            if normal_vector[2] <= 0:
-                normal_vector *= -1
+            if (normal_vector[2] > 0.0) == crs.z_inc_down:
+                normal_vector *= -1.0
             normal_vectors_array[triangle_num] = normal_vector
         if add_as_property:
             pc = rqp.PropertyCollection()

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -842,7 +842,7 @@ def test_surface_normal_vectors(tmp_model):
     triangles = tri.dt(points)
     surface = resqpy.surface.Surface(tmp_model)
     surface.set_from_triangles_and_points(triangles, points)
-    normal_vectors_expected = np.array([[-0.70710678, 0.0, 0.70710678], [0.0, 0.0, 1.0]])
+    normal_vectors_expected = np.array([[0.70710678, 0.0, -0.70710678], [0.0, 0.0, -1.0]])
 
     # Act
     normal_vectors = surface.normal_vectors()


### PR DESCRIPTION
A recent refactoring moved the computation of normal vectors into a Surface class method. During that change, the vectors reversed direction. This change is to return their direction to upwards pointing.