### PR TITLE
Pin version of sphinx

### DIFF
--- a/docs/requirements-extras.txt
+++ b/docs/requirements-extras.txt
@@ -1,2 +1,3 @@
 autoclasstoc==1.3.0
+sphinx==5.3.0
 sphinx_rtd_theme<1.0.0


### PR DESCRIPTION
Fixes failing Sphinx builds, by pinning Sphinx version, avoiding breaking changes in `6.0.0`.

Link to build: https://readthedocs.org/projects/resqpy/builds/19316764/

Link to preview docs for this branch: https://resqpy.readthedocs.io/en/docs/