### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Development Status :: 5 - Production/Stable",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Filesystems",
@@ -40,7 +41,7 @@ include = ["data/*.json"]
 #   - https://semver.org/
 # See here for "caret" style dependency specifications:
 #   - https://python-poetry.org/docs/dependency-specification/
-python = ">= 3.9, < 3.13"
+python = ">= 3.9, < 3.14"
 numpy = "^1.26"
 pandas = "^2.2"
 h5py = "^3.7"


### PR DESCRIPTION
Resolves https://github.com/bp/resqpy/issues/886, to see how the pipeline goes with it.

There are other things that will need to be updated too. For example:
* https://github.com/numba/numba/issues/9413, may need to bump numba to 0.61 to support Python 3.13 - this would increase the minimum Python version from 3.9 to 3.10
