### PR TITLE
fault incl file concatenation fix

### DIFF
--- a/resqpy/fault/_gcs_functions.py
+++ b/resqpy/fault/_gcs_functions.py
@@ -216,7 +216,7 @@ def add_connection_set_and_tmults(model, fault_incl, tmult_dict = None):
                 for fname in fault_incl:
                     with open(fname) as infile:
                         for line in infile:
-                            outfile.write(line.strip() + '\n')
+                            outfile.write(line.rstrip() + '\n')
         else:
             temp_faults = fault_incl[0]
     else:

--- a/resqpy/fault/_gcs_functions.py
+++ b/resqpy/fault/_gcs_functions.py
@@ -216,7 +216,7 @@ def add_connection_set_and_tmults(model, fault_incl, tmult_dict = None):
                 for fname in fault_incl:
                     with open(fname) as infile:
                         for line in infile:
-                            outfile.write(line)
+                            outfile.write(line.strip() + '\n')
         else:
             temp_faults = fault_incl[0]
     else:


### PR DESCRIPTION
In order to add nexus faults to a resqml model, resqpy.fault calls add_connection_set_and_tmults
This function concatenates all the fault include files into a single temp file 'faults_combined_temp.txt'

I have encountered several cases of RMS-exported fault include files not containing a trailing line break at the end of the file. This results in the last line of one file being merged with the first line of the next file in one line.

For example:
```
MULT	TX	ALL	MINUS	MULT
	GRID	ROOT
	FNAME	FAULT_EXAMPLE_A
	1	10	26	26	16	100	1.0
	1	10	27	27	16	100	1.0
	1	10	28	28	16	100	1.0C  =====================================
C  
C  Exported from Grid_model_v1
C  
```
In the example above you can see the concatenation error on the last line of the FNAME definition "1.0C ====..."

Adding a .strip() + '\n' to the creation of the faults_combined_temp.txt is a straightforward safeguard against this behavior.