### PR TITLE
Grid frontier polygon method

### DIFF
--- a/resqpy/grid/_extract_functions.py
+++ b/resqpy/grid/_extract_functions.py
@@ -184,8 +184,8 @@ def __process_axis(axis, child_count_list_list, child_weight_list_list, grid, in
             if intervals_info.child_count_per_interval[interval] == intervals_info.parent_count_per_interval[interval]:
                 continue  # one-to-one
             if refining_flag is None:
-                refining_flag = (intervals_info.child_count_per_interval[interval]
-                                 > intervals_info.parent_count_per_interval[interval])
+                refining_flag = (intervals_info.child_count_per_interval[interval] >
+                                 intervals_info.parent_count_per_interval[interval])
             assert refining_flag == (intervals_info.child_count_per_interval[interval] >
                                      intervals_info.parent_count_per_interval[interval]), \
                 'mixture of refining and coarsening in one local grid – allowed by RESQML but not handled by this code'

--- a/resqpy/grid/_extract_functions.py
+++ b/resqpy/grid/_extract_functions.py
@@ -184,8 +184,8 @@ def __process_axis(axis, child_count_list_list, child_weight_list_list, grid, in
             if intervals_info.child_count_per_interval[interval] == intervals_info.parent_count_per_interval[interval]:
                 continue  # one-to-one
             if refining_flag is None:
-                refining_flag = (intervals_info.child_count_per_interval[interval] >
-                                 intervals_info.parent_count_per_interval[interval])
+                refining_flag = (intervals_info.child_count_per_interval[interval]
+                                 > intervals_info.parent_count_per_interval[interval])
             assert refining_flag == (intervals_info.child_count_per_interval[interval] >
                                      intervals_info.parent_count_per_interval[interval]), \
                 'mixture of refining and coarsening in one local grid – allowed by RESQML but not handled by this code'
@@ -501,7 +501,7 @@ def extract_inactive_mask(grid, check_pinchout = False):
     geom_defined = grr_dg.cell_geometry_is_defined_ref(grid)
     if grid.inactive is None:
         if geom_defined is None or geom_defined is True:
-            grid.inactive = np.zeros(tuple(grid.extent_kji))  # ie. all active
+            grid.inactive = np.zeros(tuple(grid.extent_kji), dtype = bool)  # ie. all active
         else:
             grid.inactive = np.logical_not(grr_dg.cell_geometry_is_defined_ref(grid))
     if check_pinchout:
@@ -524,6 +524,7 @@ def extract_inactive_mask(grid, check_pinchout = False):
             active_gpc = rprop.selective_version_of_collection(active_gpc,
                                                                time_index = grid.time_index,
                                                                time_series_uuid = grid.time_series_uuid)
+            active_parts = active_gpc.parts()
         else:
             active_parts = []
             for part in active_gpc.parts():

--- a/tests/unit_tests/grid/test_xyz.py
+++ b/tests/unit_tests/grid/test_xyz.py
@@ -714,3 +714,31 @@ def test_global_to_local_crs_full_transformation(basic_regular_grid, a, a_expect
 
     # Assert
     np.testing.assert_array_almost_equal(a_transformed, a_expected)
+
+
+def test_frontier_regular_z_non_zero(basic_regular_grid):
+    frontier = basic_regular_grid.frontier(set_z_zero = False)
+    assert frontier is not None
+    assert frontier.coordinates.shape == (2 * (basic_regular_grid.nj + basic_regular_grid.ni), 3)
+    assert np.all(frontier.coordinates[:, 2]) > 0.0
+
+
+def test_frontier_regular_z_zero(basic_regular_grid):
+    frontier = basic_regular_grid.frontier(set_z_zero = True)
+    assert frontier is not None
+    assert frontier.coordinates.shape == (2 * (basic_regular_grid.nj + basic_regular_grid.ni), 3)
+    np.testing.assert_array_almost_equal(frontier.coordinates[:, 2], 0.0)
+
+
+def test_frontier_faulted_z_non_zero(faulted_grid):
+    frontier = faulted_grid.frontier(set_z_zero = False)
+    assert frontier is not None
+    assert frontier.coordinates.shape == (2 * (faulted_grid.nj + faulted_grid.ni), 3)
+    assert np.all(frontier.coordinates[:, 2]) > 0.0
+
+
+def test_frontier_faulted_z_zero(faulted_grid):
+    frontier = faulted_grid.frontier(set_z_zero = True)
+    assert frontier is not None
+    assert frontier.coordinates.shape == (2 * (faulted_grid.nj + faulted_grid.ni), 3)
+    np.testing.assert_array_almost_equal(frontier.coordinates[:, 2], 0.0)


### PR DESCRIPTION
This change enhances the Grid class with:

- a frontier() method which generates a frontier polygon for the edge of the grid

- option to not load the inactive mask attribute when opening an existing grid
