### PR TITLE
nan z in tri mesh origin being set to zero

### DIFF
--- a/resqpy/surface/__init__.py
+++ b/resqpy/surface/__init__.py
@@ -10,7 +10,7 @@ from ._combined_surface import CombinedSurface
 from ._mesh import Mesh
 from ._triangulated_patch import TriangulatedPatch
 from ._pointset import PointSet
-from ._surface import Surface, distill_triangle_points, _adjust_flange_z
+from ._surface import Surface, distill_triangle_points, nan_removed_triangles_and_points, _adjust_flange_z
 from ._tri_mesh import TriMesh
 
 # Set "module" attribute of all public objects to this path.

--- a/resqpy/surface/_tri_mesh.py
+++ b/resqpy/surface/_tri_mesh.py
@@ -77,8 +77,14 @@ class TriMesh(rqs.Mesh):
             xyz *= t_side
             if z_values is not None:
                 xyz[:, :, 2] = z_values
+            o_a = None
             if origin is not None:
-                xyz += np.expand_dims(np.expand_dims(origin, axis = 0), axis = 0)
+                o_a = np.array(origin, dtype = float)
+                assert o_a.shape == (3,)
+                if np.isnan(o_a[2]):
+                    o_a[2] = 0.0
+                assert not np.any(np.isnan(o_a))
+                xyz += np.expand_dims(np.expand_dims(o_a, axis = 0), axis = 0)
             super().__init__(parent_model,
                              mesh_flavour = 'explicit',
                              xyz_values = xyz,
@@ -90,10 +96,7 @@ class TriMesh(rqs.Mesh):
                              originator = originator,
                              extra_metadata = extra_metadata)
             self.t_side = t_side
-            self.origin = None
-            if origin is not None:
-                self.origin = np.array(origin, dtype = float)
-                assert self.origin.shape == (3,)
+            self.origin = o_a
             self.z_uom = z_uom
             self.extra_metadata['t side'] = str(t_side)
             if z_uom:

--- a/tests/unit_tests/surface/test_tri_mesh.py
+++ b/tests/unit_tests/surface/test_tri_mesh.py
@@ -317,6 +317,41 @@ def test_tri_mesh_nodes_in_triangles_with_origin(example_model_and_crs):
             assert ji in [(1, 3), (2, 2), (2, 3)]
 
 
+def test_tri_mesh_nodes_in_triangles_with_origin_nan_z(example_model_and_crs):
+    model, crs = example_model_and_crs
+    origin = (127.34, -1523.19, np.nan)
+    trim = rqs.TriMesh(model,
+                       t_side = 10.0,
+                       nj = 5,
+                       ni = 6,
+                       origin = origin,
+                       crs_uuid = crs.uuid,
+                       title = 'test tri mesh')
+    other_t = np.array([[(7.0, 5.0), (7.0, 25.0),
+                         (37.0, 5.0)], [(37.0, 25.0), (7.0, 25.0),
+                                        (37.0, 5.0)], [(42.0, 15.0), (55.0, 15.0),
+                                                       (51.0, 3.0)], [(43.0, 25.0), (47.0, 25.0), (45.0, 28.0)]],
+                       dtype = float)
+    other_t += np.expand_dims(np.expand_dims(np.array(origin[:2], dtype = float), axis = 0), axis = 0)
+    nit = trim.tri_nodes_in_triangles(other_t)
+    assert nit.ndim == 2 and nit.shape[1] == 3
+    assert len(nit) == 7
+    assert np.all(np.logical_or(np.logical_or(nit[:, 0] == 0, nit[:, 0] == 1), nit[:, 0] == 3))  # other triangle number
+    assert np.all(np.logical_and(nit[:-1, 1] > 0, nit[:-1, 1] < 3))  # node j index
+    assert np.all(np.logical_and(nit[:-1, 2] > 0, nit[:-1, 2] < 4))  # node i index
+    assert np.all(nit[-1] == (3, 3, 4))  # other triangle number, node j, node i; here assumed to be last in return list
+    assert np.count_nonzero(nit[:, 0] == 0) == 3
+    assert np.count_nonzero(nit[:, 0] == 1) == 3
+    assert np.count_nonzero(nit[:, 0] == 2) == 0
+    assert np.count_nonzero(nit[:, 0] == 3) == 1
+    for i in range(6):
+        ji = tuple(nit[i, 1:])
+        if nit[i, 0] == 0:
+            assert ji in [(1, 1), (1, 2), (2, 1)]
+        else:
+            assert ji in [(1, 3), (2, 2), (2, 3)]
+
+
 def test_tri_mesh_axial_edge_crossing(example_model_and_crs):
     model, crs = example_model_and_crs
     z_values = np.array([(-100.0, -100.0, -100.0, -100.0), (100.0, 100.0, 100.0, 100.0), (500.0, 500.0, 500.0, 500.0)],


### PR DESCRIPTION
This patch handles a NaN z value in a tri mesh origin, simply replacing it with zero.
The surface module nan_removed_triangles_and_points() function is also added to the surface package init.