### PR TITLE
Support properties that are indexed per-node in more mesh types

### DIFF
--- a/resqpy/property/_collection_get_attributes.py
+++ b/resqpy/property/_collection_get_attributes.py
@@ -499,6 +499,8 @@ def _supporting_shape_gridconnectionset(support, indexable_element):
 def _supporting_shape_other(support, indexable_element):
     if indexable_element is None or indexable_element == 'cells':
         shape_list = [support.cell_count]
+    elif indexable_element == 'nodes':
+        shape_list = [support.node_count]
     elif indexable_element == 'faces per cell':
         support.cache_all_geometry_arrays()
         shape_list = [len(support.faces_per_cell)]


### PR DESCRIPTION
Writing a property on an unstructured mesh as support is currently supported with "cells" as indexable element, but not "nodes".  It appears that the only change needed to support "nodes" as indexable element for, e.g., a TetraMesh is in the code that verifies the shape of the input array.  Our proposed code change is similar to how nodes were added as indexable elements to structured meshes in [PR #214](https://github.com/bp/resqpy/pull/214).

We would like to add a test to this PR that covers writing nodes-indexed properties on unstructured, and possibly properties on unstructured grids more generally.  Where do you propose that we add these tests, in tests/unit_tests/unstructured or in tests/unit_tests/property?
