### PR TITLE
adding support for composite grid faces properties

### DIFF
--- a/resqpy/fault/_gcs_functions.py
+++ b/resqpy/fault/_gcs_functions.py
@@ -387,7 +387,9 @@ def combined_tr_mult_from_gcs_mults(model,
 
     notes:
         each gcs, which is the supporting representation for each input tr mult property, must be for a single
-        grid and that grid must be the same for all the gcs'es
+        grid and that grid must be the same for all the gcs'es;
+        the three arrays returned by this function can be flattened and concatenated to create a composite
+        array compatible with RESQML documentation for grid properties with indexable elmement of 'faces'
     """
 
     assert merge_mode in ['minimum', 'multiply', 'maximum', 'exception']

--- a/resqpy/property/_collection_get_attributes.py
+++ b/resqpy/property/_collection_get_attributes.py
@@ -439,10 +439,18 @@ def _supporting_shape_grid(support, indexable_element, direction):
 
 
 def _supporting_shape_grid_faces(direction, support):
-    assert direction is not None and direction.upper() in 'IJK'
-    axis = 'KJI'.index(direction.upper())
-    shape_list = [support.nk, support.nj, support.ni]
-    shape_list[axis] += 1  # note: properties for grid faces include outer faces
+    if direction is None:  # a composite 1D array (the RESQML standard)
+        count = 0
+        for axis in range(3):
+            batch = np.array(support.extent_kji, dtype = int)
+            batch[axis] += 1
+            count += np.product(batch)
+        shape_list = [count]
+    else:
+        assert direction.upper() in 'IJK'
+        axis = 'KJI'.index(direction.upper())
+        shape_list = [support.nk, support.nj, support.ni]
+        shape_list[axis] += 1  # note: properties for grid faces include outer faces
     return shape_list
 
 

--- a/tests/unit_tests/fault/test_fault_connection_set.py
+++ b/tests/unit_tests/fault/test_fault_connection_set.py
@@ -177,6 +177,32 @@ def test_fault_connection_set(tmp_path):
             assert_array_almost_equal(c_trm_i, 1.0)
             assert np.count_nonzero(c_trm_j < 0.9) == 2 if lazy else 4
             assert not np.any(np.isnan(c_trm_j))
+            g_trm_k_uuid,  g_trm_j_uuid,  g_trm_i_uuid =  \
+                g2.combined_tr_mult_properties_from_gcs_mults(gcs_uuid_list = [g2_fcs.uuid],
+                                                              merge_mode = merge_mode,
+                                                              sided = sided,
+                                                              fill_value = 1.0,
+                                                              composite_property = False)
+            assert g_trm_k_uuid is not None and g_trm_j_uuid is not None and g_trm_i_uuid is not None
+            g_trm_k = rqp.Property(model, uuid = g_trm_k_uuid).array_ref()
+            g_trm_j = rqp.Property(model, uuid = g_trm_j_uuid).array_ref()
+            g_trm_i = rqp.Property(model, uuid = g_trm_i_uuid).array_ref()
+            assert g_trm_k is not None and g_trm_j is not None and g_trm_i is not None
+            assert np.all(g_trm_k == c_trm_k)
+            assert np.all(g_trm_j == c_trm_j)
+            assert np.all(g_trm_i == c_trm_i)
+            g_trm_list = g2.combined_tr_mult_properties_from_gcs_mults(gcs_uuid_list = [g2_fcs.uuid],
+                                                                       merge_mode = merge_mode,
+                                                                       sided = sided,
+                                                                       fill_value = 1.0,
+                                                                       composite_property = True)
+            assert len(g_trm_list) == 1
+            g_trm = rqp.Property(model, uuid = g_trm_list[0]).array_ref()
+            assert g_trm.ndim == 1
+            assert g_trm.size == g_trm_k.size + g_trm_j.size + g_trm_i.size
+            assert np.all(g_trm[:g_trm_k.size] == g_trm_k.flat)
+            assert np.all(g_trm[g_trm_k.size:g_trm_k.size + g_trm_j.size] == g_trm_j.flat)
+            assert np.all(g_trm[g_trm_k.size + g_trm_j.size:] == g_trm_i.flat)
 
     # I face split with full juxtaposition of kji0 (1, *, 0) with (0, *, 1)
     # pattern 4, 4 (or 3, 3) diagram 1

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -39,6 +39,28 @@ def test_property(tmp_path):
                                  property_kind = 'net to gross ratio',
                                  indexable_element = 'cells',
                                  uom = 'm3/m3')
+    a6 = np.random.random(grid.extent_kji) * 300.0
+    p6 = rqp.Property.from_array(model,
+                                 a6,
+                                 source_info = 'random',
+                                 keyword = 'PERMXY',
+                                 facet_type = 'direction',
+                                 facet = 'IJ',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'permeability rock',
+                                 indexable_element = 'cells',
+                                 uom = 'mD')
+    a7 = np.random.random(grid.extent_kji) * 100.0
+    p7 = rqp.Property.from_array(model,
+                                 a7,
+                                 source_info = 'random',
+                                 keyword = 'PERMZ',
+                                 facet_type = 'direction',
+                                 facet = 'K',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'permeability rock',
+                                 indexable_element = 'cells',
+                                 uom = 'mD')
     a3 = np.random.random((grid.nk + 1, grid.nj + 1, grid.ni + 1))
     p3 = rqp.Property.from_array(model,
                                  a3,
@@ -73,6 +95,12 @@ def test_property(tmp_path):
                                   facet_type = 'direction',
                                   facet = 'K',
                                   uom = 'Euc')
+    grid.property_collection = None
+    tr_from_composite = grid.transmissibility(use_tr_properties = True)
+    assert len(tr_from_composite) == 3
+    assert tr_from_composite[0].shape == (grid.nk + 1, grid.nj, grid.ni)
+    assert tr_from_composite[1].shape == (grid.nk, grid.nj + 1, grid.ni)
+    assert tr_from_composite[2].shape == (grid.nk, grid.nj, grid.ni + 1)
     p5j = rqp.Property.from_array(model,
                                   a5j,
                                   source_info = 'random',
@@ -188,8 +216,8 @@ def test_property(tmp_path):
     assert p3p.array_ref().shape == (grid.nk + 1, grid.nj + 1, grid.ni + 1)
     jiggle_per_cell_uuid = model.uuid(parts_list = jiggle_parts, title = 'per cell', title_mode = 'ends')
     assert jiggle_per_cell_uuid is not None
-    # eight properties created here, plus 3 regular grid cell lengths properties
-    assert grid.property_collection.number_of_parts() == 11
+    # 10 properties created here, plus 3 regular grid cell lengths properties
+    assert grid.property_collection.number_of_parts() == 13
     collection = rqp.selective_version_of_collection(grid.property_collection,
                                                      property_kind = 'length',
                                                      uuid = jiggle_per_cell_uuid)

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -59,6 +59,50 @@ def test_property(tmp_path):
                                  property_kind = 'length',
                                  indexable_element = 'nodes per cell',
                                  uom = 'm3')
+    a5k = np.random.random((grid.nk + 1, grid.nj, grid.ni))
+    a5j = np.random.random((grid.nk, grid.nj + 1, grid.ni))
+    a5i = np.random.random((grid.nk, grid.nj, grid.ni + 1))
+    a5 = np.concatenate((a5k.flat, a5j.flat, a5i.flat))
+    p5k = rqp.Property.from_array(model,
+                                  a5k,
+                                  source_info = 'random',
+                                  keyword = 'k face tr mult',
+                                  support_uuid = grid.uuid,
+                                  property_kind = 'transmissibility multiplier',
+                                  indexable_element = 'faces',
+                                  facet_type = 'direction',
+                                  facet = 'K',
+                                  uom = 'Euc')
+    p5j = rqp.Property.from_array(model,
+                                  a5j,
+                                  source_info = 'random',
+                                  keyword = 'j face tr mult',
+                                  support_uuid = grid.uuid,
+                                  property_kind = 'transmissibility multiplier',
+                                  indexable_element = 'faces',
+                                  facet_type = 'direction',
+                                  facet = 'J',
+                                  uom = 'Euc')
+    p5i = rqp.Property.from_array(model,
+                                  a5i,
+                                  source_info = 'random',
+                                  keyword = 'i face tr mult',
+                                  support_uuid = grid.uuid,
+                                  property_kind = 'transmissibility multiplier',
+                                  indexable_element = 'faces',
+                                  facet_type = 'direction',
+                                  facet = 'I',
+                                  uom = 'Euc')
+    p5 = rqp.Property.from_array(model,
+                                 a5,
+                                 source_info = 'random',
+                                 keyword = 'composite tr mult',
+                                 support_uuid = grid.uuid,
+                                 property_kind = 'transmissibility multiplier',
+                                 indexable_element = 'faces',
+                                 facet_type = None,
+                                 facet = None,
+                                 uom = 'Euc')
     pk = rqp.PropertyKind(model, title = 'facies', parent_property_kind = 'discrete')
     pk.create_xml()
     facies_dict = {0: 'background'}
@@ -144,8 +188,8 @@ def test_property(tmp_path):
     assert p3p.array_ref().shape == (grid.nk + 1, grid.nj + 1, grid.ni + 1)
     jiggle_per_cell_uuid = model.uuid(parts_list = jiggle_parts, title = 'per cell', title_mode = 'ends')
     assert jiggle_per_cell_uuid is not None
-    # four properties created here, plus 3 regular grid cell lengths properties
-    assert grid.property_collection.number_of_parts() == 7
+    # eight properties created here, plus 3 regular grid cell lengths properties
+    assert grid.property_collection.number_of_parts() == 11
     collection = rqp.selective_version_of_collection(grid.property_collection,
                                                      property_kind = 'length',
                                                      uuid = jiggle_per_cell_uuid)
@@ -154,6 +198,22 @@ def test_property(tmp_path):
     p4p = rqp.Property.from_singleton_collection(collection)
     assert p4p is not None
     assert p4p.array_ref().shape == (grid.nk, grid.nj, grid.ni, 2, 2, 2)
+    collection = rqp.selective_version_of_collection(grid.property_collection,
+                                                     property_kind = 'transmissibility multiplier')
+    assert collection is not None
+    assert collection.number_of_parts() == 4
+    p5ka = collection.single_array_ref(facet_type = 'direction', facet = 'K')
+    assert p5ka is not None
+    assert_array_almost_equal(p5ka, a5k)
+    p5ja = collection.single_array_ref(facet_type = 'direction', facet = 'J')
+    assert p5ja is not None
+    assert_array_almost_equal(p5ja, a5j)
+    p5ia = collection.single_array_ref(facet_type = 'direction', facet = 'I')
+    assert p5ia is not None
+    assert_array_almost_equal(p5ia, a5i)
+    p5a = collection.single_array_ref(facet_type = 'none')
+    assert p5a is not None
+    assert_array_almost_equal(p5a, a5)
 
 
 def test_create_Property_from_singleton_collection(tmp_model):


### PR DESCRIPTION
This change adds support for directionally composite grid properties with indexable elements of 'faces', which is compatible with shape information given in RESQML documentation. (Till now, resqpy has worked with a direction facet for such properties – a mode which is still supported.)