### PR TITLE
masking fip array in GridConnectionSet.grid_face_arrays()

### DIFF
--- a/resqpy/fault/_grid_connection_set.py
+++ b/resqpy/fault/_grid_connection_set.py
@@ -2125,6 +2125,7 @@ class GridConnectionSet(BaseResqpy):
 
         if active_mask is not None:
             cip = cip[active_mask, :, :]
+            fip = fip[active_mask, :, :]
             value_array = value_array[active_mask]
 
         side_list = ([0] if lazy else [0, 1])

--- a/tests/unit_tests/fault/test_fault_connection_set.py
+++ b/tests/unit_tests/fault/test_fault_connection_set.py
@@ -138,6 +138,15 @@ def test_fault_connection_set(tmp_path):
     g2_fcs.create_xml()
     g2_fcs_again.write_hdf5()
     g2_fcs_again.create_xml()
+    g2_fcs_pc = g2_fcs.extract_property_collection()
+    g2_fcs_pc.add_cached_array_to_imported_list(np.array([True, True], dtype = bool),
+                                                'unit test active',
+                                                'ACTIVE',
+                                                property_kind = 'active',
+                                                discrete = True,
+                                                indexable_element = 'faces')
+    g2_fcs_pc.write_hdf5_for_imported_list()
+    g2_fcs_pc.create_xml_for_imported_list_and_add_parts_to_model()
     gcs_p_a = np.array((37, 51), dtype = int)
     p = rqp.Property.from_array(model,
                                 gcs_p_a,


### PR DESCRIPTION
When active_only option is in use, the fip array needs to be masked alongside cip. This is a bug fix.