### PR TITLE
handling of grid geometry stored in parametric line form

### DIFF
--- a/resqpy/grid/_create_grid_xml.py
+++ b/resqpy/grid/_create_grid_xml.py
@@ -433,15 +433,11 @@ def _add_pillar_points_parametric_lines_xml(geom, grid, ext_uuid):
     line_kind_indices.set(ns['xsi'] + 'type', ns['resqml2'] + 'IntegerConstantArray')
     line_kind_indices.text = '\n'
     lki_value = rqet.SubElement(line_kind_indices, ns['resqml2'] + 'Value')
-    knot_count.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
-    knot_count.text = '1'
+    lki_value.set(ns['xsi'] + 'type', ns['xsd'] + 'integer')
+    lki_value.text = '1'
     lki_count = rqet.SubElement(line_kind_indices, ns['resqml2'] + 'Count')
-    knot_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
-    assert grid.points_cached is not None and grid.points_cached.ndim in [3, 4]
-    pillar_count = grid.points_cached.shape[1]
-    if grid.points_cached.ndim == 4:
-        pillar_count *= grid.points_cached.shape[2]
-    knot_count.text = str(pillar_count)
+    lki_count.set(ns['xsi'] + 'type', ns['xsd'] + 'positiveInteger')
+    lki_count.text = str((grid.nj + 1) * (grid.ni + 1))  # primary pillar count
 
 
 def _add_constant_pillar_geometry_is_defined(geom, extent_kji):

