### PR TITLE
cleaniing up unit test warnings

### DIFF
--- a/resqpy/grid_surface/grid_surface_cuda.py
+++ b/resqpy/grid_surface/grid_surface_cuda.py
@@ -1,7 +1,8 @@
 """Cuda based grid surface intersection functionality for GPU processing.
 
-note:
-   use of this module requires accessible GPUs and the corresponding numba.cuda and cupy packages to be installed
+notes:
+   use of this module requires accessible GPUs and the corresponding numba.cuda and cupy packages to be installed;
+   currently excluded from automated unit tests due to those requirements
 """
 
 import logging
@@ -30,27 +31,27 @@ compiler_lock = threading.Lock()  # Numba compiler is not threadsafe
 
 # cuda device wrappers for numpy functions
 @cuda.jit(device = True)
-def _cross_d(A: DeviceNDArray, B: DeviceNDArray, c: DeviceNDArray):
+def _cross_d(A: DeviceNDArray, B: DeviceNDArray, c: DeviceNDArray):  # pragma: no cover
     c[0] = A[1] * B[2] - A[2] * B[1]
     c[1] = A[2] * B[0] - A[0] * B[2]
     c[2] = A[0] * B[1] - A[1] * B[0]
 
 
 @cuda.jit(device = True)
-def _negative_d(v: DeviceNDArray, nv: DeviceNDArray):
+def _negative_d(v: DeviceNDArray, nv: DeviceNDArray):  # pragma: no cover
     for d in range(v.shape[0]):
         nv[d] = numba.float32(-1.0) * v[d]
 
 
 @cuda.jit(device = True)
-def _dot_d(v1: DeviceNDArray, v2: DeviceNDArray, prod: DeviceNDArray):
+def _dot_d(v1: DeviceNDArray, v2: DeviceNDArray, prod: DeviceNDArray):  # pragma: no cover
     prod[0] = 0.0
     for d in range(v1.shape[0]):
         prod[0] += v1[d] * v2[d]
 
 
 @cuda.jit(device = True)
-def _norm_d(v: DeviceNDArray, n: DeviceNDArray):
+def _norm_d(v: DeviceNDArray, n: DeviceNDArray):  # pragma: no cover
     n[0] = 0.0
     for dim in range(3):
         n[0] += v[dim]**2.0
@@ -82,7 +83,7 @@ def project_polygons_to_surfaces(
     offsets: DeviceNDArray,
     return_triangles: bool,
     triangle_per_face: DeviceNDArray,
-):
+):  # pragma: no cover
     """Maps the projection of a 3D polygon to 2D grid surfaces along a given axis, using GPUs.
 
     arguments:
@@ -286,7 +287,7 @@ def project_polygons_to_surfaces(
 
 
 @cuda.jit
-def _diffuse_closed_faces(a, k_faces, j_faces, i_faces, index1, index2, axis, start, stop, inc):
+def _diffuse_closed_faces(a, k_faces, j_faces, i_faces, index1, index2, axis, start, stop, inc):  # pragma: no cover
 
     tidx, tidy = cuda.grid(2)
     stridex, stridey = cuda.gridsize(2)
@@ -320,7 +321,7 @@ def bisector_from_faces_cuda(
     k_faces: np.ndarray,
     j_faces: np.ndarray,
     i_faces: np.ndarray,
-) -> Tuple[np.ndarray, bool]:
+) -> Tuple[np.ndarray, bool]:  # pragma: no cover
     """Returns a numpy bool array denoting the bisection of the grid by the face sets, using GPUs.
 
     arguments:
@@ -421,7 +422,7 @@ def find_faces_to_represent_surface_regular_cuda_sgpu(
     i_gpu = 0,
     gcs_list = None,
     props_dict_list = None,
-):
+):  # pragma: no cover
     """Returns a grid connection set containing those cell faces which are deemed to represent the surface, using GPUs.
 
     arguments:
@@ -829,7 +830,7 @@ def find_faces_to_represent_surface_regular_cuda_mgpu(
     feature_type = "fault",
     progress_fn = None,
     return_properties = None,
-):
+):  # pragma: no cover
     """Returns a grid connection set containing those cell faces which are deemed to represent the surface, using GPUs.
 
     arguments:

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -2768,7 +2768,7 @@ class BlockedWell(BaseResqpy):
             'SKIN': ('Euc', 'skin', False),
             'WI': ('Euc', 'well connection index', False),
         }
