### PR TITLE
use_pack option made available in mp wrapper for find_faces...

### DIFF
--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -40,7 +40,8 @@ def find_faces_to_represent_surface_regular_wrapper(
         progress_fn: Optional[Callable] = None,
         extra_metadata = None,
         return_properties: Optional[List[str]] = None,
-        raw_bisector: bool = False) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
+        raw_bisector: bool = False,
+        use_pack: bool = False) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
     """Multiprocessing wrapper function of find_faces_to_represent_surface_regular_optimised.
 
     arguments:
@@ -81,6 +82,8 @@ def find_faces_to_represent_surface_regular_wrapper(
            the returned dictionary has the passed strings as keys and numpy arrays as values
         raw_bisector (bool, default False): if True and grid bisector is requested then it is left in a raw
            form without assessing which side is shallower (True values indicate same side as origin cell)
+        use_pack (bool, default False): if True, boolean properties will be stored in numpy packed format,
+           which will only be readable by resqpy based applications
 
     returns:
         Tuple containing:
@@ -351,13 +354,13 @@ def find_faces_to_represent_surface_regular_wrapper(
                 raise ValueError(f'unrecognised property name {p_name}')
         if property_collection.number_of_imports() > 0:
             # log.debug('writing gcs property hdf5 data')
-            property_collection.write_hdf5_for_imported_list()
+            property_collection.write_hdf5_for_imported_list(use_pack = use_pack)
             uuids_properties = property_collection.create_xml_for_imported_list_and_add_parts_to_model(
                 find_local_property_kinds = True)
             uuid_list.extend(uuids_properties)
         if grid_pc is not None and grid_pc.number_of_imports() > 0:
             # log.debug('writing grid property (bisector) hdf5 data')
-            grid_pc.write_hdf5_for_imported_list()
+            grid_pc.write_hdf5_for_imported_list(use_pack = use_pack)
             # log.debug('creating xml for grid property (bisector)')
             uuids_properties = grid_pc.create_xml_for_imported_list_and_add_parts_to_model(
                 find_local_property_kinds = True)

--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -301,7 +301,7 @@ def cut_extra_metadata(root):
     """Removes all the extra metadata children under root node."""
 
     for child in root:
-        if child.tag == 'ExtraMetadata':
+        if match(child.tag, 'ExtraMetadata'):
             root.remove(child)
 
 

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -2,6 +2,7 @@ from resqpy.model import Model
 from typing import Tuple
 from resqpy.grid import RegularGrid
 from resqpy.surface import Surface
+import resqpy.property as rqp
 from resqpy.multi_processing.wrappers.grid_surface_mp import find_faces_to_represent_surface_regular_wrapper
 from resqpy.multi_processing._multiprocessing import rm_tree
 import resqpy.olio.xml_et as rqet
@@ -171,3 +172,51 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties_flange(small
     assert len(model.uuids(obj_type = 'ContinuousProperty')) == 4
     assert len(model.uuids()) == 16
     assert len(uuid_list) == 10
+
+
+def test_find_faces_to_represent_surface_extended_bisector_use_pack(small_grid_and_extended_surface: Tuple[RegularGrid,
+                                                                                                           Surface]):
+    # Arrange
+    grid, surface = small_grid_and_extended_surface
+    grid_epc = surface_epc = grid.model.epc_file
+    grid_uuid = grid.uuid
+    surface_uuid = surface.uuid
+    return_properties = ["triangle", "offset", "grid bisector", "grid shadow"]
+
+    name = "test"
+    input_index = 0
+    use_index_as_realisation = False
+
+    # Act
+    index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
+        input_index,
+        "tmp_dir",
+        use_index_as_realisation,
+        grid_epc,
+        grid_uuid,
+        surface_epc,
+        surface_uuid,
+        name,
+        return_properties = return_properties,
+        use_pack = True)
+    model = Model(epc_file = epc_file)
+
+    # Assert
+    assert success is True
+    assert index == input_index
+    assert len(model.uuids(obj_type = 'LocalDepth3dCrs')) == 1
+    assert len(model.uuids(obj_type = 'IjkGridRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'TriangulatedSetRepresentation')) == 2
+    assert len(model.uuids(obj_type = 'GridConnectionSetRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'FaultInterpretation')) == 1
+    assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
+    assert len(model.uuids(obj_type = 'DiscreteProperty')) == 3
+    assert len(model.uuids(obj_type = 'ContinuousProperty')) == 4
+    assert len(model.uuids()) == 18
+    assert len(uuid_list) == 11
+
+    for uuid in model.uuids(obj_type = 'DiscreteProperty'):
+        a = rqp.Property(model, uuid = uuid).array_ref()
+        assert a is not None
+
+    rm_tree("tmp_dir")


### PR DESCRIPTION
This change makes the packing option available for boolean properties generated by the find_faces... functionality. Note that non-resqpy applications will not be able to read properties that have been stored in the packed form.