### PR TITLE
Update grid_surface_mp.py to ensure correct dtype for boolean property.

### DIFF
--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -424,16 +424,7 @@ def find_faces_to_represent_surface_regular_wrapper(
                     indexable_element = "cells",
                 )
             elif p_name == 'flange bool':
-                property_collection.add_cached_array_to_imported_list(
-                    array,
-                    f"from find_faces function for {surface.title}",
-                    f'{surface.title} {p_name}',
-                    discrete = True,
-                    null_value = -1,
-                    property_kind = "flange bool",
-                    realization = realisation,
-                    indexable_element = "faces",
-                )
+                log.debug('flange bool processed separately to ensure correct dtype for packing')
             else:
                 raise ValueError(f'unrecognised property name {p_name}')
         if property_collection.number_of_imports() > 0:
@@ -442,6 +433,28 @@ def find_faces_to_represent_surface_regular_wrapper(
             uuids_properties = property_collection.create_xml_for_imported_list_and_add_parts_to_model(
                 find_local_property_kinds = True)
             uuid_list.extend(uuids_properties)
+
+        if 'flange bool' in properties.keys():
+            log.debug('flange bool processed separately to ensure correct dtype for packing')
+            p_name = 'flange bool'
+            array = properties['flange bool']
+            property_collection.add_cached_array_to_imported_list(
+                array,
+                f"from find_faces function for {surface.title}",
+                f'{surface.title} {p_name}',
+                discrete = True,
+                null_value = -1,
+                property_kind = "flange bool",
+                realization = realisation,
+                indexable_element = "faces"
+            )
+        if property_collection.number_of_imports() > 0:
+            # log.debug('writing gcs property hdf5 data')
+            property_collection.write_hdf5_for_imported_list(use_pack = use_pack, dtype=np.int8)
+            uuids_properties = property_collection.create_xml_for_imported_list_and_add_parts_to_model(
+                find_local_property_kinds = True)
+            uuid_list.extend(uuids_properties)
+
         if grid_pc is not None and grid_pc.number_of_imports() > 0:
             # log.debug('writing grid property (bisector) hdf5 data')
             grid_pc.write_hdf5_for_imported_list(use_pack = use_pack)


### PR DESCRIPTION
Bug fix - previously if packing was used the dtype was not being correctly set for one property, resulting in malformed arrays on reload.