### PR TITLE
WIP: auto generation of local property kinds when abstract kind specified

### DIFF
--- a/resqpy/multiprocessing/wrappers/grid_surface_mp.py
+++ b/resqpy/multiprocessing/wrappers/grid_surface_mp.py
@@ -271,7 +271,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                     f'{surface.title} {p_name}',
                     discrete = False,
                     uom = "Euc",
-                    property_kind = "continuous",
+                    property_kind = "normal vector",
                     realization = realisation,
                     indexable_element = "faces",
                     points = True,
@@ -283,7 +283,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                     f'{surface.title} {p_name}',
                     discrete = True,
                     null_value = -1,
-                    property_kind = "discrete",
+                    property_kind = "triangle index",
                     realization = realisation,
                     indexable_element = "faces",
                 )
@@ -294,7 +294,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                     f'{surface.title} {p_name}',
                     discrete = False,
                     uom = grid.crs.z_units,
-                    property_kind = "continuous",
+                    property_kind = "offset",
                     realization = realisation,
                     indexable_element = "faces",
                 )
@@ -323,7 +323,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                     f"from find_faces function for {surface.title}",
                     f'{surface.title} {p_name}',
                     discrete = True,
-                    property_kind = "discrete",
+                    property_kind = "grid bisector",
                     facet_type = 'direction',
                     facet = 'vertical' if is_curtain else 'sloping',
                     realization = realisation,
@@ -336,7 +336,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                     f'{surface.title} {p_name}',
                     discrete = True,
                     null_value = -1,
-                    property_kind = "discrete",
+                    property_kind = "flange bool",
                     realization = realisation,
                     indexable_element = "faces",
                 )
