### PR TITLE
Remove assert in extract_stratigraphy

### DIFF
--- a/resqpy/grid/_extract_functions.py
+++ b/resqpy/grid/_extract_functions.py
@@ -445,7 +445,12 @@ def extract_stratigraphy(grid):
                                 object = grid,
                                 array_attribute = 'stratigraphic_units',
                                 dtype = 'int')
-    assert len(grid.stratigraphic_units) == grid.nk_plus_k_gaps
+    if (len(grid.stratigraphic_units) != grid.nk_plus_k_gaps):
+        log.warning(
+            "Number of stratigraphic units (%d) does not equal the number of layers plus gaps (%d)",
+            len(grid.stratigraphic_units),
+            grid.nk_plus_k_gaps,
+        )
 
 
 def extract_children(grid):


### PR DESCRIPTION
replace the assertion:
  len(grid.stratigraphic_units) == grid.nk_plus_k_gaps
with a warning message

Have encountered example files that fail this assertion.

This allowed the processing of the affected files, but I'm not sure what other impacts this change could have.
