### PR TITLE
patch boxes during bisector generation

### DIFF
--- a/resqpy/grid_surface/__init__.py
+++ b/resqpy/grid_surface/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "_where_true",
     "_first_true",
     "intersect_numba",
+    "get_box"
 ]
 
 from ._grid_skin import GridSkin
@@ -72,6 +73,7 @@ from ._find_faces import (
     _where_true,
     _first_true,
     intersect_numba,
+    get_box
 )
 
 # Set "module" attribute of all public objects to this path.

--- a/resqpy/grid_surface/__init__.py
+++ b/resqpy/grid_surface/__init__.py
@@ -1,38 +1,19 @@
 """Classes for RESQML objects related to surfaces."""
 
 __all__ = [
-    "GridSkin",
-    "generate_untorn_surface_for_layer_interface",
-    "generate_torn_surface_for_layer_interface",
-    "generate_torn_surface_for_x_section",
-    "generate_untorn_surface_for_x_section",
-    "point_is_within_cell",
-    "create_column_face_mesh_and_surface",
-    "find_intersections_of_trajectory_with_surface",
-    "find_intersections_of_trajectory_with_layer_interface",
-    "find_first_intersection_of_trajectory_with_surface",
+    "GridSkin", "generate_untorn_surface_for_layer_interface", "generate_torn_surface_for_layer_interface",
+    "generate_torn_surface_for_x_section", "generate_untorn_surface_for_x_section", "point_is_within_cell",
+    "create_column_face_mesh_and_surface", "find_intersections_of_trajectory_with_surface",
+    "find_intersections_of_trajectory_with_layer_interface", "find_first_intersection_of_trajectory_with_surface",
     "find_first_intersection_of_trajectory_with_layer_interface",
     "find_first_intersection_of_trajectory_with_cell_surface",
-    "find_intersection_of_trajectory_interval_with_column_face",
-    "trajectory_grid_overlap",
-    "populate_blocked_well_from_trajectory",
-    "generate_surface_for_blocked_well_cells",
-    "find_faces_to_represent_surface_staffa",
-    "find_faces_to_represent_surface_regular",
-    "find_faces_to_represent_surface_regular_optimised",
-    "find_faces_to_represent_surface_regular_dense_optimised",
-    "find_faces_to_represent_surface",
-    "bisector_from_faces",
-    "bisector_from_face_indices",
-    "packed_bisector_from_face_indices",
-    "column_bisector_from_faces",
-    "shadow_from_faces",
-    "get_boundary",
-    "get_boundary_dict",
-    "_where_true",
-    "_first_true",
-    "intersect_numba",
-    "get_box"
+    "find_intersection_of_trajectory_interval_with_column_face", "trajectory_grid_overlap",
+    "populate_blocked_well_from_trajectory", "generate_surface_for_blocked_well_cells",
+    "find_faces_to_represent_surface_staffa", "find_faces_to_represent_surface_regular",
+    "find_faces_to_represent_surface_regular_optimised", "find_faces_to_represent_surface_regular_dense_optimised",
+    "find_faces_to_represent_surface", "bisector_from_faces", "bisector_from_face_indices",
+    "packed_bisector_from_face_indices", "column_bisector_from_faces", "shadow_from_faces", "get_boundary",
+    "get_boundary_dict", "_where_true", "_first_true", "intersect_numba", "get_box"
 ]
 
 from ._grid_skin import GridSkin
@@ -57,24 +38,12 @@ from ._blocked_well_populate import (
     populate_blocked_well_from_trajectory,
     generate_surface_for_blocked_well_cells,
 )
