### PR TITLE
fix error in wellspec parsing

### DIFF
--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -442,9 +442,8 @@ def get_well_data(
     all_null = True
     while True:
         kf.skip_comments(file)
-        if (kf.specific_keyword_next(file, "WELLSPEC") or
-            kf.specific_keyword_next(file, "WELLMOD") or
-            kf.specific_keyword_next(file, "TIME")):
+        if (kf.specific_keyword_next(file, "WELLSPEC") or kf.specific_keyword_next(file, "WELLMOD") or
+                kf.specific_keyword_next(file, "TIME")):
             break
         line = kf.strip_trailing_comment(file.readline())
         words = line.split()

--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -442,12 +442,14 @@ def get_well_data(
     all_null = True
     while True:
         kf.skip_comments(file)
-        if kf.specific_keyword_next(file, "WELLSPEC") or kf.specific_keyword_next(file, "WELLMOD") or kf.specific_keyword_next(file, "TIME"):
+        if (kf.specific_keyword_next(file, "WELLSPEC") or
+            kf.specific_keyword_next(file, "WELLMOD") or
+            kf.specific_keyword_next(file, "TIME")):
             break
         line = kf.strip_trailing_comment(file.readline())
         words = line.split()
         if len(words) == 0:
-            break ## end of file
+            break  # end of file
         assert len(words) >= len(columns_present), f"Insufficient data in line of wellspec table {well_name} [{line}]."
         if selecting:
             for col_index, col in enumerate(column_list):

--- a/resqpy/olio/wellspec_keywords.py
+++ b/resqpy/olio/wellspec_keywords.py
@@ -442,12 +442,12 @@ def get_well_data(
     all_null = True
     while True:
         kf.skip_comments(file)
-        if kf.blank_line(file):
-            break  # unclear from Nexus doc what marks end of table
-        if kf.specific_keyword_next(file, "WELLSPEC") or kf.specific_keyword_next(file, "WELLMOD"):
+        if kf.specific_keyword_next(file, "WELLSPEC") or kf.specific_keyword_next(file, "WELLMOD") or kf.specific_keyword_next(file, "TIME"):
             break
         line = kf.strip_trailing_comment(file.readline())
         words = line.split()
+        if len(words) == 0:
+            break ## end of file
         assert len(words) >= len(columns_present), f"Insufficient data in line of wellspec table {well_name} [{line}]."
         if selecting:
             for col_index, col in enumerate(column_list):


### PR DESCRIPTION
Previous version had some misspecifications on how WELLSPEC block terminates.

-Removed kf.blank_line(file) as reason to break and return well data (user may have several blank lines withinin their wellspec block)
-Added "TIME" keyword as reason to break and return well data
-Added if len(words) == 0: break (end of file) to return well data

Have encountered this issue several times - where user has blank lines in middle of wellspec data, causing blocked well data to be added prematurely, or not at all (e.g. when blank line immediately follows IW JW L ... line)