### PR TITLE
Support for packing and unpacking of bool array into bits for hdf5 storage

### DIFF
--- a/resqpy/model/_model.py
+++ b/resqpy/model/_model.py
@@ -1344,7 +1344,8 @@ class Model():
               required to cache or access cached array
            dtype (string or data type): the data type of the elements of the array (need not match hdf5 array in precision)
            required_shape (tuple of ints, optional): if not None, the hdf5 array will be reshaped to this shape; if index
-              is not None, it is taken to be applicable to the required shape
+              is not None, it is taken to be applicable to the required shape; required if the array is bool data that was
+              written with resqpy specific dtype of 'pack'
 
         returns:
            if index is None, then None;

--- a/resqpy/olio/write_hdf5.py
+++ b/resqpy/olio/write_hdf5.py
@@ -54,7 +54,8 @@ class H5Register():
            be as if the copy argument is True regardless of its setting;
            the use of 'pack' as dtype will result in hdf5 data that will not generally be readable
            by non-resqpy applications; when reading packed data, the required shape must be specified;
-           packing only takes place over the last axis
+           packing only takes place over the last axis; do not use packing if the array needs to be
+           read or updated in slices, or read a single value at a time with index values
         """
 
         # log.debug('registering dataset with uuid ' + str(object_uuid) + ' and group tail ' + group_tail)

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -804,7 +804,7 @@ class PropertyCollection():
                          title = None,
                          title_mode = None,
                          related_uuid = None,
-                         use_pack = False):
+                         use_pack = True):
         """Returns the array of data for a single part selected by those arguments which are not None.
 
         arguments:
@@ -816,6 +816,8 @@ class PropertyCollection():
               will also be masked out
            multiple_handling (string, default 'exception'): one of 'exception', 'none', 'first', 'oldest', 'newest'
            title (string, optional): synonym for citation_title argument
+           use_pack (boolean, default True): if True, and the property is a boolean array, the hdf5 data will
+              be unpacked if its shape indicates that it has been packed into bits
 
         Other optional arguments:
         realization, support_uuid, continuous, points, count, indexable, property_kind, facet_type, facet,
@@ -1728,7 +1730,7 @@ class PropertyCollection():
             return None  # could treat as fatal error
         return model.h5_uuid_and_path_for_node(first_values_node, tag = tag)
 
-    def cached_part_array_ref(self, part, dtype = None, masked = False, exclude_null = False, use_pack = False):
+    def cached_part_array_ref(self, part, dtype = None, masked = False, exclude_null = False, use_pack = True):
         """Returns a numpy array containing the data for the property part; the array is cached in this collection.
 
         arguments:
@@ -1739,7 +1741,7 @@ class PropertyCollection():
               the mask is set to the inactive array attribute of the support object if present
            exclude_null (boolean, default False): if True, and masked is also True, then elements of the array
               holding the null value will also be masked out
-           use_pack (boolean, default False): if True, and the property is a boolean array, the hdf5 data will
+           use_pack (boolean, default True): if True, and the property is a boolean array, the hdf5 data will
               be unpacked if its shape indicates that it has been packed into bits
 
         returns:
@@ -1868,13 +1870,15 @@ class PropertyCollection():
     def facets_array_ref(self,
                          use_32_bit = False,
                          indexable_element = None,
-                         use_pack = False):  # todo: add masked argument
+                         use_pack = True):  # todo: add masked argument
         """Returns a +1D array of all parts with first axis being over facet values; Use facet_list() for lookup.
 
         arguments:
            use_32_bit (boolean, default False): if True, the resulting numpy array will use a 32 bit dtype; if False, 64 bit
            indexable_element (string, optional): the indexable element for the properties in the collection; if None, will
               be determined from the data
+           use_pack (boolean, default True): if True, and the property is a boolean array, the hdf5 data will
+              be unpacked if its shape indicates that it has been packed into bits
 
         returns:
            numpy array containing all the data in the collection, the first axis being over facet values and the rest of
@@ -2346,7 +2350,7 @@ class PropertyCollection():
         a = self.cached_part_array_ref(part)
         tail = 'points_patch0' if self.points_for_part(part) else 'values_patch0'
         dtype = None
