### PR TITLE
replacing deprecated numpy.product() with prod()

### DIFF
--- a/resqpy/grid/_regular_grid.py
+++ b/resqpy/grid/_regular_grid.py
@@ -578,7 +578,7 @@ class RegularGrid(grr_g.Grid):
 
         required_uom = self.get_volume_uom(required_uom)
         conversion_factor = self.get_volume_conversion_factor(required_uom)
-        vol = np.product(vec.naive_lengths(self.block_dxyz_dkji))
+        vol = np.prod(vec.naive_lengths(self.block_dxyz_dkji))
         if conversion_factor is not None:
             vol *= conversion_factor
         if cell_kji0 is not None:

--- a/resqpy/olio/load_data.py
+++ b/resqpy/olio/load_data.py
@@ -167,7 +167,7 @@ def load_array_from_file(file_name,
         cell_count = -1  # np.fromfile interprets this as 'read everything'
         log.debug('Loading unknown number of array data elements from file ' + file_name)
     else:
-        cell_count = np.product(extent)
+        cell_count = np.prod(extent)
         log.debug('Loading %1d array data elements from file %s', cell_count, file_name)
 
     ascii_file_name = file_name
@@ -282,7 +282,7 @@ def load_array_from_ascii_file(file_name,
         cell_count = -1  # np.fromfile interprets this as 'read everything'
         log.debug('Loading unknown number of array data elements from ascii file ' + file_name)
     else:
-        cell_count = np.product(extent)
+        cell_count = np.prod(extent)
         log.debug('Loading %1d array data elements from ascii file %s', cell_count, file_name)
 
     if data_type in ['real', 'float', float]:

--- a/resqpy/property/_collection_create_xml.py
+++ b/resqpy/property/_collection_create_xml.py
@@ -91,7 +91,7 @@ def _create_xml_patch_node(collection, p_node, points, const_value, indexable_el
     if const_value is not None and not expand_const_arrays:
         s_shape = collection.supporting_shape(indexable_element = indexable_element, direction = direction)
         assert s_shape is not None
-        const_count = np.product(np.array(s_shape, dtype = int))
+        const_count = np.prod(np.array(s_shape, dtype = int))
     else:
         const_value = None
     _ = collection.model.create_patch(p_uuid,

--- a/resqpy/property/_collection_get_attributes.py
+++ b/resqpy/property/_collection_get_attributes.py
@@ -444,7 +444,7 @@ def _supporting_shape_grid_faces(direction, support):
         for axis in range(3):
             batch = np.array(support.extent_kji, dtype = int)
             batch[axis] += 1
-            count += np.product(batch)
+            count += np.prod(batch)
         shape_list = [count]
     else:
         assert direction.upper() in 'IJK'


### PR DESCRIPTION
This patch updates numpy.product() calls with numpy.prod() due to deprecation of product().