### PR TITLE
adding argument to control random or non random agitation

### DIFF
--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -182,6 +182,7 @@ def find_faces_to_represent_surface_regular(
     title = None,
     centres = None,
     agitate = False,
+    random_agitation = False,
     feature_type = "fault",
     progress_fn = None,
     consistent_side = False,
@@ -196,9 +197,11 @@ def find_faces_to_represent_surface_regular(
         title (str, optional): the citation title to use for the grid connection set; defaults to name
         centres (numpy float array of shape (nk, nj, ni, 3), optional): precomputed cell centre points in
            local grid space, to avoid possible crs issues; required if grid's crs includes an origin (offset)?
-        agitate (bool, default False): if True, the points of the surface are perturbed by a small random
+        agitate (bool, default False): if True, the points of the surface are perturbed by a small
            offset, which can help if the surface has been built from a regular mesh with a periodic resonance
            with the grid
+        random_agitation (bool, default False): if True, the agitation is by a small random distance; if False,
+           a constant positive shift of 5.0e-6 is applied to x, y & z values; ignored if agitate is False
         feature_type (str, default 'fault'): 'fault', 'horizon' or 'geobody boundary'
         progress_fn (f(x: float), optional): a callback function to be called at intervals by this function;
            the argument will progress from 0.0 to 1.0 in unspecified and uneven increments
@@ -261,7 +264,10 @@ def find_faces_to_represent_surface_regular(
     t, p = surface.triangles_and_points()
     assert t is not None and p is not None, f"surface {surface.title} is empty"
     if agitate:
-        p += 1.0e-5 * (np.random.random(p.shape) - 0.5)
+        if random_agitation:
+            p += 1.0e-5 * (np.random.random(p.shape) - 0.5)
+        else:
+            p += 5.0e-6
     log.debug(f"surface: {surface.title}; p0: {p[0]}; crs uuid: {surface.crs_uuid}")
     log.debug(f"surface min xyz: {np.min(p, axis = 0)}")
     log.debug(f"surface max xyz: {np.max(p, axis = 0)}")
@@ -495,6 +501,7 @@ def find_faces_to_represent_surface_regular_optimised(
     name,
     title = None,
     agitate = False,
+    random_agitation = False,
     feature_type = "fault",
     is_curtain = False,
     progress_fn = None,
@@ -509,9 +516,11 @@ def find_faces_to_represent_surface_regular_optimised(
         surface (Surface): the surface to be intersected with the grid
         name (str): the feature name to use in the grid connection set
         title (str, optional): the citation title to use for the grid connection set; defaults to name
-        agitate (bool, default False): if True, the points of the surface are perturbed by a small random
+        agitate (bool, default False): if True, the points of the surface are perturbed by a small
            offset, which can help if the surface has been built from a regular mesh with a periodic resonance
            with the grid
+        random_agitation (bool, default False): if True, the agitation is by a small random distance; if False,
+           a constant positive shift of 5.0e-6 is applied to x, y & z values; ignored if agitate is False
         feature_type (str, default 'fault'): 'fault', 'horizon' or 'geobody boundary'
         is_curtain (bool, default False): if True, only the top layer of the grid is processed and the bisector
            property, if requested, is generated with indexable element columns
@@ -591,7 +600,10 @@ def find_faces_to_represent_surface_regular_optimised(
     triangles, points = surface.triangles_and_points()
     assert (triangles is not None and points is not None), f"surface {surface.title} is empty"
     if agitate:
-        points += 1.0e-5 * (np.random.random(points.shape) - 0.5)
+        if random_agitation:
+            points += 1.0e-5 * (np.random.random(points.shape) - 0.5)
+        else:
+            points += 5.0e-6
     # log.debug(f'surface: {surface.title}; p0: {points[0]}; crs uuid: {surface.crs_uuid}')
     # log.debug(f'surface min xyz: {np.min(points, axis = 0)}')
     # log.debug(f'surface max xyz: {np.max(points, axis = 0)}')

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -29,6 +29,7 @@ def find_faces_to_represent_surface_regular_wrapper(
         name: str,
         title: Optional[str] = None,
         agitate: bool = False,
+        random_agitation: bool = False,
         feature_type: str = 'fault',
         trimmed: bool = False,
         is_curtain = False,
@@ -55,9 +56,11 @@ def find_faces_to_represent_surface_regular_wrapper(
         surface_uuid (UUID or str): UUID (universally unique identifier) of the surface (or point set) object.
         name (str): the feature name to use in the grid connection set.
         title (str): the citation title to use for the grid connection set; defaults to name
-        agitate (bool): if True, the points of the surface are perturbed by a small random
-           offset, which can help if the surface has been built from a regular mesh with a periodic resonance
+        agitate (bool): if True, the points of the surface are perturbed by a small offset,
+           which can help if the surface has been built from a regular mesh with a periodic resonance
            with the grid
+        random_agitation (bool, default False): if True, the agitation is by a small random distance; if False,
+           a constant positive shift of 5.0e-6 is applied to x, y & z values; ignored if agitate is False
         feature_type (str, default 'fault'): one of 'fault', 'horizon', or 'geobody boundary'
         trimmed (bool, default True): if True the surface has already been trimmed
         is_curtain (bool, default False): if True, only the top layer is intersected with the surface and bisector
@@ -221,6 +224,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                                                                      name,
                                                                      title,
                                                                      agitate,
+                                                                     random_agitation,
                                                                      feature_type,
                                                                      is_curtain,
                                                                      progress_fn,

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -29,6 +29,46 @@ def test_find_faces_to_represent_surface_regular_wrapper(small_grid_and_surface:
                                                                                           surface_epc,
                                                                                           surface_uuid,
                                                                                           name,
+                                                                                          random_agitation = False,
+                                                                                          trimmed = True)
+    model = Model(epc_file = epc_file)
+    rm_tree("tmp_dir")
+
+    # Assert
+    assert success is True
+    assert index == input_index
+    assert len(model.uuids(obj_type = 'LocalDepth3dCrs')) == 1
+    assert len(model.uuids(obj_type = 'IjkGridRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'TriangulatedSetRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'GridConnectionSetRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'FaultInterpretation')) == 1
+    assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
+    assert len(model.uuids()) == 9
+    assert len(uuid_list) == 7
+
+
+def test_find_faces_to_represent_surface_regular_wrapper_random_agitation(small_grid_and_surface: Tuple[RegularGrid,
+                                                                                                        Surface]):
+    # Arrange
+    grid, surface = small_grid_and_surface
+    grid_epc = surface_epc = grid.model.epc_file
+    grid_uuid = grid.uuid
+    surface_uuid = surface.uuid
+
+    name = "test"
+    input_index = 0
+    use_index_as_realisation = False
+
+    # Act
+    index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(input_index,
+                                                                                          "tmp_dir",
+                                                                                          use_index_as_realisation,
+                                                                                          grid_epc,
+                                                                                          grid_uuid,
+                                                                                          surface_epc,
+                                                                                          surface_uuid,
+                                                                                          name,
+                                                                                          random_agitation = True,
                                                                                           trimmed = True)
     model = Model(epc_file = epc_file)
     rm_tree("tmp_dir")

--- a/tests/unit_tests/test_grid_surface.py
+++ b/tests/unit_tests/test_grid_surface.py
@@ -26,6 +26,27 @@ def test_find_faces_to_represent_surface_regular_optimised(small_grid_and_surfac
     np.testing.assert_array_equal(fip_normal, fip_optimised)
 
 
+def test_find_faces_to_represent_surface_regular_optimised_random_agitation(small_grid_and_surface):
+    # Arrange
+    grid = small_grid_and_surface[0]
+    surface = small_grid_and_surface[1]
+    name = "test"
+    assert grid.is_aligned
+
+    # Act
+    gcs_normal = rqgs.find_faces_to_represent_surface_regular(grid, surface, name, random_agitation = True)
+    cip_normal = gcs_normal.cell_index_pairs
+    fip_normal = gcs_normal.face_index_pairs
+
+    gcs_optimised = rqgs.find_faces_to_represent_surface_regular_optimised(grid, surface, name, random_agitation = True)
+    cip_optimised = gcs_optimised.cell_index_pairs
+    fip_optimised = gcs_optimised.face_index_pairs
+
+    # Assert
+    np.testing.assert_array_equal(cip_normal, cip_optimised)
+    np.testing.assert_array_equal(fip_normal, fip_optimised)
+
+
 def test_find_faces_to_represent_surface_regular_optimised_with_return_properties(small_grid_and_surface,):
     # Arrange
     grid = small_grid_and_surface[0]

--- a/tests/unit_tests/test_grid_surface.py
+++ b/tests/unit_tests/test_grid_surface.py
@@ -26,6 +26,35 @@ def test_find_faces_to_represent_surface_regular_optimised(small_grid_and_surfac
     np.testing.assert_array_equal(fip_normal, fip_optimised)
 
 
+def test_find_faces_to_represent_surface_regular_optimised_constant_agitation(small_grid_and_surface):
+    # Arrange
+    grid = small_grid_and_surface[0]
+    surface = small_grid_and_surface[1]
+    name = "test"
+    assert grid.is_aligned
+
+    # Act
+    gcs_normal = rqgs.find_faces_to_represent_surface_regular(grid,
+                                                              surface,
+                                                              name,
+                                                              agitate = True,
+                                                              random_agitation = False)
+    cip_normal = gcs_normal.cell_index_pairs
+    fip_normal = gcs_normal.face_index_pairs
+
+    gcs_optimised = rqgs.find_faces_to_represent_surface_regular_optimised(grid,
+                                                                           surface,
+                                                                           name,
+                                                                           agitate = True,
+                                                                           random_agitation = False)
+    cip_optimised = gcs_optimised.cell_index_pairs
+    fip_optimised = gcs_optimised.face_index_pairs
+
+    # Assert
+    np.testing.assert_array_equal(cip_normal, cip_optimised)
+    np.testing.assert_array_equal(fip_normal, fip_optimised)
+
+
 def test_find_faces_to_represent_surface_regular_optimised_random_agitation(small_grid_and_surface):
     # Arrange
     grid = small_grid_and_surface[0]
@@ -34,11 +63,19 @@ def test_find_faces_to_represent_surface_regular_optimised_random_agitation(smal
     assert grid.is_aligned
 
     # Act
-    gcs_normal = rqgs.find_faces_to_represent_surface_regular(grid, surface, name, random_agitation = True)
+    gcs_normal = rqgs.find_faces_to_represent_surface_regular(grid,
+                                                              surface,
+                                                              name,
+                                                              agitate = True,
+                                                              random_agitation = True)
     cip_normal = gcs_normal.cell_index_pairs
     fip_normal = gcs_normal.face_index_pairs
 
-    gcs_optimised = rqgs.find_faces_to_represent_surface_regular_optimised(grid, surface, name, random_agitation = True)
+    gcs_optimised = rqgs.find_faces_to_represent_surface_regular_optimised(grid,
+                                                                           surface,
+                                                                           name,
+                                                                           agitate = True,
+                                                                           random_agitation = True)
     cip_optimised = gcs_optimised.cell_index_pairs
     fip_optimised = gcs_optimised.face_index_pairs
 


### PR DESCRIPTION
This change adds an argument to the find_faces...regular() and ...optimised() functions that controls whether any agitation is random (as before) or constant (a small positive offset to x, y & z). The constant option can be useful for ensuring multiple coincident surfaces are gridded to the same faces. It also helps with reproducibility without having to use a random seed.