### PR TITLE
replacing np.product() with np.prod() in unit tests

### DIFF
--- a/tests/unit_tests/grid/test_regular_grid.py
+++ b/tests/unit_tests/grid/test_regular_grid.py
@@ -46,7 +46,7 @@ def test_volume(basic_regular_grid):
 
 def test_volume_mixed_units_default(aligned_regular_grid_mixed_units):
     cell_vol = aligned_regular_grid_mixed_units.volume(cell_kji0 = (0, 1, 2))
-    expected_cell_vol = np.product(aligned_regular_grid_mixed_units.aligned_dxyz())
+    expected_cell_vol = np.prod(aligned_regular_grid_mixed_units.aligned_dxyz())
     # following assumes mixed units are 'm' for xy, 'ft' for z
     expected_cell_vol *= 1.0 / (0.3048 * 0.3048)
     assert maths.isclose(cell_vol, expected_cell_vol)
@@ -55,7 +55,7 @@ def test_volume_mixed_units_default(aligned_regular_grid_mixed_units):
 def test_volume_mixed_units_required_uom(aligned_regular_grid_mixed_units):
     cell_vol_ft3 = aligned_regular_grid_mixed_units.volume(cell_kji0 = (1, 1, 1), required_uom = 'ft3')
     cell_vol_m3 = aligned_regular_grid_mixed_units.volume(cell_kji0 = (1, 1, 1), required_uom = 'm3')
-    expected_cell_vol = np.product(aligned_regular_grid_mixed_units.aligned_dxyz())
+    expected_cell_vol = np.prod(aligned_regular_grid_mixed_units.aligned_dxyz())
     # following assumes mixed units are 'm' for xy, 'ft' for z
     expected_cell_vol_ft3 = expected_cell_vol / (0.3048 * 0.3048)
     expected_cell_vol_m3 = 0.3048 * expected_cell_vol

--- a/tests/unit_tests/olio/test_write_hdf5.py
+++ b/tests/unit_tests/olio/test_write_hdf5.py
@@ -53,7 +53,7 @@ def test_dtype_size(tmp_path):
 def test_use_int32(tmp_path):
 
     extent_kji = (11, 23, 37)
-    a = np.arange(np.product(extent_kji), dtype = int).reshape(extent_kji)
+    a = np.arange(np.prod(extent_kji), dtype = int).reshape(extent_kji)
 
     for use_option in [True, False, None]:
 


### PR DESCRIPTION
The np.product() synonym has been dropped from more recent versions of numpy.