-        if use_pack and str(a.dtype) == 'bool':
+        if use_pack and 'bool' in str(a.dtype):
             dtype = 'pack'
         h5_reg.register_dataset(self.uuid_for_part(part), tail, a, dtype = dtype)
         h5_reg.write(file = file_name, mode = mode)

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -1742,7 +1742,7 @@ class PropertyCollection():
            exclude_null (boolean, default False): if True, and masked is also True, then elements of the array
               holding the null value will also be masked out
            use_pack (boolean, default True): if True, and the property is a boolean array, the hdf5 data will
-              be unpacked if its shape indicates that it has been packed into bits
+              be unpacked if its shape indicates that it has been packed into bits for storage
 
         returns:
            reference to a cached numpy array containing the actual property data; multiple calls will return
@@ -2311,8 +2311,7 @@ class PropertyCollection():
               as 32 bit; if None, the system default is to write as 32 bit; if True, 32 bit is used; if
               False, 64 bit data is written; ignored if dtype is not None
            use_pack (bool, default False): if True, bool arrays will be packed along their last axis; this
-              will generally result in hdf5 data that is not readable by non-resqpy applications; also, when
-              reading back such data, the required shape must be specified
+              will generally result in hdf5 data that is not readable by non-resqpy applications
 
         :meta common:
         """

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -58,7 +58,8 @@ class PropertyCollection():
         """
 
         assert property_set_root is None or support is not None, \
-            'support (grid, wellbore frame, blocked well, mesh, or grid connection set) must be specified when populating property collection from property set'
+            'support (grid, wellbore frame, blocked well, mesh, or grid connection set) must be specified ' + \
+            'when populating property collection from property set'
 
         self.dict = {}  # main dictionary of model property parts which are members of the collection
         # above is mapping from part_name to:
@@ -802,7 +803,8 @@ class PropertyCollection():
                          multiple_handling = 'exception',
                          title = None,
                          title_mode = None,
-                         related_uuid = None):
+                         related_uuid = None,
+                         use_pack = False):
         """Returns the array of data for a single part selected by those arguments which are not None.
 
         arguments:
@@ -856,7 +858,11 @@ class PropertyCollection():
                               related_uuid = related_uuid)
         if part is None:
             return None
-        return self.cached_part_array_ref(part, dtype = dtype, masked = masked, exclude_null = exclude_null)
+        return self.cached_part_array_ref(part,
+                                          dtype = dtype,
+                                          masked = masked,
+                                          exclude_null = exclude_null,
+                                          use_pack = use_pack)
 
     def number_of_parts(self):
         """Returns the number of parts (properties) in this collection.
@@ -1722,7 +1728,7 @@ class PropertyCollection():
             return None  # could treat as fatal error
         return model.h5_uuid_and_path_for_node(first_values_node, tag = tag)
 
-    def cached_part_array_ref(self, part, dtype = None, masked = False, exclude_null = False):
+    def cached_part_array_ref(self, part, dtype = None, masked = False, exclude_null = False, use_pack = False):
         """Returns a numpy array containing the data for the property part; the array is cached in this collection.
 
         arguments:
@@ -1733,6 +1739,8 @@ class PropertyCollection():
               the mask is set to the inactive array attribute of the support object if present
            exclude_null (boolean, default False): if True, and masked is also True, then elements of the array
               holding the null value will also be masked out
+           use_pack (boolean, default False): if True, and the property is a boolean array, the hdf5 data will
+              be unpacked if its shape indicates that it has been packed into bits
 
         returns:
            reference to a cached numpy array containing the actual property data; multiple calls will return
@@ -1746,7 +1754,8 @@ class PropertyCollection():
            if the indexable element is set to the typical value for the class of supporting representation, eg.
            'cells' for grid objects); if exclude_null is set True then null value elements will also be masked out
            (as long as masked is True); however, it is recommended simply to use np.NaN values in floating point
-           property arrays if the commonality is not needed
+           property arrays if the commonality is not needed;
+           set use_pack True if the hdf5 data may have been written with a similar setting
 
         :meta common:
         """
@@ -1757,7 +1766,7 @@ class PropertyCollection():
             return None
 
         if not hasattr(self, cached_array_name):
-            pcga._cached_part_array_ref_get_array(self, part, dtype, model, cached_array_name)
+            pcga._cached_part_array_ref_get_array(self, part, dtype, model, cached_array_name, use_pack)
 
         if masked:
             exclude_value = self.null_value_for_part(part) if exclude_null else None
