### PR TITLE
adding ftUS as alias for tf[US]

### DIFF
--- a/resqpy/weights_and_measures/weights_and_measures.py
+++ b/resqpy/weights_and_measures/weights_and_measures.py
@@ -30,6 +30,7 @@ UOM_ALIASES = {
     # Length
     'm': {'m', 'metre', 'metres', 'meter', 'meters'},
     'ft': {'ft', 'foot', 'feet'},
+    'ft[US]': {'ftUS'},
     'cm': {'centimetre', 'centimetres', 'centimeter', 'centimeters'},
 
     # Time

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1289,3 +1289,22 @@ def test_from_tri_mesh_excluding_nans(example_model_and_crs):
     assert np.isnan(z_sample[0])
     assert np.isnan(z_sample[2])
     assert 950.0 <= z_sample[1] <= 1050.0
+
+
+def test_set_to_split_surface(example_model_and_crs):
+    model, crs = example_model_and_crs
+    z_values = np.random.random((30, 20)) * 100.0 + 950.0
+    trim = rqs.TriMesh(model,
+                       t_side = 100.0,
+                       nj = 30,
+                       ni = 20,
+                       z_values = z_values,
+                       crs_uuid = crs.uuid,
+                       title = 'surface for split')
+    surf = rqs.Surface.from_tri_mesh(trim)
+    split_surf = rqs.Surface(model, crs_uuid = crs.uuid, title = 'split surface')
+    line = np.array([(-100.0, 150.0, 0.0), (2100.0, 2500.0, 0.0)], dtype = float)
+    delta_xyz = np.array([(50.0, -50.0, 50.0), (-30.0, 30.0, -30.0)], dtype = float)
+    split_surf.set_to_split_surface(surf, line, delta_xyz)
+    split_surf.write_hdf5()
+    split_surf.create_xml()

--- a/tests/unit_tests/test_weights_measures.py
+++ b/tests/unit_tests/test_weights_measures.py
@@ -61,7 +61,7 @@ def test_aliases_are_unique():
                                                      ('1E6 m3/day', '1E6 m3/d'), ('lb', 'lbm'), ('DEGREESC', 'degC'),
                                                      ('BTU', 'Btu[IT]'), ('SCF/LB', 'ft3/lbm'), ('(RM3/SM3)', 'm3/m3'),
                                                      ('(MMSTB)', '1E6 bbl'), ('LB/(cu.ft.)', 'lbm/ft3'),
-                                                     ('(KJ)            ', 'kJ')])
+                                                     ('(KJ)            ', 'kJ'), ('ftUS', 'ft[US]')])
 def test_uom_from_string(input_uom, expected_uom):
     validated_uom = wam.rq_uom(input_uom)
     assert expected_uom == validated_uom

--- a/tests/unit_tests/test_weights_measures.py
+++ b/tests/unit_tests/test_weights_measures.py
@@ -282,3 +282,16 @@ def test_nexus_units():
     assert wam.nexus_uom_for_quantity('METBAR', 'permeability rock') == 'mD'
     assert wam.nexus_uom_for_quantity('ENGLISH', 'rock permeability') == 'mD'
     assert wam.nexus_uom_for_quantity('ENGLISH', 'permeability rock') == 'mD'
+
+
+def test_rq_uom_list():
+    ul = wam.rq_uom_list(('m', 'metres', 'ft', 'feet', 'ftUS'))
+    assert tuple(ul) == ('m', 'm', 'ft', 'ft', 'ft[US]')
+
+
+def test_rq_time_unit():
+    assert wam.rq_time_unit('seconds') == 's'
+    assert wam.rq_time_unit('sec') == 's'
+    assert wam.rq_time_unit('year') == 'a'
+    assert wam.rq_time_unit('yr') == 'a'
+    assert wam.rq_time_unit('day') == 'd'


### PR DESCRIPTION
This patch adds ftUS as an alias for RESQML length unit of measure ft[US].