### PR TITLE
improvements to grid coarsening etc

### DIFF
--- a/resqpy/derived_model/_coarsened_grid.py
+++ b/resqpy/derived_model/_coarsened_grid.py
@@ -28,7 +28,7 @@ def coarsened_grid(epc_file,
                    infill_missing_geometry = True,
                    new_grid_title = None,
                    new_epc_file = None):
-    """Generates a coarsened version of an unsplit source grid, todo: optionally inheriting properties.
+    """Generates a coarsened version of an unsplit source grid, optionally inheriting properties.
 
     arguments:
        epc_file (string): file name to rewrite the model's xml to; if source grid is None, model is loaded from this file

--- a/resqpy/fault/__init__.py
+++ b/resqpy/fault/__init__.py
@@ -3,14 +3,15 @@
 __all__ = [
     'GridConnectionSet', 'pinchout_connection_set', 'k_gap_connection_set', 'cell_set_skin_connection_set',
     'add_connection_set_and_tmults', 'grid_columns_property_from_gcs_property', 'zero_base_cell_indices_in_faces_df',
-    'standardize_face_indicator_in_faces_df', 'remove_external_faces_from_faces_df'
+    'standardize_face_indicator_in_faces_df', 'remove_external_faces_from_faces_df', 'combined_tr_mult_from_gcs_mults'
 ]
 
 from ._grid_connection_set import GridConnectionSet
 from ._gcs_functions import pinchout_connection_set, k_gap_connection_set,  \
     cell_set_skin_connection_set, add_connection_set_and_tmults,  \
     grid_columns_property_from_gcs_property, zero_base_cell_indices_in_faces_df,  \
-    standardize_face_indicator_in_faces_df, remove_external_faces_from_faces_df
+    standardize_face_indicator_in_faces_df, remove_external_faces_from_faces_df,  \
+    combined_tr_mult_from_gcs_mults
 
 # Set "module" attribute of all public objects to this path.
 for _name in __all__:

--- a/resqpy/fault/_gcs_functions.py
+++ b/resqpy/fault/_gcs_functions.py
@@ -438,7 +438,7 @@ def combined_tr_mult_from_gcs_mults(model,
     # for each of the 3 combined tr mult arrays, replace unused values with the default fill value
     # also check that any set values are non-negative
     for combo_trm in (combo_trm_k, combo_trm_j, combo_trm_i):
-        if not np.isnan(fill_value):
+        if fill_value is not None and not np.isnan(fill_value):
             combo_trm[:] = np.where(np.isnan(combo_trm), fill_value, combo_trm)
             assert np.all(combo_trm >= 0.0)
         else:

--- a/resqpy/fault/_gcs_functions.py
+++ b/resqpy/fault/_gcs_functions.py
@@ -360,7 +360,8 @@ def combined_tr_mult_from_gcs_mults(model,
                                     gcs_tr_mult_uuid_list,
                                     merge_mode = 'minimum',
                                     sided = None,
-                                    fill_value = 1.0):
+                                    fill_value = 1.0,
+                                    active_only = True):
     """Returns a triplet of transmissibility multiplier arrays over grid faces by combining those from gcs'es.
 
     arguments:
@@ -373,6 +374,8 @@ def combined_tr_mult_from_gcs_mults(model,
             default to False if merge mode is multiply, True otherwise
         fill_value (float, optional): the value to use for grid faces not present in any of the gcs'es;
             if None, NaN will be used
+        active_only (bool, default True): if True and an active property exists for a grid connection set,
+            then only active faces are used when combining to make the grid face arrays
 
     returns:
         triple numpy float arrays being transmissibility multipliers for K, J, and I grid faces; arrays have
@@ -412,7 +415,10 @@ def combined_tr_mult_from_gcs_mults(model,
             assert bu.matching_uuids(gcs.grid_list[0].uuid, grid.uuid)
 
         # get gcs tr mult data in form of triplet of grid faces arrays
-        gcs_trm_k, gcs_trm_j, gcs_trm_i = gcs.grid_face_arrays(tr_mult_uuid, default_value = np.NaN, lazy = not sided)
+        gcs_trm_k, gcs_trm_j, gcs_trm_i = gcs.grid_face_arrays(tr_mult_uuid,
+                                                               default_value = np.NaN,
+                                                               active_only = active_only,
+                                                               lazy = not sided)
         assert all([trm is not None for trm in (gcs_trm_k, gcs_trm_j, gcs_trm_i)])
 
         # merge in each of the three directional face arrays for this gcs with combined arrays

--- a/resqpy/grid/_grid.py
+++ b/resqpy/grid/_grid.py
@@ -13,6 +13,8 @@ import numpy as np
 
 import resqpy.grid as grr
 import resqpy.grid_surface as rqgs
+import resqpy.fault as rqf
+import resqpy.property as rqp
 import resqpy.olio.grid_functions as gf
 import resqpy.olio.uuid as bu
 import resqpy.olio.write_hdf5 as rwh5
@@ -2133,6 +2135,78 @@ class Grid(BaseResqpy):
            of the horizons points array
         """
         return split_horizons_points(self, min_k0 = min_k0, max_k0 = max_k0, masked = masked)