@@ -1856,7 +1865,10 @@ class PropertyCollection():
             assert len(patch_list) == 1  # todo: handle more than one patch of values
             return model.h5_uuid_and_path_for_node(rqet.find_tag(patch_list[0], 'Values'))
 
-    def facets_array_ref(self, use_32_bit = False, indexable_element = None):  # todo: add masked argument
+    def facets_array_ref(self,
+                         use_32_bit = False,
+                         indexable_element = None,
+                         use_pack = False):  # todo: add masked argument
         """Returns a +1D array of all parts with first axis being over facet values; Use facet_list() for lookup.
 
         arguments:
@@ -1897,7 +1909,7 @@ class PropertyCollection():
 
         for part in self.parts():
             facet_index = facet_list.index(self.facet_for_part(part))
-            pa = self.cached_part_array_ref(part, dtype = dtype)
+            pa = self.cached_part_array_ref(part, dtype = dtype, use_pack = use_pack)
             a[facet_index] = pa
             self.uncache_part_array(part)
 
@@ -2278,7 +2290,8 @@ class PropertyCollection():
                                      mode = 'a',
                                      expand_const_arrays = False,
                                      dtype = None,
-                                     use_int32 = None):
+                                     use_int32 = None,
+                                     use_pack = False):
         """Create or append to an hdf5 file, writing datasets for the imported arrays.
 
         arguments:
@@ -2293,6 +2306,9 @@ class PropertyCollection():
            use_int32 (bool, optional): if dtype is None, this controls whether 64 bit int arrays are written
               as 32 bit; if None, the system default is to write as 32 bit; if True, 32 bit is used; if
               False, 64 bit data is written; ignored if dtype is not None
