### PR TITLE
Enhancement to _add_surfaces.py to allow for fault and geobody types on import

### DIFF
--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -23,7 +23,7 @@ def add_surfaces(
         quad_triangles = False,  # if True, 4 triangles per quadrangle will be used for mesh formats, otherwise 2
         surface_file_list = None,  # list of full file names (paths), each holding one surface
         make_horizon_interpretations_and_features = True,  # if True, feature and interpretation objects are created
-        interpretation_type = 'horizon'
+        interpretation_type = 'horizon',
         fault_is_normal = True):
     """Process a list of surface files, adding each surface as a new part in the resqml model.
 

--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -119,9 +119,9 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
         elif interpretation_type == 'fault':
             feature = rqo.TectonicBoundaryFeature(model, kind = 'fault', feature_name = short_name)
             feature.create_xml()
-            interp = rqo.FaultInterpretation(model, 
-                                             tectonic_boundary_feature = feature, 
-                                             domain = 'depth', 
+            interp = rqo.FaultInterpretation(model,
+                                             tectonic_boundary_feature = feature,
+                                             domain = 'depth',
                                              is_normal = True)
             interp_root = interp.create_xml()
         else:

--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -53,7 +53,8 @@ def add_surfaces(
 
     for surf_file in surface_file_list:
         model = _add_single_surface(model, surf_file, surface_file_format, surface_role, quad_triangles, crs_uuid,
-                                    rq_class, make_horizon_interpretations_and_features, interpretation_type)
+                                    rq_class, make_horizon_interpretations_and_features, interpretation_type,
+                                    fault_is_normal)
 
     # mark model as modified
     model.set_modified()
@@ -66,7 +67,7 @@ def add_surfaces(
 
 
 def _add_single_surface(model, surf_file, surface_file_format, surface_role, quad_triangles, crs_uuid, rq_class,
-                        make_horizon_interpretations_and_features, interpretation_type):
+                        make_horizon_interpretations_and_features, interpretation_type, fault_is_normal):
     _, short_name = os.path.split(surf_file)
     dot = short_name.rfind('.')
     if dot > 0:

--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -15,15 +15,15 @@ import resqpy.surface as rqs
 
 
 def add_surfaces(
-    epc_file,  # existing resqml model
-    crs_uuid = None,  # optional crs uuid, defaults to crs associated with model (usually main grid crs)
-    surface_file_format = 'zmap',  # zmap, rms (roxar) or GOCAD-Tsurf only formats currently supported
-    rq_class = 'surface',  # 'surface' or 'mesh': the class of object to be created
-    surface_role = 'map',  # 'map' or 'pick'
-    quad_triangles = False,  # if True, 4 triangles per quadrangle will be used for mesh formats, otherwise 2
-    surface_file_list = None,  # list of full file names (paths), each holding one surface
-    make_horizon_interpretations_and_features = True,  # if True, feature and interpretation objects are created
-    interpretation_type = 'horizon'):
+        epc_file,  # existing resqml model
+        crs_uuid = None,  # optional crs uuid, defaults to crs associated with model (usually main grid crs)
+        surface_file_format = 'zmap',  # zmap, rms (roxar) or GOCAD-Tsurf only formats currently supported
+        rq_class = 'surface',  # 'surface' or 'mesh': the class of object to be created
+        surface_role = 'map',  # 'map' or 'pick'
+        quad_triangles = False,  # if True, 4 triangles per quadrangle will be used for mesh formats, otherwise 2
+        surface_file_list = None,  # list of full file names (paths), each holding one surface
+        make_horizon_interpretations_and_features = True,  # if True, feature and interpretation objects are created
+        interpretation_type = 'horizon'):
     """Process a list of surface files, adding each surface as a new part in the resqml model.
 
     Arguments:

--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -23,7 +23,8 @@ def add_surfaces(
         quad_triangles = False,  # if True, 4 triangles per quadrangle will be used for mesh formats, otherwise 2
         surface_file_list = None,  # list of full file names (paths), each holding one surface
         make_horizon_interpretations_and_features = True,  # if True, feature and interpretation objects are created
-        interpretation_type = 'horizon'):
+        interpretation_type = 'horizon'
+        fault_is_normal = True):
     """Process a list of surface files, adding each surface as a new part in the resqml model.
 
     Arguments:
@@ -36,11 +37,10 @@ def add_surfaces(
         surface_file_list (list, default None): list of full file names (paths), each holding one surface
         make_horizon_interpretations_and_features (bool, default True): if True, feature and interpretation objects are created
         interpretation_type (str, default 'horizon'): if 'make_horizon_interpretations_and_features' is True, feature and interpretation objects are added. Default is 'horizon', other options are 'fault' and 'geobody'
+        fault_is_normal (bool, default True): if 'interpretation_type' is 'fault', define if the fault is a normal fault. Default True
 
     Returns:
         resqml model object with added surfaces
-
-    Note: where interpretation_type is 'fault' the faultinterpretation added will be defined as a normal fault.
     """
 
     assert surface_file_list, 'surface file list is empty or missing'
