### PR TITLE
restoring line that clipped trailing C comments

### DIFF
--- a/resqpy/olio/read_nexus_fault.py
+++ b/resqpy/olio/read_nexus_fault.py
@@ -58,7 +58,7 @@ def load_nexus_fault_mult_table(file_name):
                 if len(line.strip()):
                     if (not line.strip()[0] == '!') & (not line.strip()[0] == 'C'):
                         line = line.partition('!')[0]  # removing trailing comments
-                        # line = line.partition('C')[0]  # removing trailing comments
+                        line = line.partition('C')[0]  # removing trailing comments
                         tokens = line.split()
                         if ISTABLE:
                             if is_number(tokens[0]):


### PR DESCRIPTION
Small fix to resqpy.olio.read_nexus_fault.load_nexus_fault_mult_table function
Previous version had commented out line that partitioned comments out by line.partition('C')
Restoring this line - it's still needed for the rare case where a user is still using C for comments.
