### PR TITLE
exposing flange radius control in grid surface mp wrapper

### DIFF
--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -42,7 +42,8 @@ def find_faces_to_represent_surface_regular_wrapper(
         extra_metadata = None,
         return_properties: Optional[List[str]] = None,
         raw_bisector: bool = False,
-        use_pack: bool = False) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
+        use_pack: bool = False,
+        flange_radius = None) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
     """Multiprocessing wrapper function of find_faces_to_represent_surface_regular_optimised.
 
     arguments:
@@ -93,6 +94,8 @@ def find_faces_to_represent_surface_regular_wrapper(
            form without assessing which side is shallower (True values indicate same side as origin cell)
         use_pack (bool, default False): if True, boolean properties will be stored in numpy packed format,
            which will only be readable by resqpy based applications
+        flange_radius (float, optional): the radial distance to use for outer flange extension points; if None,
+           a large value will be calculated from the grid size; units are xy units of grid crs
 
     returns:
         Tuple containing:
@@ -138,7 +141,8 @@ def find_faces_to_represent_surface_regular_wrapper(
             log.warning(f'grid cell length property {prop_title} NOT found')
     grid = grr.RegularGrid(parent_model = model, uuid = grid_uuid)
     assert grid.is_aligned
-    flange_radius = 5.0 * np.sum(np.array(grid.extent_kji, dtype = float) * np.array(grid.aligned_dxyz()))
+    if flange_radius is None:
+        flange_radius = 5.0 * np.sum(np.array(grid.extent_kji, dtype = float) * np.array(grid.aligned_dxyz()))
     s_model = rq.Model(surface_epc, quiet = True)
     model.copy_uuid_from_other_model(s_model, uuid = str(surface_uuid))
     repr_type = model.type_of_part(model.part(uuid = surface_uuid), strip_obj = True)
@@ -175,6 +179,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                                               extend_with_flange = extend_fault_representation,
                                               flange_inner_ring = flange_inner_ring,
                                               saucer_parameter = saucer_parameter,
+                                              flange_radial_factor = 1.2,
                                               flange_radial_distance = flange_radius,
                                               make_clockwise = False)
         extended = extend_fault_representation

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -214,8 +214,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties_flange(small
     assert len(uuid_list) == 10
 
 
-def test_find_faces_to_represent_surface_regular_wrapper_flange_radius(small_grid_and_surface:
-                                                                           Tuple[RegularGrid, Surface]):
+def test_find_faces_to_represent_surface_regular_wrapper_flange_radius(small_grid_and_surface: Tuple[RegularGrid,
+                                                                                                     Surface]):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -1,7 +1,7 @@
 from resqpy.model import Model
 from typing import Tuple
 from resqpy.grid import RegularGrid
-from resqpy.surface import Surface
+from resqpy.surface import Surface, PointSet
 import resqpy.property as rqp
 from resqpy.multi_processing.wrappers.grid_surface_mp import find_faces_to_represent_surface_regular_wrapper
 from resqpy.multi_processing._multiprocessing import rm_tree
@@ -44,6 +44,50 @@ def test_find_faces_to_represent_surface_regular_wrapper(small_grid_and_surface:
     assert len(model.uuids(obj_type = 'FaultInterpretation')) == 1
     assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
     assert len(model.uuids()) == 9
+    assert len(uuid_list) == 7
+
+
+def test_find_faces_to_represent_surface_regular_wrapper_point_set(small_grid_and_surface: Tuple[RegularGrid, Surface]):
+    # Arrange
+    grid, surface = small_grid_and_surface
+    grid_epc = surface_epc = grid.model.epc_file
+    grid_uuid = grid.uuid
+    _, p = surface.triangles_and_points()
+    ps = PointSet(surface.model, points_array = p, crs_uuid = surface.crs_uuid, title = surface.title)
+    ps.write_hdf5()
+    ps.create_xml()
+    ps_uuid = ps.uuid
+    ps.model.store_epc()
+
+    name = "test pointset"
+    input_index = 0
+    use_index_as_realisation = False
+
+    # Act
+    index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(input_index,
+                                                                                          "tmp_dir",
+                                                                                          use_index_as_realisation,
+                                                                                          grid_epc,
+                                                                                          grid_uuid,
+                                                                                          surface_epc,
+                                                                                          ps_uuid,
+                                                                                          name,
+                                                                                          random_agitation = False,
+                                                                                          trimmed = True)
+    model = Model(epc_file = epc_file)
+    rm_tree("tmp_dir")
+
+    # Assert
+    assert success is True
+    assert index == input_index
+    assert len(model.uuids(obj_type = 'LocalDepth3dCrs')) == 1
+    assert len(model.uuids(obj_type = 'IjkGridRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'TriangulatedSetRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'PointSetRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'GridConnectionSetRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'FaultInterpretation')) == 1
+    assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
+    assert len(model.uuids()) == 10
     assert len(uuid_list) == 7
 
 

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -214,6 +214,50 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties_flange(small
     assert len(uuid_list) == 10
 
 
+def test_find_faces_to_represent_surface_regular_wrapper_flange_radius(small_grid_and_surface:
+                                                                           Tuple[RegularGrid, Surface]):
+    # Arrange
+    grid, surface = small_grid_and_surface
+    grid_epc = surface_epc = grid.model.epc_file
+    grid_uuid = grid.uuid
+    surface_uuid = surface.uuid
+    return_properties = ["triangle", "offset"]
+
+    name = "test"
+    input_index = 0
+    use_index_as_realisation = False
+
+    # Act
+    index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
+        input_index,
+        "tmp_dir",
+        use_index_as_realisation,
+        grid_epc,
+        grid_uuid,
+        surface_epc,
+        surface_uuid,
+        name,
+        return_properties = return_properties,
+        extend_fault_representation = True,
+        flange_radius = 3000.0)
+    model = Model(epc_file = epc_file)
+    rm_tree("tmp_dir")
+
+    # Assert
+    assert success is True
+    assert index == input_index
+    assert len(model.uuids(obj_type = 'LocalDepth3dCrs')) == 1
+    assert len(model.uuids(obj_type = 'IjkGridRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'TriangulatedSetRepresentation')) == 2
+    assert len(model.uuids(obj_type = 'GridConnectionSetRepresentation')) == 1
+    assert len(model.uuids(obj_type = 'FaultInterpretation')) == 1
+    assert len(model.uuids(obj_type = 'TectonicBoundaryFeature')) == 1
+    assert len(model.uuids(obj_type = 'DiscreteProperty')) == 2
+    assert len(model.uuids(obj_type = 'ContinuousProperty')) == 4
+    assert len(model.uuids()) == 16
+    assert len(uuid_list) == 10
+
+
 def test_find_faces_to_represent_surface_extended_bisector_use_pack(small_grid_and_extended_surface: Tuple[RegularGrid,
                                                                                                            Surface]):
     # Arrange


### PR DESCRIPTION
When gridding surfaces to a regular grid using the multi processing wrapper, this change adds a new argument, flange_radius, and reduces the radial factor.