@@ -345,13 +345,15 @@ def find_faces_to_represent_surface_regular_wrapper(
         if property_collection.number_of_imports() > 0:
             # log.debug('writing gcs property hdf5 data')
             property_collection.write_hdf5_for_imported_list()
-            uuids_properties = property_collection.create_xml_for_imported_list_and_add_parts_to_model()
+            uuids_properties = property_collection.create_xml_for_imported_list_and_add_parts_to_model(
+                find_local_property_kinds = True)
             uuid_list.extend(uuids_properties)
         if grid_pc is not None and grid_pc.number_of_imports() > 0:
             # log.debug('writing grid property (bisector) hdf5 data')
             grid_pc.write_hdf5_for_imported_list()
             # log.debug('creating xml for grid property (bisector)')
-            uuids_properties = grid_pc.create_xml_for_imported_list_and_add_parts_to_model()
+            uuids_properties = grid_pc.create_xml_for_imported_list_and_add_parts_to_model(
+                find_local_property_kinds = True)
             assert uuids_properties
             uuid_list.extend(uuids_properties)
             if related_uuid is not None:

--- a/resqpy/property/_collection_create_xml.py
+++ b/resqpy/property/_collection_create_xml.py
@@ -84,6 +84,7 @@ def _create_xml_property_kind(collection, p_node, find_local_property_kinds, pro
                                          property_kind_uuid,
                                          content_type = 'obj_PropertyKind',
                                          root = p_kind_node)
+    return property_kind_uuid
 
 
 def _create_xml_patch_node(collection, p_node, points, const_value, indexable_element, direction, p_uuid, ext_uuid,

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -2504,7 +2504,10 @@ class PropertyCollection():
               standard property kind
            find_local_property_kinds (boolean, default True): if True and property_kind is not in standard supported
               property kind list and property_kind_uuid is None, the citation titles of PropertyKind objects in the
-              model are compared with property_kind and if a match is found, that local property kind is used
+              model are compared with property_kind and if a match is found, that local property kind is used;
+              if no match is found, a new local property kind is created; the same logic is applied if the specified
+              property kind is abstract ('continuous', 'discrete', 'categorical') in which case the property title
+              is also used as the property kind title
            indexable_element (string, optional): if present, is used as the indexable element in the property node;
               if None, 'cells' are used for grid properties and 'nodes' for wellbore frame properties
            count (int, default 1): the number of values per indexable element; if greater than one then this axis
@@ -2528,6 +2531,8 @@ class PropertyCollection():
            between the properties and the supporting representation
         """
 
+        assert title, 'missing title when creating xml for property'
+
         #      log.debug('creating property node for ' + title)
         # currently assumes discrete properties to be 32 bit integers and continuous to be 64 bit reals
         # also assumes property_kind is one of the standard resqml property kinds; todo: allow local p kind node as optional arg
@@ -2547,6 +2552,9 @@ class PropertyCollection():
         #    uom are valid units for property_kind
         assert property_kind, 'missing property kind when creating xml for property'
 
+        if find_local_property_kinds and property_kind in ['continuous', 'discrete', 'categorical']:
+            property_kind = title
+
         pcga._get_property_type_details(self, discrete, string_lookup_uuid, points)
         p_node, p_uuid = pcxml._create_xml_get_p_node(self, p_uuid)
 
@@ -2556,8 +2564,8 @@ class PropertyCollection():
         pcxml._create_xml_realization_node(realization, p_node)
         related_time_series_node = pcxml._create_xml_time_series_node(self, time_series_uuid, time_index, p_node,
                                                                       support_uuid, support_type, support_root)
-        pcxml._create_xml_property_kind(self, p_node, find_local_property_kinds, property_kind, uom, discrete,
-                                        property_kind_uuid)
+        property_kind_uuid = pcxml._create_xml_property_kind(self, p_node, find_local_property_kinds, property_kind,
+                                                             uom, discrete, property_kind_uuid)
         pcxml._create_xml_patch_node(self, p_node, points, const_value, indexable_element, direction, p_uuid, ext_uuid,
                                      expand_const_arrays)
         pcxml._create_xml_facet_node(facet_type, facet, p_node)

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -759,11 +759,11 @@ class Surface(BaseSurface):
                                                  "computed from surface",
                                                  "normal vector",
                                                  uom = crs.xy_units,
-                                                 property_kind = "continuous",
+                                                 property_kind = "normal vector",
                                                  indexable_element = "faces",
                                                  points = True)
             pc.write_hdf5_for_imported_list()
-            pc.create_xml_for_imported_list_and_add_parts_to_model()
+            pc.create_xml_for_imported_list_and_add_parts_to_model(find_local_property_kinds = True)
         return normal_vectors_array
 
     def write_hdf5(self, file_name = None, mode = 'a'):

--- a/tests/unit_tests/model/test_model.py
+++ b/tests/unit_tests/model/test_model.py
@@ -341,7 +341,7 @@ def test_multiple_epc_sharing_one_hdf5(tmp_path, example_model_with_prop_ts_rels
         model.store_epc()
 
         # check the number of parts in the sub model is as expected (includes crs and ext)
-        assert model.number_of_parts() == 6 + len(discrete_prop_uuid_list)
+        assert model.number_of_parts() == 6 + 2 * len(discrete_prop_uuid_list)
 
     # re-open all 3 models and see how they shape up
     full_model = rq.Model(full_epc_path)
@@ -356,7 +356,7 @@ def test_multiple_epc_sharing_one_hdf5(tmp_path, example_model_with_prop_ts_rels
         # switch off hdf5 filename override
         model.h5_set_default_override('none')
         # check that the number of parts in the sub model is still as expected
-        assert model.number_of_parts() == 6 + len(discrete_prop_uuid_list)
+        assert model.number_of_parts() == 6 + 2 * len(discrete_prop_uuid_list)
         # check that all sub model uuids exist in the full model, and have the same type
         for uuid in model.uuids():
             found = False

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -81,7 +81,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties(small_grid_a
     assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
     assert len(model.uuids(obj_type = 'DiscreteProperty')) == 1
     assert len(model.uuids(obj_type = 'ContinuousProperty')) == 4
-    assert len(model.uuids()) == 12
+    assert len(model.uuids()) == 14
     assert len(uuid_list) == 9
 
 
@@ -123,7 +123,7 @@ def test_find_faces_to_represent_surface_extended_bisector(small_grid_and_extend
     assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
     assert len(model.uuids(obj_type = 'DiscreteProperty')) == 2
     assert len(model.uuids(obj_type = 'ContinuousProperty')) == 4
-    assert len(model.uuids()) == 13
+    assert len(model.uuids()) == 16
     assert len(uuid_list) == 10
 
 
@@ -166,5 +166,5 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties_flange(small
     assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
     assert len(model.uuids(obj_type = 'DiscreteProperty')) == 2
     assert len(model.uuids(obj_type = 'ContinuousProperty')) == 4
-    assert len(model.uuids()) == 13
+    assert len(model.uuids()) == 16
     assert len(uuid_list) == 10

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -545,8 +545,8 @@ def test_part_str(example_model_with_prop_ts_rels):
     part_facet = pc.parts()[4]
 
     # Act / Assert
-    assert pc.part_str(part_disc) == 'discrete (Zone)'
-    assert pc.part_str(part_disc, include_citation_title = False) == 'discrete'
+    assert pc.part_str(part_disc) == 'Zone (Zone)'
+    assert pc.part_str(part_disc, include_citation_title = False) == 'Zone'
     assert pc.part_str(part_cont) == 'saturation: water; timestep: 2 (SW)'
     assert pc.part_str(part_cont, include_citation_title = False) == 'saturation: water; timestep: 2'
     assert pc.part_str(part_facet) == 'rock permeability: J (Perm)'
@@ -563,7 +563,7 @@ def test_part_filename(example_model_with_prop_ts_rels):
     part_facet = pc.parts()[4]
 
     # Act / Assert
-    assert pc.part_filename(part_disc) == 'discrete'
+    assert pc.part_filename(part_disc) == 'Zone'
     assert pc.part_filename(part_cont) == 'saturation_water_ts_2'
     assert pc.part_filename(part_facet) == 'rock_permeability_J'
 
@@ -1561,7 +1561,9 @@ def test_property_kind_list(example_model_with_properties):
     element = pc.property_kind_list()
 
     # Assert
-    assert element == ['discrete', 'net to gross ratio', 'porosity', 'rock permeability', 'saturation']
+    assert element == [
+        'Facies', 'Fault block', 'VPC', 'Zone', 'net to gross ratio', 'porosity', 'rock permeability', 'saturation'
+    ]
 
 
 def test_indexable_list(example_model_with_properties):
@@ -1984,7 +1986,7 @@ def test_import_ab_properties(example_model_with_properties, test_data_path):
     facies = [part for part in pc.parts() if pc.citation_title_for_part(part) == 'ab_facies'][0]
     facies_array = pc.cached_part_array_ref(facies)
     assert not pc.continuous_for_part(facies)
-    assert pc.property_kind_for_part(facies) == 'discrete'
+    assert pc.property_kind_for_part(facies) == 'ab_facies'  # local property kind now automatically generated
     assert np.min(facies_array) == 0
     assert np.max(facies_array) == 5
     assert np.sum(facies_array) == 170

--- a/tests/unit_tests/rq_import/test_import_vdb_ensemble.py
+++ b/tests/unit_tests/rq_import/test_import_vdb_ensemble.py
@@ -18,10 +18,10 @@ def test_default_args(tmp_path):
     ensemble_dir = f'{base_folder}/test_data/wren'
     epc_file = f'{tmp_path}/test.epc'
     parts_expected = [('ContinuousProperty', 123), ('DiscreteProperty', 15), ('EpcExternalPartReference', 1),
-                      ('IjkGridRepresentation', 1), ('LocalDepth3dCrs', 1), ('PropertyKind', 1), ('PropertySet', 7),
+                      ('IjkGridRepresentation', 1), ('LocalDepth3dCrs', 1), ('PropertyKind', 2), ('PropertySet', 7),
                       ('TimeSeries', 1)]
     pk_list_expected = [
-        'cell length', 'code', 'continuous', 'depth', 'fluid volume', 'index', 'permeability thickness', 'pore volume',
+        'TNSC', 'cell length', 'code', 'depth', 'fluid volume', 'index', 'permeability thickness', 'pore volume',
         'pressure', 'region initialization', 'rock volume', 'saturation', 'thickness', 'transmissibility'
     ]
     pc_titles_expected = {
@@ -89,7 +89,7 @@ def test_existing_epc_true(tmp_path):
     model = rq.Model(epc_file)
 
     # Assert
-    assert model.number_of_parts() == 150
+    assert model.number_of_parts() == 151
 
 
 def test_keyword_list(tmp_path):


### PR DESCRIPTION
This change causes automatic generation of a local property kind when adding a property with one of the 3 main abstract property kinds: 'continuous', 'discrete', 'categorical'. This change is needed for inter-operability with recent versions of Fesapi, and for strict adherence to one of the ancillary xml files in the RESQML v2.0.1 standard.