### PR TITLE
resampling trianglulated surfaces

### DIFF
--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -939,7 +939,7 @@ class Surface(rqsb.BaseSurface):
         for i in range(len(rt)):
             tris.extend([[rt[i][0], count1 + i, count3 + i], [rt[i][1], count2 + i, count3 + i],
                          [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
-        
+
         if title is None: 
             title = self.citation_title
         resampled = rqs.Surface(self.model, 

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -918,7 +918,7 @@ class Surface(rqsb.BaseSurface):
 
         return ep
 
-    def resampled_surface(self, title=None):
+    def resampled_surface(self, title = None):
         """Creates a new triangulated set which is a resampled version of the current triangulated set. Each existing triangle in the tset is divided equally into 4 new triangles.
            
         arguments:

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -941,7 +941,8 @@ class Surface(rqsb.BaseSurface):
                          [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
 
         points_unique, inverse = np.unique(allpoints, axis = 0, return_inverse = True)
-        tris_unique = np.empty(shape = np.array(tris).shape)
+        tris = np.array(tris)
+        tris_unique = np.empty(shape = tris.shape)
         tris_unique[:, 0] = inverse[tris[:, 0]]
         tris_unique[:, 1] = inverse[tris[:, 1]]
         tris_unique[:, 2] = inverse[tris[:, 2]]

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -940,7 +940,7 @@ class Surface(rqsb.BaseSurface):
             tris.extend([[rt[i][0], count1 + i, count3 + i], [rt[i][1], count2 + i, count3 + i],
                          [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
 
-        if title is None: 
+        if title is None:
             title = self.citation_title
         resampled = rqs.Surface(self.model,
                                 title = title,

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -928,9 +928,9 @@ class Surface(rqsb.BaseSurface):
             resqpy.surface.Surface object, with extra_metadata ('resampled from surface': <uuid>), where uuid is the origin surface uuid
         """
         rt, rp = self.triangles_and_points()
-        edge1 = np.mean(rp[rt[:]][:,::2,:], axis = 1)
-        edge2 = np.mean(rp[rt[:]][:,1:,:], axis = 1)
-        edge3 = np.mean(rp[rt[:]][:,:2,:], axis = 1)
+        edge1 = np.mean(rp[rt[:]][:, ::2, :], axis = 1)
+        edge2 = np.mean(rp[rt[:]][:, 1:, :], axis = 1)
+        edge3 = np.mean(rp[rt[:]][:, :2, :], axis = 1)
         allpoints = np.concatenate((rp, edge1, edge2, edge3), axis = 0)
         count1 = len(rp)
         count2 = count1 + len(edge1)
@@ -940,7 +940,8 @@ class Surface(rqsb.BaseSurface):
             tris.extend([[rt[i][0], count1 + i, count3 + i], [rt[i][1], count2 + i, count3 + i],
                         [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
         
-        if title is None: title = self.citation_title
+        if title is None: 
+            title = self.citation_title
         resampled = rqs.Surface(self.model, 
                                 title = title, 
                                 crs_uuid = self.crs_uuid, 

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -940,13 +940,19 @@ class Surface(rqsb.BaseSurface):
             tris.extend([[rt[i][0], count1 + i, count3 + i], [rt[i][1], count2 + i, count3 + i],
                          [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
 
+        points_unique, inverse = np.unique(allpoints, axis = 0, return_inverse = True)
+        tris_unique = np.empty(shape = np.array(tris).shape)
+        tris_unique[:, 0] = inverse[tris[:, 0]]
+        tris_unique[:, 1] = inverse[tris[:, 1]]
+        tris_unique[:, 2] = inverse[tris[:, 2]]
+
         if title is None:
             title = self.citation_title
         resampled = rqs.Surface(self.model,
                                 title = title,
                                 crs_uuid = self.crs_uuid,
                                 extra_metadata = {'resampled from surface': str(self.uuid)})
-        resampled.set_from_triangles_and_points(np.array(tris), allpoints)
+        resampled.set_from_triangles_and_points(tris_unique, points_unique)
 
         return resampled
 

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -940,6 +940,7 @@ class Surface(rqsb.BaseSurface):
             tris.extend([[rt[i][0], count1 + i, count3 + i], [rt[i][1], count2 + i, count3 + i],
                          [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
 
+        # TODO: implement alternate solution using edge functions in olio triangulation to optimise
         points_unique, inverse = np.unique(allpoints, axis = 0, return_inverse = True)
         tris = np.array(tris)
         tris_unique = np.empty(shape = tris.shape)

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -918,6 +918,37 @@ class Surface(rqsb.BaseSurface):
 
         return ep
 
+    def resampled_surface(self, title=None):
+        """Creates a new triangulated set which is a resampled version of the current triangulated set. 
+           Each existing triangle in the tset is divided equally into 4 new triangles.
+           
+        arguments:
+            title (str): a new title for the output triangulated set, if None the title will have the same title as the input triangulated set
+        
+        returns:
+            resqpy.surface.Surface object, with extra_metadata ('resampled from surface': <uuid>), where uuid is the origin surface uuid
+        """
+        rt, rp = self.triangles_and_points()
+        edge1 = np.mean(rp[rt[:]][:,::2,:],axis=1)
+        edge2 = np.mean(rp[rt[:]][:,1:,:],axis=1)
+        edge3 = np.mean(rp[rt[:]][:,:2,:],axis=1)
+        allpoints = np.concatenate((rp, edge1, edge2, edge3), axis=0)
+        count1 = len(rp)
+        count2 = count1 + len(edge1)
+        count3 = count2 + len(edge2)
+        tris = []
+        for i in range(len(rt)):
+            tris.extend([[rt[i][0], count1+i, count3+i],
+                        [rt[i][1], count2+i, count3+i],
+                        [rt[i][2], count1+i, count2+i],
+                        [count1+i, count2+i, count3+i]])
+        
+        if title is None: title = self.citation_title
+        resampled = rqs.Surface(self.model, title=title, crs_uuid=self.crs_uuid, extra_metadata={'resampled from surface': str(self.uuid)})
+        resampled.set_from_triangles_and_points(np.array(tris), allpoints)
+
+        return resampled
+
     def write_hdf5(self, file_name = None, mode = 'a'):
         """Create or append to an hdf5 file, writing datasets for the triangulated patches after caching arrays.
 

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -942,7 +942,7 @@ class Surface(rqsb.BaseSurface):
 
         if title is None: 
             title = self.citation_title
-        resampled = rqs.Surface(self.model, 
+        resampled = rqs.Surface(self.model,
                                 title = title,
                                 crs_uuid = self.crs_uuid,
                                 extra_metadata = {'resampled from surface': str(self.uuid)})

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -938,13 +938,13 @@ class Surface(rqsb.BaseSurface):
         tris = []
         for i in range(len(rt)):
             tris.extend([[rt[i][0], count1 + i, count3 + i], [rt[i][1], count2 + i, count3 + i],
-                        [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
+                         [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
         
         if title is None: 
             title = self.citation_title
         resampled = rqs.Surface(self.model, 
-                                title = title, 
-                                crs_uuid = self.crs_uuid, 
+                                title = title,
+                                crs_uuid = self.crs_uuid,
                                 extra_metadata = {'resampled from surface': str(self.uuid)})
         resampled.set_from_triangles_and_points(np.array(tris), allpoints)
 

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -919,8 +919,7 @@ class Surface(rqsb.BaseSurface):
         return ep
 
     def resampled_surface(self, title=None):
-        """Creates a new triangulated set which is a resampled version of the current triangulated set. 
-           Each existing triangle in the tset is divided equally into 4 new triangles.
+        """Creates a new triangulated set which is a resampled version of the current triangulated set. Each existing triangle in the tset is divided equally into 4 new triangles.
            
         arguments:
             title (str): a new title for the output triangulated set, if None the title will have the same title as the input triangulated set

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -928,22 +928,23 @@ class Surface(rqsb.BaseSurface):
             resqpy.surface.Surface object, with extra_metadata ('resampled from surface': <uuid>), where uuid is the origin surface uuid
         """
         rt, rp = self.triangles_and_points()
-        edge1 = np.mean(rp[rt[:]][:,::2,:],axis=1)
-        edge2 = np.mean(rp[rt[:]][:,1:,:],axis=1)
-        edge3 = np.mean(rp[rt[:]][:,:2,:],axis=1)
-        allpoints = np.concatenate((rp, edge1, edge2, edge3), axis=0)
+        edge1 = np.mean(rp[rt[:]][:,::2,:], axis = 1)
+        edge2 = np.mean(rp[rt[:]][:,1:,:], axis = 1)
+        edge3 = np.mean(rp[rt[:]][:,:2,:], axis = 1)
+        allpoints = np.concatenate((rp, edge1, edge2, edge3), axis = 0)
         count1 = len(rp)
         count2 = count1 + len(edge1)
         count3 = count2 + len(edge2)
         tris = []
         for i in range(len(rt)):
-            tris.extend([[rt[i][0], count1+i, count3+i],
-                        [rt[i][1], count2+i, count3+i],
-                        [rt[i][2], count1+i, count2+i],
-                        [count1+i, count2+i, count3+i]])
+            tris.extend([[rt[i][0], count1 + i, count3 + i], [rt[i][1], count2 + i, count3 + i],
+                        [rt[i][2], count1 + i, count2 + i], [count1 + i, count2 + i, count3 + i]])
         
         if title is None: title = self.citation_title
-        resampled = rqs.Surface(self.model, title=title, crs_uuid=self.crs_uuid, extra_metadata={'resampled from surface': str(self.uuid)})
+        resampled = rqs.Surface(self.model, 
+                                title = title, 
+                                crs_uuid = self.crs_uuid, 
+                                extra_metadata = {'resampled from surface': str(self.uuid)})
         resampled.set_from_triangles_and_points(np.array(tris), allpoints)
 
         return resampled

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1017,9 +1017,9 @@ def test_resampling(tmp_path):
     assert np.max(rp[:, 1]) == np.max(op[:, 1])
     assert np.min(rp[:, 2]) == np.min(op[:, 2])
     assert np.max(rp[:, 2]) == np.max(op[:, 2])
-    for coords in [np.array([2.5, 2.5]), np.array([3.4, 3.4]), np.array([4.6, 4.6])]:
-        np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords),
-                                             resampled.sample_z_at_xy_points(coords))
+    coords = np.array([[2.5, 2.5], [3.4, 3.4], [4.6, 4.6]])
+    np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords),
+                                         resampled.sample_z_at_xy_points(coords))
 
     assert resampled.crs_uuid == surf.crs_uuid
     assert resampled.citation_title == surf.citation_title

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1018,8 +1018,7 @@ def test_resampling(tmp_path):
     assert resampled_name is not None
 
     coords = np.array([[2.5, 2.5], [3.4, 3.4], [4.6, 4.6]])
-    np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords),
-                                         resampled.sample_z_at_xy_points(coords))
+    np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords), resampled.sample_z_at_xy_points(coords))
     rt, rp = resampled.triangles_and_points()
 
     assert len(rt) == 4 * len(ot)

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -982,18 +982,18 @@ def test_adjust_flange_z(example_model_and_crs):
 def test_resampling(tmp_path):
     # Arrange
     model = rq.new_model(f"{tmp_path}\test.epc")
-    crs = rcrs.Crs(model, title='crs example')
+    crs = rcrs.Crs(model, title = 'crs example')
     crs.create_xml()
     model.store_epc()
 
-    x = np.linspace(1,5,5)
-    y = np.linspace(1,5,5)
-    xs, ys = np.meshgrid(x,y)
-    zs = np.random.randint(low=5, high=10, size=xs.shape)
-    points = np.array([xs, ys, zs], dtype=float).T
+    x = np.linspace(1, 5, 5)
+    y = np.linspace(1, 5, 5)
+    xs, ys = np.meshgrid(x, y)
+    zs = np.random.randint(low = 5, high = 10, size = xs.shape)
+    points = np.array([xs, ys, zs], dtype = float).T
 
-    pointset = resqpy.surface.PointSet(model, title=f'points', crs_uuid=crs.uuid, points_array=points)
-    surf = resqpy.surface.Surface(model, title=f'surface', crs_uuid=crs.uuid, point_set=pointset)
+    pointset = resqpy.surface.PointSet(model, title = 'points', crs_uuid = crs.uuid, points_array = points)
+    surf = resqpy.surface.Surface(model, title = 'surface', crs_uuid = crs.uuid, point_set = pointset)
     
     surf.write_hdf5()
     surf.create_xml()
@@ -1001,8 +1001,8 @@ def test_resampling(tmp_path):
     ot, op = surf.triangles_and_points()
 
     # Act
-    resampled = surf.resampled_surface(title=None)
-    resampled_name = surf.resampled_surface(title='testing')
+    resampled = surf.resampled_surface(title = None)
+    resampled_name = surf.resampled_surface(title = 'testing')
 
     # Assert
     assert resampled is not None

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1004,10 +1004,22 @@ def test_resampling(tmp_path):
     # Act
     resampled = surf.resampled_surface(title = None)
     resampled_name = surf.resampled_surface(title = 'testing')
+    resampled.write_hdf5()
+    resampled.create_xml()
+    resampled_name.write_hdf5()
+    resampled_name.create_xml()
+    model.store_epc()
 
     # Assert
+    reload = rq.Model(model.epc_file)
+    resampled = resqpy.surface.Surface(reload, resampled.uuid)
+    resampled_name = resqpy.surface.Surface(reload, resampled_name.uuid)
     assert resampled is not None
     assert resampled_name is not None
+
+    coords = np.array([[2.5, 2.5], [3.4, 3.4], [4.6, 4.6]])
+    np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords),
+                                         resampled.sample_z_at_xy_points(coords))
     rt, rp = resampled.triangles_and_points()
 
     assert len(rt) == 4 * len(ot)
@@ -1017,9 +1029,6 @@ def test_resampling(tmp_path):
     assert np.max(rp[:, 1]) == np.max(op[:, 1])
     assert np.min(rp[:, 2]) == np.min(op[:, 2])
     assert np.max(rp[:, 2]) == np.max(op[:, 2])
-    coords = np.array([[2.5, 2.5], [3.4, 3.4], [4.6, 4.6]])
-    np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords),
-                                         resampled.sample_z_at_xy_points(coords))
 
     assert resampled.crs_uuid == surf.crs_uuid
     assert resampled.citation_title == surf.citation_title

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1017,6 +1017,9 @@ def test_resampling(tmp_path):
     assert np.max(rp[:, 1]) == np.max(op[:, 1])
     assert np.min(rp[:, 2]) == np.min(op[:, 2])
     assert np.max(rp[:, 2]) == np.max(op[:, 2])
+    for coords in [(2.5, 2.5), (3.4, 3.4), (4.6, 4.6)]:
+        np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords), resampled.sample_z_at_xy_points(coords))
+
     assert resampled.crs_uuid == surf.crs_uuid
     assert resampled.citation_title == surf.citation_title
     assert resampled_name.citation_title == 'testing'

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -994,7 +994,7 @@ def test_resampling(tmp_path):
 
     pointset = resqpy.surface.PointSet(model, title = 'points', crs_uuid = crs.uuid, points_array = points)
     surf = resqpy.surface.Surface(model, title = 'surface', crs_uuid = crs.uuid, point_set = pointset)
