### PR TITLE
MAINT: Fix codecov upload, bump github action tags

### DIFF
--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -14,12 +14,12 @@ runs:
   steps:
     - name: Set up Python
       id: setup-python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Load cached Poetry installation
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.local  # the path depends on the OS
         key: poetry-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-0  # increment to reset cache
@@ -39,7 +39,7 @@ runs:
       
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-1

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,7 @@
 # See https://docs.codecov.io/docs/codecov-yaml
 
 codecov:
-  require_ci_to_pass: no
+  require_ci_to_pass: yes
 
 coverage:
   # Colour chart range

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -67,7 +67,7 @@ jobs:
     
       - name: Upload pytest artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (Python ${{ matrix.python-version }})
           path: pytest.xml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -73,11 +73,11 @@ jobs:
           path: pytest.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   legacy-dependencies:
     # Test against older versions of numpy and pandas,

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/actions/prepare-poetry
@@ -55,7 +55,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/actions/prepare-poetry
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/actions/prepare-poetry

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Fix the codecov action by bumping the version, and updating the repo upload token.

Reset `fail_ci_if_error: true`.

Also bump outdated `upload-artifact`, `cache` and `setup-python` actions.