### PR TITLE
optimising the combining of tr mults from multiple grid connection sets

### DIFF
--- a/resqpy/fault/_gcs_functions.py
+++ b/resqpy/fault/_gcs_functions.py
@@ -439,29 +439,29 @@ def combined_tr_mult_from_gcs_mults(model,
 
         # merge in each of the three directional face arrays for this gcs with combined arrays
         for (combo_trm, gcs_trm) in [(combo_trm_k, gcs_trm_k), (combo_trm_j, gcs_trm_j), (combo_trm_i, gcs_trm_i)]:
-            mask = np.logical_not(np.isnan(gcs_trm))  # true where this tr mult is present
+            mask = np.logical_not(np.isnan(gcs_trm)).astype(bool)  # true where this tr mult is present
             clash_mask = np.logical_and(mask, np.logical_not(np.isnan(combo_trm)))  # true where combined value clashes
             if np.any(clash_mask):
                 if merge_mode == 'exception':
                     raise ValueError('gcs transmissibility multiplier conflict when merging')
                 if merge_mode == 'minimum':
-                    combo_trm[:] = np.where(clash_mask, np.minimum(combo_trm, gcs_trm), combo_trm)
+                    combo_trm[clash_mask] = np.minimum(combo_trm, gcs_trm)[clash_mask]
                 elif merge_mode == 'maximum':
-                    combo_trm[:] = np.where(clash_mask, np.maximum(combo_trm, gcs_trm), combo_trm)
+                    combo_trm[clash_mask] = np.maximum(combo_trm, gcs_trm)[clash_mask]
                 elif merge_mode == 'multiply':
-                    combo_trm[:] = np.where(clash_mask, combo_trm * gcs_trm, combo_trm)
+                    combo_trm[clash_mask] = (combo_trm * gcs_trm)[clash_mask]
                 else:
                     raise Exception(f'code failure with unrecognised merge mode {merge_mode}')
                 mask = np.logical_and(mask,
                                       np.logical_not(clash_mask))  # remove clash faces from mask (already handled)
             if np.any(mask):
-                combo_trm[:] = np.where(mask, gcs_trm, combo_trm)  # update combined array from individual array
+                combo_trm[mask] = gcs_trm[mask]  # update combined array from individual array
 
     # for each of the 3 combined tr mult arrays, replace unused values with the default fill value
     # also check that any set values are non-negative
     for combo_trm in (combo_trm_k, combo_trm_j, combo_trm_i):
         if fill_value is not None and not np.isnan(fill_value):
-            combo_trm[:] = np.where(np.isnan(combo_trm), fill_value, combo_trm)
+            combo_trm[:][np.isnan(combo_trm).astype(bool)] = fill_value
             assert np.all(combo_trm >= 0.0)
         else:
             assert np.all(np.logical_or(np.isnan(combo_trm), combo_trm >= 0.0))

--- a/resqpy/grid/_grid.py
+++ b/resqpy/grid/_grid.py
@@ -2255,9 +2255,9 @@ class Grid(BaseResqpy):
         pc = self.extract_property_collection()
 
         if baffle_triplet is not None:
-            trm_k[1:-1] = np.where(baffle_triplet[0], 0.0, trm_k[1:-1])
-            trm_j[:, 1:-1] = np.where(baffle_triplet[1], 0.0, trm_j[:, 1:-1])
-            trm_i[:, :, 1:-1] = np.where(baffle_triplet[2], 0.0, trm_i[:, :, 1:-1])
+            trm_k[1:-1][baffle_triplet[0]] = 0.0
+            trm_j[:, 1:-1][baffle_triplet[1]] = 0.0
+            trm_i[:, :, 1:-1][baffle_triplet[2]] = 0.0
 
         if composite_property:
             tr_composite = np.concatenate((trm_k.flat, trm_j.flat, trm_i.flat))


### PR DESCRIPTION
This is an optimisation to speed up the expansion of a grid connection set property into a triplet of arrays on grid faces (which can be concatenated into a single 'faces' property). This function is called by the function which combines transmissibility multipliers from multiple grid connection sets.