### PR TITLE
Update Sphinx config to V2, and enable docs builds on PRs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,11 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
 
@@ -16,7 +21,6 @@ formats:
 # Python environment
 # Equivalent to: pip install resqpy
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -222,10 +222,9 @@ versions of the code:
 These automatically re-build when the relevant branch is updated, or when a new
 tag is pushed.
 
-The `docs` version is intended for previewing changes to documentation. Just
-create a new feature branch called `docs` and push changes there; you can then
-use the link above to check it renders correctly. One can delete the `docs` git
-branch as usual when closing a PR, and re-create it when needed.
+The documentation is also automatically built in a temporary staging area for
+all open Pull Requests. Check the "Checks" section of your Pull Request to see
+how the docs will look.
 
 You may find it helpful to run a linter to check that the syntax of your
 ReStructured text is correct: the python package `restructuredtext-lint` is


### PR DESCRIPTION
I saw by email that our ReadtheDocs config format is deprecated, and the build is currently failing. This change should fix it. Link: <https://blog.readthedocs.com/migrate-configuration-v2/>

Example build now passes successfully: <https://readthedocs.org/projects/resqpy/builds/22562103/>

I also enabled the setting to build docs on all PRs. This may not take effect for this PR, but should work for future ones.

<https://docs.readthedocs.io/page/guides/autobuild-docs-for-pull-requests.html>