### PR TITLE
Updates to ensure reorientation before flange point generation, even where triangulation is completed in non-reoriented space

### DIFF
--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -210,23 +210,15 @@ def find_faces_to_represent_surface_regular_wrapper(index: int,
         pset = rqs.PointSet(model, points_array = p, crs_uuid = grid.crs.uuid, title = surf_title)
         if extend_fault_representation and not surf_title.endswith('extended'):
             surf_title += ' extended'
-        if saucer_parameter is not None and not reorient:
-            surface, flange_bool = surface.extend_surface_with_flange(convexity_parameter = 2.0,
-                                                                      reorient = reorient,
-                                                                      saucer_parameter = saucer_parameter,
-                                                                      flange_radial_distance = flange_radius,
-                                                                      make_clockwise = False)
-            surface.title = surf_title
-        else:
-            surface = rqs.Surface(model, crs_uuid = grid.crs.uuid, title = surf_title)
-            flange_bool = surface.set_from_point_set(pset,
-                                                     convexity_parameter = 2.0,
-                                                     reorient = reorient,
-                                                     extend_with_flange = extend_fault_representation,
-                                                     flange_inner_ring = flange_inner_ring,
-                                                     saucer_parameter = saucer_parameter,
-                                                     flange_radial_distance = flange_radius,
-                                                     make_clockwise = False)
+        surface = rqs.Surface(model, crs_uuid = grid.crs.uuid, title = surf_title)
+        flange_bool = surface.set_from_point_set(pset,
+                                                    convexity_parameter = 2.0,
+                                                    reorient = reorient,
+                                                    extend_with_flange = extend_fault_representation,
+                                                    flange_inner_ring = flange_inner_ring,
+                                                    saucer_parameter = saucer_parameter,
+                                                    flange_radial_distance = flange_radius,
+                                                    make_clockwise = False)
         del pset
         extended = extend_fault_representation
         retriangulated = True

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -212,13 +212,13 @@ def find_faces_to_represent_surface_regular_wrapper(index: int,
             surf_title += ' extended'
         surface = rqs.Surface(model, crs_uuid = grid.crs.uuid, title = surf_title)
         flange_bool = surface.set_from_point_set(pset,
-                                                    convexity_parameter = 2.0,
-                                                    reorient = reorient,
-                                                    extend_with_flange = extend_fault_representation,
-                                                    flange_inner_ring = flange_inner_ring,
-                                                    saucer_parameter = saucer_parameter,
-                                                    flange_radial_distance = flange_radius,
-                                                    make_clockwise = False)
+                                                 convexity_parameter = 2.0,
+                                                 reorient = reorient,
+                                                 extend_with_flange = extend_fault_representation,
+                                                 flange_inner_ring = flange_inner_ring,
+                                                 saucer_parameter = saucer_parameter,
+                                                 flange_radial_distance = flange_radius,
+                                                 make_clockwise = False)
         del pset
         extended = extend_fault_representation
         retriangulated = True

--- a/resqpy/olio/triangulation.py
+++ b/resqpy/olio/triangulation.py
@@ -884,7 +884,7 @@ def surrounding_xy_ring(p,
             assert abs(saucer_angle) < 90.0
             z_shift = radius * maths.tan(vec.radians_from_degrees(saucer_angle))
             ring[:, 2] -= z_shift
-        return ring, radius
+        return ring
 
     assert p.shape[-1] == 3
     assert radial_factor >= 1.0

--- a/resqpy/olio/triangulation.py
+++ b/resqpy/olio/triangulation.py
@@ -884,7 +884,7 @@ def surrounding_xy_ring(p,
             assert abs(saucer_angle) < 90.0
             z_shift = radius * maths.tan(vec.radians_from_degrees(saucer_angle))
             ring[:, 2] -= z_shift
-        return ring
+        return ring, radius
 
     assert p.shape[-1] == 3
     assert radial_factor >= 1.0
@@ -899,7 +899,7 @@ def surrounding_xy_ring(p,
         inner_radius = p_radius * 1.1
         assert radius > inner_radius
         in_ring = make_ring(2 * count, centre, inner_radius, saucer_angle)
-        return np.concatenate((in_ring, ring), axis = 0)
+        return np.concatenate((in_ring, ring), axis = 0), radius
     return ring, radius
 
 

--- a/resqpy/olio/triangulation.py
+++ b/resqpy/olio/triangulation.py
@@ -25,7 +25,7 @@ import resqpy.olio.vector_utilities as vec
 
 def _dt_scipy(points: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Calculates the Delaunay triangulation for an array of points and the convex hull indices.
-    
+
     arguments:
         points (np.ndarray): coordinates of the points to triangulate; array has shape
             (npoints, ndim)
@@ -871,6 +871,7 @@ def surrounding_xy_ring(p,
        numpy float array of shape (N, 3) being xyz points in surrounding ring(s); z is set constant to
        mean value of z in p (optionally adjussted based on saucer_angle);
        N is count if inner_ring is False, 3 * count if True
+       radius used for ring of additional points
     """
 
     def make_ring(count, centre, radius, saucer_angle):
@@ -899,7 +900,7 @@ def surrounding_xy_ring(p,
         assert radius > inner_radius
         in_ring = make_ring(2 * count, centre, inner_radius, saucer_angle)
         return np.concatenate((in_ring, ring), axis = 0)
-    return ring
+    return ring, radius
 
 
 def edges(t):

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -655,15 +655,14 @@ class Surface(rqsb.BaseSurface):
             unit_adjusted_p = p.copy()
             wam.convert_lengths(unit_adjusted_p[:, 2], crs.z_units, crs.xy_units)
         # reorient the points to the fault normal vector
-        p_xy, self.normal_vector, reorient_matrix = triangulate.reorient(unit_adjusted_p,
-                                                                             max_dip = reorient_max_dip)
+        p_xy, self.normal_vector, reorient_matrix = triangulate.reorient(unit_adjusted_p, max_dip = reorient_max_dip)
         if extend_with_flange:
             flange_points, radius = triangulate.surrounding_xy_ring(p_xy,
-                                                            count = flange_point_count,
-                                                            radial_factor = flange_radial_factor,
-                                                            radial_distance = flange_radial_distance,
-                                                            inner_ring = flange_inner_ring,
-                                                            saucer_angle = 0)
+                                                                    count = flange_point_count,
+                                                                    radial_factor = flange_radial_factor,
+                                                                    radial_distance = flange_radial_distance,
+                                                                    inner_ring = flange_inner_ring,
+                                                                    saucer_angle = 0)
             flange_points_reverse_oriented = vec.rotate_array(reorient_matrix.T, flange_points)
             if reorient:
                 p_xy_e = np.concatenate((p_xy, flange_points), axis = 0)

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -620,23 +620,17 @@ class Surface(rqsb.BaseSurface):
            suitable for adding as a property for the surface, with indexable element 'faces';
            when flange extension occurs, the radius is the greater of the values determined from the radial factor
            and radial distance arguments;
-           the saucer_parameter is interpreted in one of two ways: (1) +ve fractoinal values between zero and one
-           are the fractional distance from the centre of the points to its rim at which to sample the surface for
-           extrapolation and thereby modify the recumbent z of flange points; 0 will usually give shallower and
-           smoother saucer; larger values (must be less than one) will lead to stronger and more erratic saucer
-           shape in flange; (2) other values between -90.0 and 90.0 are interpreted as an angle to apply out of
-           the plane of the original points, to give a simple (and less computationally demanding) saucer shape;
-           +ve angles result in the shift being in the direction of the -ve z hemisphere; -ve angles result in
-           the shift being in the +ve z hemisphere; in either case the direction of the shift is perpendicular
-           to the average plane of the original points
+           the saucer_parameter must be between -90.0 and 90.0, and is interpreted as an angle to apply out of
+           the plane of the original points, to give a simple saucer shape; +ve angles result in the shift being in 
+           the direction of the -ve z hemisphere; -ve angles result in the shift being in the +ve z hemisphere; in 
+           either case the direction of the shift is perpendicular to the average plane of the original points
         """
 
         simple_saucer_angle = None
-        if saucer_parameter is not None and (saucer_parameter > 1.0 or saucer_parameter < 0.0):
+        if saucer_parameter is not None:
             assert -90.0 < saucer_parameter < 90.0, f'simple saucer angle parameter must be less than 90 degrees; too big: {saucer_parameter}'
             simple_saucer_angle = saucer_parameter
             saucer_parameter = None
-        assert saucer_parameter is None, 'saucer_parameter no longer supported, use simple_saucer_angle'
         crs = rqc.Crs(self.model, uuid = point_set.crs_uuid)
         p = point_set.full_array_ref()
         assert p.ndim >= 2

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -649,7 +649,7 @@ class Surface(rqsb.BaseSurface):
                 f'removing {len(p) - np.count_nonzero(row_mask)} NaN points from point set {point_set.title} prior to surface triangulation'
             )
             p = p[row_mask, :]
-        if crs.xy_units == crs.z_units or not reorient:
+        if crs.xy_units == crs.z_units:
             unit_adjusted_p = p
         else:
             unit_adjusted_p = p.copy()
@@ -662,7 +662,7 @@ class Surface(rqsb.BaseSurface):
                                                                     radial_factor = flange_radial_factor,
                                                                     radial_distance = flange_radial_distance,
                                                                     inner_ring = flange_inner_ring,
-                                                                    saucer_angle = 0)
+                                                                    saucer_angle = 0.0)
             flange_points_reverse_oriented = vec.rotate_array(reorient_matrix.T, flange_points)
             if reorient:
                 p_xy_e = np.concatenate((p_xy, flange_points), axis = 0)

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -664,10 +664,10 @@ class Surface(rqsb.BaseSurface):
                                                             radial_distance = flange_radial_distance,
                                                             inner_ring = flange_inner_ring,
                                                             saucer_angle = 0)
+            flange_points_reverse_oriented = vec.rotate_array(reorient_matrix.T, flange_points)
             if reorient:
                 p_xy_e = np.concatenate((p_xy, flange_points), axis = 0)
             else:
-                flange_points_reverse_oriented = vec.rotate_array(reorient_matrix.T, flange_points)
                 p_xy_e = np.concatenate((unit_adjusted_p, flange_points_reverse_oriented), axis = 0)
 
         else:

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -688,7 +688,7 @@ class Surface(rqsb.BaseSurface):
                 z_shift = radius * maths.tan(vec.radians_from_degrees(simple_saucer_angle))
                 flange_points[:, 2] -= z_shift
                 flange_points_reverse_oriented = vec.rotate_array(reorient_matrix.T, flange_points)
-            if crs.xy_units != crs.z_units and reorient:
+            if crs.xy_units != crs.z_units:
                 wam.convert_lengths(flange_points_reverse_oriented[:, 2], crs.xy_units, crs.z_units)
             p_e = np.concatenate((p, flange_points_reverse_oriented))
         else:

--- a/tests/unit_tests/olio/test_triangulation.py
+++ b/tests/unit_tests/olio/test_triangulation.py
@@ -370,18 +370,18 @@ def test_surrounding_xy_ring_with_simple_saucer():
         r = np.sqrt(ring[:, 0] * ring[:, 0] + ring[:, 1] * ring[:, 1])
         assert_array_almost_equal(r, 10.0 * P_radius)
     for n in (5, 17):
-        ring,  _ = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False, saucer_angle = -45.0)
+        ring, _ = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False, saucer_angle = -45.0)
         assert ring.shape == (n, 3)
         assert_array_almost_equal(ring[:, 2], 457.0 + 10.0 * P_radius)
         r = np.sqrt(ring[:, 0] * ring[:, 0] + ring[:, 1] * ring[:, 1])
         assert_array_almost_equal(r, 10.0 * P_radius)
     for n in (6, 11):
         ring, _ = tri.surrounding_xy_ring(p,
-                                       count = n,
-                                       radial_factor = 2.0,
-                                       radial_distance = 234.0,
-                                       inner_ring = True,
-                                       saucer_angle = 30.0)
+                                          count = n,
+                                          radial_factor = 2.0,
+                                          radial_distance = 234.0,
+                                          inner_ring = True,
+                                          saucer_angle = 30.0)
         tan_theta = maths.tan(np.radians(30.0))
         assert ring.shape == (3 * n, 3)
         r = np.sqrt(ring[:, 0] * ring[:, 0] + ring[:, 1] * ring[:, 1])

