### PR TITLE
setting pre packed False for curtains in find faces wrapper

### DIFF
--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -1575,7 +1575,6 @@ def packed_bisector_from_face_indices(  # type: ignore
     is_curtain = _packed_shallow_or_curtain_temp_bitwise_count(array, true_count, raw_bisector)
     # todo: switch to numpy bitwise_count when numba supports it and resqpy has dropped older numpy versions
     # is_curtain = _packed_shallow_or_curtain(array, true_count, raw_bisector)
-    print(f'**** array shape: {array.shape}; dtype: {array.dtype}')
 
     return array, is_curtain
 

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -353,7 +353,7 @@ def find_faces_to_represent_surface_regular_wrapper(index: int,
                                                           ('vertical' if is_curtain else 'sloping'),
                                                           realization = realisation,
                                                           indexable_element = "columns" if is_curtain else "cells",
-                                                          pre_packed = use_pack)
+                                                          pre_packed = False if is_curtain else use_pack)
             elif p_name == 'grid shadow':
                 if grid_pc is None:
                     grid_pc = rqp.PropertyCollection()


### PR DESCRIPTION
The find faces wrapper was using the use_pack argument to indicate the pre-packed state when adding every bisector array to the property collection. However, curtain bisectors are always returned in an unpacked form. This change fixes this bug.