### PR TITLE
Derived model add_faults() enhancement

### DIFF
--- a/resqpy/derived_model/_add_faults.py
+++ b/resqpy/derived_model/_add_faults.py
@@ -184,7 +184,7 @@ def _fault_from_pillar_list(grid, full_pillar_list, delta_throw_left, delta_thro
     # this function introduces new data into the RESQML arrays representing split pillars
     # familiarity with those array representations is needed if working on this function
 
-    if full_pillar_list is None or len(full_pillar_list) < 3:
+    if full_pillar_list is None or len(full_pillar_list) < 2:
         return
     assert grid.z_units() == grid.xy_units(),  \
         'crs used by grid has differing xy and z units – mix not supported when adding faults'
@@ -192,6 +192,7 @@ def _fault_from_pillar_list(grid, full_pillar_list, delta_throw_left, delta_thro
     assert hasattr(grid, 'points_cached')
     # make grid into a faulted grid if hitherto unfaulted
     if not grid.has_split_coordinate_lines:
+        log.debug('converting grid to split pillar representation')
         grid.points_cached = grid.points_cached.reshape((grid.nk_plus_k_gaps + 1, (grid.nj + 1) * (grid.ni + 1), 3))
         grid.split_pillar_indices_cached = np.array([], dtype = int)
         grid.cols_for_split_pillars = np.array([], dtype = int)
@@ -204,8 +205,12 @@ def _fault_from_pillar_list(grid, full_pillar_list, delta_throw_left, delta_thro
         cl = grid.cols_for_split_pillars_cl[-1]
     original_p = np.zeros((grid.nk_plus_k_gaps + 1, 3), dtype = float)
     n_primaries = (grid.nj + 1) * (grid.ni + 1)
-    for p_index in range(1, len(full_pillar_list) - 1):
+    for p_index in range(len(full_pillar_list)):
         primary_ji0 = full_pillar_list[p_index]
+        # if end pillar is internal to model, do not split
+        if p_index == 0 or p_index == len(full_pillar_list) - 1:
+            if not (primary_ji0[0] in (0, grid.nj) or primary_ji0[1] in (0, grid.ni)):
+                continue
         primary = primary_ji0[0] * (grid.ni + 1) + primary_ji0[1]
         p_vector = np.array(_pillar_vector(grid, primary), dtype = float)
         if p_vector is None:

--- a/resqpy/derived_model/_add_faults.py
+++ b/resqpy/derived_model/_add_faults.py
@@ -108,6 +108,7 @@ def add_faults(epc_file,
     # build pillar list dict for polylines if necessary
     if full_pillar_list_dict is None:
         full_pillar_list_dict = {}
+        log.debug('using polylines for defining faults')
         _populate_composite_face_sets_for_polylines(model, grid, polylines, lines_crs_uuid, grid.crs, lines_file_list,
                                                     full_pillar_list_dict, composite_face_set_dict)
 
@@ -115,7 +116,7 @@ def add_faults(epc_file,
         _populate_composite_face_sets_for_pillar_lists(source_grid, full_pillar_list_dict, composite_face_set_dict)
 
     # log.debug(f'full_pillar_list_dict:\n{full_pillar_list_dict}')
-
+    log.debug(f'number of faults to be added: {len(full_pillar_list_dict)}')
     _process_full_pillar_list_dict(grid, full_pillar_list_dict, left_right_throw_dict)
 
     collection = rqdm_c._prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_realization,
@@ -344,6 +345,7 @@ def _processs_foursome(grid, n_primaries, primary, original_p, existing_foursome
 
 def _process_full_pillar_list_dict(grid, full_pillar_list_dict, left_right_throw_dict):
     for fault_key in full_pillar_list_dict:
+        log.debug(f'processing fault: {fault_key}')
         full_pillar_list = full_pillar_list_dict[fault_key]
         left_right_throw = None
         if left_right_throw_dict is not None:

--- a/resqpy/derived_model/_common.py
+++ b/resqpy/derived_model/_common.py
@@ -67,6 +67,11 @@ def _prepare_simple_inheritance(grid, source_grid, inherit_properties, inherit_r
             collection.set_grid(grid)
             collection.extend_imported_list_copying_properties_from_other_grid_collection(
                 source_collection, realization = inherit_realization, copy_all_realizations = inherit_all_realizations)
+        if source_grid.model is not grid.model:
+            uuids = source_collection.time_series_uuid_list(sort_list = False)
+            uuids += source_collection.string_lookup_uuid_list(sort_list = False)
+            for uuid in uuids:
+                grid.model.copy_uuid_from_other_model(source_grid.model, uuid)
     return collection
 
 

--- a/resqpy/olio/grid_functions.py
+++ b/resqpy/olio/grid_functions.py
@@ -553,12 +553,17 @@ def columns_to_nearest_split_face(grid):
 def left_right_foursome(full_pillar_list, p_index):
     """Returns (2, 2) bool numpy array indicating which columns around a primary pillar are to the right of a line."""
 
-    assert 0 < p_index < len(full_pillar_list) - 1
+    assert 0 <= p_index <= len(full_pillar_list) - 1
     here = np.array(full_pillar_list[p_index], dtype = int)
-    previous = np.array(full_pillar_list[p_index - 1], dtype = int)
-    next = np.array(full_pillar_list[p_index + 1], dtype = int)
-    entry = tuple(here - previous)
-    exit = tuple(next - here)
+    previous = np.array(full_pillar_list[p_index - 1], dtype = int) if p_index > 0 else None
+    next = np.array(full_pillar_list[p_index + 1], dtype = int) if p_index < len(full_pillar_list) - 1 else None
+    assert previous is not None or next is not None
+    entry = None if previous is None else tuple(here - previous)
+    exit = None if next is None else tuple(next - here)
+    if entry is None:
+        entry = exit
+    elif exit is None:
+        exit = entry
     # yapf: disable
     entry_tuples_list = [(0, 1), (0, -1), (1, 0), (-1, 0)]
     exit_tuples_list = [[(-1, 0), (0, 1),  (1, 0)],

--- a/resqpy/property/_collection_get_attributes.py
+++ b/resqpy/property/_collection_get_attributes.py
@@ -58,25 +58,26 @@ def _get_property_kind_uuid(collection, property_kind_uuid, property_kind, uom, 
     return property_kind_uuid
 
 
-def _get_property_type_details(collection, discrete, string_lookup_uuid, points):
+def _get_property_type_details(discrete, string_lookup_uuid, points, null_value):
+    d_or_c_text = xsd_type = hdf5_type = None
     if discrete:
         if string_lookup_uuid is None:
-            collection.d_or_c_text = 'Discrete'
-
+            d_or_c_text = 'Discrete'
         else:
-            collection.d_or_c_text = 'Categorical'
-        collection.xsd_type = 'integer'
-        collection.hdf5_type = 'IntegerHdf5Array'
+            d_or_c_text = 'Categorical'
+        xsd_type = 'integer'
+        hdf5_type = 'IntegerHdf5Array'
     elif points:
-        collection.d_or_c_text = 'Points'
-        collection.xsd_type = 'double'
-        collection.hdf5_type = 'Point3dHdf5Array'
-        collection.null_value = None
+        d_or_c_text = 'Points'
+        xsd_type = 'double'
+        hdf5_type = 'Point3dHdf5Array'
+        null_value = None
     else:
-        collection.d_or_c_text = 'Continuous'
-        collection.xsd_type = 'double'
-        collection.hdf5_type = 'DoubleHdf5Array'
-        collection.null_value = None
+        d_or_c_text = 'Continuous'
+        xsd_type = 'double'
+        hdf5_type = 'DoubleHdf5Array'
+        null_value = None
+    return d_or_c_text, xsd_type, hdf5_type, null_value
 
 
 def _get_property_array_min_max_value(collection, property_array, const_value, discrete, min_value, max_value,

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -2566,7 +2566,8 @@ class PropertyCollection():
         if find_local_property_kinds and property_kind in ['continuous', 'discrete', 'categorical']:
             property_kind = title
 
-        d_or_c_text, xsd_type, hdf5_type, null_value = pcga._get_property_type_details(discrete, string_lookup_uuid, points, null_value)
+        d_or_c_text, xsd_type, hdf5_type, null_value = pcga._get_property_type_details(
+            discrete, string_lookup_uuid, points, null_value)
         p_node, p_uuid = pcxml._create_xml_get_p_node(self, p_uuid, d_or_c_text)
 
         pcxml._create_xml_add_basics_to_p_node(self, p_node, title, originator, extra_metadata, source, count,

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -2549,8 +2549,7 @@ class PropertyCollection():
         # currently assumes discrete properties to be 32 bit integers and continuous to be 64 bit reals
         # also assumes property_kind is one of the standard resqml property kinds; todo: allow local p kind node as optional arg
         support_root, support_uuid, ext_uuid = pcxml._create_xml_get_basics(self, discrete, points, const_value,
-                                                                            facet_type, null_value, support_uuid,
-                                                                            ext_uuid)
+                                                                            facet_type, support_uuid, ext_uuid)
 
         support_type = self.model.type_of_part(self.model.part_for_uuid(support_uuid))
         indexable_element = pcga._get_indexable_element(indexable_element, support_type)
@@ -2567,8 +2566,8 @@ class PropertyCollection():
         if find_local_property_kinds and property_kind in ['continuous', 'discrete', 'categorical']:
             property_kind = title
 
-        pcga._get_property_type_details(self, discrete, string_lookup_uuid, points)
-        p_node, p_uuid = pcxml._create_xml_get_p_node(self, p_uuid)
+        d_or_c_text, xsd_type, hdf5_type, null_value = pcga._get_property_type_details(discrete, string_lookup_uuid, points, null_value)
+        p_node, p_uuid = pcxml._create_xml_get_p_node(self, p_uuid, d_or_c_text)
 
         pcxml._create_xml_add_basics_to_p_node(self, p_node, title, originator, extra_metadata, source, count,
                                                indexable_element)
@@ -2579,11 +2578,11 @@ class PropertyCollection():
         property_kind_uuid = pcxml._create_xml_property_kind(self, p_node, find_local_property_kinds, property_kind,
                                                              uom, discrete, property_kind_uuid)
         pcxml._create_xml_patch_node(self, p_node, points, const_value, indexable_element, direction, p_uuid, ext_uuid,
-                                     expand_const_arrays)
+                                     expand_const_arrays, hdf5_type, xsd_type, null_value)
         pcxml._create_xml_facet_node(facet_type, facet, p_node)
 
         pcxml._create_xml_property_min_max(self, property_array, const_value, discrete, add_min_max, p_node, min_value,
-                                           max_value, string_lookup_uuid is not None, null_value, points)
+                                           max_value, string_lookup_uuid is not None, null_value, points, xsd_type)
 
         if discrete:
             sl_root = pcxml._create_xml_lookup_node(self, p_node, string_lookup_uuid)
@@ -2593,7 +2592,7 @@ class PropertyCollection():
             sl_root = None
         pcxml._create_xml_add_as_part(self, add_as_part, p_uuid, p_node, add_relationships, support_root,
                                       property_kind_uuid, related_time_series_node, sl_root, discrete,
-                                      string_lookup_uuid, const_value, ext_uuid)
+                                      string_lookup_uuid, const_value, ext_uuid, d_or_c_text)
 
         return p_node
 

--- a/tests/unit_tests/derived_model/test_derived_model.py
+++ b/tests/unit_tests/derived_model/test_derived_model.py
@@ -970,12 +970,12 @@ def test_add_faults(tmp_path):
         model = rq.Model(epc)
         assert len(model.titles(obj_type = 'IjkGridRepresentation')) == 8
         g1 = model.grid(title = 'ttt_f7')
-        assert g1.split_pillars_count == 5
+        assert g1.split_pillars_count == 9
         cpm = g1.create_column_pillar_mapping()
         assert cpm.shape == (3, 3, 2, 2)
         extras = (cpm >= 16)
-        assert np.count_nonzero(extras) == 7
-        assert np.all(np.sort(np.unique(cpm)) == np.arange(21))
+        assert np.count_nonzero(extras) == 11
+        assert np.all(np.sort(np.unique(cpm)) == np.arange(25))
 
 
 def test_add_faults_and_scaling(tmp_path):
@@ -1019,7 +1019,7 @@ def test_add_faults_and_scaling(tmp_path):
     # prepare dictionaries to define more faults and their throws
     pillar_list_dict = {}
     pillar_list_dict['step_fault'] = [(1, 0), (1, 1), (2, 1), (2, 2), (2, 3), (2, 4), (1, 4), (1, 5)]
-    pillar_list_dict['north_south_fault'] = [(0, 3), (4, 3)]
+    pillar_list_dict['north_south_fault'] = [(0, 3), (1, 3), (2, 3), (3, 3), (4, 3)]
     throw_dict = {}
     throw_dict['step_fault'] = (7.0, -7.0)
     throw_dict['north_south_fault'] = (-3.3, 4.8)
@@ -1069,8 +1069,8 @@ def test_add_faults_and_scaling(tmp_path):
 
     g = grr.Grid(model, uuid = f2a_grid_uuid)
     gbox = g.xyz_box(lazy = False)
-    # assert_array_almost_equal(gbox, np.array([(0.0, 0.0, -10.3), (500.0, 750.0, 71.8)]))
-    assert_array_almost_equal(gbox, np.array([(0.0, 0.0, -7.0), (500.0, 750.0, 67.0)]))
+    assert_array_almost_equal(gbox, np.array([(0.0, 0.0, -10.3), (500.0, 750.0, 71.8)]))
+    # assert_array_almost_equal(gbox, np.array([(0.0, 0.0, -7.0), (500.0, 750.0, 67.0)]))
 
     g = grr.Grid(model, uuid = f1b_grid_uuid)
     gbox = g.xyz_box(lazy = False)
@@ -1079,7 +1079,8 @@ def test_add_faults_and_scaling(tmp_path):
 
     g = grr.Grid(model, uuid = f2b_grid_uuid)
     gbox = g.xyz_box(lazy = False)
-    assert_array_almost_equal(gbox, np.array([(0.0, 0.0, -10.5), (500.0, 750.0, 70.5)]))
+    # assert_array_almost_equal(gbox, np.array([(0.0, 0.0, -10.5), (500.0, 750.0, 70.5)]))
+    assert_array_almost_equal(gbox, np.array([(0.0, 0.0, -18.4), (500.0, 750.0, 79.9)]))
 
 
 def test_drape_to_surface(tmp_path):

--- a/tests/unit_tests/fault/test_fault_connection_set.py
+++ b/tests/unit_tests/fault/test_fault_connection_set.py
@@ -1459,12 +1459,12 @@ def test_add_faults(tmp_path):
         model = rq.Model(epc)
         assert len(model.titles(obj_type = 'IjkGridRepresentation')) == 8
         g1 = model.grid(title = 'ttt_f7')
-        assert g1.split_pillars_count == 5
+        assert g1.split_pillars_count == 9
         cpm = g1.create_column_pillar_mapping()
         assert cpm.shape == (3, 3, 2, 2)
         extras = (cpm >= 16)
-        assert np.count_nonzero(extras) == 7
-        assert np.all(np.sort(np.unique(cpm)) == np.arange(21))
+        assert np.count_nonzero(extras) == 11
+        assert np.all(np.sort(np.unique(cpm)) == np.arange(25))
 
 
 def test_gcs_face_surface_normal_vectors(example_model_with_properties):


### PR DESCRIPTION
This change modifies the behaviour of the add_faults() function when a fault reaches the edge of the grid. The new code preserves the throw in that situation, rather than reducing to zero as happens at the end of fault within the grid.

There are also some minor enhancements to the inheritance of properties in the derived model functions.