-    
+
     surf.write_hdf5()
     surf.create_xml()
     model.store_epc()
@@ -1009,13 +1009,13 @@ def test_resampling(tmp_path):
     assert resampled_name is not None
     rt, rp = resampled.triangles_and_points()
 
-    assert len(rt) == 4*len(ot)
-    assert np.min(rp[:,0]) == np.min(op[:,0])
-    assert np.max(rp[:,0]) == np.max(op[:,0])
-    assert np.min(rp[:,1]) == np.min(op[:,1])
-    assert np.max(rp[:,1]) == np.max(op[:,1])
-    assert np.min(rp[:,2]) == np.min(op[:,2])
-    assert np.max(rp[:,2]) == np.max(op[:,2])
+    assert len(rt) == 4 * len(ot)
+    assert np.min(rp[:, 0]) == np.min(op[:, 0])
+    assert np.max(rp[:, 0]) == np.max(op[:, 0])
+    assert np.min(rp[:, 1]) == np.min(op[:, 1])
+    assert np.max(rp[:, 1]) == np.max(op[:, 1])
+    assert np.min(rp[:, 2]) == np.min(op[:, 2])
+    assert np.max(rp[:, 2]) == np.max(op[:, 2])
     assert resampled.crs_uuid == surf.crs_uuid
     assert resampled.citation_title == surf.citation_title
     assert resampled_name.citation_title == 'testing'

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -979,6 +979,7 @@ def test_adjust_flange_z(example_model_and_crs):
         assert maths.isclose(p[outer_start + 2, 2], -ez[i])
         assert maths.isclose(p[outer_start + 3, 2], 0.0, abs_tol = 1.0e-6)
 
