### PR TITLE
fix of bug affecting StringTableLookup references in xml in derived_model.gather_ensemble()

### DIFF
--- a/resqpy/derived_model/_gather_ensemble.py
+++ b/resqpy/derived_model/_gather_ensemble.py
@@ -99,22 +99,20 @@ def gather_ensemble(case_epc_list,
                     assert host_index is not None, 'failed to match grids when gathering ensemble'
                     composite_model.force_consolidation_uuid_equivalence(grid_uuid, host_grid_uuids[host_index])
                     grid_relatives = case_model.parts(related_uuid = grid_uuid)
-                    t_props = 0.0
                     composite_h5_file_name = composite_model.h5_file_name()
                     composite_h5_uuid = composite_model.h5_uuid()
                     case_h5_file_name = case_model.h5_file_name()
                     for part in grid_relatives:
                         if 'Property' in part:
-                            t_p_start = time()
                             composite_model.copy_part_from_other_model(case_model,
                                                                        part,
                                                                        realization = r,
                                                                        consolidate = True,
-                                                                       force = shared_time_series,
+                                                                       force = shared_time_series and
+                                                                       'Categorical' not in part,
                                                                        self_h5_file_name = composite_h5_file_name,
                                                                        h5_uuid = composite_h5_uuid,
                                                                        other_h5_file_name = case_h5_file_name)
-                            t_props += time() - t_p_start
             else:
                 composite_model.copy_all_parts_from_other_model(case_model, realization = r, consolidate = consolidate)
         log.debug(f'case time: {time() - t_r_start:.2f} secs')  # debug

--- a/resqpy/model/_forestry.py
+++ b/resqpy/model/_forestry.py
@@ -652,6 +652,7 @@ def _copy_referenced_parts(model, other_model, realization, consolidate, force, 
     relatives = other_model.uuid_rels_dict.get(uuid.int)
     if relatives is None:  # todo: have a think about whether this is indicating a problem
         return
+    # log.debug(f'copying {len(relatives[0])} referenced parts for uuid: {uuid} of type: {model.type_of_uuid(uuid)}')
     for ref_uuid_int in relatives[0]:  # using dict in other model instead of duplicated xml
         if ref_uuid_int in model.uuid_part_dict:
             m_x._create_reciprocal_relationship(model, root_node, 'sourceObject',

--- a/resqpy/olio/consolidation.py
+++ b/resqpy/olio/consolidation.py
@@ -24,7 +24,8 @@ consolidatable_list = [
 
 ordering_list = consolidatable_list + [
     'MdDatum', 'WellboreTrajectoryRepresentation', 'WellboreFrameRepresentation', 'WellboreMarkerFrameRepresentation',
-    'IjkGridRepresentation', 'BlockedWellboreRepresentation'
+    'IjkGridRepresentation', 'BlockedWellboreRepresentation', 'TriangulatedSetRepresentation', 'Grid2dRepresentation',
+    'PointSetRepresentation'
 ]
 # todo: add to this list as other classes gain an is_equivalent() method
 

--- a/resqpy/organize/genetic_boundary_feature.py
+++ b/resqpy/organize/genetic_boundary_feature.py
@@ -35,7 +35,7 @@ class GeneticBoundaryFeature(BaseResqpy):
     def _load_from_xml(self):
         self.kind = rqet.find_tag_text(self.root, 'GeneticBoundaryKind')
         age_node = rqet.find_tag(self.root, 'AbsoluteAge')
-        if age_node:
+        if age_node is not None:
             self.absolute_age = (rqet.find_tag_text(age_node, 'DateTime'), rqet.find_tag_int(age_node, 'YearOffset')
                                 )  # year offset may be None
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -129,11 +129,11 @@ def test_data_path(tmp_path):
    Use a fresh temporary directory for each test.
    """
     master_path = (Path(__file__) / '../../test_data').resolve()
-    data_path = Path(tmp_path) / 'test_data'
+    data_path = os.path.join(tmp_path, 'test_data')
 
     assert master_path.exists()
-    assert not data_path.exists()
-    copytree(str(master_path), str(data_path))
+    assert not os.path.exists(data_path)
+    copytree(str(master_path), data_path)
     return data_path
 
 
@@ -390,7 +390,7 @@ def example_model_with_prop_ts_rels(tmp_path):
     - SW (continuous) (recurrent)
     """
     epc = os.path.join(tmp_path, 'test_model.epc')
-    return model_with_prop_ts_rels(tmp_path)
+    return model_with_prop_ts_rels(epc)
 
 
 @pytest.fixture

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -225,19 +225,18 @@ def example_model_with_properties(tmp_path):
     return model
 
 
-@pytest.fixture
-def example_model_with_prop_ts_rels(tmp_path):
-    """Model with a grid (5x5x3) and properties.
-   Properties:
-   - Zone (discrete)
-   - VPC (discrete)
-   - Fault block (discrete)
-   - Facies (discrete)
-   - NTG (continuous)
-   - POR (continuous)
-   - SW (continuous) (recurrent)
-   """
-    model_path = str(tmp_path / 'test_model.epc')
+def model_with_prop_ts_rels(model_path):
+    """Model with a grid (5x5x3) and properties, including a time series and string lookup.
+
+    Properties:
+    - Zone (discrete)
+    - VPC (discrete)
+    - Fault block (discrete)
+    - Facies (discrete)
+    - NTG (continuous)
+    - POR (continuous)
+    - SW (continuous) (recurrent)
+    """
     model = Model(create_basics = True, create_hdf5_ext = True, epc_file = model_path, new_epc = True)
     model.store_epc(model.epc_file)
 
@@ -376,6 +375,41 @@ def example_model_with_prop_ts_rels(tmp_path):
     model.store_epc()
 
     return model
+
+
+@pytest.fixture
+def example_model_with_prop_ts_rels(tmp_path):
+    """Model with a grid (5x5x3) and properties, including a time series and string lookup.
+    Properties:
+    - Zone (discrete)
+    - VPC (discrete)
+    - Fault block (discrete)
+    - Facies (discrete)
+    - NTG (continuous)
+    - POR (continuous)
+    - SW (continuous) (recurrent)
+    """
+    epc = os.path.join(tmp_path, 'test_model.epc')
+    return model_with_prop_ts_rels(tmp_path)
+
+
+@pytest.fixture
+def pair_of_models_with_prop_ts_rels(tmp_path):
+    """Model with a grid (5x5x3) and properties, including a time series and string lookup.
+    Properties:
+    - Zone (discrete)
+    - VPC (discrete)
+    - Fault block (discrete)
+    - Facies (discrete)
+    - NTG (continuous)
+    - POR (continuous)
+    - SW (continuous) (recurrent)
+    """
+    epc1 = os.path.join(tmp_path, 'test_model_1.epc')
+    epc2 = os.path.join(tmp_path, 'test_model_2.epc')
+    m1 = model_with_prop_ts_rels(epc1)
+    m2 = model_with_prop_ts_rels(epc2)
+    return (m1, m2)
 
 
 @pytest.fixture

--- a/tests/unit_tests/lines/test_lines.py
+++ b/tests/unit_tests/lines/test_lines.py
@@ -93,7 +93,7 @@ def test_lineset(example_model_and_crs, tmp_path):
 def test_charisma(example_model_and_crs, test_data_path):
     # Set up a PolylineSet
     model, crs = example_model_and_crs
-    charisma_file = test_data_path / "Charisma_example.txt"
+    charisma_file = os.path.join(test_data_path, "Charisma_example.txt")
     lines = resqpy.lines.PolylineSet(parent_model = model, charisma_file = str(charisma_file))
     lines.write_hdf5()
     lines.create_xml()
@@ -112,7 +112,7 @@ def test_charisma(example_model_and_crs, test_data_path):
 def test_irap(example_model_and_crs, test_data_path):
     # Set up a PolylineSet
     model, crs = example_model_and_crs
-    irap_file = test_data_path / "IRAP_example.txt"
+    irap_file = os.path.join(test_data_path, "IRAP_example.txt")
     lines = resqpy.lines.PolylineSet(parent_model = model, irap_file = str(irap_file))
     lines.write_hdf5()
     lines.create_xml()

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -127,7 +127,7 @@ def test_delaunay_triangulation(example_model_and_crs):
 def test_surface_from_mesh_file(example_model_and_crs, test_data_path, mesh_file, mesh_format, firstval):
     # Arrange
     model, crs = example_model_and_crs
-    in_file = test_data_path / mesh_file
+    in_file = os.path.join(test_data_path, mesh_file)
 
     # Act
     surface = rqs.Surface(parent_model = model, mesh_file = in_file, mesh_format = mesh_format)
@@ -142,7 +142,7 @@ def test_surface_from_mesh_file(example_model_and_crs, test_data_path, mesh_file
 def test_surface_from_tsurf_file(example_model_and_crs, test_data_path):
     # Arrange
     model, crs = example_model_and_crs
-    in_file = test_data_path / 'Surface_tsurf.txt'
+    in_file = os.path.join(test_data_path, 'Surface_tsurf.txt')
 
     # Act
     surface = rqs.Surface(parent_model = model, tsurf_file = in_file, title = 'horizon')
@@ -346,7 +346,7 @@ def test_explicit_mesh(example_model_and_crs):
 def test_mesh_file(example_model_and_crs, test_data_path, flavour, infile, filetype):
     model, crs = example_model_and_crs
 
-    mesh_file = test_data_path / infile
+    mesh_file = os.path.join(test_data_path, infile)
 
     # make an explicit mesh representation
     mesh = rqs.Mesh(model,
@@ -496,7 +496,7 @@ def test_pointset_from_charisma(example_model_and_crs, test_data_path, tmp_path)
     # Set up a PointSet and save to resqml file
     model, crs = example_model_and_crs
 
-    charisma_file = test_data_path / "Charisma_points.txt"
+    charisma_file = os.path.join(test_data_path, "Charisma_points.txt")
     points = rqs.PointSet(parent_model = model, charisma_file = str(charisma_file), crs_uuid = crs.uuid)
     points.write_hdf5()
     points.create_xml()
@@ -514,7 +514,7 @@ def test_pointset_from_charisma(example_model_and_crs, test_data_path, tmp_path)
     assert coords.shape == (15, 3), f'Expected shape (15,3), not {coords.shape}'
 
     # Test write back to file
-    out_file = str(tmp_path / "Charisma_points_out.txt")
+    out_file = os.path.join(tmp_path, "Charisma_points_out.txt")
     reload.convert_to_charisma(out_file)
 
     assert os.path.exists(out_file)
@@ -527,7 +527,7 @@ def test_pointset_from_charisma(example_model_and_crs, test_data_path, tmp_path)
 def test_pointset_from_irap(example_model_and_crs, test_data_path, tmp_path):
     # Set up a PointSet and save to resqml file
     model, crs = example_model_and_crs
-    irap_file = test_data_path / "IRAP_points.txt"
+    irap_file = os.path.join(test_data_path, "IRAP_points.txt")
     points = rqs.PointSet(parent_model = model, irap_file = str(irap_file), crs_uuid = crs.uuid)
     points.write_hdf5()
     points.create_xml()
@@ -545,7 +545,7 @@ def test_pointset_from_irap(example_model_and_crs, test_data_path, tmp_path):
     assert coords.shape == (9, 3), f'Expected shape (9,3), not {coords.shape}'
 
     # Test write back to file
-    out_file = str(tmp_path / "IRAP_points_out.txt")
+    out_file = os.path.join(tmp_path, "IRAP_points_out.txt")
     reload.convert_to_irap(out_file)
 
     assert os.path.exists(out_file)

--- a/tests/unit_tests/time_series/test_time_series_functions.py
+++ b/tests/unit_tests/time_series/test_time_series_functions.py
@@ -46,8 +46,6 @@ def test_merge_timeseries():
     for idx, timestamp in enumerate(newts2.datetimes()):
         assert timestamp == sortedtimestamps[idx]
 
-    return True
-
 
 def test_time_series_from_list(tmp_path):
     epc = os.path.join(tmp_path, 'ts_list.epc')


### PR DESCRIPTION
This patch fixes a bug whereby xml reference nodes to a string lookup were not being updated for categorical properties, in the derived_model.gather_ensemble() function.

Resolves issue #775 