### PR TITLE
using weights and measures valid property kinds as supported property kind list

### DIFF
--- a/resqpy/property/_collection_create_xml.py
+++ b/resqpy/property/_collection_create_xml.py
@@ -66,7 +66,7 @@ def _create_xml_property_kind(collection, p_node, find_local_property_kinds, pro
         property_kind = 'rock permeability'
     p_kind_node = rqet.SubElement(p_node, ns['resqml2'] + 'PropertyKind')
     p_kind_node.text = rqet.null_xml_text
-    if find_local_property_kinds and property_kind not in rqp_c.supported_property_kind_list:
+    if find_local_property_kinds and property_kind not in wam.valid_property_kinds():
         property_kind_uuid = pcga._get_property_kind_uuid(collection, property_kind_uuid, property_kind, uom, discrete)
 
     if property_kind_uuid is None:

--- a/resqpy/property/property_common.py
+++ b/resqpy/property/property_common.py
@@ -12,18 +12,13 @@ import numpy as np
 import resqpy.property as rqp
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.weights_and_measures as bwam
+import resqpy.weights_and_measures as wam
 
 # the following resqml property kinds and facet types are 'known about' by this module in relation to nexus
 # other property kinds should be handled okay but without any special treatment
 # see property_kind_and_facet_from_keyword() for simulator keyword to property kind and facet mapping
 
-supported_property_kind_list = [
-    'continuous', 'discrete', 'categorical', 'code', 'index', 'depth', 'rock volume', 'pore volume', 'volume',
-    'thickness', 'length', 'cell length', 'area', 'net to gross ratio', 'porosity', 'permeability thickness',
-    'permeability length', 'permeability rock', 'rock permeability', 'fluid volume', 'transmissibility', 'pressure',
-    'saturation', 'solution gas-oil ratio', 'vapor oil-gas ratio', 'property multiplier', 'thermodynamic temperature'
-]
+supported_property_kind_list = wam.valid_property_kinds()
 
 supported_local_property_kind_list = [
     'active', 'transmissibility multiplier', 'fault transmissibility', 'mat transmissibility'
@@ -326,7 +321,7 @@ def infer_property_kind(name, unit):
 
     # Currently unit is ignored
 
-    valid_kinds = bwam.valid_property_kinds()
+    valid_kinds = wam.valid_property_kinds()
 
     if name in valid_kinds:
         kind = name

--- a/resqpy/property/property_common.py
+++ b/resqpy/property/property_common.py
@@ -18,7 +18,7 @@ import resqpy.weights_and_measures as wam
 # other property kinds should be handled okay but without any special treatment
 # see property_kind_and_facet_from_keyword() for simulator keyword to property kind and facet mapping
 
-supported_property_kind_list = wam.valid_property_kinds()
+supported_property_kind_list = list(wam.valid_property_kinds())
 
 supported_local_property_kind_list = [
     'active', 'transmissibility multiplier', 'fault transmissibility', 'mat transmissibility'

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -3074,3 +3074,10 @@ def test_no_pack_unpack_bits_ni_one(example_model_and_crs):
     b = rqp.Property(model, uuid = bp.uuid).array_ref(dtype = bool)
     assert b is not None and b.shape == shape
     assert np.all(b == brray)
+
+
+def test_specific_property_kinds():
+
+    assert 'density' in rqp.supported_property_kind_list
+    assert 'thermal conductivity' in rqp.supported_property_kind_list
+    assert 'fluid volume' in rqp.supported_property_kind_list


### PR DESCRIPTION
This change resolves issue #802 

Note that the resqpy.property.supported_property_kind_list is maintained for backward compatibility but it is preferable for calling code to use the underlying function instead: resqpy.weights_and_measures.valid_property_kinds(), which returns a set.