### PR TITLE
Tri mesh area method

### DIFF
--- a/resqpy/surface/_tri_mesh.py
+++ b/resqpy/surface/_tri_mesh.py
@@ -570,6 +570,17 @@ class TriMesh(rqs.Mesh):
         return p
 
     def area(self, required_uom = None):
+        """Returns approximate area of tri mesh based on proportion of non-NaN z values.
+
+        arguments:
+            - required_uom (str, optional): RESQML area unit of measure string for result
+
+        returns:
+            - float being the approximate area of the tri mesh in its xy projection
+
+        note:
+            - default uom is crs xy_units squared
+        """
         a = 1.0 - (float(np.count_nonzero(np.isnan(self.full_array_ref()[..., 2]))) / float(self.nj * self.ni))
         a *= float((self.nj - 1) * (self.ni - 1)) * self.t_side * self.t_side * root_3_by_2
         if required_uom is not None:

--- a/resqpy/surface/_tri_mesh.py
+++ b/resqpy/surface/_tri_mesh.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import resqpy.crs as rqc
 import resqpy.surface as rqs
+import resqpy.weights_and_measures as wam
 import resqpy.olio.vector_utilities as vec
 import resqpy.olio.uuid as bu
 
@@ -567,6 +568,16 @@ class TriMesh(rqs.Mesh):
                 p = np.concatenate((p, w[crossing]))
 
         return p
+
+    def area(self, required_uom = None):
+        a = 1.0 - (float(np.count_nonzero(np.isnan(self.full_array_ref()[..., 2]))) / float(self.nj * self.ni))
+        a *= float((self.nj - 1) * (self.ni - 1)) * self.t_side * self.t_side * root_3_by_2
+        if required_uom is not None:
+            crs = rqc.Crs(self.model, uuid = self.crs_uuid)
+            if required_uom != crs.xy_units + '2':
+                uom = ('ft' if crs.xy_units.startswith('ft') else crs.xy_units) + '2'
+                a = wam.convert(a, uom, required_uom)
+        return a
 
     def is_compatible_with(self, other_tri_mesh):
         """Returns True if this tri mesh has the same xy points as the other."""

--- a/tests/unit_tests/surface/test_tri_mesh.py
+++ b/tests/unit_tests/surface/test_tri_mesh.py
@@ -541,3 +541,46 @@ def test_tri_mesh_compatible(example_model_and_crs):
                          title = 'test tri mesh b')
     assert trim_a.is_compatible_with(trim_b)
     assert trim_b.is_compatible_with(trim_a)
+
+
+def test_tri_mesh_area(example_model_and_crs):
+    model, crs = example_model_and_crs
+    z_values = np.array([(-100.0, -100.0, -100.0, -100.0), (100.0, 100.0, 100.0, 100.0), (500.0, 500.0, 500.0, 500.0)],
+                        dtype = float)
+    trim = rqs.TriMesh(model,
+                       t_side = 100.0,
+                       nj = 3,
+                       ni = 4,
+                       z_values = z_values,
+                       crs_uuid = crs.uuid,
+                       title = 'test tri mesh area')
+
+    area = trim.area()  # default uom based on crs xy units
+    area_m2 = trim.area(required_uom = 'm2')
+    area_ha = trim.area(required_uom = 'ha')
+
+    expected_area = float(2 * 3) * 100.0 * 100.0 * maths.sqrt(3.0) / 2.0
+    assert maths.isclose(area, expected_area)
+    assert maths.isclose(area_m2, expected_area)
+    assert maths.isclose(area_ha, expected_area / 10000.0)
+
+    z_values = np.array([(-100.0, -100.0, np.nan, -100.0), (100.0, np.nan, 100.0, 100.0),
+                         (np.nan, 500.0, 500.0, 500.0)],
+                        dtype = float)
+    trim2 = rqs.TriMesh(model,
+                        t_side = 100.0,
+                        nj = 3,
+                        ni = 4,
+                        z_values = z_values,
+                        crs_uuid = crs.uuid,
+                        title = 'test tri mesh nan area')
+
+    area = trim2.area()  # default uom based on crs xy units
+    area_m2 = trim2.area(required_uom = 'm2')
+    area_ha = trim2.area(required_uom = 'ha')
+
+    # note: area is approximation based directly on proportion of non-NaN points, not area of triangles without NaN points
+    expected_area = (float(9) / float(12)) * float(2 * 3) * 100.0 * 100.0 * maths.sqrt(3.0) / 2.0
+    assert maths.isclose(area, expected_area)
+    assert maths.isclose(area_m2, expected_area)
+    assert maths.isclose(area_ha, expected_area / 10000.0)


### PR DESCRIPTION
Adds an area() method to the TriMesh class, returning an approximate area based on the proportion of non-NaN z values.