### PR TITLE
handling pre-packed arrays in property collection

### DIFF
--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -18,32 +18,32 @@ import resqpy.surface as rqs
 import resqpy.olio.uuid as bu
 
 
-def find_faces_to_represent_surface_regular_wrapper(
-        index: int,
-        parent_tmp_dir: str,
-        use_index_as_realisation: bool,
-        grid_epc: str,
-        grid_uuid: Union[UUID, str],
-        surface_epc: str,
-        surface_uuid: Union[UUID, str],
-        name: str,
-        title: Optional[str] = None,
-        agitate: bool = False,
-        random_agitation: bool = False,
-        feature_type: str = 'fault',
-        trimmed: bool = False,
-        is_curtain = False,
-        extend_fault_representation: bool = False,
-        flange_inner_ring = False,
-        saucer_parameter = None,
-        retriangulate: bool = False,
-        related_uuid = None,
-        progress_fn: Optional[Callable] = None,
-        extra_metadata = None,
-        return_properties: Optional[List[str]] = None,
-        raw_bisector: bool = False,
-        use_pack: bool = False,
-        flange_radius = None) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
+def find_faces_to_represent_surface_regular_wrapper(index: int,
+                                                    parent_tmp_dir: str,
+                                                    use_index_as_realisation: bool,
+                                                    grid_epc: str,
+                                                    grid_uuid: Union[UUID, str],
+                                                    surface_epc: str,
+                                                    surface_uuid: Union[UUID, str],
+                                                    name: str,
+                                                    title: Optional[str] = None,
+                                                    agitate: bool = False,
+                                                    random_agitation: bool = False,
+                                                    feature_type: str = 'fault',
+                                                    trimmed: bool = False,
+                                                    is_curtain = False,
+                                                    extend_fault_representation: bool = False,
+                                                    flange_inner_ring = False,
+                                                    saucer_parameter = None,
+                                                    retriangulate: bool = False,
+                                                    related_uuid = None,
+                                                    progress_fn: Optional[Callable] = None,
+                                                    extra_metadata = None,
+                                                    return_properties: Optional[List[str]] = None,
+                                                    raw_bisector: bool = False,
+                                                    use_pack: bool = False,
+                                                    flange_radius = None,
+                                                    n_threads = 20) -> Tuple[int, bool, str, List[Union[UUID, str]]]:
     """Multiprocessing wrapper function of find_faces_to_represent_surface_regular_optimised.
 
     arguments:
@@ -92,10 +92,11 @@ def find_faces_to_represent_surface_regular_wrapper(
            the returned dictionary has the passed strings as keys and numpy arrays as values
         raw_bisector (bool, default False): if True and grid bisector is requested then it is left in a raw
            form without assessing which side is shallower (True values indicate same side as origin cell)
-        use_pack (bool, default False): if True, boolean properties will be stored in numpy packed format,
-           which will only be readable by resqpy based applications
+        use_pack (bool, default False): if True, boolean properties will be generated and stored in numpy
+           packed format, which will only be readable by resqpy based applications
         flange_radius (float, optional): the radial distance to use for outer flange extension points; if None,
            a large value will be calculated from the grid size; units are xy units of grid crs
+        n_threads (int, default 20): the number of parallel threads to use in numba points in triangles function
 
     returns:
         Tuple containing:
@@ -250,7 +251,9 @@ def find_faces_to_represent_surface_regular_wrapper(
                                                                      is_curtain,
                                                                      progress_fn,
                                                                      return_properties,
-                                                                     raw_bisector = raw_bisector)
+                                                                     raw_bisector = raw_bisector,
+                                                                     n_batches = n_threads,
+                                                                     packed_bisectors = use_pack)
 
     success = False
 
@@ -340,17 +343,17 @@ def find_faces_to_represent_surface_regular_wrapper(
                 if grid_pc is None:
                     grid_pc = rqp.PropertyCollection()
                     grid_pc.set_support(support = grid)
-                grid_pc.add_cached_array_to_imported_list(
-                    array,
-                    f"from find_faces function for {surface.title}",
-                    f'{surface.title} {p_name}',
-                    discrete = True,
-                    property_kind = "grid bisector",
-                    facet_type = 'direction',
-                    facet = 'raw' if raw_bisector else ('vertical' if is_curtain else 'sloping'),
-                    realization = realisation,
-                    indexable_element = "columns" if is_curtain else "cells",
-                )
+                grid_pc.add_cached_array_to_imported_list(array,
+                                                          f"from find_faces function for {surface.title}",
+                                                          f'{surface.title} {p_name}',
+                                                          discrete = True,
+                                                          property_kind = "grid bisector",
+                                                          facet_type = 'direction',
+                                                          facet = 'raw' if raw_bisector else
+                                                          ('vertical' if is_curtain else 'sloping'),
+                                                          realization = realisation,
+                                                          indexable_element = "columns" if is_curtain else "cells",
+                                                          pre_packed = use_pack)
             elif p_name == 'grid shadow':
                 if grid_pc is None:
                     grid_pc = rqp.PropertyCollection()

--- a/resqpy/olio/write_hdf5.py
+++ b/resqpy/olio/write_hdf5.py
@@ -101,7 +101,7 @@ class H5Register():
         assert chunks is None or isinstance(chunks, str) or isinstance(chunks, tuple)
         assert compression is None or (isinstance(compression, str) and compression in ['gzip', 'lzf', 'none'])
         if str(dtype) == 'pack':
-            a = np.packbits(a, axis = -1)  # todo: check this returns uint8 array
+            a = np.packbits(a, axis = -1)
             dtype = 'uint8'
         elif dtype is not None:
             a = a.astype(dtype, copy = copy)

--- a/resqpy/property/_collection_add_part.py
+++ b/resqpy/property/_collection_add_part.py
@@ -199,7 +199,7 @@ def _process_imported_property(collection, attributes, property_kind_uuid, strin
                                extra_metadata, expand_const_arrays):
     (p_uuid, p_file_name, p_keyword, p_cached_name, p_discrete, p_uom, p_time_index, p_null_value, p_min_value,
      p_max_value, property_kind, facet_type, facet, realization, indexable_element, count, local_property_kind_uuid,
-     const_value, points, p_time_series_uuid, p_string_lookup_uuid) = attributes
+     const_value, points, p_time_series_uuid, p_string_lookup_uuid, pre_packed) = attributes
 
     log.debug('processing imported property ' + str(p_keyword))
     assert not points or not p_discrete
@@ -214,7 +214,7 @@ def _process_imported_property(collection, attributes, property_kind_uuid, strin
                                                                  p_keyword, p_discrete, string_lookup_uuid, points)
 
     p_array = _process_imported_property_get_p_array(collection, p_cached_name)
-    p_array_bool = isinstance(const_value, bool) if p_array is None else p_array.dtype in [bool, np.int8]
+    p_array_bool = isinstance(const_value, bool) if p_array is None else p_array.dtype in [bool, np.int8, np.uint8]
 
     add_min_max = pcga._process_imported_property_get_add_min_max(points, property_kind, string_lookup_uuid,
                                                                   local_property_kind_uuid, p_array_bool)
@@ -251,7 +251,8 @@ def _process_imported_property(collection, attributes, property_kind_uuid, strin
         find_local_property_kinds = find_local_property_kinds,
         extra_metadata = extra_metadata,
         const_value = const_value,
-        expand_const_arrays = expand_const_arrays)
+        expand_const_arrays = expand_const_arrays,
+        pre_packed = pre_packed)
     if p_node is not None:
         return p_node
     else:

--- a/resqpy/property/_collection_create_xml.py
+++ b/resqpy/property/_collection_create_xml.py
@@ -246,8 +246,10 @@ def _create_xml_facet_node(facet_type, facet, p_node):
         facet_value_node.text = facet
 
 
-def _check_shape_list(collection, indexable_element, direction, property_array, points, count):
+def _check_shape_list(collection, indexable_element, direction, property_array, points, count, pre_packed):
     shape_list = collection.supporting_shape(indexable_element = indexable_element, direction = direction)
+    if pre_packed:
+        shape_list[-1] = (shape_list[-1] - 1) // 8 + 1
     if shape_list is not None:
         if count > 1:
             shape_list.append(count)


### PR DESCRIPTION
Following on from support for generating grid bisectors in a packed form (in find_faces..), this change adds support for the pre-packed arrays in the PropertyCollection imported list, and in the multiprocessing wrapper for find faces.