### PR TITLE
old root_node references in Trajectory class updated

### DIFF
--- a/resqpy/well/_trajectory.py
+++ b/resqpy/well/_trajectory.py
@@ -933,7 +933,7 @@ class Trajectory(BaseResqpy):
         """
 
         if self.deviation_survey is not None:
-            ds_root = self.deviation_survey.root_node
+            ds_root = self.deviation_survey.root
             self.model.create_ref_node('DeviationSurvey',
                                        rqet.find_tag(rqet.find_tag(ds_root, 'Citation'), 'Title').text,
                                        bu.uuid_from_string(ds_root.attrib['uuid']),
@@ -971,7 +971,7 @@ class Trajectory(BaseResqpy):
                                                           'sourceObject')
                 if self.deviation_survey is not None:
                     self.model.create_reciprocal_relationship(wbt_node, 'destinationObject',
-                                                              self.deviation_survey.root_node, 'sourceObject')
+                                                              self.deviation_survey.root, 'sourceObject')
                 if interp_root is not None:
                     self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', interp_root,
                                                               'sourceObject')

--- a/resqpy/well/_trajectory.py
+++ b/resqpy/well/_trajectory.py
@@ -970,8 +970,8 @@ class Trajectory(BaseResqpy):
                 self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', self.md_datum.root,
                                                           'sourceObject')
                 if self.deviation_survey is not None:
-                    self.model.create_reciprocal_relationship(wbt_node, 'destinationObject',
-                                                              self.deviation_survey.root, 'sourceObject')
+                    self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', self.deviation_survey.root,
+                                                              'sourceObject')
                 if interp_root is not None:
                     self.model.create_reciprocal_relationship(wbt_node, 'destinationObject', interp_root,
                                                               'sourceObject')

--- a/tests/unit_tests/well/test_trajectory.py
+++ b/tests/unit_tests/well/test_trajectory.py
@@ -192,6 +192,27 @@ def test_load_from_ascii_file(example_model_and_crs):
     trajectory_data_file_path = os.path.join(model.epc_directory, 'trajectory_data.csv')
     source_dataframe.to_csv(trajectory_data_file_path)
 
+    # Create a deviation survey
+    data = dict(
+        title = 'Majestic Umlaut ö',
+        originator = 'Thor, god of sparkles',
+        md_uom = 'ft',
+        angle_uom = 'rad',
+        is_final = True,
+    )
+    array_data = dict(
+        measured_depths = np.array([1, 2, 3], dtype = float) + 1000.0,
+        azimuths = np.array([4, 5, 6], dtype = float),
+        inclinations = np.array([1, 2, 3], dtype = float),
+        first_station = np.array([0, -1, 999], dtype = float),
+    )
+    survey = resqpy.well.DeviationSurvey(
+        parent_model = model,
+        md_datum = datum,
+        **data,
+        **array_data,
+    )
+
     for well_name in well_names:
         if well_name is None:
             # --------- Act ----------
@@ -200,7 +221,8 @@ def test_load_from_ascii_file(example_model_and_crs):
                 trajectory_from_ascii = resqpy.well.Trajectory(parent_model = model,
                                                                ascii_trajectory_file = trajectory_data_file_path,
                                                                length_uom = 'm',
-                                                               md_datum = datum)
+                                                               md_datum = datum,
+                                                               deviation_survey = survey)
 
             # -------- Assert ---------
             assert "attempt to set trajectory for unidentified well from ascii file holding data for multiple wells" in str(

--- a/tests/unit_tests/well/test_trajectory.py
+++ b/tests/unit_tests/well/test_trajectory.py
@@ -212,6 +212,8 @@ def test_load_from_ascii_file(example_model_and_crs):
         **data,
         **array_data,
     )
+    survey.write_hdf5()
+    survey.create_xml()
 
     for well_name in well_names:
         if well_name is None:
@@ -238,6 +240,8 @@ def test_load_from_ascii_file(example_model_and_crs):
                                                            deviation_survey = survey)
             # -------- Assert ---------
             assert trajectory_from_ascii is not None
+            trajectory_from_ascii.write_hdf5()
+            trajectory_from_ascii.create_xml()
             np.testing.assert_almost_equal(trajectory_from_ascii.tangent_vectors[0],
                                            trajectory_from_ascii.tangent_vectors[1])
             vec.isclose(trajectory_from_ascii.tangent_vectors[:, 2], np.array([1, 1]), 0.01)

--- a/tests/unit_tests/well/test_trajectory.py
+++ b/tests/unit_tests/well/test_trajectory.py
@@ -221,8 +221,7 @@ def test_load_from_ascii_file(example_model_and_crs):
                 trajectory_from_ascii = resqpy.well.Trajectory(parent_model = model,
                                                                ascii_trajectory_file = trajectory_data_file_path,
                                                                length_uom = 'm',
-                                                               md_datum = datum,
-                                                               deviation_survey = survey)
+                                                               md_datum = datum)
 
             # -------- Assert ---------
             assert "attempt to set trajectory for unidentified well from ascii file holding data for multiple wells" in str(
@@ -235,7 +234,8 @@ def test_load_from_ascii_file(example_model_and_crs):
                                                            well_name = well_name,
                                                            length_uom = 'm',
                                                            md_datum = datum,
-                                                           set_tangent_vectors = True)
+                                                           set_tangent_vectors = True,
+                                                           deviation_survey = survey)
             # -------- Assert ---------
             assert trajectory_from_ascii is not None
             np.testing.assert_almost_equal(trajectory_from_ascii.tangent_vectors[0],


### PR DESCRIPTION
This patch fixes a bug involving some old references to a root_node attribute in the Trajectory class when relating to a DeviationSurvey. The attribute has long since been replaced with a class property called root.