-        return uom_pk_discrete_dict.get(extra, ('Euc', 'continuous', False))
+        return uom_pk_discrete_dict.get(extra, ('Euc', 'generic continuous', False))
 
     def _get_uom_pk_discrete_for_length_based_properties(self, length_uom, extra):
         if length_uom is None or length_uom == 'Euc':

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -202,8 +202,8 @@ def example_model_with_properties(tmp_path):
     for array, name, kind, discrete, facet_type, facet in zip(
         [zone_array, vpc_array, fb_array, facies_array, ntg_array, por_array, sat_array, perm_array, perm_v_array],
         ['Zone', 'VPC', 'Fault block', 'Facies', 'NTG', 'POR', 'SW', 'Perm', 'PERMZ'], [
-            'discrete', 'discrete', 'discrete', 'discrete', 'net to gross ratio', 'porosity', 'saturation',
-            'rock permeability', 'permeability rock'
+            'zone', 'vpc', 'fault block', 'facies', 'net to gross ratio', 'porosity', 'saturation', 'rock permeability',
+            'permeability rock'
         ], [True, True, True, True, False, False, False, False, False],
         [None, None, None, None, None, None, 'what', 'direction', 'direction'],
         [None, None, None, None, None, None, 'water', 'I', 'K']):
@@ -307,7 +307,7 @@ def model_with_prop_ts_rels(model_path):
     # Add non-varying properties
     for array, name, kind, discrete, facet_type, facet in zip([zone_array, vpc_array, fb_array, perm_array],
                                                               ['Zone', 'VPC', 'Fault block', 'Perm'],
-                                                              ['discrete', 'discrete', 'discrete', 'permeability rock'],
+                                                              ['zone', 'vpc', 'fault block', 'permeability rock'],
                                                               [True, True, True, False],
                                                               [None, None, None, 'direction'], [None, None, None, 'J']):
         collection.add_cached_array_to_imported_list(cached_array = array,
@@ -350,7 +350,7 @@ def model_with_prop_ts_rels(model_path):
                                                  uom = None,
                                                  time_index = None,
                                                  null_value = None,
-                                                 property_kind = 'discrete',
+                                                 property_kind = 'facies',
                                                  facet_type = None,
                                                  facet = None,
                                                  realization = None)

--- a/tests/unit_tests/fault/test_fault_connection_set.py
+++ b/tests/unit_tests/fault/test_fault_connection_set.py
@@ -138,7 +138,7 @@ def test_fault_connection_set(tmp_path):
                                 'test',
                                 'juxtapose',
                                 g2_fcs.uuid,
-                                property_kind = 'discrete',
+                                property_kind = 'discrete test pk',
                                 indexable_element = 'faces',
                                 discrete = True,
                                 null_value = -1)