--- a/tests/unit_tests/olio/test_triangulation.py
+++ b/tests/unit_tests/olio/test_triangulation.py
@@ -345,13 +345,13 @@ def test_surrounding_xy_ring():
                  dtype = float)
     P_radius = maths.sqrt(2 * 23.0 * 23.0)
     for n in (5, 17):
-        ring = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False)
+        ring, _ = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False)
         assert ring.shape == (n, 3)
         assert_array_almost_equal(ring[:, 2], 457.0)
         r = np.sqrt(ring[:, 0] * ring[:, 0] + ring[:, 1] * ring[:, 1])
         assert_array_almost_equal(r, 10.0 * P_radius)
     for n in (6, 11):
-        ring = tri.surrounding_xy_ring(p, count = n, radial_factor = 2.0, radial_distance = 234.0, inner_ring = True)
+        ring, _ = tri.surrounding_xy_ring(p, count = n, radial_factor = 2.0, radial_distance = 234.0, inner_ring = True)
         assert ring.shape == (3 * n, 3)
         assert_array_almost_equal(ring[:, 2], 457.0)
         r = np.sqrt(ring[:, 0] * ring[:, 0] + ring[:, 1] * ring[:, 1])
@@ -364,19 +364,19 @@ def test_surrounding_xy_ring_with_simple_saucer():
                  dtype = float)
     P_radius = maths.sqrt(2 * 23.0 * 23.0)
     for n in (5, 17):
