### PR TITLE
using 'Uom' as extra metadata Name in line with technical reference

### DIFF
--- a/resqpy/property/_collection_create_xml.py
+++ b/resqpy/property/_collection_create_xml.py
@@ -162,7 +162,7 @@ def _create_xml_uom_node(collection, p_node, uom, property_kind, min_value, max_
         collection.model.uom_node(p_node, uom)
     else:
         collection.model.uom_node(p_node, 'Euc')
-        rqet.create_metadata_xml(p_node, {'uom': uom})
+        rqet.create_metadata_xml(p_node, {'Uom': uom})
 
 
 def _create_xml_add_relationships(collection, p_node, support_root, property_kind_uuid, related_time_series_node,

--- a/resqpy/surface/_mesh.py
+++ b/resqpy/surface/_mesh.py
@@ -193,7 +193,7 @@ class Mesh(rqsb.BaseSurface):
         if em is None:
             em = {}
         if em_uom is not None:
-            em['uom'] = em_uom
+            em['Uom'] = em_uom
         mesh = cls(parent_model,
                    mesh_flavour = 'reg&z',
                    nj = grid.nj,

--- a/tests/unit_tests/unstructured/test_unstructured.py
+++ b/tests/unit_tests/unstructured/test_unstructured.py
@@ -478,7 +478,7 @@ def test_vertical_prism_grid_from_surfaces(tmp_path):
                                          count = 1,
                                          indexable_element = 'faces per cell')
     pc.write_hdf5_for_imported_list()
-    pc.create_xml_for_imported_list_and_add_parts_to_model(extra_metadata = {'uom': 'm3.cP/(d.kPa)'})
+    pc.create_xml_for_imported_list_and_add_parts_to_model(extra_metadata = {'Uom': 'm3.cP/(d.kPa)'})
 
     model.store_epc()
 


### PR DESCRIPTION
Previously any non-standard uom would be added as extra metadata with Name 'uom'. This change brings resqpy in line with the RESQML technical reference by changing the Name to 'Uom'.