--- a/tests/unit_tests/grid/conftest.py
+++ b/tests/unit_tests/grid/conftest.py
@@ -111,11 +111,10 @@ def example_model_with_properties(tmp_path) -> Model:
     collection.set_grid(grid)
     for array, name, kind, discrete, facet_type, facet in zip(
         [zone_array, vpc_array, fb_array, facies_array, ntg_array, por_array, sat_array, perm_array],
-        ['Zone', 'VPC', 'Fault block', 'Facies', 'NTG', 'POR', 'SW', 'Perm'], [
-            'discrete', 'discrete', 'discrete', 'discrete', 'net to gross ratio', 'porosity', 'saturation',
-            'rock permeability'
-        ], [True, True, True, True, False, False, False, False],
-        [None, None, None, None, None, None, None, 'direction'], [None, None, None, None, None, None, None, 'I']):
+        ['Zone', 'VPC', 'Fault block', 'Facies', 'NTG', 'POR', 'SW', 'Perm'],
+        ['zone', 'vpc', 'fault block', 'facies', 'net to gross ratio', 'porosity', 'saturation', 'rock permeability'],
+        [True, True, True, True, False, False, False, False], [None, None, None, None, None, None, None, 'direction'],
+        [None, None, None, None, None, None, None, 'I']):
         collection.add_cached_array_to_imported_list(cached_array = array,
                                                      source_info = '',
                                                      keyword = name,

--- a/tests/unit_tests/model/test_model.py
+++ b/tests/unit_tests/model/test_model.py
@@ -216,7 +216,7 @@ def test_model_copy_all_parts_non_resqpy_hdf5_paths(example_model_with_propertie
         prop.prepare_import(cached_array = data,
                             source_info = 'test data',
                             keyword = f'TEST{i}',
-                            property_kind = 'continuous',
+                            property_kind = 'continuous test pk',
                             uom = 'm')
         for entry in prop.collection.imported_list:  # only one entry
             # override internal hdf5 path

--- a/tests/unit_tests/olio/test_write_hdf5.py
+++ b/tests/unit_tests/olio/test_write_hdf5.py
@@ -19,9 +19,12 @@ def test_dtype_size(tmp_path):
     hdf5_sizes = []
 
     extent_kji = (1000, 100, 100)
-    a = np.random.random(extent_kji)
+    b = np.random.random(extent_kji)
 
     for filename, dtype in zip(filenames, dtypes):
+        restore = np.seterr(under = 'ignore')
+        a = b.astype(dtype)
+        np.seterr(**restore)
         epc = os.path.join(tmp_path, filename + '.epc')
         h5_file = epc[:-4] + '.h5'
         model = rq.new_model(epc)

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -139,7 +139,7 @@ def test_property(tmp_path):
     assert_array_almost_equal(tr_from_directional[0], tr_from_composite[0])
     assert_array_almost_equal(tr_from_directional[1], tr_from_composite[1])
     assert_array_almost_equal(tr_from_directional[2], tr_from_composite[2])
-    pk = rqp.PropertyKind(model, title = 'facies', parent_property_kind = 'discrete')
+    pk = rqp.PropertyKind(model, title = 'facies', parent_property_kind = 'facies')
     pk.create_xml()
     facies_dict = {0: 'background'}
     for i in range(1, 10):
@@ -347,7 +347,7 @@ def test_constant_array_expansion(tmp_path):
                                  source_info = 'test',
                                  keyword = 'constant pi',
                                  support_uuid = grid.uuid,
-                                 property_kind = 'continuous',
+                                 property_kind = 'continuous test pk',
                                  indexable_element = 'cells',
                                  const_value = maths.pi,
                                  expand_const_arrays = True)
@@ -356,7 +356,7 @@ def test_constant_array_expansion(tmp_path):
                                  source_info = 'test',
                                  keyword = 'constant three',
                                  support_uuid = grid.uuid,
-                                 property_kind = 'discrete',
+                                 property_kind = 'discrete test pk',
                                  discrete = True,
                                  indexable_element = 'cells',
                                  const_value = 3,
@@ -695,8 +695,8 @@ def test_part_str(example_model_with_prop_ts_rels):
     part_facet = pc.parts()[4]
 
     # Act / Assert
-    assert pc.part_str(part_disc) == 'Zone (Zone)'
-    assert pc.part_str(part_disc, include_citation_title = False) == 'Zone'
+    assert pc.part_str(part_disc) == 'zone (Zone)'
+    assert pc.part_str(part_disc, include_citation_title = False) == 'zone'
     assert pc.part_str(part_cont) == 'saturation: water; timestep: 2 (SW)'
     assert pc.part_str(part_cont, include_citation_title = False) == 'saturation: water; timestep: 2'
     assert pc.part_str(part_facet) == 'rock permeability: J (Perm)'
@@ -713,7 +713,7 @@ def test_part_filename(example_model_with_prop_ts_rels):
     part_facet = pc.parts()[4]
 
     # Act / Assert
-    assert pc.part_filename(part_disc) == 'Zone'
+    assert pc.part_filename(part_disc) == 'zone'
     assert pc.part_filename(part_cont) == 'saturation_water_ts_2'
     assert pc.part_filename(part_facet) == 'rock_permeability_J'
 
@@ -1204,7 +1204,7 @@ def test_create_xml_minmax_none(example_model_with_properties):
     p_node = pc.create_xml(ext_uuid = ext_uuid,
                            property_array = array,
                            title = 'Tester',
-                           property_kind = 'continuous',
+                           property_kind = 'continuous test pk',
                            support_uuid = support_uuid,
                            p_uuid = bu.new_uuid(),
                            uom = 'Euc',
@@ -1229,7 +1229,7 @@ def test_create_xml_all_nan_minmax_none(example_model_with_properties):
     p_node = pc.create_xml(ext_uuid = ext_uuid,
                            property_array = array,
                            title = 'all nan',
-                           property_kind = 'continuous',
+                           property_kind = 'continuous test pk',
                            support_uuid = support_uuid,
                            p_uuid = bu.new_uuid(),
                            uom = 'Euc',
@@ -1305,7 +1305,7 @@ def test_create_xml_minmax_none_discrete(example_model_with_properties):
     p_node = pc.create_xml(ext_uuid = ext_uuid,
                            property_array = array,
                            title = 'Tester',
-                           property_kind = 'discrete',
+                           property_kind = 'discrete test pk',
                            support_uuid = support_uuid,
                            p_uuid = bu.new_uuid(),
                            uom = 'Euc',
@@ -1843,12 +1843,11 @@ def test_property_kind_list(example_model_with_properties):
     pc = model.grid().property_collection
 
     # Act
-    element = pc.property_kind_list()
+    element = set(pc.property_kind_list())
 
     # Assert
-    assert element == [
-        'Facies', 'Fault block', 'VPC', 'Zone', 'net to gross ratio', 'porosity', 'rock permeability', 'saturation'
-    ]
+    assert element == set(
+        ['facies', 'fault block', 'vpc', 'zone', 'net to gross ratio', 'porosity', 'rock permeability', 'saturation'])
 
 
 def test_indexable_list(example_model_with_properties):
@@ -2194,7 +2193,7 @@ expected_disc = np.ones(shape = (3, 5, 5))  # for discrete array result is the v
                           (porarray, 'por', False, 'porosity', None, None, expected_por),
                           (satarray, 'sw', False, 'saturation', None, None, expected_sat),
                           (karray, 'kx', False, 'rock permeability', 'direction', 'I', expected_k),
-                          (discarray, 'zone', True, 'discrete', None, None, expected_disc)])
+                          (discarray, 'zone', True, 'zone', None, None, expected_disc)])
 def test_coarsening_reservoir_properties(example_fine_coarse_model, inarray, keyword, discrete, kind, facettype, facet,
                                          outarray):
     # Arrange
