### PR TITLE
Update _blocked_well.py to ensure dtype is maintained when adding grid property

### DIFF
--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -3468,7 +3468,7 @@ class BlockedWell(BaseResqpy):
                     for part in parts:
                         array = gridpc.cached_part_array_ref(part)
                         indices = self.cell_indices_for_grid_uuid(grid.uuid)
-                        bwarray = np.empty(shape = (indices.shape[0],), dtype=array.dtype)
+                        bwarray = np.empty(shape = (indices.shape[0],), dtype = array.dtype)
                         for i, ind in enumerate(indices):
                             bwarray[i] = array[tuple(ind)]
                         bwpc.add_cached_array_to_imported_list(

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -3468,7 +3468,7 @@ class BlockedWell(BaseResqpy):
                     for part in parts:
                         array = gridpc.cached_part_array_ref(part)
                         indices = self.cell_indices_for_grid_uuid(grid.uuid)
-                        bwarray = np.empty(shape = (indices.shape[0],))
+                        bwarray = np.empty(shape = (indices.shape[0],), dtype=array.dtype)
                         for i, ind in enumerate(indices):
                             bwarray[i] = array[tuple(ind)]
                         bwpc.add_cached_array_to_imported_list(

--- a/tests/unit_tests/well/test_blocked_well.py
+++ b/tests/unit_tests/well/test_blocked_well.py
@@ -1062,7 +1062,7 @@ def test_add_grid_properties(example_model_and_crs):
     grid_pc.write_hdf5_for_imported_list()
     uuids_static = grid_pc.create_xml_for_imported_list_and_add_parts_to_model(string_lookup_uuid = slup2.uuid)
 
-    array3 = np.random.rand(size = (5, 3, 3))
+    array3 = np.random.rand(5, 3, 3)
     grid_pc.add_cached_array_to_imported_list(array3,
                                               'unit test',
                                               'continuous array',
@@ -1097,5 +1097,5 @@ def test_add_grid_properties(example_model_and_crs):
     assert len(bw_pc.time_series_uuid_list()) == 1
     assert len(bw_pc.string_lookup_uuid_list()) == 2
 
-    assert bw_pc.single_array_ref(property_kind='example data continuous').dtype == float64
-    assert bw_pc.single_array_ref(property_kind='example data').dtype == int
+    assert bw_pc.single_array_ref(property_kind = 'example data continuous').dtype == float64
+    assert bw_pc.single_array_ref(property_kind = 'example data').dtype == int

--- a/tests/unit_tests/well/test_blocked_well.py
+++ b/tests/unit_tests/well/test_blocked_well.py
@@ -1062,13 +1062,22 @@ def test_add_grid_properties(example_model_and_crs):
     grid_pc.write_hdf5_for_imported_list()
     uuids_static = grid_pc.create_xml_for_imported_list_and_add_parts_to_model(string_lookup_uuid = slup2.uuid)
 
+    array3 = np.random.rand(size = (5, 3, 3))
+    grid_pc.add_cached_array_to_imported_list(array3,
+                                              'unit test',
+                                              'continuous array',
+                                              discrete = False,
+                                              property_kind = 'example data continuous')
+    grid_pc.write_hdf5_for_imported_list()
+    uuids_static_continuous = grid_pc.create_xml_for_imported_list_and_add_parts_to_model()
+
     well_name = 'VERTICAL'
     bw = rqw.BlockedWell(model, well_name = well_name, trajectory = trajectory)
     bw.write_hdf5()
     bw.create_xml()
     model.store_epc()
 
-    uuids_to_add = uuids_nosl + uuids_sl + uuids_static
+    uuids_to_add = uuids_nosl + uuids_sl + uuids_static + uuids_static_continuous
     orig_counts_dict = model.parts_count_dict()
 
     # ---------- Act ------------
@@ -1081,8 +1090,12 @@ def test_add_grid_properties(example_model_and_crs):
 
     assert new_counts_dict['CategoricalProperty'] - orig_counts_dict['CategoricalProperty'] == 4
     assert new_counts_dict['DiscreteProperty'] - orig_counts_dict['DiscreteProperty'] == 3
+    assert new_counts_dict['ContinuousProperty'] - orig_counts_dict['ContinuousProperty'] == 1
 
     bw = rqw.BlockedWell(reload, uuid = bw.uuid)
     bw_pc = bw.extract_property_collection()
     assert len(bw_pc.time_series_uuid_list()) == 1
     assert len(bw_pc.string_lookup_uuid_list()) == 2
+
+    assert bw_pc.single_array_ref(property_kind='example data continuous').dtype == float64
+    assert bw_pc.single_array_ref(property_kind='example data').dtype == int

--- a/tests/unit_tests/well/test_blocked_well.py
+++ b/tests/unit_tests/well/test_blocked_well.py
@@ -1058,7 +1058,7 @@ def test_add_grid_properties(example_model_and_crs):
                                               'unit test',
                                               'sl data',
                                               discrete = True,
-                                              property_kind = 'example data')
+                                              property_kind = 'example data static')
     grid_pc.write_hdf5_for_imported_list()
     uuids_static = grid_pc.create_xml_for_imported_list_and_add_parts_to_model(string_lookup_uuid = slup2.uuid)
 
@@ -1098,4 +1098,4 @@ def test_add_grid_properties(example_model_and_crs):
     assert len(bw_pc.string_lookup_uuid_list()) == 2
 
     assert bw_pc.single_array_ref(property_kind = 'example data continuous').dtype == float
-    assert bw_pc.single_array_ref(property_kind = 'example data').dtype == int
+    assert bw_pc.single_array_ref(property_kind = 'example data static').dtype == int

--- a/tests/unit_tests/well/test_blocked_well.py
+++ b/tests/unit_tests/well/test_blocked_well.py
@@ -1097,5 +1097,5 @@ def test_add_grid_properties(example_model_and_crs):
     assert len(bw_pc.time_series_uuid_list()) == 1
     assert len(bw_pc.string_lookup_uuid_list()) == 2
 
-    assert bw_pc.single_array_ref(property_kind = 'example data continuous').dtype == float64
+    assert bw_pc.single_array_ref(property_kind = 'example data continuous').dtype == float
     assert bw_pc.single_array_ref(property_kind = 'example data').dtype == int


### PR DESCRIPTION
This minor edit ensures the dtype of the original property array is maintained when adding property to blocked well from a grid. 

There is also an update to the unit tests for this code to add a continuous property, and check the dtype of one continuous and one discrete property are correct.