@@ -122,7 +122,7 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
             interp = rqo.FaultInterpretation(model,
                                              tectonic_boundary_feature = feature,
                                              domain = 'depth',
-                                             is_normal = True)
+                                             is_normal = fault_is_normal)
             interp_root = interp.create_xml()
         else:
             feature = rqo.GeobodyFeature(model, feature_name = short_name)

--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -119,7 +119,10 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
         elif interpretation_type == 'fault':
             feature = rqo.TectonicBoundaryFeature(model, kind = 'fault', feature_name = short_name)
             feature.create_xml()
-            interp = rqo.FaultInterpretation(model, tectonic_boundary_feature = feature, domain = 'depth', is_normal = True)
+            interp = rqo.FaultInterpretation(model, 
+                                             tectonic_boundary_feature = feature, 
+                                             domain = 'depth', 
+                                             is_normal = True)
             interp_root = interp.create_xml()
         else:
             feature = rqo.GeobodyFeature(model, feature_name = short_name)

--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -39,6 +39,8 @@ def add_surfaces(
 
     Returns:
         resqml model object with added surfaces
+
+    Note: where interpretation_type is 'fault' the faultinterpretation added will be defined as a normal fault.
     """
 
     assert surface_file_list, 'surface file list is empty or missing'
@@ -117,7 +119,7 @@ def _add_single_surface(model, surf_file, surface_file_format, surface_role, qua
         elif interpretation_type == 'fault':
             feature = rqo.TectonicBoundaryFeature(model, kind = 'fault', feature_name = short_name)
             feature.create_xml()
-            interp = rqo.FaultInterpretation(model, tectonic_boundary_feature = feature, domain = 'depth')
+            interp = rqo.FaultInterpretation(model, tectonic_boundary_feature = feature, domain = 'depth', is_normal = True)
             interp_root = interp.create_xml()
         else:
             feature = rqo.GeobodyFeature(model, feature_name = short_name)

--- a/tests/unit_tests/rq_import/test_rq_import.py
+++ b/tests/unit_tests/rq_import/test_rq_import.py
@@ -358,7 +358,7 @@ def test_add_surfaces_different_types(example_model_and_crs, test_data_path, sur
 
     if interptype == 'horizon':
         assert len(model.parts_list_of_type('obj_HorizonInterpretation')) == len(surfaces)
-        assert len(model.parts_list_of_type('obj_GenericBoundaryFeature')) == len(surfaces)
+        assert len(model.parts_list_of_type('obj_GeneticBoundaryFeature')) == len(surfaces)
     elif interptype == 'fault':
         assert len(model.parts_list_of_type('obj_FaultInterpretation')) == len(surfaces)
         assert len(model.parts_list_of_type('obj_TectonicBoundaryFeature')) == len(surfaces)

--- a/tests/unit_tests/rq_import/test_rq_import.py
+++ b/tests/unit_tests/rq_import/test_rq_import.py
@@ -323,6 +323,7 @@ def test_add_surfaces(example_model_and_crs, test_data_path, surfaces, format, r
     if interp_and_feat:
         assert len(model.parts_list_of_type('obj_HorizonInterpretation')) == len(surfaces)
 
+
 @pytest.mark.parametrize('surfaces,format,interp_and_feat,role,rqclass,newparts,interptype',
                          [(['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'horizon'),
                           (['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'fault'),
@@ -332,7 +333,7 @@ def test_add_surfaces(example_model_and_crs, test_data_path, surfaces, format, r
                           (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 2, 'geobody'),
                           (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'horizon'),
                           (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'fault'),
-                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'geobody'))
+                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'geobody')])
 def test_add_surfaces_different_types(example_model_and_crs, test_data_path, surfaces, format, rqclass, interp_and_feat, role,
                       newparts, interptype):
     model, crs = example_model_and_crs

--- a/tests/unit_tests/rq_import/test_rq_import.py
+++ b/tests/unit_tests/rq_import/test_rq_import.py
@@ -334,8 +334,8 @@ def test_add_surfaces(example_model_and_crs, test_data_path, surfaces, format, r
                           (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'horizon'),
                           (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'fault'),
                           (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'geobody')])
-def test_add_surfaces_different_types(example_model_and_crs, test_data_path, surfaces, format, rqclass, interp_and_feat, role,
-                      newparts, interptype):
+def test_add_surfaces_different_types(example_model_and_crs, test_data_path, surfaces, format, rqclass, interp_and_feat,
+                                      role, newparts, interptype):
     model, crs = example_model_and_crs
     model.store_epc()
 

--- a/tests/unit_tests/rq_import/test_rq_import.py
+++ b/tests/unit_tests/rq_import/test_rq_import.py
@@ -325,15 +325,15 @@ def test_add_surfaces(example_model_and_crs, test_data_path, surfaces, format, r
 
 
 @pytest.mark.parametrize('surfaces,format,interp_and_feat,role,rqclass,newparts,interptype',
-                         [(['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'horizon'),
-                          (['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'fault'),
-                          (['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'geobody'),
-                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 2, 'horizon'),
-                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 2, 'fault'),
-                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 2, 'geobody'),
-                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'horizon'),
-                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'fault'),
-                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'geobody')])
+                         [(['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 4, 'horizon'),
+                          (['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 4, 'fault'),
+                          (['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 4, 'geobody'),
+                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 4, 'horizon'),
+                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 4, 'fault'),
+                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 4, 'geobody'),
+                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 4, 'horizon'),
+                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 4, 'fault'),
+                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 4, 'geobody')])
 def test_add_surfaces_different_types(example_model_and_crs, test_data_path, surfaces, format, rqclass, interp_and_feat,
                                       role, newparts, interptype):
     model, crs = example_model_and_crs

--- a/tests/unit_tests/rq_import/test_rq_import.py
+++ b/tests/unit_tests/rq_import/test_rq_import.py
@@ -323,6 +323,48 @@ def test_add_surfaces(example_model_and_crs, test_data_path, surfaces, format, r
     if interp_and_feat:
         assert len(model.parts_list_of_type('obj_HorizonInterpretation')) == len(surfaces)
 
+@pytest.mark.parametrize('surfaces,format,interp_and_feat,role,rqclass,newparts,interptype',
+                         [(['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'horizon'),
+                          (['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'fault'),
+                          (['Surface_zmap.dat'], 'zmap', True, 'map', 'surface', 2, 'geobody'),
+                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 2, 'horizon'),
+                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 2, 'fault'),
+                          (['Surface_roxartext.txt'], 'rms', True, 'map', 'surface', 2, 'geobody'),
+                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'horizon'),
+                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'fault'),
+                          (['Surface_tsurf.txt'], 'GOCAD-Tsurf', True, 'map', 'surface', 2, 'geobody'))
+def test_add_surfaces_different_types(example_model_and_crs, test_data_path, surfaces, format, rqclass, interp_and_feat, role,
+                      newparts, interptype):
+    model, crs = example_model_and_crs
+    model.store_epc()
+
+    surface_paths = [os.path.join(test_data_path, surf) for surf in surfaces]
+
+    rqi.add_surfaces(epc_file = model.epc_file,
+                     surface_file_format = format,
+                     surface_file_list = surface_paths,
+                     surface_role = role,
+                     rq_class = rqclass,
+                     make_horizon_interpretations_and_features = interp_and_feat,
+                     interpretation_type = interptype)
+
+    model = rq.Model(model.epc_file)
+    assert len(model.parts()) == newparts
+    if rqclass in ['surface', 'TriangulatedSet']:
+        assert len(model.parts_list_of_type('obj_TriangulatedSetRepresentation')) == len(surfaces)
+    else:
+        assert len(model.parts_list_of_type('obj_Grid2dRepresentation')) == len(surfaces)
+
+    if interptype == 'horizon':
+        assert len(model.parts_list_of_type('obj_HorizonInterpretation')) == len(surfaces)
+        assert len(model.parts_list_of_type('obj_GenericBoundaryFeature')) == len(surfaces)
+    elif interptype == 'fault':
+        assert len(model.parts_list_of_type('obj_FaultInterpretation')) == len(surfaces)
+        assert len(model.parts_list_of_type('obj_TectonicBoundaryFeature')) == len(surfaces)
+    else:
+        assert len(model.parts_list_of_type('obj_GeobodyInterpretation')) == len(surfaces)
+        assert len(model.parts_list_of_type('obj_GeobodyFeature')) == len(surfaces)
+
 
 def test_add_ab_properties(example_model_with_properties, test_data_path):
     # Arrange


### PR DESCRIPTION
Update to allow the required "interpretation_type" (horizon, fault, geobody) when importing using "add_surface" and adding features and interpretations. If horizon is selected (default) then GeneticBoundaryFeature and HorizonInterpretation is added, if fault is selected then TectonicBoundaryFeature and FaultInterpretation is added, if geobody is selected then GeobodyFeature and GeobodyInterpretation is added.