### PR TITLE
fine tuning optimisation of olio.xml_et.match() and list_obj_references()

### DIFF
--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -158,17 +158,6 @@ def find_faces_to_represent_surface_regular_wrapper(
         surf.create_xml()
         inherit_interpretation_relationship(model, surface_uuid, surf.uuid)
         surface_uuid = surf.uuid
-        if flange_bool is not None:
-            flange_p = rqp.Property.from_array(parent_model = model,
-                                               cached_array = flange_bool,
-                                               source_info = 'flange bool array',
-                                               keyword = 'flange bool',
-                                               support_uuid = surface_uuid,
-                                               property_kind = 'flange bool',
-                                               find_local_property_kind = True,
-                                               indexable_element = 'faces',
-                                               discrete = True)
-            uuid_list.append(flange_p.uuid)
 
     surface = rqs.Surface(parent_model = model, uuid = str(surface_uuid))
     surf_title = surface.title

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -138,7 +138,7 @@ def find_faces_to_represent_surface_regular_wrapper(
             f'boundary {name} representation {pset.title} has no xyz overlap with grid'
         pset_points = pset.full_array_ref()
         log.debug(f'trimmed point set {pset.title} contains {len(pset_points)} points; about to triangulate')
-        if len(pset_points) > 1000:
+        if len(pset_points) > 50_000:
             log.warning(
                 f'trimmed point set {pset.title} has {len(pset_points)} points, which might take a while to triangulate'
             )


### PR DESCRIPTION
This change largely restores Andy's versions of the two xml_et functions:

- match()
- list_obj_references()

whilst maintaining use of the LRU cache and empty list rather than None to terminate recursion in list_obj_references()