### PR TITLE
reloading of extra metadata Uom when present

### DIFF
--- a/resqpy/property/_collection_add_part.py
+++ b/resqpy/property/_collection_add_part.py
@@ -109,9 +109,15 @@ def _add_part_to_dict_get_uom(collection, part, continuous, xml_node, trust_uom,
     uom = None
     if continuous and not points:
         uom_node = rqet.find_tag(xml_node, 'UOM')
-        if uom_node is not None and (trust_uom or uom_node.text not in ['', 'Euc']):
-            uom = uom_node.text
-        else:
+        if uom_node is not None:
+            if uom_node.text == 'Euc':
+                em = rqet.load_metadata_from_xml(collection.model.root_for_part(part))
+                uom = em.get('Uom')
+                if uom is None and trust_uom:
+                    uom = 'Euc'
+            elif trust_uom or uom_node.text != '':
+                uom = uom_node.text
+        if uom is None:
             if not collection.guess_warning:
                 collection.guess_warning = True
                 log.warning("Guessing unit of measure for one or more properties")

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -38,10 +38,10 @@ class PropertyCollection():
         """Initialise an empty Property Collection, optionally populate properties from a supporting representation.
 
         arguments:
-           support (optional): a grid.Grid object or a well.WellboreFrame object which belongs to a resqpy.Model which includes
-              associated properties; if this argument is given, and property_set_root is None, the properties in the support's
-              parent model which are for this representation (ie. have this grid or wellbore frame as the supporting representation)
-              are added to this collection as part of the initialisation
+           support (optional): a grid.Grid object, or a well.BlockedWell, or a well.WellboreFrame object which belongs to a
+              resqpy.Model which includes associated properties; if this argument is given, and property_set_root is None,
+              the properties in the support's parent model which are for this representation (ie. have this object as the
+              supporting representation) are added to this collection as part of the initialisation
            property_set_root (optional): if present, the collection is populated with the properties defined in the xml tree
               of the property set
            realization (integer, optional): if present, the single realisation (within an ensemble) that this collection is for;

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -290,9 +290,10 @@ def test_property_extra_metadata(tmp_path):
                                             a,
                                             'length',
                                             title = 'nonsense',
-                                            uom = 'm',
+                                            uom = 'how long is a piece of string',
                                             realization = 7,
                                             extra_metadata = em)
+    em['Uom'] = 'how long is a piece of string'
     # re-open the model and check that extra metadata has been preserved
     model = rq.Model(epc)
     p = rqp.Property(model, uuid = uuid)


### PR DESCRIPTION
This change adds a small piece of missing functionality – to reload a non standard unit of measure from extra metadata when it is present. A unit test for that situation is also added.