### PR TITLE
FIX: allows yearOffset at 0 for geologic time series

### DIFF
--- a/resqpy/time_series/_any_time_series.py
+++ b/resqpy/time_series/_any_time_series.py
@@ -34,7 +34,7 @@ class AnyTimeSeries(BaseResqpy):
             dt_text = rqet.find_tag_text(child, 'DateTime')
             assert dt_text, 'missing DateTime field in xml for time series'
             year_offset = rqet.find_tag_int(child, 'YearOffset')
-            if year_offset:
+            if isinstance(year_offset, int):
                 assert self.timeframe == 'geologic'
                 self.timestamps.append(year_offset)  # todo: trim and check timestamp
             else:


### PR DESCRIPTION
Currently Geological time series can't be 0 as this line check for `falsy`. Suggesting this PR to check for `int` instead.
User case: Storing values that goes from geological past to present-day which is denoted as `0`