### PR TITLE
saving surface extrapolation flange property as np.unit8 dtype

### DIFF
--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -1152,18 +1152,18 @@ def shadow_from_faces(extent_kji, k_faces):
         c = np.logical_and(shadow[:-1] == 0, shadow[1:] == 1)
         if np.count_nonzero(c) == 0:
             break
-        shadow[:-1] = np.where(c, 1, shadow[:-1])
+        shadow[:-1][c] = 1
     for _ in range(limit):
         c = np.logical_and(shadow[1:] == 0, shadow[:-1] == 2)
         if np.count_nonzero(c) == 0:
             break
-        shadow[1:] = np.where(c, 2, shadow[1:])
+        shadow[1:][c] = 2
     for _ in range(limit):
         c = np.logical_and(shadow[:-1] >= 2, shadow[1:] == 1)
         if np.count_nonzero(c) == 0:
             break
-        shadow[:-1] = np.where(c, 3, shadow[:-1])
-        shadow[1:] = np.where(c, 3, shadow[1:])
+        shadow[:-1][c] = 3
+        shadow[1:][c] = 3
     return shadow
 
 

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -815,7 +815,7 @@ def find_faces_to_represent_surface_regular_optimised(grid,
                                               related_uuid = surface.uuid)
         assert (flange_bool_uuid is not None), f"No flange bool property found for surface: {surface.title}"
         flange_bool = rqp.Property(surface.model, uuid = flange_bool_uuid)
-        flange_array = flange_bool.array_ref()
+        flange_array = flange_bool.array_ref(dtype = bool)
         all_flange = np.take(flange_array, all_tris)
         assert all_flange.shape == (gcs.count,)
 
@@ -994,12 +994,21 @@ def bisector_from_faces(  # type: ignore
     changing_array = np.zeros_like(bounding_array, dtype = np.bool_)
 
     # Repeatedly spreading True values to neighbouring cells that are not the other side of a face.
-    open_k = np.logical_not(k_faces)[boundary["k_min"]:boundary["k_max"], boundary["j_min"]:boundary["j_max"] + 1,
-                                     boundary["i_min"]:boundary["i_max"] + 1,]
-    open_j = np.logical_not(j_faces)[boundary["k_min"]:boundary["k_max"] + 1, boundary["j_min"]:boundary["j_max"],
-                                     boundary["i_min"]:boundary["i_max"] + 1,]
-    open_i = np.logical_not(i_faces)[boundary["k_min"]:boundary["k_max"] + 1, boundary["j_min"]:boundary["j_max"] + 1,
-                                     boundary["i_min"]:boundary["i_max"],]
+    open_k = np.logical_not(k_faces)[
+        boundary["k_min"]:boundary["k_max"],
+        boundary["j_min"]:boundary["j_max"] + 1,
+        boundary["i_min"]:boundary["i_max"] + 1,
+    ]
+    open_j = np.logical_not(j_faces)[
+        boundary["k_min"]:boundary["k_max"] + 1,
+        boundary["j_min"]:boundary["j_max"],
+        boundary["i_min"]:boundary["i_max"] + 1,
+    ]
+    open_i = np.logical_not(i_faces)[
+        boundary["k_min"]:boundary["k_max"] + 1,
+        boundary["j_min"]:boundary["j_max"] + 1,
+        boundary["i_min"]:boundary["i_max"],
+    ]
     while True:
         changing_array[:] = False
 
@@ -1027,8 +1036,11 @@ def bisector_from_faces(  # type: ignore
 
     # Setting up the full bisectors array and assigning the bounding box values.
     array = np.zeros(grid_extent_kji, dtype = np.bool_)
-    array[boundary["k_min"]:boundary["k_max"] + 1, boundary["j_min"]:boundary["j_max"] + 1,
-          boundary["i_min"]:boundary["i_max"] + 1,] = bounding_array
+    array[
+        boundary["k_min"]:boundary["k_max"] + 1,
+        boundary["j_min"]:boundary["j_max"] + 1,
+        boundary["i_min"]:boundary["i_max"] + 1,
+    ] = bounding_array
 
     # Setting values outside of the bounding box.
     if boundary["k_max"] != grid_extent_kji[0] - 1 and np.any(bounding_array[-1, :, :]):

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -994,6 +994,7 @@ def bisector_from_faces(  # type: ignore
     changing_array = np.zeros_like(bounding_array, dtype = np.bool_)
 
     # Repeatedly spreading True values to neighbouring cells that are not the other side of a face.
+    # yapf: disable
     open_k = np.logical_not(k_faces)[
         boundary["k_min"]:boundary["k_max"],
         boundary["j_min"]:boundary["j_max"] + 1,
@@ -1009,6 +1010,7 @@ def bisector_from_faces(  # type: ignore
         boundary["j_min"]:boundary["j_max"] + 1,
         boundary["i_min"]:boundary["i_max"],
     ]
+    # yapf: enable
     while True:
         changing_array[:] = False
 
@@ -1036,11 +1038,13 @@ def bisector_from_faces(  # type: ignore
 
     # Setting up the full bisectors array and assigning the bounding box values.
     array = np.zeros(grid_extent_kji, dtype = np.bool_)
+    # yapf: disable
     array[
         boundary["k_min"]:boundary["k_max"] + 1,
         boundary["j_min"]:boundary["j_max"] + 1,
         boundary["i_min"]:boundary["i_max"] + 1,
     ] = bounding_array
+    # yapf: enable
 
     # Setting values outside of the bounding box.
     if boundary["k_max"] != grid_extent_kji[0] - 1 and np.any(bounding_array[-1, :, :]):

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -235,7 +235,8 @@ def find_faces_to_represent_surface_regular_wrapper(
                                            property_kind = 'flange bool',
                                            find_local_property_kind = True,
                                            indexable_element = 'faces',
-                                           discrete = True)
+                                           discrete = True,
+                                           dtype = np.uint8)
         uuid_list.append(flange_p.uuid)
     uuid_list.append(surface_uuid)
 


### PR DESCRIPTION
This patch stores the surface extrapolation flange property in numpy.uint8 dtype.