### PR TITLE
adding minimal test for olio.xml_et.print_xml_tree()

### DIFF
--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -413,7 +413,7 @@ def print_xml_tree(root,
                                     log_level = log_level,
                                     max_lines = max_lines,
                                     line_count = line_count)
-        if line_count > max_lines:
+        if max_lines and line_count > max_lines:
             break
     return line_count
 

--- a/tests/unit_tests/olio/test_xml_et.py
+++ b/tests/unit_tests/olio/test_xml_et.py
@@ -15,3 +15,37 @@ def test_list_obj_references(example_model_with_well):
     assert len(d_refs) == 1  # crs reference
     assert len(t_refs) == 3  # interp, crs & datum references
     assert len(t_refs_with_hdf5) == 5  # as above, plus mds and control points hdf5 references
+
+
+def test_print_xml_tree(example_model_with_well):
+    # note: this test only does a rudimentary check of the number of lines reported
+
+    model, well_interp, datum, traj = example_model_with_well
+
+    lines = rqet.print_xml_tree(datum.root,
+                                level = 0,
+                                max_level = None,
+                                strip_tag_refs = True,
+                                to_log = False,
+                                log_level = None,
+                                max_lines = 0,
+                                line_count = 0)
+    assert lines == 15
+    lines = rqet.print_xml_tree(well_interp.root,
+                                level = 0,
+                                max_level = 10,
+                                strip_tag_refs = True,
+                                to_log = False,
+                                log_level = None,
+                                max_lines = 0,
+                                line_count = 0)
+    assert lines == 12
+    lines = rqet.print_xml_tree(traj.root,
+                                level = 0,
+                                max_level = 4,
+                                strip_tag_refs = False,
+                                to_log = True,
+                                log_level = 'info',
+                                max_lines = 20,
+                                line_count = 0)
+    assert lines == 21


### PR DESCRIPTION
also fixing a bug in that function which was causing it to return prematurely if a maximum line count was not provided