### PR TITLE
adding support for per-line properties on PolylineSet

### DIFF
--- a/resqpy/property/_collection_get_attributes.py
+++ b/resqpy/property/_collection_get_attributes.py
@@ -538,6 +538,8 @@ def _supporting_shape_polylineset(support, indexable_element):
         shape_list = [len(support.coordinates) - reduction]
     elif indexable_element == 'nodes':
         shape_list = [len(support.coordinates)]
+    elif indexable_element in ['patches', 'enumerated elements', 'contacts']:  # one value per polyline within the set
+        shape_list = [len(support.count_perpol)]
     return shape_list
 
 


### PR DESCRIPTION
This small change adds support for properties with a supporting representation of PolylineSet and one value per polyline within the set. The indexable element may be 'patches', 'enumerated elements' or 'contacts'.