+
+    def combined_tr_mult_properties_from_gcs_mults(self,
+                                                   gcs_uuid_list = None,
+                                                   realization = None,
+                                                   merge_mode = 'minimum',
+                                                   sided = None,
+                                                   fill_value = 1.0):
+        """Add triplet of transmissibility multiplier properties by combining gcs properties.
+
+        arguments:
+            gcs_uuid_list (list of UUID, optional): if None, all grid connection sets related to this grid will
+                be used
+            realization (int, optional): if present, is used to filter tranmissibility multiplier input
+                properties and is added to the output properties
+            merge_mode (str, default 'minimum'): one of 'minimum', 'multiply', 'maximum', 'exception'; how to
+                handle multiple values applicable to the same grid face
+            sided (bool, optional): whether to apply values on both sides of each gcs cell-face pair; if None,
+                will default to False if merge mode is multiply, True otherwise
+            fill_value (float, optional, default 1.0): the value to use for grid faces not present in any of
+                the gcs'es; if None, NaN will be used
+
+        returns:
+            list of 3 uuids, one for each of the newly created transmissibility multiplier properties
+
+        notes:
+            each grid connection set must refer to this grid only;
+            the generated properties have indexable element 'faces', not 'faces per cell', so may not be
+            suitable for faulted grids
+        """
+
+        if not gcs_uuid_list:
+            gcs_uuid_list = self.model.uuids(obj_type = 'GridConnectionSet', related_uuid = self.uuid)
+        assert gcs_uuid_list, 'no grid connections sets identified for transmissibility multiplier combining'
+
+        tr_mult_uuid_list = []
+        for gcs_uuid in gcs_uuid_list:
+            gcs_pc = rqp.PropertyCollection(support_uuid = gcs_uuid)
+            assert gcs_pc is not None
+            tr_mult_part = gcs_pc.singleton(property_kind = 'transmissibility multiplier',
+                                            realization = realization,
+                                            continuous = True,
+                                            indexable = 'faces')
+            if tr_mult_part is None:
+                log.warning(f'no transmissibility multiplier found for gcs uuid: {gcs_uuid}')
+            else:
+                tr_mult_uuid_list = self.model.uuid_for_part(tr_mult_part)
+        log.info(f'{len(tr_mult_uuid_list)} gcs transmissibility multiplier sets being combined')
+        assert len(tr_mult_uuid_list) > 0, 'no gcs multipliers found for combining'
+
+        trm_k, trm_j, trm_i = rqf.combined_tr_mult_from_gcs_mults(self.model,
+                                                                  tr_mult_uuid_list,
+                                                                  merge_mode = merge_mode,
+                                                                  sided = sided,
+                                                                  fill_value = fill_value)
+        assert trm_k is not None and trm_j is not None and trm_i is not None
+        pc = self.extract_property_collection()
+
+        for axis, trm in enumerate((trm_k, trm_j, trm_i)):
+            axis_ch = 'KJI'[axis]
+            pc.add_cached_array_to_imported_list(trm,
+                                                 'combined from gcs tr mults',
+                                                 'TMULT' + axis_ch,
+                                                 discrete = False,
+                                                 uom = 'Euc',
+                                                 property_kind = 'transmissibility multiplier',
+                                                 facet_type = 'direction',
+                                                 facet = axis_ch,
+                                                 realization = realization,
+                                                 indexable_element = 'faces')
+
+        pc.write_hdf5_for_imported_list()
+        return pc.create_xml_for_imported_list_and_add_parts_to_model()
 
     def _add_geom_points_xml(self, geom_node, ext_uuid):
         """Generate geometry points node in xml, called during create_xml, overridden for RegularGrid."""

