### PR TITLE
DRAFT: wellspec with dtop dbot

### DIFF
--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -575,6 +575,38 @@ class BlockedWell(BaseResqpy):
 
         return self.derive_from_dataframe(df, self.well_name, grid, use_face_centres = True, length_uom = length_uom)
 
+    def dtop_dbot_to_layers(self, df, grid):
+        """Populates the wellspec dataframe with corresponding L when DTOP and DBOT are specified but L is not
+        arguments
+          df (pd.DataFrame): Dataframe of wellspec information
+          grid (grid.Grid object): Grid where well is located
+        returns
+          df_expanded (pd.DataFrame): DataFrame of wellspec information where L is populated with the layers corresponding to the DTOP and DBOT depths
+        """
+        corp = grid.corner_points()
+        nk,nj,ni = corp.shape[:3]
+        df_expanded = []
+
+        for ix,data in df.iterrows():
+            if np.isnan(data['L']):
+                dtop = data['DTOP']
+                dbot = data['DBOT']
+                j,i = int(data['JW']), int(data['IW'])
+                for k in range(nk):
+                    if dbot == 'BOT':
+                        data['L'] = k
+                        df_expanded.append(data.copy())
+                    elif (corp[k,j,i,0,:,:,2].min() > dtop) and (corp[k,j,i,1,:,:,2].max() < dbot):
+                        data['L'] = k
+                        df_expanded.append(data.copy())
+            else:
+                df_expanded.append(data.copy())
+
+        df_expanded = pd.DataFrame(df_expanded).reset_index(drop = True)
+        df_expanded[['IW','JW','L']] = df_expanded[['IW','JW','L']].astype(int)
+
+        return df_expanded
+
     def derive_from_wellspec(self,
                              wellspec_file,
                              well_name,
@@ -626,7 +658,7 @@ class BlockedWell(BaseResqpy):
         name_for_check, col_list = rqwu._derive_from_wellspec_check_grid_name(check_grid_name = check_grid_name,
                                                                               grid = grid,
                                                                               col_list = col_list)
-
+        
         wellspec_dict, dates_list = wsk.load_wellspecs(wellspec_file,
                                                        well = well_name,
                                                        column_list = col_list,
@@ -757,6 +789,11 @@ class BlockedWell(BaseResqpy):
 
         angles_present = ('ANGLV' in df.columns and 'ANGLA' in df.columns and not pd.isnull(df.iloc[0]['ANGLV']) and
                           not pd.isnull(df.iloc[0]['ANGLA']))
+        
+        dtop_dbot_present = ('DTOP' in df.columns and ~pd.isnull(df['DTOP']).all()) and ('DBOT' in df.columns and ~pd.isnull(df['DBOT']).all())
+
+        if dtop_dbot_present:
+            df = self.dtop_dbot_to_layers(df, grid)
 
         if not angles_present and not use_face_centres:
             log.warning(f'ANGLV and/or ANGLA data unavailable for well {well_name}: using face centres')

--- a/resqpy/well/well_utils.py
+++ b/resqpy/well/well_utils.py
@@ -138,7 +138,7 @@ def _derive_from_wellspec_verify_col_list(add_properties):
         else:
             col_list = []
     else:
-        col_list = ['IW', 'JW', 'L', 'ANGLA', 'ANGLV']
+        col_list = ['IW', 'JW', 'L', 'ANGLA', 'ANGLV', 'DTOP', 'DBOT']
     return col_list
 
 


### PR DESCRIPTION
I recently encountered a model that used the DTOP and DBOT nexus keywords to define a well.

`WELLSPEC A_20-1`\
`IW JW L  KH RADW   SKIN   RADB WI PPERF  DTOP      DBOT  `\
`1  1  NA NA 0.2500 0.0100 NA   NA 0.0    6325.0    6330.0 `
`1  1  NA NA 0.2500 0.0200 NA   NA 1.0    8332.0    8370.0`

This creates an issue when trying to derive a BlockedWell from a wellspec. Specifically, when `BlockedWell.derive_from_wellspec` calls `BlockedWell.derive_from_dataframe`, there will not be any information in the dataframe's L (layer) column to populate the `cell_kji0 = BlockedWell.__cell_kji0_from_df(df, i)` variable.

Proposed fix as follows:
`BlockedWell.dtop_dbot_to_layers` function converts the existing `DTOP`/`DBOT`columns in the wellspec dataframe into corresponding k-layers. It does this by:
-loading `corp = grid.corner_points()` 
-iterating through nk and checking if the k,j,i min and max depth is between is in between `DTOP` and `DBOT`
-if cell is in the `DTOP`-DBASE span, a new row is added to the modified dataframe with the corresponding L = k+1
-returns modified dataframe with corresponding L = k+1 values

This function is only called if there are non-null values in the `DTOP`and `DBOT` columns.

Additionally, `resqpy.well.well_utils._derive_from_wellspec_verify_col_list` function has been updated to provide `DTOP` and `DBOT` as defaults (along with `IW`, `JW`, `L`, `ANGLA`, `ANGLV`). This ensures the `DTOP` and `DBOT` columns are checked every time a well is loaded from wellspec.`