--- a/resqpy/grid/_grid.py
+++ b/resqpy/grid/_grid.py
@@ -495,7 +495,6 @@ class Grid(BaseResqpy):
         """Writes grid geometry arrays to hdf5; a thin wrapper around write_hdf5_from_caches().
 
         arguments:
-
             expand_const_arrays (bool, default False): if True, any constant properties being written will be expanded to full arrays
             use_parametric_lines (bool, default False): if True, the grid geomatry points will be stored using a 2 point (straight)
                 parametric line form rather than the more commonly used full coordinate form; this argument must match that used

--- a/resqpy/grid/_grid_types.py
+++ b/resqpy/grid/_grid_types.py
@@ -26,7 +26,7 @@ def grid_flavour(grid_root):
                 p_type = rqet.node_type(p_node)
                 if p_type == 'Point3dLatticeArray':
                     flavour = 'IjkBlockGrid'
-                elif p_type == 'Point3dHdf5Array':
+                elif p_type in ['Point3dHdf5Array', 'Point3dParametricArray']:
                     flavour = 'IjkGrid'
                 else:
                     raise ValueError(f'grid geometry points type not supported: {p_type}')

--- a/resqpy/grid/_points_functions.py
+++ b/resqpy/grid/_points_functions.py
@@ -252,7 +252,7 @@ def point_raw(grid, index = None, points_root = None, cache_array = True):
         # create interpolation fractions from parameters (and control points parameters, with pillar indirection)
         cpp_range = cpp[1] - cpp[0]
         assert np.all(cpp_range != 0.0), 'some parametric lines are horizontal or not defined'
-        f = (grid.temp_parameters - np.expand_dims(cpp[0], axis = 0)) / np.expand_dims(cpp_range, axis = 0)
+        f = np.expand_dims((grid.temp_parameters - np.expand_dims(cpp[0], axis = 0)) / np.expand_dims(cpp_range, axis = 0), axis = -1)
         # populate points cached by interpolating between control points using interpolation fractions
         grid.points_cached = np.empty((grid.nk_plus_k_gaps + 1, pillar_count, 3), dtype = float)
         grid.points_cached[:] = np.expand_dims(cp[0], axis = 0) * (1.0 - f) + np.expand_dims(cp[1], axis = 0) * f

--- a/resqpy/grid/_points_functions.py
+++ b/resqpy/grid/_points_functions.py
@@ -252,7 +252,8 @@ def point_raw(grid, index = None, points_root = None, cache_array = True):
         # create interpolation fractions from parameters (and control points parameters, with pillar indirection)
         cpp_range = cpp[1] - cpp[0]
         assert np.all(cpp_range != 0.0), 'some parametric lines are horizontal or not defined'
-        f = np.expand_dims((grid.temp_parameters - np.expand_dims(cpp[0], axis = 0)) / np.expand_dims(cpp_range, axis = 0), axis = -1)
+        f = np.expand_dims(
+            (grid.temp_parameters - np.expand_dims(cpp[0], axis = 0)) / np.expand_dims(cpp_range, axis = 0), axis = -1)
         # populate points cached by interpolating between control points using interpolation fractions
         grid.points_cached = np.empty((grid.nk_plus_k_gaps + 1, pillar_count, 3), dtype = float)
         grid.points_cached[:] = np.expand_dims(cp[0], axis = 0) * (1.0 - f) + np.expand_dims(cp[1], axis = 0) * f

--- a/resqpy/grid/_write_hdf5_from_caches.py
+++ b/resqpy/grid/_write_hdf5_from_caches.py
@@ -21,14 +21,13 @@ def _write_hdf5_from_caches(grid,
                             write_active = None,
                             stratigraphy = True,
                             expand_const_arrays = False,
-                            use_int32 = None):
-    """Create or append to an hdf5 file.
-
-    Writes datasets for the grid geometry (and parent grid mapping) and properties from cached arrays.
-    """
+                            use_int32 = None,
+                            use_parametric_lines = False):
+    """Writes hdf5 arrays for the grid geometry (and parent grid mapping) and (optionally) properties from cached arrays."""
     # NB: when writing a new geometry, all arrays must be set up and exist as the appropriate attributes prior to calling this function
     # if saving properties, active cell array should be added to imported_properties based on logical negation of inactive attribute
     # xml is not created here for property objects
+    # the use_parametric_lines argument must match the value used in the create_xml() call
 
     if write_active is None:
         existing_active = rqp.property_parts(grid.model,
@@ -48,7 +47,7 @@ def _write_hdf5_from_caches(grid,
         h5_reg.register_dataset(grid.uuid, 'unitIndices', grid.stratigraphic_units, dtype = 'uint32')
 
     if geometry:
-        __write_geometry(grid, h5_reg)
+        __write_geometry(grid, h5_reg, use_parametric_lines)
 
     if write_active and grid.inactive is not None:
         if imported_properties is None:
@@ -83,7 +82,7 @@ def _write_hdf5_from_caches(grid,
     h5_reg.write(file, mode = mode, use_int32 = use_int32)
 
 
-def __write_geometry(grid, h5_reg):
+def __write_geometry(grid, h5_reg, use_parametric_lines):
     if always_write_pillar_geometry_is_defined_array or not grid.geometry_defined_for_all_pillars(cache_array = True):
         if not hasattr(grid, 'array_pillar_geometry_is_defined') or grid.array_pillar_geometry_is_defined is None:
             grid.array_pillar_geometry_is_defined = np.full((grid.nj + 1, grid.ni + 1), True, dtype = bool)
@@ -99,7 +98,32 @@ def __write_geometry(grid, h5_reg):
                                 grid.array_cell_geometry_is_defined,
                                 dtype = 'uint8')
     # todo: PillarGeometryIsDefined ?
-    h5_reg.register_dataset(grid.uuid, 'Points', grid.points_cached)
+    assert grid.points_cached is not None and 3 <= grid.points_cached.ndim <= 4 and grid.points_cached.shape[-1] == 3
+    if use_parametric_lines:
+        # convert points_cached into 2 point parametric line form and write arrays
+        primary_pillar_count = (grid.nj + 1) * (grid.ni + 1)
+        p = grid.points_cached.reshape((grid.points_cached.shape[0], -1, 3))
+        assert p.shape[1] >= primary_pillar_count
+        # parameters – could be interpolation fractions for each point on the parametric line?
+        # here we use z values directly for interpolation (will not handle horizontal pillars)
+        # todo: check for and handle NaNs?
+        parameters = p[:, :, 2]
+        h5_reg.register_dataset(grid.uuid, 'parameters', parameters, copy = True)
+        # Parametric lines section arrays:
+        # controlPoints – xyz data for 2 end points for each pillar
+        cp = np.empty((2, primary_pillar_count, 3), dtype = float)
+        cp[0] = p[0, :primary_pillar_count]
+        cp[1] = p[-1, :primary_pillar_count]
+        h5_reg.register_dataset(grid.uuid, 'controlPoints', cp, copy = True)
+        # controlPointParameters – use top and base z values
+        h5_reg.register_dataset(grid.uuid, 'controlPointParameters', cp[:, :, 2], copy = True)
+        # notes:
+        #   KnotCount is a scalar metadata item and must be set to 2 in create xml
+        #   LineKindIndex can be set as a constant array in create xml, with a value of 1 (segmented piecewise linear)
+        #   split coordinate line arrays and is defined arrays etc. to be written as normal
+        raise NotImplementedError('writing hdf5 data in parametric line form for grid geometry')
+    else:
+        h5_reg.register_dataset(grid.uuid, 'Points', grid.points_cached)
     if grid.has_split_coordinate_lines:
         h5_reg.register_dataset(grid.uuid, 'PillarIndices', grid.split_pillar_indices_cached, dtype = 'uint32')
         h5_reg.register_dataset(grid.uuid,

--- a/resqpy/grid/_write_hdf5_from_caches.py
+++ b/resqpy/grid/_write_hdf5_from_caches.py
@@ -121,7 +121,6 @@ def __write_geometry(grid, h5_reg, use_parametric_lines):
         #   KnotCount is a scalar metadata item and must be set to 2 in create xml
         #   LineKindIndex can be set as a constant array in create xml, with a value of 1 (segmented piecewise linear)
         #   split coordinate line arrays and is defined arrays etc. to be written as normal
-        raise NotImplementedError('writing hdf5 data in parametric line form for grid geometry')
     else:
         h5_reg.register_dataset(grid.uuid, 'Points', grid.points_cached)
     if grid.has_split_coordinate_lines:

--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -568,7 +568,7 @@ def node_text(node, unknown_if_none = False):
 def node_bool(node):
     """Returns stripped node text as bool, or None."""
 
-    if node is None:
+    if node is None or node.text is None:
         return None
     return bool_from_text(node.text)
 
@@ -576,7 +576,7 @@ def node_bool(node):
 def node_int(node):
     """Returns stripped node text as int, or None."""
 
-    if node is None:
+    if node is None or node.text is None:
         return None
     text = node.text.strip()
     if text.lower() == 'none':
@@ -589,7 +589,7 @@ def node_int(node):
 def node_float(node):
     """Returns stripped node text as float, or None."""
 
-    if node is None:
+    if node is None or node.text is None:
         return None
     text = node.text.strip()
     if text.lower() == 'none':

--- a/tests/unit_tests/grid/test_parametric_line_geometry.py
+++ b/tests/unit_tests/grid/test_parametric_line_geometry.py
@@ -1,0 +1,62 @@
+import pytest
+import numpy as np
+
+import resqpy.model as rq
+import resqpy.grid as grr
+
+
+def test_parametric_line_geometry(basic_regular_grid):
+    # finish converting the regular grid to irregular form
+    old_model = basic_regular_grid.model
+    basic_regular_grid.write_hdf5()
+    basic_regular_grid.create_xml()
+    basic_grid = grr.Grid(old_model, uuid = basic_regular_grid.uuid)
+    new_file = f'{old_model.epc_file[:-4]}_pl_basic.epc'
+    new_model = rq.new_model(new_file)
+    # copy crs
+    new_model.copy_uuid_from_other_model(old_model, basic_grid.crs_uuid)
+    # hijack grid
+    basic_grid.cache_all_geometry_arrays()
+    basic_grid.model = new_model
+    # write hdf5 data for grid using paramtric lines option
+    basic_grid.write_hdf5(use_parametric_lines = True)
+    # create xml for grid using parametric lines option
+    basic_grid.create_xml(use_parametric_lines = True)
+    # store new version of model and reload
+    new_model.store_epc()
+    reload_model = rq.Model(new_model.epc_file)
+    # check reloaded grid
+    reload_grid = reload_model.grid()
+    reload_grid.cache_all_geometry_arrays()
+    # assertions
+    assert tuple(reload_grid.extent_kji) == tuple(basic_grid.extent_kji)
+    assert reload_grid.points_cached is not None
+    assert reload_grid.points_cached.shape == basic_grid.points_cached.shape
+    np.testing.assert_array_almost_equal(reload_grid.points_cached, basic_grid.points_cached)
+
+
+def test_parametric_line_geometry_faulted(faulted_grid):
+    # Act
+    old_model = faulted_grid.model
+    new_file = f'{old_model.epc_file[:-4]}_pl_faulted.epc'
+    new_model = rq.new_model(new_file)
+    # copy crs
+    new_model.copy_uuid_from_other_model(old_model, faulted_grid.crs_uuid)
+    # hijack grid
+    faulted_grid.cache_all_geometry_arrays()
+    faulted_grid.model = new_model
+    # write hdf5 data for grid using paramtric lines option
+    faulted_grid.write_hdf5(use_parametric_lines = True)
+    # create xml for grid using parametric lines option
+    faulted_grid.create_xml(use_parametric_lines = True)
+    # store new version of model and reload
+    new_model.store_epc()
+    reload_model = rq.Model(new_model.epc_file)
+    # check reloaded grid
+    reload_grid = reload_model.grid()
+    reload_grid.cache_all_geometry_arrays()
+    # assertions
+    assert tuple(reload_grid.extent_kji) == tuple(faulted_grid.extent_kji)
+    assert reload_grid.points_cached is not None
+    assert reload_grid.points_cached.shape == faulted_grid.points_cached.shape
+    np.testing.assert_array_almost_equal(reload_grid.points_cached, faulted_grid.points_cached)

--- a/tests/unit_tests/grid/test_points_functions.py
+++ b/tests/unit_tests/grid/test_points_functions.py
@@ -572,3 +572,17 @@ def test_find_cell_for_x_sect_xz(faulted_grid):
                                         azimuth = 0.0)
     k, j = pf.find_cell_for_x_sect_xz(x_sect, 250.0, 3030.0)
     assert k == 1 and j == 2
+
+
+def test_point_areally(basic_regular_grid):
+    dots = basic_regular_grid.point_areally()
+    assert dots is not None
+    assert dots.shape == (2, 2, 2)
+    assert not np.any(dots)
+
+
+def test_point_areally_faulted(faulted_grid):
+    dots = faulted_grid.point_areally()
+    assert dots is not None
+    assert dots.shape == (3, 5, 8)
+    assert not np.any(dots)


### PR DESCRIPTION
This change introduces support for the parametric line form of grid geometry. There are some restrictions:

- internal python representation is as before (convert on read and write)
- only a constant line kind index of 1 and knot count of 2 is supported (straight lines)
- horizontal or undefined parametric lines will raise an assertion error
- undefined topmost or basal cached points for any pillar will cause failure if writing in parametric line form

The code aims to be compatible with the geometry representation used by RMS when exporting to RESQML.

Resolves issue #723 

RMS is a trademark of AspenTech.