### PR TITLE
Update dtype to allow int64 when pulling from grid properties

### DIFF
--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -3485,7 +3485,7 @@ class BlockedWell(BaseResqpy):
                             facet = gridpc.facet_for_part(part),
                             realization = gridpc.realization_for_part(part),
                             indexable_element = 'cells')
-                    bwpc.write_hdf5_for_imported_list()
+                    bwpc.write_hdf5_for_imported_list(use_int32 = False)
                     bwpc.create_xml_for_imported_list_and_add_parts_to_model(time_series_uuid = time_uuid,
                                                                              string_lookup_uuid = sl_uuid)
         else:


### PR DESCRIPTION
Update code to ensure that dtype of int64 is maintained where present while creating blocked well properties from grid cell properties.