+
 def test_resampling(tmp_path):
     # Arrange
     model = rq.new_model(f"{tmp_path}\test.epc")

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1017,8 +1017,9 @@ def test_resampling(tmp_path):
     assert np.max(rp[:, 1]) == np.max(op[:, 1])
     assert np.min(rp[:, 2]) == np.min(op[:, 2])
     assert np.max(rp[:, 2]) == np.max(op[:, 2])
-    for coords in [(2.5, 2.5), (3.4, 3.4), (4.6, 4.6)]:
-        np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords), resampled.sample_z_at_xy_points(coords))
+    for coords in [[2.5, 2.5], [3.4, 3.4], [4.6, 4.6]]:
+        np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords), 
+                                             resampled.sample_z_at_xy_points(coords))
 
     assert resampled.crs_uuid == surf.crs_uuid
     assert resampled.citation_title == surf.citation_title

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1017,8 +1017,8 @@ def test_resampling(tmp_path):
     assert np.max(rp[:, 1]) == np.max(op[:, 1])
     assert np.min(rp[:, 2]) == np.min(op[:, 2])
     assert np.max(rp[:, 2]) == np.max(op[:, 2])
-    for coords in [[2.5, 2.5], [3.4, 3.4], [4.6, 4.6]]:
-        np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords), 
+    for coords in [np.array([2.5, 2.5]), np.array([3.4, 3.4]), np.array([4.6, 4.6])]:
+        np.testing.assert_array_almost_equal(surf.sample_z_at_xy_points(coords),
                                              resampled.sample_z_at_xy_points(coords))
 
     assert resampled.crs_uuid == surf.crs_uuid


### PR DESCRIPTION
New method on resqpy.surface.Surface to resample a Surface / triangulated set. Each existing triangle is split into 4 new triangles, with the edges defined by the mid-point of each original triangle edge.

Tests also included.