### PR TITLE
removing not-a-number points from point set prior to triangulation

### DIFF
--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -539,6 +539,16 @@ class Surface(rqsb.BaseSurface):
         assert saucer_parameter is None or 0.0 <= saucer_parameter < 1.0
         crs = rqc.Crs(self.model, uuid = point_set.crs_uuid)
         p = point_set.full_array_ref()
+        assert p.ndim >= 2
+        assert p.shape[-1] == 3
+        p = p.reshape((-1, 3))
+        nan_mask = np.isnan(p)
+        if np.any(nan_mask):
+            row_mask = np.logical_not(np.any(nan_mask, axis = -1))
+            log.warning(
+                f'removing {len(p) - np.count_nonzero(row_mask)} NaN points from point set prior to surface triangulation'
+            )
+            p = p[row_mask, :]
         if crs.xy_units == crs.z_units or not reorient:
             unit_adjusted_p = p
         else:

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -545,8 +545,8 @@ class Surface(rqsb.BaseSurface):
         nan_mask = np.isnan(p)
         if np.any(nan_mask):
             row_mask = np.logical_not(np.any(nan_mask, axis = -1))
-            log.warning(
-                f'removing {len(p) - np.count_nonzero(row_mask)} NaN points from point set prior to surface triangulation'
+            log.info(
+                f'removing {len(p) - np.count_nonzero(row_mask)} NaN points from point set {point_set.title} prior to surface triangulation'
             )
             p = p[row_mask, :]
         if crs.xy_units == crs.z_units or not reorient:

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -228,7 +228,7 @@ def test_surface_from_point_set_with_nan_removal(example_model_and_crs):
     surf.set_from_point_set(ps, reorient = True, reorient_max_dip = None, extend_with_flange = False)
     surf.write_hdf5()
     surf.create_xml()
-    assert surf.node_count() == 32
+    assert surf.node_count() == 17
 
 
 @pytest.mark.parametrize('mesh_file,mesh_format,firstval', [('Surface_roxartext.txt', 'rms', 0.4229),


### PR DESCRIPTION
Delauney triangulation fails if there are any not-a-number (NaN) values present amongst the points. This patch removes such points and gives a warning prior to triangulating a Surface from a PointSet.