@@ -2285,7 +2284,7 @@ def test_import_ab_properties(example_model_with_properties, test_data_path):
     ab_ntg = os.path.join(test_data_path, 'ntg_355.db')
 
     # Act
-    pc.import_ab_property_to_cache(ab_facies, keyword = 'ab_facies', discrete = True, property_kind = 'discrete')
+    pc.import_ab_property_to_cache(ab_facies, keyword = 'ab_facies', discrete = True, property_kind = 'facies')
 
     pc.import_ab_property_to_cache(ab_ntg, keyword = 'ab_ntg', discrete = False, property_kind = 'net to gross ratio')
     pc.write_hdf5_for_imported_list()
@@ -2306,7 +2305,7 @@ def test_import_ab_properties(example_model_with_properties, test_data_path):
     facies = [part for part in pc.parts() if pc.citation_title_for_part(part) == 'ab_facies'][0]
     facies_array = pc.cached_part_array_ref(facies)
     assert not pc.continuous_for_part(facies)
-    assert pc.property_kind_for_part(facies) == 'ab_facies'  # local property kind now automatically generated
+    assert pc.property_kind_for_part(facies) == 'facies'
     assert np.min(facies_array) == 0
     assert np.max(facies_array) == 5
     assert np.sum(facies_array) == 170
