### PR TITLE
Update _grid_connection_set.py for stable sorting

### DIFF
--- a/resqpy/fault/_grid_connection_set.py
+++ b/resqpy/fault/_grid_connection_set.py
@@ -2316,7 +2316,7 @@ def _sort_and_remove_duplicates(a: np.ndarray, props: Optional[list[np.ndarray]]
     if no_props:
         a = np.sort(a)
     else:
-        si = np.argsort(a)
+        si = np.argsort(a, kind = 'stable')
         a = a[si]
     m = np.empty(a.size, dtype = bool)
     m[0] = True


### PR DESCRIPTION
Previously tests were failing on occasion as the sorting was not stable and so different results were possible where a cell face could be claimed by two triangles. Stable sorting aims to avoid this ambiguity