### PR TITLE
converting length, radw and radb properties to requested uom in BlockedWell.dataframe()

### DIFF
--- a/tests/unit_tests/well/test_blocked_well.py
+++ b/tests/unit_tests/well/test_blocked_well.py
@@ -87,6 +87,13 @@ def test_wellspec_properties(example_model_and_crs):
                        perforation_list = [(125, 175)])
     for col in ['SKIN', 'RADW']:
         assert_array_almost_equal(np.array(source_df[col]), np.array(df3[col]))
+    length_df3 = np.array(df3['LENGTH'])
+    df4 = bw.dataframe(extra_columns_list = ['ANGLV', 'ANGLA', 'LENGTH', 'SKIN', 'RADW', 'PPERF'],
+                       use_properties = ['LENGTH', 'RADW'],
+                       perforation_list = [(125, 175)],
+                       length_uom = 'ft')
+    assert_array_almost_equal(3.2808 * np.array(source_df['RADW']), np.array(df4['RADW']), decimal = 3)
+    assert_array_almost_equal(3.2808 * length_df3, np.array(df4['LENGTH']), decimal = 2)
 
 
 @pytest.mark.parametrize('check_grid_name,name_for_check,col_list', [(True, 'BATTLESHIP', ['IW', 'JW', 'L', 'GRID']),


### PR DESCRIPTION
This change converts the units of measure of the LENGTH, RADW and RADB data to the requested length uom in the BlockedWell.dataframe() method. The change also affects the write_wellspec() method which calls the dataframe() method.

Resolves issue #747 