### PR TITLE
Storing surface normal vector as extra metadata (if established at time of create_xml)

### DIFF
--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -716,7 +716,7 @@ class Surface(rqsb.BaseSurface):
 
         _, p = self.triangles_and_points()
         crs = rqc.Crs(self.model, uuid = self.crs_uuid)
-        if crs.xy_units == self.z_units:
+        if crs.xy_units == crs.z_units:
             return p
         unit_adjusted_p = p.copy()
         wam.convert_lengths(unit_adjusted_p[:, 2], crs.z_units, crs.xy_units)

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -59,6 +59,15 @@ def test_faces_for_surface(tmp_model):
     assert surf is not None
     assert surf.node_count() == 4
     assert surf.triangle_count() == 2
+    assert_array_almost_equal(surf.normal(), (-0.707107, 0.0, 0.707107))
+    surf.write_hdf5()
+    surf.create_xml()
+    surf = rqs.Surface(tmp_model, uuid = surf.uuid)
+    assert surf is not None
+    assert surf.node_count() == 4
+    assert surf.triangle_count() == 2
+    assert surf.normal_vector is not None
+    assert_array_almost_equal(surf.normal_vector, (-0.707107, 0.0, 0.707107))
     for mode in ['staffa', 'regular', 'auto']:
         gcs = rqgs.find_faces_to_represent_surface(grid, surf, name = mode, mode = mode)
         assert gcs is not None


### PR DESCRIPTION
This patch stores (and reloads) a Surface normal vector if it has been established at the time of the create_xml() call. (The normal vector can be established by calling the Surface.normal() method, which caches the result as the normal_vector attribute.)