-        ring = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False, saucer_angle = 45.0)
+        ring, _ = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False, saucer_angle = 45.0)
         assert ring.shape == (n, 3)
         assert_array_almost_equal(ring[:, 2], 457.0 - 10.0 * P_radius)
         r = np.sqrt(ring[:, 0] * ring[:, 0] + ring[:, 1] * ring[:, 1])
         assert_array_almost_equal(r, 10.0 * P_radius)
     for n in (5, 17):
-        ring = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False, saucer_angle = -45.0)
+        ring,  _ = tri.surrounding_xy_ring(p, count = n, radial_factor = 10.0, inner_ring = False, saucer_angle = -45.0)
         assert ring.shape == (n, 3)
         assert_array_almost_equal(ring[:, 2], 457.0 + 10.0 * P_radius)
         r = np.sqrt(ring[:, 0] * ring[:, 0] + ring[:, 1] * ring[:, 1])
         assert_array_almost_equal(r, 10.0 * P_radius)
     for n in (6, 11):
-        ring = tri.surrounding_xy_ring(p,
+        ring, _ = tri.surrounding_xy_ring(p,
                                        count = n,
                                        radial_factor = 2.0,
                                        radial_distance = 234.0,

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -1026,7 +1026,8 @@ def test_resample_surface_unique_edges(tmp_path):
 
     assert resampled.crs_uuid == surf.crs_uuid
     assert resampled.citation_title == surf.citation_title
-    assert resampled.extra_metadata == {'resampled from surface': str(surf.uuid)}
+    assert 'resampled from surface' in resampled.extra_metadata.keys()
+    assert resampled.extra_metadata['resampled from surface'] == str(surf.uuid)
 
 
 def test_from_downsampling_surface(example_model_and_crs):

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -160,7 +160,7 @@ def test_surface_from_point_set_with_flange_extension(example_model_and_crs):
                             flange_radial_distance = None,
                             flange_inner_ring = False,
                             saucer_parameter = None,
-                            make_clockwise = False)
+                            make_clockwise = True)
     surf.write_hdf5()
     surf.create_xml()
     assert surf.node_count() == 35


### PR DESCRIPTION
These changes revert previous changes using the non-triangulation method when a saucer is required, but reorient is False. Instead the set_from_point_set method can now handle saucers without reorientation.

These changes mean that when a flange points are being added, but reorientation is False, the flange points are still generated and added based on the reoriented points (to the normal vector orientation), however the triangulation is completed in non-reoriented space