--- a/resqpy/grid/_grid.py
+++ b/resqpy/grid/_grid.py
@@ -2141,7 +2141,8 @@ class Grid(BaseResqpy):
                                                    realization = None,
                                                    merge_mode = 'minimum',
                                                    sided = None,
-                                                   fill_value = 1.0):
+                                                   fill_value = 1.0,
+                                                   active_only = True):
         """Add triplet of transmissibility multiplier properties by combining gcs properties.
 
         arguments:
@@ -2155,6 +2156,8 @@ class Grid(BaseResqpy):
                 will default to False if merge mode is multiply, True otherwise
             fill_value (float, optional, default 1.0): the value to use for grid faces not present in any of
                 the gcs'es; if None, NaN will be used
+            active_only (bool, default True): if True and an active property exists for a grid connection set,
+                then only active faces are used when combining to make the grid face properties
 
         returns:
             list of 3 uuids, one for each of the newly created transmissibility multiplier properties
@@ -2188,7 +2191,8 @@ class Grid(BaseResqpy):
                                                                   tr_mult_uuid_list,
                                                                   merge_mode = merge_mode,
                                                                   sided = sided,
-                                                                  fill_value = fill_value)
+                                                                  fill_value = fill_value,
+                                                                  active_only = active_only)
         assert trm_k is not None and trm_j is not None and trm_i is not None
         pc = self.extract_property_collection()
 

--- a/resqpy/grid/_xyz.py
+++ b/resqpy/grid/_xyz.py
@@ -119,10 +119,10 @@ def _local_to_global_crs(grid,
 
     crs = rqc.Crs(grid.model, uuid = crs_uuid)
 
-    if crs.rotated:
-        a[:] = vec.rotate_array(crs.rotation_matrix, a)
-
     flat_a = a.reshape((-1, 3))  # flattened view of array a as vector of (x, y, z) points, in situ
+
+    if crs.rotated:
+        flat_a[:] = vec.rotate_array(crs.rotation_matrix, flat_a)
 
     # note: here negation is made in local crs; if z_offset is not zero, this might not be what is intended
     if global_z_increasing_downward is not None:
@@ -140,7 +140,8 @@ def _local_to_global_crs(grid,
     if global_z_units is not None:
         bwam.convert_lengths(flat_a[:, 2], crs.z_units, global_z_units)  # z
 
-    return flat_a.reshape(a.shape)
+    a[:] = flat_a.reshape(a.shape)  # probably not needed
+    return a
 
 
 def z_inc_down(grid):
@@ -191,7 +192,8 @@ def _global_to_local_crs(grid,
     if crs.rotated:
         flat_a[:] = vec.rotate_array(crs.reverse_rotation_matrix, flat_a)
 
-    return flat_a.reshape(a.shape)
+    a[:] = flat_a.reshape(a.shape)  # probably not needed
+    return a
 
 
 def check_top_and_base_cell_edge_directions(grid):

--- a/resqpy/multiprocessing/wrappers/grid_surface_mp.py
+++ b/resqpy/multiprocessing/wrappers/grid_surface_mp.py
@@ -18,27 +18,27 @@ import uuid
 
 
 def find_faces_to_represent_surface_regular_wrapper(
-    index: int,
-    parent_tmp_dir: str,
-    use_index_as_realisation: bool,
-    grid_epc: str,
-    grid_uuid: Union[UUID, str],
-    surface_epc: str,
-    surface_uuid: Union[UUID, str],
-    name: str,
-    title: Optional[str] = None,
-    agitate: bool = False,
-    feature_type: str = 'fault',
-    trimmed: bool = False,
-    is_curtain = False,
-    extend_fault_representation: bool = False,
-    retriangulate: bool = False,
-    related_uuid = None,
-    progress_fn: Optional[Callable] = None,
-    consistent_side: bool = False,
-    extra_metadata = None,
-    return_properties: Optional[List[str]] = None,
-) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
+        index: int,
+        parent_tmp_dir: str,
+        use_index_as_realisation: bool,
+        grid_epc: str,
+        grid_uuid: Union[UUID, str],
+        surface_epc: str,
+        surface_uuid: Union[UUID, str],
+        name: str,
+        title: Optional[str] = None,
+        agitate: bool = False,
+        feature_type: str = 'fault',
+        trimmed: bool = False,
+        is_curtain = False,
+        extend_fault_representation: bool = False,
+        retriangulate: bool = False,
+        related_uuid = None,
+        progress_fn: Optional[Callable] = None,
+        consistent_side: bool = False,
+        extra_metadata = None,
+        return_properties: Optional[List[str]] = None,
+        raw_bisector: bool = False) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
     """Wrapper function of find_faces_to_represent_surface_regular_optimised.
 
     Used for multiprocessing to create a new model that is saved in a temporary epc file
