### PR TITLE
Codecov off

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,7 @@
 # See https://docs.codecov.io/docs/codecov-yaml
 
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: no
 
 coverage:
   # Colour chart range

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   legacy-dependencies:
     # Test against older versions of numpy and pandas,


### PR DESCRIPTION
Temporarily making Codecov okay to fail in test pipeline, until token issue resolved.