### PR TITLE
using shorter title when importing surfaces

### DIFF
--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -67,6 +67,8 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
     if dot > 0:
         short_name = short_name[:dot]
 
+    em = {'source': surf_file}
+
     log.info('surface ' + short_name + ' processing file: ' + surf_file + ' using format: ' + surface_file_format)
     if rq_class == 'surface':
         if surface_file_format == 'GOCAD-Tsurf':
@@ -74,14 +76,16 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
                                   tsurf_file = surf_file,
                                   surface_role = surface_role,
                                   quad_triangles = quad_triangles,
-                                  crs_uuid = crs_uuid)
+                                  crs_uuid = crs_uuid,
+                                  extra_metadata = em)
         else:
             surface = rqs.Surface(model,
                                   mesh_file = surf_file,
                                   mesh_format = surface_file_format,
                                   surface_role = surface_role,
                                   quad_triangles = quad_triangles,
-                                  crs_uuid = crs_uuid)
+                                  crs_uuid = crs_uuid,
+                                  extra_metadata = em)
     elif rq_class == 'mesh':
         if surface_file_format == 'GOCAD-Tsurf':
             log.info(f"Cannot convert a GOCAD-Tsurf to mesh, only to TriangulatedSurface - skipping file {surf_file}")
@@ -92,7 +96,8 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
                                mesh_format = surface_file_format,
                                mesh_flavour = 'reg&z',
                                surface_role = surface_role,
-                               crs_uuid = crs_uuid)
+                               crs_uuid = crs_uuid,
+                               extra_metadata = em)
     else:
         log.critical('this is impossible')
     # NB. surface may be either a Surface object or a Mesh object
@@ -107,10 +112,7 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
         interp_root = interp.create_xml()
         surface.set_represented_interpretation_root(interp_root)
 
-    surface.create_xml(add_as_part = True,
-                       add_relationships = True,
-                       title = short_name + ' sourced from ' + surf_file,
-                       originator = None)
+    surface.create_xml(add_as_part = True, add_relationships = True, title = short_name, originator = None)
 
     return model
 


### PR DESCRIPTION
This change uses a shorter title when importing surfaces. The source file name is stored as an extra metadata item with key 'source'.