@@ -81,7 +81,9 @@ def find_faces_to_represent_surface_regular_wrapper(
            normal vector is a unit vector normal to the surface triangle; each array has an entry for each face
            in the gcs; grid bisector is a grid cell boolean property holding True for the set of cells on one
            side of the surface, deemed to be shallower;
-           the returned dictionary has the passed strings as keys and numpy arrays as values.
+           the returned dictionary has the passed strings as keys and numpy arrays as values
+        raw_bisector (bool, default False): if True and grid bisector is requested then it is left in a raw
+           form without assessing which side is shallower (True values indicate same side as origin cell)
 
     Returns:
         Tuple containing:
@@ -230,7 +232,7 @@ def find_faces_to_represent_surface_regular_wrapper(
         progress_fn,
         consistent_side,
         return_properties,
-    )
+        raw_bisector = raw_bisector)
 
     success = False
 
@@ -327,7 +329,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                     discrete = True,
                     property_kind = "grid bisector",
                     facet_type = 'direction',
-                    facet = 'vertical' if is_curtain else 'sloping',
+                    facet = 'raw' if raw_bisector else ('vertical' if is_curtain else 'sloping'),
                     realization = realisation,
                     indexable_element = "columns" if is_curtain else "cells",
                 )

--- a/resqpy/olio/fine_coarse.py
+++ b/resqpy/olio/fine_coarse.py
@@ -248,9 +248,10 @@ class FineCoarse:
         assert isinstance(vector, np.ndarray) and vector.ndim == 1
         assert str(vector.dtype).startswith('int')
         assert len(vector) == self.coarse_extent_kji[axis],  \
-               'length of vector of refinement ratios does not match coarse extent'
+               f'length of vector {len(vector)} of refinement ratios ' +  \
+               f'does not match coarse extent {self.coarse_extent_kji[axis]}'
         assert np.sum(vector) == self.fine_extent_kji[axis],  \
-               'sum of refinement ratios in vector does not match fine extent'
+               f'sum of refinement ratios {np.sum(vector)} in vector does not match fine extent'
         minimum = np.min(vector)
         assert minimum > 0
         if minimum == np.max(vector):

--- a/resqpy/property/_collection_add_part.py
+++ b/resqpy/property/_collection_add_part.py
@@ -174,7 +174,7 @@ def _process_imported_property(collection, attributes, property_kind_uuid, strin
                                extra_metadata, expand_const_arrays):
     (p_uuid, p_file_name, p_keyword, p_cached_name, p_discrete, p_uom, p_time_index, p_null_value, p_min_value,
      p_max_value, property_kind, facet_type, facet, realization, indexable_element, count, local_property_kind_uuid,
-     const_value, points) = attributes
+     const_value, points, p_time_series_uuid) = attributes
 
     log.debug('processing imported property ' + str(p_keyword))
     assert not points or not p_discrete