-from ._find_faces import (
-    find_faces_to_represent_surface_staffa,
-    find_faces_to_represent_surface_regular,
-    find_faces_to_represent_surface_regular_optimised,
-    find_faces_to_represent_surface_regular_dense_optimised,
-    find_faces_to_represent_surface,
-    bisector_from_faces,
-    bisector_from_face_indices,
-    packed_bisector_from_face_indices,
-    column_bisector_from_faces,
-    shadow_from_faces,
-    get_boundary,
-    get_boundary_dict,
-    _where_true,
-    _first_true,
-    intersect_numba,
-    get_box
-)
+from ._find_faces import (find_faces_to_represent_surface_staffa, find_faces_to_represent_surface_regular,
+                          find_faces_to_represent_surface_regular_optimised,
+                          find_faces_to_represent_surface_regular_dense_optimised, find_faces_to_represent_surface,
+                          bisector_from_faces, bisector_from_face_indices, packed_bisector_from_face_indices,
+                          column_bisector_from_faces, shadow_from_faces, get_boundary, get_boundary_dict, _where_true,
+                          _first_true, intersect_numba, get_box)
 
 # Set "module" attribute of all public objects to this path.
 for _name in __all__:

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -1505,7 +1505,7 @@ def bisector_from_face_indices(  # type: ignore
         j_faces_kji0: Union[np.ndarray, None],
         i_faces_kji0: Union[np.ndarray, None],
         raw_bisector: bool,
-        box: Union[np.ndarray, None]) -> Tuple[np.ndarray, bool]:
+        p_box: Union[np.ndarray, None]) -> Tuple[np.ndarray, bool]:
     # yapf: enable
     """Creates a boolean array denoting the bisection of the grid by the face sets.
 
@@ -1515,7 +1515,7 @@ def bisector_from_face_indices(  # type: ignore
         - j_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the j dimension
         - i_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the i dimension
         - raw_bisector (bool): if True, the bisector is returned without determining which side is shallower
-        - box (np.ndarray): a python protocol box to limit the bisector evaluation over
+        - p_box (np.ndarray): a python protocol box to limit the bisector evaluation over
 
     returns:
         Tuple containing:
@@ -1533,10 +1533,10 @@ def bisector_from_face_indices(  # type: ignore
     # find the surface boundary (includes a buffer slice where surface does not reach edge of grid)
     face_box = get_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
     box = np.empty((2, 3), dtype = np.int32)
-    if box is None:
+    if p_box is None:
         box[:] = face_box
     else:
-        box[:] = box_intersection(box, face_box)
+        box[:] = box_intersection(p_box, face_box)
         if np.all(box == 0):
             box[:] = face_box
     # set k_faces as bool arrays covering box
@@ -1595,7 +1595,7 @@ def packed_bisector_from_face_indices(  # type: ignore
         j_faces_kji0: Union[np.ndarray, None],
         i_faces_kji0: Union[np.ndarray, None],
         raw_bisector: bool,
-        box: Union[np.ndarray, None]) -> Tuple[np.ndarray, bool]:
+        p_box: Union[np.ndarray, None]) -> Tuple[np.ndarray, bool]:
     # yapf: enable
     """Creates a uint8 (packed bool) array denoting the bisection of the grid by the face sets.
 