+           use_pack (bool, default False): if True, bool arrays will be packed along their last axis; this
+              will generally result in hdf5 data that is not readable by non-resqpy applications; also, when
+              reading back such data, the required shape must be specified
 
         :meta common:
         """
@@ -2315,10 +2331,13 @@ class PropertyCollection():
                 uuid = entry[0]
                 cached_name = entry[3]
             tail = 'points_patch0' if entry[18] else 'values_patch0'
+            if use_pack and (str(dtype).startswith('bool') or
+                             (dtype is None and str(self.__dict__[cached_name].dtype) == 'bool')):
+                dtype = 'pack'
             h5_reg.register_dataset(uuid, tail, self.__dict__[cached_name], dtype = dtype)
         h5_reg.write(file = file_name, mode = mode, use_int32 = use_int32)
 
-    def write_hdf5_for_part(self, part, file_name = None, mode = 'a'):
+    def write_hdf5_for_part(self, part, file_name = None, mode = 'a', use_pack = False):
         """Create or append to an hdf5 file, writing dataset for the specified part."""
 
         if self.constant_value_for_part(part) is not None:
@@ -2326,7 +2345,10 @@ class PropertyCollection():
         h5_reg = rwh5.H5Register(self.model)
         a = self.cached_part_array_ref(part)
         tail = 'points_patch0' if self.points_for_part(part) else 'values_patch0'
-        h5_reg.register_dataset(self.uuid_for_part(part), tail, a)
+        dtype = None
+        if use_pack and str(a.dtype) == 'bool':
+            dtype = 'pack'
+        h5_reg.register_dataset(self.uuid_for_part(part), tail, a, dtype = dtype)
         h5_reg.write(file = file_name, mode = mode)
 
     def create_xml_for_imported_list_and_add_parts_to_model(self,

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -2265,3 +2265,40 @@ def test_surface_support(example_model_and_crs):
     assert_array_almost_equal(tpf_reload, t_prop_float)
     assert np.all(tpi_reload == t_prop_int)
     assert_array_almost_equal(ppf_reload, p_prop_float)
+
+
+def test_pack_unpack_bits(example_model_with_properties):
+    model = example_model_with_properties
+    pc = model.grid().property_collection
+    array = np.zeros(shape = (3 * 5 * 5,), dtype = bool)
+    i = 0
+    ip = 1
+    while True:
+        array[i] = True
+        i += ip
+        ip += 1
+        if i >= len(array):
+            break
+    array = array.reshape((3, 5, 5))
+
+    pc.add_cached_array_to_imported_list(cached_array = array.copy(),
+                                         source_info = 'test',
+                                         keyword = 'bisector',
+                                         property_kind = 'bisector',
+                                         discrete = True)
+    pc.write_hdf5_for_imported_list(use_pack = True)
+    pc.create_xml_for_imported_list_and_add_parts_to_model()
+    model.store_epc()
+    assert np.all(pc.single_array_ref(property_kind = 'bisector') == array)
+
+    model = rq.Model(model.epc_file)
+    grid = model.grid()
+    pc = grid.extract_property_collection()
+    a = pc.single_array_ref(property_kind = 'bisector')  # without unpacking
+    assert a is not None and a.shape == (3, 5, 1)
+    pc = None
+    grid.property_collection = None
+    pc = grid.extract_property_collection()
+    a = pc.single_array_ref(property_kind = 'bisector', dtype = bool, use_pack = True)  # without unpacking
+    assert a is not None and a.shape == (3, 5, 5)
+    assert np.all(a == array)

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -2313,6 +2313,7 @@ def test_pack_unpack_bits_larger_aligned(example_model_and_crs):
     grid.create_xml()
     pc = grid.extract_property_collection()
     array = (np.random.random(shape) > 0.5)
+    brray = np.logical_not(array)
 
     pc.add_cached_array_to_imported_list(cached_array = array.copy(),
                                          source_info = 'testy',
@@ -2321,6 +2322,14 @@ def test_pack_unpack_bits_larger_aligned(example_model_and_crs):
                                          discrete = True)
     pc.write_hdf5_for_imported_list(use_pack = True)
     pc.create_xml_for_imported_list_and_add_parts_to_model()
+    bp = rqp.Property.from_array(model,
+                                 brray,
+                                 'nonsense',
+                                 'negated',
+                                 grid.uuid,
+                                 property_kind = 'sandy',
+                                 discrete = True,
+                                 use_pack = True)
     model.store_epc()
 
     model = rq.Model(model.epc_file)
@@ -2329,6 +2338,9 @@ def test_pack_unpack_bits_larger_aligned(example_model_and_crs):
     a = pc.single_array_ref(property_kind = 'shale', dtype = bool, use_pack = True)  # with unpacking
     assert a is not None and a.shape == shape
     assert np.all(a == array)
+    b = rqp.Property(model, uuid = bp.uuid).array_ref(dtype = bool)
+    assert b is not None and b.shape == shape
+    assert np.all(b == brray)
 
 
 def test_pack_unpack_bits_larger_unaligned(example_model_and_crs):
@@ -2340,6 +2352,7 @@ def test_pack_unpack_bits_larger_unaligned(example_model_and_crs):
     grid.create_xml()
     pc = grid.extract_property_collection()
     array = (np.random.random(shape) > 0.5)
+    brray = np.logical_not(array)
 
     pc.add_cached_array_to_imported_list(cached_array = array.copy(),
                                          source_info = 'testy',
@@ -2348,6 +2361,14 @@ def test_pack_unpack_bits_larger_unaligned(example_model_and_crs):
                                          discrete = True)
     pc.write_hdf5_for_imported_list(use_pack = True)
     pc.create_xml_for_imported_list_and_add_parts_to_model()
+    bp = rqp.Property.from_array(model,
+                                 brray,
+                                 'nonsense',
+                                 'negated',
+                                 grid.uuid,
+                                 property_kind = 'sandy',
+                                 discrete = True,
+                                 use_pack = True)
     model.store_epc()
 
     model = rq.Model(model.epc_file)
@@ -2356,3 +2377,6 @@ def test_pack_unpack_bits_larger_unaligned(example_model_and_crs):
     a = pc.single_array_ref(property_kind = 'shale', dtype = bool, use_pack = True)  # with unpacking
     assert a is not None and a.shape == shape
     assert np.all(a == array)
+    b = rqp.Property(model, uuid = bp.uuid).array_ref(dtype = bool)
+    assert b is not None and b.shape == shape
+    assert np.all(b == brray)


### PR DESCRIPTION
This change adds an option to pack bool arrays into bits (along the last axis) for hdf5 storage.  Note that using this option will generally result in non-resqpy applications not being able to read the array data for such properties.