### PR TITLE
Accepting YearOffset of zero for geologic time series; replaces PR #797

### DIFF
--- a/resqpy/time_series/_any_time_series.py
+++ b/resqpy/time_series/_any_time_series.py
@@ -34,8 +34,10 @@ class AnyTimeSeries(BaseResqpy):
             dt_text = rqet.find_tag_text(child, 'DateTime')
             assert dt_text, 'missing DateTime field in xml for time series'
             year_offset = rqet.find_tag_int(child, 'YearOffset')
-            if year_offset:
+            if year_offset is not None:
                 assert self.timeframe == 'geologic'
+                if year_offset > 0:
+                    log.warning(f'positive year offset in xml indicates future geological time: {year_offset}')
                 self.timestamps.append(year_offset)  # todo: trim and check timestamp
             else:
                 assert self.timeframe == 'human'

--- a/resqpy/time_series/_geologic_time_series.py
+++ b/resqpy/time_series/_geologic_time_series.py
@@ -29,7 +29,7 @@ class GeologicTimeSeries(ats.AnyTimeSeries):
 
         note:
            if instantiating from an existing RESQML time series, its Time entries must all have YearOffset data
-           which should be large negative integers
+           which should be large negative integers (or zero if reaching the current era)
 
         :meta common:
         """


### PR DESCRIPTION
This change is functionally equivalent to #797, to allow test pipeline to run. The change allows the year offset in the timestamps of geological time series to be zero.