@@ -2461,13 +2460,13 @@ def test_mesh_support(example_model_and_crs):
                                          source_info = 'cellarray',
                                          keyword = 'TESTcell',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          indexable_element = 'cells')
     pc.add_cached_array_to_imported_list(node_prop,
                                          source_info = 'nodearray',
                                          keyword = 'TESTnode',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          indexable_element = 'nodes')
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()
@@ -2525,7 +2524,7 @@ def test_surface_support(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)
     pc.add_cached_array_to_imported_list(p_prop_float,
                                          source_info = '',
@@ -2580,7 +2579,7 @@ def test_point_set_support(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()
@@ -2622,7 +2621,7 @@ def test_polyline_support_closed(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)  # should default to intervals
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()
@@ -2664,7 +2663,7 @@ def test_polyline_support_not_closed(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)  # should default to intervals
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()
@@ -2715,7 +2714,7 @@ def test_polyline_set_support_all_closed(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)  # should default to intervals
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()
@@ -2766,7 +2765,7 @@ def test_polyline_set_support_all_not_closed(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)  # should default to intervals
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()
@@ -2817,7 +2816,7 @@ def test_polyline_set_support_most_closed(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)  # should default to intervals
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()
@@ -2868,7 +2867,7 @@ def test_polyline_set_support_most_not_closed(example_model_and_crs):
                                          source_info = '',
                                          keyword = 'test int',
                                          discrete = True,
-                                         property_kind = 'discrete',
+                                         property_kind = 'discrete test pk',
                                          null_value = -1)  # should default to intervals
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()

--- a/tests/unit_tests/rq_import/test_rq_import.py
+++ b/tests/unit_tests/rq_import/test_rq_import.py
@@ -330,7 +330,7 @@ def test_add_ab_properties(example_model_with_properties, test_data_path):
     ab_facies = os.path.join(test_data_path, 'facies.ib')
     ab_ntg = os.path.join(test_data_path, 'ntg_355.db')
 
-    ab_list = [(ab_facies, 'facies_ab', 'discrete', None, None, None, None, None, True, None),
+    ab_list = [(ab_facies, 'facies_ab', 'facies', None, None, None, None, None, True, None),
                (ab_ntg, 'ntg_ab', 'net to gross ratio', None, None, None, None, None, False, None)]
 
     rqi.add_ab_properties(model.epc_file, ab_property_list = ab_list)

--- a/tests/unit_tests/well/test_blocked_well.py
+++ b/tests/unit_tests/well/test_blocked_well.py
@@ -1084,6 +1084,9 @@ def test_add_grid_properties(example_model_and_crs):
     bw = rqw.BlockedWell(model, well_name = well_name, trajectory = trajectory)
     bw.write_hdf5()
     bw.create_xml()
+    bw_lazy = rqw.BlockedWell(model, well_name = well_name, trajectory = trajectory, lazy = True)
+    bw_lazy.write_hdf5()
+    bw_lazy.create_xml()
     model.store_epc()
 
     uuids_to_add = uuids_nosl + uuids_sl + uuids_static + uuids_static_continuous
@@ -1108,6 +1111,12 @@ def test_add_grid_properties(example_model_and_crs):
 
     assert bw_pc.single_array_ref(property_kind = 'example data continuous').dtype == float
     assert bw_pc.single_array_ref(property_kind = 'example data static').dtype == int
+
+    bw_lazy = rqw.BlockedWell(reload, uuid = bw_lazy.uuid)
+    assert bw_lazy.cell_count == bw.cell_count
+    assert bw_lazy.node_count == bw.node_count
+    assert np.all(bw_lazy.cell_indices == bw.cell_indices)
+    assert_array_almost_equal(bw_lazy.node_mds, bw.node_mds)
 
 
 def test_temporary_handling_of_badly_formed_grid_indices(example_model_and_crs):

--- a/tests/unit_tests/well/test_wellbore_marker_frame.py
+++ b/tests/unit_tests/well/test_wellbore_marker_frame.py
@@ -387,7 +387,7 @@ def test_property_collection(example_model_and_crs):
                                          keyword = 'interval prop',
                                          discrete = True,
                                          null_value = -1,
-                                         property_kind = 'discrete',
+                                         property_kind = 'wellbore interval',
                                          indexable_element = 'intervals')
     pc.write_hdf5_for_imported_list()
     pc.create_xml_for_imported_list_and_add_parts_to_model()


### PR DESCRIPTION
Adjusting unit tests so they don't generate warnings:

- removing instances of abstract 'discrete' and 'continuous' as property kind
- floating point underflow when testing writing floating point data to hdf5 at reduced precision