@@ -204,7 +204,7 @@ def _process_imported_property(collection, attributes, property_kind_uuid, strin
         facet_type = facet_type,
         facet = facet,
         discrete = p_discrete,  # todo: time series bits
-        time_series_uuid = time_series_uuid,
+        time_series_uuid = time_series_uuid if p_time_series_uuid is None else p_time_series_uuid,
         time_index = p_time_index,
         uom = p_uom,
         null_value = p_null_value,

--- a/resqpy/property/grid_property_collection.py
+++ b/resqpy/property/grid_property_collection.py
@@ -13,17 +13,17 @@ import os
 
 import numpy as np
 
+import resqpy.property as rqp
 import resqpy.olio.ab_toolbox as abt
 import resqpy.olio.box_utilities as bxu
 import resqpy.olio.load_data as ld
 import resqpy.olio.write_data as wd
 import resqpy.olio.xml_et as rqet
 
-from .property_collection import PropertyCollection
 from .property_common import selective_version_of_collection
 
 
-class GridPropertyCollection(PropertyCollection):
+class GridPropertyCollection(rqp.PropertyCollection):
     """Class for RESQML Property collection for an IJK Grid, inheriting from PropertyCollection."""
 
     def __init__(self, grid = None, property_set_root = None, realization = None):
@@ -878,7 +878,8 @@ def _add_to_imported(collection, a, title, info, null_value = None, const_value 
         facet = info[9],
         realization = info[0],
         const_value = const_value,
-        points = info[21])
+        points = info[21],
+        time_series_uuid = info[11])
 
 
 def _extend_imported_initial_assertions(other, box, refinement, coarsening):
@@ -1066,8 +1067,13 @@ def _extend_imported_coarsen_lengths(other, box, collection, realization, uncach
         if not copy_all_realizations and info[0] != realization:
             continue
         fine_cl_array = _array_box(other, part, box = box, uncache_other_arrays = uncache_other_arrays)
-        assert info[5] == 1 and info[8] == 'direction'
-        axis = 'KJI'.index(info[9][0].upper())
+        assert info[5] == 1  # count
+        facet_type = info[8]
+        facet = info[9]
+        if not facet_type:
+            (_, facet_type, facet) = rqp.property_kind_and_facet_from_keyword(info[10])
+        assert facet_type == 'direction'
+        axis = 'KJI'.index(facet[0].upper())
         coarse_cl_array = _coarsening_sum(coarsening, fine_cl_array, axis = axis)
         _add_to_imported(collection, coarse_cl_array, 'coarsened from grid ' + str(other.support.uuid), info)
 
@@ -1135,7 +1141,8 @@ def _extend_imported_no_coarsening_single(source_collection, part, info, collect
         facet = info[9],
         realization = info[0],
         const_value = const_value,
-        points = info[21])
+        points = info[21],
+        time_series_uuid = info[11])
 
 
 def _extend_imported_no_coarsening_single_resampling(a, info, collection, refinement):

--- a/tests/unit_tests/fault/test_fault_connection_set.py
+++ b/tests/unit_tests/fault/test_fault_connection_set.py
@@ -148,6 +148,7 @@ def test_fault_connection_set(tmp_path):
                                              lazy = lazy)
 
         assert pk is not None and pj is not None and pi is not None
+        assert pk.shape == (3, 2, 2) and pj.shape == (2, 3, 2) and pi.shape == (2, 2, 3)
         assert np.all(pk == -1)
         assert np.all(pi == -1)
         assert np.count_nonzero(pj > 0) == 2 if lazy else 4

--- a/tests/unit_tests/test_grid_surface.py
+++ b/tests/unit_tests/test_grid_surface.py
@@ -84,7 +84,7 @@ def test_bisector_from_faces_flat_surface_k():
     ])
 
     # Act
-    a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces)
+    a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
 
     # Assert
     np.testing.assert_array_almost_equal(
@@ -117,7 +117,7 @@ def test_bisector_from_faces_flat_surface_j():
     ])
 
     # Act
-    a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces)
+    a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
 
     # Assert
     np.testing.assert_array_almost_equal(
@@ -150,7 +150,7 @@ def test_bisector_from_faces_flat_surface_i():
     ])
 
     # Act
-    a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces)
+    a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
 
     # Assert
     np.testing.assert_array_almost_equal(
@@ -184,4 +184,4 @@ def test_bisector_from_faces_flat_surface_k_hole():
 
     # Act & Assert
     with pytest.raises(AssertionError):
-        rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces)
+        rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)


### PR DESCRIPTION
This change includes support for a time_series_uuid when adding a cached array to a PropertyCollection import list. (Previously the time series could only be identified at the later step of creating xml for the import list properties.)