@@ -1605,7 +1605,7 @@ def packed_bisector_from_face_indices(  # type: ignore
         - j_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the j dimension
         - i_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the i dimension
         - raw_bisector (bool): if True, the bisector is returned without determining which side is shallower
-        - box (np.ndarray): a python protocol unshrunken box to limit the bisector evaluation over
+        - p_box (np.ndarray): a python protocol unshrunken box to limit the bisector evaluation over
 
     returns:
         Tuple containing:
@@ -1624,10 +1624,10 @@ def packed_bisector_from_face_indices(  # type: ignore
     # find the surface boundary (includes a buffer slice where surface does not reach edge of grid), and shrink the I axis
     face_box = get_packed_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
     box = np.empty((2, 3), dtype = np.int32)
-    if box is None:
+    if p_box is None:
         box[:] = face_box
     else:
-        box[:] = box_intersection(shrunk_box_for_packing(box), face_box)
+        box[:] = box_intersection(shrunk_box_for_packing(p_box), face_box)
         if np.all(box == 0):
             box[:] = face_box
 

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -1532,10 +1532,13 @@ def bisector_from_face_indices(  # type: ignore
 
     # find the surface boundary (includes a buffer slice where surface does not reach edge of grid)
     face_box = get_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
+    box = np.empty((2, 3), dtype = np.int32)
     if box is None:
-        box = face_box
+        box[:] = face_box
     else:
-        box = box_intersection(box, face_box)
+        box[:] = box_intersection(box, face_box)
+        if np.all(box == 0):
+            box[:] = face_box
     # set k_faces as bool arrays covering box
     k_faces, j_faces, i_faces = _box_face_arrays_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, box)
 

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -1246,6 +1246,7 @@ def find_faces_to_represent_surface_regular_optimised(grid,
             # log.debug('finished preparing columns bisector')
         elif patchwork:
             n_patches = surface.number_of_patches()
+            log.info(f'surface: {surface.title}; number of patches: {n_patches}')
             nkf = 0 if k_faces_kji0 is None else len(k_faces_kji0)
             njf = 0 if j_faces_kji0 is None else len(j_faces_kji0)
             nif = 0 if i_faces_kji0 is None else len(i_faces_kji0)
@@ -1263,9 +1264,15 @@ def find_faces_to_represent_surface_regular_optimised(grid,
             # populate composite bisector
             for patch in range(n_patches):
                 mask = (patch_indices == patch)
-                if np.count_nonzero(mask) == 0:
+                mask_count = np.count_nonzero(mask)
+                if mask_count == 0:
                     log.warning(f'patch {patch} of surface {surface.title} is not applicable to any cells in grid')
                     continue
+                patch_box, box_count = get_box(mask)
+                assert box_count == mask_count
+                assert np.all(patch_box[1] > patch_box[0])
+                patch_box = expanded_box(patch_box, tuple(grid.extent_kji))
+                assert np.all(patch_box[1] > patch_box[0])  # debug
                 patch_k_faces_kji0 = None
                 if k_faces_kji0 is not None:
                     patch_k_faces_kji0 = k_faces_kji0[(patch_indices_k == patch).astype(bool)]
@@ -1282,7 +1289,8 @@ def find_faces_to_represent_surface_regular_optimised(grid,
                                                           patch_k_faces_kji0,
                                                           patch_j_faces_kji0,
                                                           patch_i_faces_kji0,
-                                                          raw_bisector)
+                                                          raw_bisector,
+                                                          patch_box)
                     bisector = np.bitwise_or(np.bitwise_and(mask, patch_bisector),
                                              np.bitwise_and(np.invert(mask), bisector))
                 else:
@@ -1291,7 +1299,8 @@ def find_faces_to_represent_surface_regular_optimised(grid,
                                                    patch_k_faces_kji0,
                                                    patch_j_faces_kji0,
                                                    patch_i_faces_kji0,
-                                                   raw_bisector)
+                                                   raw_bisector,
+                                                   patch_box)
                     bisector[mask] = patch_bisector[mask]
                 if is_curtain:
                     # TODO: downgrade following to debug once downstream functionality tested
@@ -1305,13 +1314,14 @@ def find_faces_to_represent_surface_regular_optimised(grid,
                 is_curtain = True
             elif packed_bisectors:
                 bisector, is_curtain = packed_bisector_from_face_indices(tuple(grid.extent_kji), k_faces_kji0,
-                                                                         j_faces_kji0, i_faces_kji0, raw_bisector)
+                                                                         j_faces_kji0, i_faces_kji0, raw_bisector,
+                                                                         None)
                 if is_curtain:
                     bisector = np.unpackbits(bisector[0], axis = -1,
                                              count = grid.ni).astype(bool)  # reduce to a columns property
             else:
                 bisector, is_curtain = bisector_from_face_indices(tuple(grid.extent_kji), k_faces_kji0, j_faces_kji0,
-                                                                  i_faces_kji0, raw_bisector)
+                                                                  i_faces_kji0, raw_bisector, None)
                 if is_curtain:
                     bisector = bisector[0]  # reduce to a columns property
 
@@ -1487,10 +1497,14 @@ def bisector_from_faces(  # type: ignore
     return array, is_curtain
 
 
+# yapf: disable
 def bisector_from_face_indices(  # type: ignore
-        grid_extent_kji: Tuple[int, int, int], k_faces_kji0: Union[np.ndarray, None], j_faces_kji0: Union[np.ndarray,
-                                                                                                          None],
-        i_faces_kji0: Union[np.ndarray, None], raw_bisector: bool) -> Tuple[np.ndarray, bool]:
+        grid_extent_kji: Tuple[int, int, int],
+        k_faces_kji0: Union[np.ndarray, None],
+        j_faces_kji0: Union[np.ndarray, None],
+        i_faces_kji0: Union[np.ndarray, None],
+        raw_bisector: bool,
+        box: Union[np.ndarray, None]) -> Tuple[np.ndarray, bool]:
     """Creates a boolean array denoting the bisection of the grid by the face sets.
 
     arguments:
@@ -1499,6 +1513,7 @@ def bisector_from_face_indices(  # type: ignore
         - j_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the j dimension
         - i_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the i dimension
         - raw_bisector (bool): if True, the bisector is returned without determining which side is shallower
+        - box (np.ndarray): a python protocol box to limit the bisector evaluation over
 
     returns:
         Tuple containing:
@@ -1514,7 +1529,11 @@ def bisector_from_face_indices(  # type: ignore
     assert len(grid_extent_kji) == 3
 
     # find the surface boundary (includes a buffer slice where surface does not reach edge of grid)
-    box = get_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
+    face_box = get_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
+    if box is None:
+        box = face_box
+    else:
+        box = box_intersection(box, face_box)
     # set k_faces as bool arrays covering box
     k_faces, j_faces, i_faces = _box_face_arrays_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, box)
 
@@ -1564,10 +1583,15 @@ def bisector_from_face_indices(  # type: ignore
     return array, is_curtain
 
 
+# yapf: disable
 def packed_bisector_from_face_indices(  # type: ignore
-        grid_extent_kji: Tuple[int, int, int], k_faces_kji0: Union[np.ndarray, None], j_faces_kji0: Union[np.ndarray,
-                                                                                                          None],
-        i_faces_kji0: Union[np.ndarray, None], raw_bisector: bool) -> Tuple[np.ndarray, bool]:
+        grid_extent_kji: Tuple[int, int, int],
+        k_faces_kji0: Union[np.ndarray, None],
+        j_faces_kji0: Union[np.ndarray, None],
+        i_faces_kji0: Union[np.ndarray, None],
+        raw_bisector: bool,
+        box: Union[np.ndarray, None]) -> Tuple[np.ndarray, bool]:
+# yapf: enable
     """Creates a uint8 (packed bool) array denoting the bisection of the grid by the face sets.
 
     arguments:
@@ -1576,6 +1600,7 @@ def packed_bisector_from_face_indices(  # type: ignore
         - j_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the j dimension
         - i_faces_kji0 (np.ndarray): an int array of indices of which faces represent the surface in the i dimension
         - raw_bisector (bool): if True, the bisector is returned without determining which side is shallower
+        - box (np.ndarray): a python protocol unshrunken box to limit the bisector evaluation over
 
     returns:
         Tuple containing:
@@ -1592,7 +1617,12 @@ def packed_bisector_from_face_indices(  # type: ignore
     assert len(grid_extent_kji) == 3
 
     # find the surface boundary (includes a buffer slice where surface does not reach edge of grid), and shrink the I axis
-    box = get_packed_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
+    face_box = get_packed_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
+    if box is None:
+        box = face_box
+    else:
+        box = box_intersection(shrunk_box_for_packing(box), face_box)
+
     # set k_faces, j_faces & i_faces as uint8 packed bool arrays covering box
     k_faces, j_faces, i_faces = _packed_box_face_arrays_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, box)
 
@@ -1634,28 +1664,28 @@ def packed_bisector_from_face_indices(  # type: ignore
     del open_i, open_j, open_k
 
     # set up the full bisectors array and assigning the bounding box values
-    array = np.zeros(_shape_packed(grid_extent_kji), dtype = np.uint8)
-    array[box[0, 0]:box[1, 0], box[0, 1]:box[1, 1], box[0, 2]:box[1, 2]] = box_array
+    p_array = np.zeros(_shape_packed(grid_extent_kji), dtype = np.uint8)
+    p_array[box[0, 0]:box[1, 0], box[0, 1]:box[1, 1], box[0, 2]:box[1, 2]] = box_array
 
     # set bisector values outside of the bounding box
-    _set_packed_bisector_outside_box(array, box, box_array, grid_extent_kji[2] % 8)
+    _set_packed_bisector_outside_box(p_array, box, box_array, grid_extent_kji[2] % 8)
 
     # check all array elements are not the same
     if hasattr(np, 'bitwise_count'):
-        true_count = np.sum(np.bitwise_count(array))
+        true_count = np.sum(np.bitwise_count(p_array))
     else:
-        true_count = _bitwise_count_njit(array)  # note: will usually include some padding bits, so not so true!
+        true_count = _bitwise_count_njit(p_array)  # note: will usually include some padding bits, so not so true!
     cell_count = np.prod(grid_extent_kji)
     if 0 < true_count < cell_count:
         # negate the array if it minimises the mean k and determine if the surface is a curtain
-        # TODO: switch to _packed_shallow_or_curtain_temp_bitwise_count() when numba supports np.bitwise_count()
-        is_curtain = _packed_shallow_or_curtain_temp_bitwise_count(array, true_count, raw_bisector)
+        # TODO: switch to _packed_shallow_or_curtain() when numba supports np.bitwise_count()
+        is_curtain = _packed_shallow_or_curtain_temp_bitwise_count(p_array, true_count, raw_bisector)
     else:
         assert raw_bisector, 'face set for surface is leaky or empty (surface does not intersect grid)'
         log.error('face set for surface is leaky or empty (surface does not intersect grid)')
         is_curtain = False
 
-    return array, is_curtain
+    return p_array, is_curtain
 
 
 def column_bisector_from_face_indices(grid_extent_ji: Tuple[int, int], j_faces_ji0: np.ndarray,
@@ -2188,7 +2218,7 @@ def _packed_shallow_or_curtain_temp_bitwise_count(a: np.ndarray, true_count: int
     is_curtain: bool = False
     layer_count: np.int64 = 0  # type: ignore
     for k in range(a.shape[0]):
-        layer_count = _bitwise_count_njit(a[k])
+        layer_count = _bitwise_count_njit(a[k, :, :])
         k_sum += (k + 1) * layer_count
         opposite_k_sum += (k + 1) * (layer_cell_count - layer_count)
     mean_k: float = float(k_sum) / float(true_count)
@@ -2246,12 +2276,15 @@ def _box_face_arrays_from_indices(  # type: ignore
     ko = box[0, 0]
     jo = box[0, 1]
     io = box[0, 2]
+    kr = box[1, 0] - ko
+    jr = box[1, 1] - jo
+    ir = box[1, 2] - io
     if k_faces_kji0 is not None:
-        _set_face_array(k_a, k_faces_kji0, ko, jo, io)
+        _set_face_array(k_a, k_faces_kji0, ko, jo, io, kr - 1, jr, ir)
     if j_faces_kji0 is not None:
-        _set_face_array(j_a, j_faces_kji0, ko, jo, io)
+        _set_face_array(j_a, j_faces_kji0, ko, jo, io, kr, jr - 1, ir)
     if i_faces_kji0 is not None:
-        _set_face_array(i_a, i_faces_kji0, ko, jo, io)
+        _set_face_array(i_a, i_faces_kji0, ko, jo, io, kr, jr, ir - 1)
     return k_a, j_a, i_a
 
 
@@ -2265,43 +2298,62 @@ def _packed_box_face_arrays_from_indices(  # type: ignore
     ko = box[0, 0]
     jo = box[0, 1]
     io = box[0, 2] * 8
+    kr = box[1, 0] - ko
+    jr = box[1, 1] - jo
+    ir = box[1, 2] * 8 - io
     if k_faces_kji0 is not None:
-        _set_packed_face_array(k_a, k_faces_kji0, ko, jo, io)
+        _set_packed_face_array(k_a, k_faces_kji0, ko, jo, io, kr - 1, jr, ir)
     if j_faces_kji0 is not None:
-        _set_packed_face_array(j_a, j_faces_kji0, ko, jo, io)
+        _set_packed_face_array(j_a, j_faces_kji0, ko, jo, io, kr, jr - 1, ir)
     if i_faces_kji0 is not None:
-        _set_packed_face_array(i_a, i_faces_kji0, ko, jo, io)
+        _set_packed_face_array(i_a, i_faces_kji0, ko, jo, io, kr, jr, ir)
     return k_a, j_a, i_a
 
 
 @njit  # pragma: no cover
-def _set_face_array(a: np.ndarray, indices: np.ndarray, ko: int, jo: int, io: int):
+def _set_face_array(a: np.ndarray, indices: np.ndarray, ko: int, jo: int, io: int, kr: int, jr: int, ir: int) -> None:
     k: int = 0
     j: int = 0
     i: int = 0
     for ind in range(len(indices)):
         k = indices[ind, 0] - ko
+        if k < 0 or k >= kr:
+            continue
         j = indices[ind, 1] - jo
+        if j < 0 or j >= jr:
+            continue
         i = indices[ind, 2] - io
+        if i < 0 or i >= ir:
+            continue
         a[k, j, i] = True
 
 
 @njit  # pragma: no cover
-def _set_packed_face_array(a: np.ndarray, indices: np.ndarray, ko: int, jo: int, io: int):
+def _set_packed_face_array(a: np.ndarray, indices: np.ndarray, ko: int, jo: int, io: int, kr: int, jr: int, ir: int) -> None:
     k: int = 0
     j: int = 0
     i: int = 0
     for ind in range(len(indices)):
         k = indices[ind, 0] - ko
+        if k < 0 or k >= kr:
+            continue
         j = indices[ind, 1] - jo
+        if j < 0 or j >= jr:
+            continue
         i = indices[ind, 2] - io
+        if i < 0 or i >= ir:
+            continue
         ii, ib = divmod(i, 8)
         a[k, j, ii] |= (1 << (7 - ib))
 
 
+# yapf: disable
 def get_boundary_from_indices(  # type: ignore
-        k_faces_kji0: Union[np.ndarray, None], j_faces_kji0: Union[np.ndarray, None],
-        i_faces_kji0: Union[np.ndarray, None], grid_extent_kji: Tuple[int, int, int]) -> np.ndarray:
+        k_faces_kji0: Union[np.ndarray, None],
+        j_faces_kji0: Union[np.ndarray, None],
+        i_faces_kji0: Union[np.ndarray, None],
+        grid_extent_kji: Tuple[int, int, int]) -> np.ndarray:
+# yapf: enable
     """Return python protocol box containing indices"""
     k_min_kji0 = None if ((k_faces_kji0 is None) or (k_faces_kji0.size == 0)) else np.min(k_faces_kji0, axis = 0)
     k_max_kji0 = None if ((k_faces_kji0 is None) or (k_faces_kji0.size == 0)) else np.max(k_faces_kji0, axis = 0)
@@ -2335,14 +2387,21 @@ def get_boundary_from_indices(  # type: ignore
         box[1, 2] = max(box[1, 2], i_max_kji0[2])  # type: ignore
     assert np.all(box[1] >= box[0]), 'attempt to find bounding box when all faces None'
     # include buffer layer where box does not reach edge of grid
-    box[0, :] = np.maximum(box[0, :] - 1, 0)
-    extent_kji = np.array(grid_extent_kji, dtype = np.int32)
-    box[1, :] += 2  # buffer layer and python protocol
-    box[1, :] = np.minimum(box[1, :], extent_kji)
-    assert np.all(box[0] >= 0)
-    assert np.all(box[1] > box[0])
-    assert np.all(box[1] <= grid_extent_kji)
-    return box
+    box[1, :] += 1  # switch to python protocol
+    return expanded_box(box, grid_extent_kji)
+
+
+def expanded_box(box: np.ndarray, extent_kji: Tuple[int, int, int]) -> np.ndarray:
+    """Return a python protocol box expanded by a single slice on all six faces, where extent alloas."""
+    # include buffer layer where box does not reach edge of grid
+    np_extent_kji = np.array(extent_kji, dtype = np.int32)
+    e_box = np.zeros((2, 3), dtype = np.int32)
+    e_box[0, :] = np.maximum(box[0, :] - 1, 0)
+    e_box[1, :] = np.minimum(box[1, :] + 1, extent_kji)
+    assert np.all(e_box[0] >= 0)
+    assert np.all(e_box[1] > e_box[0])
+    assert np.all(e_box[1] <= np_extent_kji)
+    return e_box
 
 
 def get_packed_boundary_from_indices(  # type: ignore
@@ -2350,9 +2409,15 @@ def get_packed_boundary_from_indices(  # type: ignore
         i_faces_kji0: Union[np.ndarray, None], grid_extent_kji: Tuple[int, int, int]) -> np.ndarray:
     """Return python protocol box containing indices, with I axis packed"""
     box = get_boundary_from_indices(k_faces_kji0, j_faces_kji0, i_faces_kji0, grid_extent_kji)
-    box[0, 2] /= 8
-    box[1, 2] = ((box[1, 2] - 1) // 8) + 1
-    return box
+    return shrunk_box_for_packing(box)
+
+
+def shrunk_box_for_packing(box: np.ndarray) -> np.ndarray:
+    """Return box with I dimension shrunk for bit packing equivalent."""
+    shrunk_box = box.copy()
+    shrunk_box[0, 2] /= 8
+    shrunk_box[1, 2] = ((box[1, 2] - 1) // 8) + 1
+    return shrunk_box
 
 
 def _shape_packed(unpacked_shape):
@@ -2378,3 +2443,47 @@ def _bitwise_count_njit(a: np.ndarray) -> np.int64:
     c += np.count_nonzero(np.bitwise_and(a, 0x40))
     c += np.count_nonzero(np.bitwise_and(a, 0x80))
     return c
+
+
+@njit
+def box_intersection(box_a: np.ndarray, box_b: np.ndarray) -> np.ndarray:
+    """Return a box which is the intersection of two boxes, python protocol; all zeros if no intersection."""
+    box = np.zeros((2, 3), dtype = np.int32)
+    box[0] = np.maximum(box_a[0], box_b[0])
+    box[1] = np.minimum(box_a[1], box_b[1])
+    if np.any(box[1] <= box[0]):
+        box[:] = 0
+    return box
+
+
+@njit
+def get_box(mask: np.ndarray) -> Tuple[np.ndarray, int]:  # pragma: no cover
+    """Returns a python protocol box enclosing True elements of 3D boolean mask, and count which is zero if all False."""
+    box = np.full((2, 3), -1, dtype = np.int32)
+    count = 0
+    for k in range(mask.shape[0]):
+        for j in range(mask.shape[1]):
+            for i in range(mask.shape[2]):
+                if mask[k, j, i]:
+                    if count == 0:
+                        box[0, 0] = k
+                        box[0, 1] = j
+                        box[0, 2] = i
+                        box[1, 0] = k + 1
+                        box[1, 1] = j + 1
+                        box[1, 2] = i + 1
+                    else:
+                        if k < box[0, 0]:
+                            box[0, 0] = k
+                        elif k >= box[1, 0]:
+                            box[1, 0] = k + 1
+                        if j < box[0, 1]:
+                            box[0, 1] = j
+                        elif j >= box[1, 1]:
+                            box[1, 1] = j + 1
+                        if i < box[0, 2]:
+                            box[0, 2] = i
+                        elif i >= box[1, 2]:
+                            box[1, 2] = i + 1
+                    count += 1
+    return box, count

--- a/resqpy/model/_model.py
+++ b/resqpy/model/_model.py
@@ -1401,7 +1401,7 @@ class Model():
                          cache_array = False,
                          object = None,
                          array_attribute = None,
-                         dtype = 'float',
+                         dtype = None,
                          required_shape = None):
         """Returns one element from an hdf5 array and/or caches the array.
 

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -283,7 +283,7 @@ def find_faces_to_represent_surface_regular_wrapper(
         s_patches_array = rqp.Property(model, uuid = surface_patching_property_uuid).array_ref()
         patch_count = surface.number_of_patches()
         assert s_patches_array.shape == (patch_count,)
-        p_dtype = (np.int8 if s_patches_array.shape[0] < 128 else np.int32)
+        p_dtype = (np.int8 if s_patches_array.shape[0] < 127 else np.int32)
         patch_indices = np.full(g_patching_array.shape, -1, dtype = p_dtype)
         for patch in range(patch_count):
             gp = s_patches_array[patch]

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -1810,8 +1810,10 @@ class PropertyCollection():
         if masked:
             exclude_value = self.null_value_for_part(part) if exclude_null else None
             return self.masked_array(self.__dict__[cached_array_name], exclude_value = exclude_value)
-        else:
+        elif dtype is None:
             return self.__dict__[cached_array_name]
+        else:
+            return self.__dict__[cached_array_name].astype(dtype)
 
     def h5_slice(self, part, slice_tuple):
         """Returns a subset of the array for part, without loading the whole array.

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -495,7 +495,7 @@ class Surface(rqsb.BaseSurface):
         self.points = None
         if not equivalent_crs:
             if self.extra_metadata.pop('rotation matrix', None) is not None:
-                log.warning(f'discarding rotation matrix extra metadata during crs change of: {self.title}')
+                log.debug(f'discarding rotation matrix extra metadata during crs change of: {self.title}')
             self._load_normal_vector_from_extra_metadata()
             if self.normal_vector is not None:
                 if required_crs.z_inc_down != old_crs.z_inc_down:

--- a/tests/unit_tests/test_grid_surface.py
+++ b/tests/unit_tests/test_grid_surface.py
@@ -552,6 +552,66 @@ def test_bisector_from_faces_flat_surface_k():
     assert np.all(pa[0, :, -1] == 0xE0)  # 3 bits set in padded bytes (as ni < 8, all bytes are padded bytes here)
 
 
+def test_bisector_from_faces_flat_surface_k_patch_box():
+    # Arrange
+    grid_extent_kji = (3, 3, 3)
+    k_faces = np.array(
+        [
+            [[True, True, True], [True, True, True], [True, True, True]],
+            [[False, False, False], [False, False, False], [False, False, False]],
+        ],
+        dtype = bool,
+    )
+    k_face_indices = np.array([(0, 0, 0), (0, 0, 1), (0, 0, 2), (0, 1, 0), (0, 1, 1), (0, 1, 2), (0, 2, 0), (0, 2, 1),
+                               (0, 2, 2)],
+                              dtype = np.int32)
+    j_faces = np.array(
+        [
+            [[False, False, False], [False, False, False]],
+            [[False, False, False], [False, False, False]],
+            [[False, False, False], [False, False, False]],
+        ],
+        dtype = bool,
+    )
+    i_faces = np.array(
+        [
+            [[False, False], [False, False], [False, False]],
+            [[False, False], [False, False], [False, False]],
+            [[False, False], [False, False], [False, False]],
+        ],
+        dtype = bool,
+    )
+
+    patch_box = np.array([(0, 0, 0), (2, 3, 3)], dtype = int)
+
+    # Act
+    a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
+    pa, p_is_curtain = rqgs.packed_bisector_from_face_indices(grid_extent_kji, k_face_indices, None, None, False,
+                                                              patch_box)
+    bounds = rqgs.get_boundary_dict(k_faces, j_faces, i_faces, grid_extent_kji)
+
+    # Assert
+    np.all(a == np.array(
+        [
+            [[True, True, True], [True, True, True], [True, True, True]],
+            [[False, False, False], [False, False, False], [False, False, False]],
+            [[False, False, False], [False, False, False], [False, False, False]],
+        ],
+        dtype = bool,
+    ))
+    assert is_curtain is False
+    assert all([(bounds[f"{axis}_min"] == 0) for axis in "kji"])
+    assert bounds["k_max"] == 1
+    assert bounds["j_max"] == 2
+    assert bounds["i_max"] == 2
+    assert pa.ndim == 3
+    assert pa.shape[:2] == a.shape[:2]
+    assert pa.shape[2] == (a.shape[2] - 1) // 8 + 1
+    assert np.all(np.unpackbits(pa, axis = 2, count = a.shape[2]).astype(bool) == a)
+    assert p_is_curtain is False
+    assert np.all(pa[0, :, -1] == 0xE0)  # 3 bits set in padded bytes (as ni < 8, all bytes are padded bytes here)
+
+
 def test_where_true_and_get_boundary():
     grid_extent_kji = (7, 8, 9)
     nk, nj, ni = grid_extent_kji

--- a/tests/unit_tests/test_grid_surface.py
+++ b/tests/unit_tests/test_grid_surface.py
@@ -527,7 +527,7 @@ def test_bisector_from_faces_flat_surface_k():
 
     # Act
     a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
-    pa, p_is_curtain = rqgs.packed_bisector_from_face_indices(grid_extent_kji, k_face_indices, None, None, False)
+    pa, p_is_curtain = rqgs.packed_bisector_from_face_indices(grid_extent_kji, k_face_indices, None, None, False, None)
     bounds = rqgs.get_boundary_dict(k_faces, j_faces, i_faces, grid_extent_kji)
 
     # Assert
@@ -621,7 +621,7 @@ def test_bisector_from_faces_flat_surface_j():
 
     # Act
     a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
-    pa, p_is_curtain = rqgs.packed_bisector_from_face_indices(grid_extent_kji, None, j_face_indices, None, False)
+    pa, p_is_curtain = rqgs.packed_bisector_from_face_indices(grid_extent_kji, None, j_face_indices, None, False, None)
     ca = rqgs.column_bisector_from_faces(grid_extent_kji[1:], j_faces[0], i_faces[0])
 
     # Assert
@@ -696,7 +696,7 @@ def test_bisector_from_faces_flat_surface_i():
 
     # Act
     a, is_curtain = rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
-    pa, p_is_curtain = rqgs.packed_bisector_from_face_indices(grid_extent_kji, None, None, i_face_indices, False)
+    pa, p_is_curtain = rqgs.packed_bisector_from_face_indices(grid_extent_kji, None, None, i_face_indices, False, None)
 
     # Assert
     np.all(a == np.array(
@@ -748,7 +748,7 @@ def test_bisector_from_faces_flat_surface_k_hole():
     with pytest.raises(AssertionError):
         rqgs.bisector_from_faces(grid_extent_kji, k_faces, j_faces, i_faces, False)
     with pytest.raises(AssertionError):
-        rqgs.packed_bisector_from_face_indices(grid_extent_kji, k_face_indices, None, None, False)
+        rqgs.packed_bisector_from_face_indices(grid_extent_kji, k_face_indices, None, None, False, None)
 
 
 def test_shadow_from_faces_flat_surface_k_hole():


### PR DESCRIPTION
This optimisation reduces the search volume when creating a composite bisector for a patchwork horizon.