### PR TITLE
correcting darcy constant in metric transmissibility formulation

### DIFF
--- a/resqpy/organize/structural_organization_interpretation.py
+++ b/resqpy/organize/structural_organization_interpretation.py
@@ -1,0 +1,29 @@
+"""Class for RESQML Structural Organization Interpretation organizational objects."""
+
+from resqpy.olio.base import BaseResqpy
+
+valid_ordering_criteria = ('age', 'apparent depth', 'measured depth')
+
+valid_contact_relationships = ("frontier feature to frontier feature", "genetic boundary to frontier feature",
+                               "genetic boundary to genetic boundary", "genetic boundary to tectonic boundary",
+                               "stratigraphic unit to frontier feature", "stratigraphic unit to stratigraphic unit",
+                               "tectonic boundary to frontier feature", "tectonic boundary to genetic boundary",
+                               "tectonic boundary to tectonic boundary")
+
+
+class StructuralOrganizationInterpretation(BaseResqpy):
+    """Class for RESQML Structural Organization Interpretation organizational objects."""
+
+    resqml_type = 'StructuralOrganizationInterpretation'
+
+    def __init__(self):
+        """Initialise a structural organisation interpretation."""
+        self.ordering_criterion = 'age'  #: one of 'age' (youngest to oldest!), 'apparent depth', or 'measured depth'
+        self.fault_uuid_list = None  #: list of uuids of fault interpretation which intersect the structural object
+        self.horizon_tuple_list = None  #: list of horizon interpretation uuids along with index and rank
+        self.sides_uuid_list = None  #: list of uuids of interpretation objects for sides of structural object
+        self.top_frontier_uuid_list = None  #: list of uuids of interpretation objects for top of structural object
+        self.bottom_frontier_uuid_list = None  #: list of uuids of interpretation objects for base of structural object
+        self.contact_interpretations = None  #: list of contact interpretations
+
+    # TODO

--- a/tests/integration_tests/test_grid_transmissibility_snapshots.py
+++ b/tests/integration_tests/test_grid_transmissibility_snapshots.py
@@ -15,7 +15,7 @@ def check_load_snapshot(data, filename):
     # Compare the actual data against the stored expected array
     loaded_array = np.loadtxt(filename)
     expected_array = loaded_array.reshape(loaded_array.shape[0], loaded_array.shape[1] // data.shape[2], data.shape[2])
-    np.testing.assert_array_almost_equal(data, expected_array)
+    np.testing.assert_array_almost_equal(data, expected_array, decimal = 4)
 
 
 def test_check_transmisibility_output(test_data_path):
@@ -26,6 +26,10 @@ def test_check_transmisibility_output(test_data_path):
     grid_model = rq.Model(resqml_file_root)
     resqml_grid = grid_model.grid()
     k, j, i = resqml_grid.transmissibility()
+    # snapshots were taken with inflated transmissibilities
+    k *= 100.0
+    j *= 100.0
+    i *= 100.0
 
     snapshot_filename = current_filename + "/snapshots/transmissibility/"
     check_load_snapshot(i, f'{snapshot_filename}block_i.txt')


### PR DESCRIPTION
The built in Darcy constant used by default for grid with xy & z units of metres was 100 times too great (yielding transmissibilities in m3.cP/(bar.d) instead of the m3.cP/(kPa.d) as stored in the extra metadata Uom field). This change corrects the Darcy constant to yield the correct transmissibilities in m3.cP/(kPa.d).