### PR TITLE
patchwork grid connection set for filtered faces only

### DIFF
--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -2514,7 +2514,7 @@ def _bitwise_count_njit(a: np.ndarray) -> np.int64:
     return c
 
 
-@njit
+@njit  # pragma: no cover
 def box_intersection(box_a: np.ndarray, box_b: np.ndarray) -> np.ndarray:
     """Return a box which is the intersection of two boxes, python protocol; all zeros if no intersection."""
     box = np.zeros((2, 3), dtype = np.int32)
@@ -2525,8 +2525,8 @@ def box_intersection(box_a: np.ndarray, box_b: np.ndarray) -> np.ndarray:
     return box
 
 
-@njit
-def get_box(mask: np.ndarray) -> Tuple[np.ndarray, int]:  # pragma: no cover
+@njit  # pragma: no cover
+def get_box(mask: np.ndarray) -> Tuple[np.ndarray, int]:
     """Returns a python protocol box enclosing True elements of 3D boolean mask, and count which is zero if all False."""
     box = np.full((2, 3), -1, dtype = np.int32)
     count = 0
@@ -2558,7 +2558,7 @@ def get_box(mask: np.ndarray) -> Tuple[np.ndarray, int]:  # pragma: no cover
     return box, count
 
 
-@njit
+@njit  # pragma
 def filter_faces(faces_kji0: np.ndarray, face_patches: np.ndarray, cell_patches: np.ndarray, axis: int) -> np.ndarray:
     """Return 1D boolean selection array indicating subset of faces that are applicable to cells with matching patch."""
     n: int = len(faces_kji0)

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -2558,7 +2558,7 @@ def get_box(mask: np.ndarray) -> Tuple[np.ndarray, int]:
     return box, count
 
 
-@njit  # pragma
+@njit  # pragma: no cover
 def filter_faces(faces_kji0: np.ndarray, face_patches: np.ndarray, cell_patches: np.ndarray, axis: int) -> np.ndarray:
     """Return 1D boolean selection array indicating subset of faces that are applicable to cells with matching patch."""
     n: int = len(faces_kji0)

--- a/tests/unit_tests/surface/test_surface.py
+++ b/tests/unit_tests/surface/test_surface.py
@@ -109,8 +109,10 @@ def test_faces_for_surface(tmp_model):
                                                                                   n_batches = 2,
                                                                                   packed_bisectors = True,
                                                                                   patch_indices = grid_patch_indices)
+    reduced_cip = set([(9, 10), (6, 15), (19, 20), (0, 9), (16, 25), (15, 16), (10, 19), (25, 26)])
+    assert reduced_cip.issubset(e_cip)
     cip = set([tuple(pair) for pair in gcs_optimised.cell_index_pairs])
-    assert cip == e_cip  # note: this assumes lower cell index is first, which happens to be true
+    assert cip == reduced_cip  # note: this assumes lower cell index is first, which happens to be true
     assert props is not None
     assert len(props) == 1
     bisector, is_curtain = props['grid bisector']


### PR DESCRIPTION
This change modifies the find faces... functionality for patchwork surfaces when called with a patch indices array for the grid cells. In that case, the function now only includes faces where the related triangle patch matches that of one of the two grid cells which adjoin the face. (Previously all faces for all the surface patches were included without filtering.)