### PR TITLE
whole array overwrite method in Model

### DIFF
--- a/resqpy/model/_hdf5.py
+++ b/resqpy/model/_hdf5.py
@@ -286,6 +286,14 @@ def _h5_overwrite_array_slice(model, h5_key_pair, slice_tuple, array_slice):
     dset[slice_tuple] = array_slice
 
 
+def _h5_overwrite_array(model, h5_key_pair, array):
+    """Overwrites (updates) the whole of an hdf5 array."""
+
+    h5_root = _h5_access(model, h5_key_pair[0], mode = 'a')
+    dset = h5_root[h5_key_pair[1]]
+    dset[...] = array
+
+
 def h5_clear_filename_cache(model):
     """Clears the cached filenames associated with all ext uuids."""
 

--- a/resqpy/model/_model.py
+++ b/resqpy/model/_model.py
@@ -1475,6 +1475,21 @@ class Model():
 
         return m_h._h5_overwrite_array_slice(self, h5_key_pair, slice_tuple, array_slice)
 
+    def h5_overwrite_array(self, h5_key_pair, array):
+        """Overwrites (updates) the whole of an hdf5 array.
+
+        arguments:
+           h5_key_pair (uuid, string): the uuid of the hdf5 ext part and the hdf5 internal path to the
+              required hdf5 array
+           array (numpy array of shape to match existing hdf5 dataset): the data to write
+
+        notes:
+           this method naively updates an hdf5 array without using mpi to look after parallel updates;
+           metadata (such as uuid or property min, max values) is not modified in any way by the method
+        """
+
+        return m_h._h5_overwrite_array(self, h5_key_pair, array)
+
     def h5_clear_filename_cache(self):
         """Clears the cached filenames associated with all ext uuids."""
 


### PR DESCRIPTION
This change adds a method to the Model class for overwriting an entire hdf5 array. (There was already a method for overwriting a slice of an array.)