### PR TITLE
Blocked well initialisation de-refactoring

### DIFF
--- a/resqpy/property/_collection_add_part.py
+++ b/resqpy/property/_collection_add_part.py
@@ -280,6 +280,7 @@ def _add_part_to_dict_get_count_and_indexable(xml_node):
 
 def _add_part_to_dict_get_property_kind(xml_node, citation_title):
     perm_synonyms = ['permeability rock', 'rock permeability']
+    kh_synonyms = ['permeability thickness', 'permeability length']  # not exactly synonymous but close enough
     (p_kind_from_keyword, facet_type, facet) = rqp_c.property_kind_and_facet_from_keyword(citation_title)
     prop_kind_node = rqet.find_tag(xml_node, 'PropertyKind')
     assert (prop_kind_node is not None)
@@ -297,7 +298,8 @@ def _add_part_to_dict_get_property_kind(xml_node, citation_title):
     if (p_kind_from_keyword and p_kind_from_keyword != property_kind and
         (p_kind_from_keyword not in ['cell length', 'length', 'thickness'] or
          property_kind not in ['cell length', 'length', 'thickness'])):
-        if property_kind not in perm_synonyms or p_kind_from_keyword not in perm_synonyms:
+        if ((property_kind not in perm_synonyms or p_kind_from_keyword not in perm_synonyms) and
+            (property_kind not in kh_synonyms or p_kind_from_keyword not in kh_synonyms)):
             log.warning(
                 f'property kind {property_kind} not the expected {p_kind_from_keyword} for keyword {citation_title}')
     return property_kind, property_kind_uuid, lpk_node

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -1735,7 +1735,7 @@ class BlockedWell(BaseResqpy):
             set_perforation_fraction (bool, optional): if True, a perforation fraction property will be
                 created based on the fraction of the measured depth within a blocked well cell that is
                 flagged as active, ie. perforated at some time; if None, it will be created only if length
-                and permeability thickness are both absent
+                and permeability length are both absent
             set_frame_interval (bool, default False): if True, a static discrete property holding the index
                 of the dominant active wellbore frame interval (per blocked well cell) is created
 
@@ -3396,16 +3396,16 @@ class BlockedWell(BaseResqpy):
 
         part_list = [self.model.part_for_uuid(uuid) for uuid in uuid_list]
 
-        assert len(self.grid_list) == 1, "Only blocked wells with a single grid can be handled currently"
+        assert len(self.grid_list) == 1, "only blocked wells with a single grid can be handled currently"
         grid = self.grid_list[0]
-        parts = self.model.parts_list_filtered_by_supporting_uuid(part_list,
-                                                                  grid.uuid)  # only those properties on the grid
+        # filter to only those properties on the grid
+        parts = self.model.parts_list_filtered_by_supporting_uuid(part_list, grid.uuid)
         if len(parts) < len(uuid_list):
             log.warning(f"{len(uuid_list)-len(parts)} uuids ignored as they do not belong to the same grid as the gcs")
 
         gridpc = grid.extract_property_collection()
-        cell_parts = [part for part in parts if gridpc.indexable_for_part(part) == 'cells'
-                     ]  # only 'cell' properties are handled
+        # only 'cell' properties are handled
+        cell_parts = [part for part in parts if gridpc.indexable_for_part(part) == 'cells']
         if len(cell_parts) < len(parts):
             log.warning(f"{len(parts)-len(cell_parts)} uuids ignored as they do not have indexableelement of cells")
 
@@ -3449,5 +3449,5 @@ class BlockedWell(BaseResqpy):
                 bwpc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = time_uuid)
         else:
             log.debug(
-                "No properties added - uuids either not 'cell' properties or blocked well is associated with multiple grids"
+                "no properties added - uuids either not 'cell' properties or blocked well is associated with multiple grids"
             )


### PR DESCRIPTION
This change removes the obtuse code for selecting between different blocked well initialisation methods and reverts to a much easier to understand if...elif sequence.

There is also a change to treat 'permeability length' and 'permeability thickness' as both okay when checking the property kind of a property with title 'KH'.