### PR TITLE
Remove unused imports (auto-fixed by ruff), reducing circular imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ select = [
     "D",                         # pydocstyle (Google-style docstrings)
 ]
 ignore = [
-    "F401",  # module imported but unused: low-priority
     "F841",  # local variable assigned but never used: sometimes deliberate
     # pydocstyle exceptions for Google-style docstrings:
     "D203", "D204", "D213", "D215", "D400", "D401", "D404", "D406", "D407",

--- a/resqpy/crs.py
+++ b/resqpy/crs.py
@@ -6,7 +6,6 @@ log = logging.getLogger(__name__)
 
 import math as maths
 import uuid
-import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np

--- a/resqpy/derived_model/_add_edges_per_column_property_array.py
+++ b/resqpy/derived_model/_add_edges_per_column_property_array.py
@@ -1,6 +1,5 @@
 """High level add edges per column property array function."""
 
-import resqpy.derived_model
 import resqpy.property as rqp
 
 import resqpy.derived_model._add_one_grid_property_array as rqdm_aogp

--- a/resqpy/derived_model/_add_faults.py
+++ b/resqpy/derived_model/_add_faults.py
@@ -8,7 +8,6 @@ import os
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.grid as grr
 import resqpy.lines as rql
 import resqpy.model as rq

--- a/resqpy/derived_model/_add_wells_from_ascii_file.py
+++ b/resqpy/derived_model/_add_wells_from_ascii_file.py
@@ -7,9 +7,7 @@ log = logging.getLogger(__name__)
 import os
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.model as rq
-import resqpy.olio.xml_et as rqet
 import resqpy.well as rqw
 
 import resqpy.derived_model._common as rqdm_c

--- a/resqpy/derived_model/_add_zone_by_layer_property.py
+++ b/resqpy/derived_model/_add_zone_by_layer_property.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-import resqpy.derived_model
 import resqpy.grid as grr
 import resqpy.property.property_kind as pk
 import resqpy.model as rq

--- a/resqpy/derived_model/_coarsened_grid.py
+++ b/resqpy/derived_model/_coarsened_grid.py
@@ -8,7 +8,6 @@ import os
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.grid as grr
 import resqpy.model as rq
 import resqpy.olio.fine_coarse as fc

--- a/resqpy/derived_model/_drape_to_surface.py
+++ b/resqpy/derived_model/_drape_to_surface.py
@@ -9,9 +9,7 @@ import numpy as np
 import copy
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.grid_surface as rgs
-import resqpy.model as rq
 import resqpy.olio.intersection as meet
 import resqpy.olio.xml_et as rqet
 

--- a/resqpy/derived_model/_extract_box.py
+++ b/resqpy/derived_model/_extract_box.py
@@ -8,9 +8,7 @@ import os
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.grid as grr
-import resqpy.model as rq
 import resqpy.olio.box_utilities as bx
 import resqpy.olio.fine_coarse as fc
 import resqpy.olio.xml_et as rqet

--- a/resqpy/derived_model/_extract_box_for_well.py
+++ b/resqpy/derived_model/_extract_box_for_well.py
@@ -8,11 +8,9 @@ import os
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.grid_surface as rgs
 import resqpy.model as rq
 import resqpy.olio.box_utilities as bx
-import resqpy.olio.xml_et as rqet
 import resqpy.well as rqw
 
 import resqpy.derived_model._add_one_grid_property_array as rqdm_aogp

--- a/resqpy/derived_model/_fault_throw_scaling.py
+++ b/resqpy/derived_model/_fault_throw_scaling.py
@@ -8,7 +8,6 @@ import os
 import math as maths
 import numpy as np
 
-import resqpy.derived_model
 import resqpy.fault as rqf
 import resqpy.model as rq
 import resqpy.olio.uuid as bu

--- a/resqpy/derived_model/_interpolated_grid.py
+++ b/resqpy/derived_model/_interpolated_grid.py
@@ -8,7 +8,6 @@ import os
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.grid as grr
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet

--- a/resqpy/derived_model/_local_depth_adjustment.py
+++ b/resqpy/derived_model/_local_depth_adjustment.py
@@ -9,8 +9,6 @@ import math as maths
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.derived_model
-import resqpy.model as rq
 import resqpy.olio.xml_et as rqet
 
 import resqpy.derived_model._common as rqdm_c

--- a/resqpy/derived_model/_refined_grid.py
+++ b/resqpy/derived_model/_refined_grid.py
@@ -8,7 +8,6 @@ import os
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.derived_model
 import resqpy.grid as grr
 import resqpy.model as rq
 import resqpy.olio.fine_coarse as fc

--- a/resqpy/derived_model/_tilted_grid.py
+++ b/resqpy/derived_model/_tilted_grid.py
@@ -6,8 +6,6 @@ log = logging.getLogger(__name__)
 
 import os
 
-import resqpy.derived_model
-import resqpy.model as rq
 import resqpy.olio.vector_utilities as vec
 import resqpy.olio.xml_et as rqet
 

--- a/resqpy/derived_model/_unsplit_grid.py
+++ b/resqpy/derived_model/_unsplit_grid.py
@@ -6,8 +6,6 @@ log = logging.getLogger(__name__)
 
 import os
 
-import resqpy.derived_model
-import resqpy.model as rq
 import resqpy.olio.xml_et as rqet
 
 import resqpy.derived_model._common as rqdm_c

--- a/resqpy/derived_model/_zonal_grid.py
+++ b/resqpy/derived_model/_zonal_grid.py
@@ -7,9 +7,7 @@ log = logging.getLogger(__name__)
 import os
 import numpy as np
 
-import resqpy.derived_model
 import resqpy.grid as grr
-import resqpy.model as rq
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 import resqpy.property as rqp

--- a/resqpy/fault/_grid_connection_set.py
+++ b/resqpy/fault/_grid_connection_set.py
@@ -8,11 +8,9 @@ log = logging.getLogger(__name__)
 
 import math as maths
 import numpy as np
-import pandas as pd
 
 from typing import Optional
 import resqpy.grid as grr
-import resqpy.fault
 import resqpy.olio.read_nexus_fault as rnf
 import resqpy.olio.trademark as tm
 import resqpy.olio.uuid as bu
@@ -21,7 +19,6 @@ import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
 import resqpy.property as rqp
 import resqpy.surface as rqs
-import resqpy.crs as rqc
 import resqpy.fault._gcs_functions as rqf_gf
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/grid/__init__.py
+++ b/resqpy/grid/__init__.py
@@ -1,8 +1,8 @@
 """The Grid Module."""
 
 __all__ = [
-    'Grid', 'RegularGrid', 'extract_grid_parent', 'find_cell_for_x_sect_xz', 'grid_flavour', 'is_regular_grid',
-    'any_grid'
+    'Grid', 'RegularGrid', 'extract_grid_parent', 'extent_kji_from_root', 'find_cell_for_x_sect_xz', 'grid_flavour',
+    'is_regular_grid', 'any_grid'
 ]
 
 from ._grid import Grid

--- a/resqpy/grid/_cell_properties.py
+++ b/resqpy/grid/_cell_properties.py
@@ -10,7 +10,6 @@ import resqpy.olio.vector_utilities as vec
 import resqpy.olio.volume as vol
 import resqpy.weights_and_measures as wam
 
-import resqpy.grid
 import resqpy.grid._defined_geometry as grr_dg
 
 

--- a/resqpy/grid/_extract_functions.py
+++ b/resqpy/grid/_extract_functions.py
@@ -8,7 +8,6 @@ import resqpy.olio.fine_coarse as fc
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 import resqpy.property as rprop
-import resqpy.grid
 import resqpy.grid._intervals_info as grr_ii
 import resqpy.grid._defined_geometry as grr_dg
 

--- a/resqpy/grid/_grid.py
+++ b/resqpy/grid/_grid.py
@@ -52,8 +52,6 @@ from ._xyz import xyz_box, xyz_box_centre, bounding_box, composite_bounding_box,
     check_top_and_base_cell_edge_directions, _local_to_global_crs, _global_to_local_crs
 from ._pixel_maps import pixel_maps, pixel_map_for_split_horizon_points
 
-import warnings
-
 
 class Grid(BaseResqpy):
     """Class for RESQML Grid (extent and geometry) within RESQML model object."""

--- a/resqpy/grid/_grid_types.py
+++ b/resqpy/grid/_grid_types.py
@@ -1,7 +1,5 @@
 """functions to handle different grid types"""
 
-import warnings
-
 import resqpy.grid as grr
 import resqpy.unstructured as rug
 import resqpy.olio.xml_et as rqet

--- a/resqpy/grid/_points_functions.py
+++ b/resqpy/grid/_points_functions.py
@@ -7,13 +7,11 @@ log = logging.getLogger(__name__)
 import numpy as np
 import numpy.ma as ma
 
-import resqpy.grid as grr
 import resqpy.olio.point_inclusion as pip
 import resqpy.olio.uuid as bu
 import resqpy.olio.vector_utilities as vec
 import resqpy.olio.xml_et as rqet
 import resqpy.property as rprop
-import resqpy.weights_and_measures as wam
 import resqpy.grid._defined_geometry as grr_dg
 
 

--- a/resqpy/grid/_regular_grid.py
+++ b/resqpy/grid/_regular_grid.py
@@ -8,7 +8,6 @@ import math as maths
 import numpy as np
 
 import resqpy.crs as rqc
-import resqpy.grid
 import resqpy.olio.transmission as rqtr
 import resqpy.olio.uuid as bu
 import resqpy.olio.vector_utilities as vec

--- a/resqpy/grid/_write_nexus_corp.py
+++ b/resqpy/grid/_write_nexus_corp.py
@@ -12,7 +12,6 @@ import resqpy.olio.grid_functions as gf
 import resqpy.olio.xml_et as rqet
 import resqpy.olio.trademark as tm
 import resqpy.olio.write_data as wd
-import resqpy.crs as rqc
 import resqpy.weights_and_measures as wam
 
 

--- a/resqpy/grid/_xyz.py
+++ b/resqpy/grid/_xyz.py
@@ -6,7 +6,6 @@ log = logging.getLogger(__name__)
 
 import numpy as np
 
-import resqpy.olio.xml_et as rqet
 import resqpy.weights_and_measures as bwam
 import resqpy.crs as rqc
 import resqpy.olio.vector_utilities as vec

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -6,11 +6,9 @@ log = logging.getLogger(__name__)
 
 import numpy as np
 import warnings
-import numba  # type: ignore
 from numba import njit, prange  # type: ignore
 from typing import Tuple, Union, Dict
 
-import resqpy.model as rq
 import resqpy.crs as rqc
 import resqpy.grid as grr
 import resqpy.fault as rqf

--- a/resqpy/grid_surface/grid_surface_cuda.py
+++ b/resqpy/grid_surface/grid_surface_cuda.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 import math as maths
 import numpy as np
-from typing import Tuple, Optional, Dict
+from typing import Tuple
 import threading
 
 import numba  # type: ignore

--- a/resqpy/lines/_polyline_set.py
+++ b/resqpy/lines/_polyline_set.py
@@ -8,7 +8,6 @@ import os
 import numpy as np
 
 import resqpy.crs as rcrs
-import resqpy.lines
 import resqpy.property as rqp
 import resqpy.olio.simple_lines as rsl
 import resqpy.olio.uuid as bu

--- a/resqpy/model/_context.py
+++ b/resqpy/model/_context.py
@@ -7,7 +7,6 @@ log = logging.getLogger(__name__)
 import os
 from typing import Optional
 
-import resqpy.model
 from resqpy.model import Model, new_model
 
 

--- a/resqpy/model/_forestry.py
+++ b/resqpy/model/_forestry.py
@@ -16,7 +16,6 @@ import resqpy.olio.uuid as bu
 import resqpy.olio.write_hdf5 as whdf5
 import resqpy.olio.xml_et as rqet
 from resqpy.olio.xml_namespaces import curly_namespace as ns
-from resqpy.olio.xml_namespaces import namespace as ns_url
 
 
 def _add_to_object_parts(model, part):

--- a/resqpy/model/_xml.py
+++ b/resqpy/model/_xml.py
@@ -6,9 +6,7 @@ log = logging.getLogger(__name__)
 
 import getpass
 import os
-import warnings
 
-import resqpy.crs as rqc
 import resqpy.olio.time as time
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet

--- a/resqpy/multi_processing/_multiprocessing.py
+++ b/resqpy/multi_processing/_multiprocessing.py
@@ -4,7 +4,6 @@ import logging
 import os
 import time
 import uuid
-import joblib  # type: ignore
 from typing import List, Dict, Any, Callable, Union
 from pathlib import Path
 from joblib import Parallel, delayed, parallel_backend  # type: ignore

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -4,10 +4,8 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import os
 import numpy as np
 import uuid
-import ast
 from typing import Tuple, Union, List, Optional, Callable
 from pathlib import Path
 from uuid import UUID

--- a/resqpy/olio/base.py
+++ b/resqpy/olio/base.py
@@ -4,7 +4,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import warnings
 from abc import ABCMeta, abstractmethod
 
 import resqpy.olio.uuid as bu

--- a/resqpy/olio/dataframe.py
+++ b/resqpy/olio/dataframe.py
@@ -9,7 +9,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import warnings
 import numpy as np
 import pandas as pd
 

--- a/resqpy/olio/load_data.py
+++ b/resqpy/olio/load_data.py
@@ -10,7 +10,6 @@ import os
 import numpy as np
 
 import resqpy.olio.ab_toolbox as abt
-import resqpy.olio.box_utilities as box
 import resqpy.olio.grid_functions as gf
 import resqpy.olio.keyword_files as kf
 import resqpy.olio.write_data as wd

--- a/resqpy/olio/read_nexus_fault.py
+++ b/resqpy/olio/read_nexus_fault.py
@@ -6,7 +6,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import os
 import re
 import unicodedata
 import numpy as np

--- a/resqpy/olio/vector_utilities.py
+++ b/resqpy/olio/vector_utilities.py
@@ -14,7 +14,7 @@ import math as maths
 import numpy as np
 import numba  # type: ignore
 from numba import njit, prange  # type: ignore
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional
 
 
 def radians_from_degrees(deg):

--- a/resqpy/olio/xml_et.py
+++ b/resqpy/olio/xml_et.py
@@ -10,9 +10,7 @@ import uuid
 
 # import xml element tree parse method and classes here to allow single point for switching between lxml and etree
 # alternative to lxml.etree: xml.etree.ElementTree
-from lxml.etree import (  # type: ignore
-    Element, ElementTree, SubElement, _Element,  # noqa
-    parse)
+from lxml.etree import Element, SubElement, ElementTree, _Element, parse  # type: ignore  # noqa
 
 import resqpy.olio.uuid as bu
 from resqpy.olio.xml_namespaces import curly_namespace as cns

--- a/resqpy/organize/boundary_feature.py
+++ b/resqpy/organize/boundary_feature.py
@@ -1,7 +1,6 @@
 """Class for RESQML Boundary Feature organizational objects."""
 
 import resqpy.olio.uuid as bu
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 

--- a/resqpy/organize/boundary_feature_interpretation.py
+++ b/resqpy/organize/boundary_feature_interpretation.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.boundary_feature as obf
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/organize/earth_model_interpretation.py
+++ b/resqpy/organize/earth_model_interpretation.py
@@ -5,7 +5,6 @@ from ._utils import (equivalent_extra_metadata, extract_has_occurred_during, equ
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.organization_feature as oof
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/organize/fault_interpretation.py
+++ b/resqpy/organize/fault_interpretation.py
@@ -4,7 +4,6 @@ import math as maths
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.tectonic_boundary_feature as tbf
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/organize/fluid_boundary_feature.py
+++ b/resqpy/organize/fluid_boundary_feature.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/organize/frontier_feature.py
+++ b/resqpy/organize/frontier_feature.py
@@ -1,7 +1,6 @@
 """Class for RESQML Frontier Feature organizational objects."""
 
 import resqpy.olio.uuid as bu
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 

--- a/resqpy/organize/genetic_boundary_feature.py
+++ b/resqpy/organize/genetic_boundary_feature.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/organize/geobody_boundary_interpretation.py
+++ b/resqpy/organize/geobody_boundary_interpretation.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.genetic_boundary_feature as gbf
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/organize/geobody_feature.py
+++ b/resqpy/organize/geobody_feature.py
@@ -8,7 +8,6 @@ import logging
 log = logging.getLogger(__name__)
 
 import resqpy.olio.uuid as bu
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 

--- a/resqpy/organize/geobody_interpretation.py
+++ b/resqpy/organize/geobody_interpretation.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.geobody_feature as ogf
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/organize/geologic_unit_feature.py
+++ b/resqpy/organize/geologic_unit_feature.py
@@ -1,7 +1,6 @@
 """Class for RESQML Geologic Unit Feature organizational objects."""
 
 import resqpy.olio.uuid as bu
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 

--- a/resqpy/organize/horizon_interpretation.py
+++ b/resqpy/organize/horizon_interpretation.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.genetic_boundary_feature as gbf
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/organize/organization_feature.py
+++ b/resqpy/organize/organization_feature.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/organize/rock_fluid_unit_feature.py
+++ b/resqpy/organize/rock_fluid_unit_feature.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.boundary_feature as obf
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/organize/tectonic_boundary_feature.py
+++ b/resqpy/organize/tectonic_boundary_feature.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/organize/wellbore_feature.py
+++ b/resqpy/organize/wellbore_feature.py
@@ -1,11 +1,8 @@
 """Class for RESQML Wellbore Feature organizational objects."""
 
 import resqpy.olio.uuid as bu
-import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy
-from resqpy.olio.xml_namespaces import curly_namespace as ns
 
 
 class WellboreFeature(BaseResqpy):

--- a/resqpy/organize/wellbore_interpretation.py
+++ b/resqpy/organize/wellbore_interpretation.py
@@ -2,7 +2,6 @@
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.organize
 import resqpy.organize.wellbore_feature as wbf
 import resqpy.organize._utils as ou
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/property/_collection_add_part.py
+++ b/resqpy/property/_collection_add_part.py
@@ -8,7 +8,6 @@ log = logging.getLogger(__name__)
 
 import numpy as np
 
-import resqpy.property
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 import resqpy.property.property_common as rqp_c

--- a/resqpy/property/_collection_create_xml.py
+++ b/resqpy/property/_collection_create_xml.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 import math as maths
 import numpy as np
 
-import resqpy.property
 import resqpy.time_series as rts
 import resqpy.weights_and_measures as wam
 import resqpy.olio.uuid as bu

--- a/resqpy/property/_collection_get_attributes.py
+++ b/resqpy/property/_collection_get_attributes.py
@@ -9,10 +9,8 @@ log = logging.getLogger(__name__)
 import numpy as np
 import numpy.ma as ma
 
-import resqpy
 import resqpy.property as rqp
 import resqpy.olio.xml_et as rqet
-import resqpy.olio.uuid as bu
 import resqpy.property.property_kind as rqpk
 
 

--- a/resqpy/property/_property.py
+++ b/resqpy/property/_property.py
@@ -6,7 +6,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import resqpy.property
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 import resqpy.property.property_collection as rqp_pc

--- a/resqpy/property/attribute_property_set.py
+++ b/resqpy/property/attribute_property_set.py
@@ -6,9 +6,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import numpy as np
-import numpy.ma as ma
-
 import resqpy.property as rqp
 
 

--- a/resqpy/property/well_interval_property.py
+++ b/resqpy/property/well_interval_property.py
@@ -4,7 +4,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import resqpy.property
 import resqpy.property.property_collection as rqp_pc
 
 

--- a/resqpy/property/well_interval_property_collection.py
+++ b/resqpy/property/well_interval_property_collection.py
@@ -8,7 +8,6 @@ log = logging.getLogger(__name__)
 
 import pandas as pd
 
-import resqpy.property
 import resqpy.property.property_collection as rqp_pc
 import resqpy.property.well_interval_property as rqp_wip
 import resqpy.property.property_common as rqp_c

--- a/resqpy/property/well_log.py
+++ b/resqpy/property/well_log.py
@@ -4,7 +4,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import resqpy.property
 import resqpy.property.property_collection as rqp_pc
 
 

--- a/resqpy/property/well_log_collection.py
+++ b/resqpy/property/well_log_collection.py
@@ -9,7 +9,6 @@ import pandas as pd
 import lasio
 from datetime import datetime
 
-import resqpy.property
 import resqpy.weights_and_measures as bwam
 
 import resqpy.property.property_collection as rqp_pc

--- a/resqpy/rq_import/_add_surfaces.py
+++ b/resqpy/rq_import/_add_surfaces.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 import os
 
 import resqpy.model as rq
-import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
 import resqpy.surface as rqs
 

--- a/resqpy/strata/_binary_contact_interpretation.py
+++ b/resqpy/strata/_binary_contact_interpretation.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.strata
 import resqpy.strata._strata_common as rqstc
 from resqpy.olio.xml_namespaces import curly_namespace as ns
 

--- a/resqpy/strata/_geologic_unit_interpretation.py
+++ b/resqpy/strata/_geologic_unit_interpretation.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
-import resqpy.strata
 import resqpy.strata._strata_common as rqstc
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/strata/_stratigraphic_column.py
+++ b/resqpy/strata/_stratigraphic_column.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
-import resqpy.strata
 import resqpy.strata._strata_common as rqstc
 import resqpy.strata._stratigraphic_column_rank as rqscr
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/strata/_stratigraphic_column_rank.py
+++ b/resqpy/strata/_stratigraphic_column_rank.py
@@ -10,7 +10,6 @@ log = logging.getLogger(__name__)
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
-import resqpy.strata
 import resqpy.strata._strata_common as rqstc
 import resqpy.strata._binary_contact_interpretation as rqsbc
 import resqpy.strata._stratigraphic_unit_interpretation as rqsui

--- a/resqpy/strata/_stratigraphic_unit_interpretation.py
+++ b/resqpy/strata/_stratigraphic_unit_interpretation.py
@@ -8,7 +8,6 @@ log = logging.getLogger(__name__)
 
 import resqpy.olio.uuid as bu
 import resqpy.olio.xml_et as rqet
-import resqpy.strata
 import resqpy.strata._strata_common as rqstc
 import resqpy.strata._geologic_unit_interpretation as rqsgui
 import resqpy.strata._stratigraphic_unit_feature as rqsui

--- a/resqpy/surface/__init__.py
+++ b/resqpy/surface/__init__.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     'BaseSurface', 'CombinedSurface', 'Mesh', 'TriangulatedPatch', 'PointSet', 'Surface', 'TriMesh', 'TriMeshStencil',
-    'distill_triangle_points', '_adjust_flange_z'
+    'distill_triangle_points', 'nan_removed_triangles_and_points', '_adjust_flange_z'
 ]
 
 from ._base_surface import BaseSurface

--- a/resqpy/surface/_mesh.py
+++ b/resqpy/surface/_mesh.py
@@ -7,7 +7,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import warnings
 import math as maths
 import numpy as np
 
@@ -19,7 +18,6 @@ import resqpy.olio.write_hdf5 as rwh5
 import resqpy.olio.xml_et as rqet
 import resqpy.property as rqp
 import resqpy.weights_and_measures as wam
-import resqpy.surface
 import resqpy.surface._base_surface as rqsb
 import resqpy.surface._surface as rqss
 from resqpy.olio.xml_namespaces import curly_namespace as ns

--- a/resqpy/surface/_pointset.py
+++ b/resqpy/surface/_pointset.py
@@ -15,7 +15,6 @@ import resqpy.olio.vector_utilities as vec
 import resqpy.olio.write_hdf5 as rwh5
 import resqpy.olio.xml_et as rqet
 import resqpy.property as rqp
-import resqpy.surface
 import resqpy.surface._base_surface as rqsb
 from resqpy.olio.xml_namespaces import curly_namespace as ns
 

--- a/resqpy/time_series/_from_nexus_summary.py
+++ b/resqpy/time_series/_from_nexus_summary.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 import datetime as dt
 import os
 
-import resqpy.time_series
 import resqpy.time_series._time_series as rqts
 import resqpy.weights_and_measures as wam
 

--- a/resqpy/time_series/_geologic_time_series.py
+++ b/resqpy/time_series/_geologic_time_series.py
@@ -4,7 +4,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import resqpy.time_series
 import resqpy.time_series._any_time_series as ats
 
 

--- a/resqpy/time_series/_time_series.py
+++ b/resqpy/time_series/_time_series.py
@@ -5,9 +5,7 @@ import logging
 log = logging.getLogger(__name__)
 
 import datetime as dt
-import warnings
 
-import resqpy.time_series
 import resqpy.time_series._any_time_series as ats
 import resqpy.time_series._time_duration as td
 

--- a/resqpy/unstructured/_hexa_grid.py
+++ b/resqpy/unstructured/_hexa_grid.py
@@ -9,7 +9,6 @@ import numpy as np
 import resqpy.grid as grr
 import resqpy.olio.volume as vol
 import resqpy.property as rqp
-import resqpy.unstructured
 import resqpy.unstructured._unstructured_grid as rug
 
 

--- a/resqpy/unstructured/_prism_grid.py
+++ b/resqpy/unstructured/_prism_grid.py
@@ -16,7 +16,6 @@ import resqpy.olio.vector_utilities as vec
 import resqpy.property as rqp
 import resqpy.surface as rqs
 import resqpy.weights_and_measures as wam
-import resqpy.unstructured
 import resqpy.unstructured._unstructured_grid as rug
 
 

--- a/resqpy/unstructured/_pyramid_grid.py
+++ b/resqpy/unstructured/_pyramid_grid.py
@@ -8,7 +8,6 @@ import numpy as np
 
 import resqpy.grid as grr
 import resqpy.olio.volume as vol
-import resqpy.unstructured
 import resqpy.unstructured._unstructured_grid as rug
 
 

--- a/resqpy/unstructured/_tetra_grid.py
+++ b/resqpy/unstructured/_tetra_grid.py
@@ -10,7 +10,6 @@ import resqpy.crs as rqc
 import resqpy.grid as grr
 import resqpy.olio.vector_utilities as vec
 import resqpy.olio.volume as vol
-import resqpy.unstructured
 import resqpy.unstructured._unstructured_grid as rug
 
 

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -11,7 +11,6 @@ import math as maths
 import numpy as np
 import pandas as pd
 import warnings
-from functools import partial
 
 import resqpy.crs as crs
 import resqpy.grid as grr

--- a/resqpy/well/_deviation_survey.py
+++ b/resqpy/well/_deviation_survey.py
@@ -16,7 +16,6 @@ import resqpy.olio.write_hdf5 as rwh5
 import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
 import resqpy.weights_and_measures as bwam
-import resqpy.well
 import resqpy.well._md_datum as rqmdd
 import resqpy.well.well_utils as rqwu
 from resqpy.olio.base import BaseResqpy

--- a/resqpy/well/_md_datum.py
+++ b/resqpy/well/_md_datum.py
@@ -7,7 +7,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import warnings
 import numpy as np
 
 import resqpy.olio.uuid as bu

--- a/resqpy/well/_trajectory.py
+++ b/resqpy/well/_trajectory.py
@@ -23,7 +23,6 @@ import resqpy.olio.write_hdf5 as rwh5
 import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
 import resqpy.weights_and_measures as wam
-import resqpy.well
 import resqpy.well._md_datum as rqmdd
 import resqpy.well._wellbore_frame as rqwbf
 import resqpy.well._deviation_survey as rqds

--- a/resqpy/well/_wellbore_marker_frame.py
+++ b/resqpy/well/_wellbore_marker_frame.py
@@ -14,7 +14,6 @@ import resqpy.olio.uuid as bu
 import resqpy.olio.write_hdf5 as rwh5
 import resqpy.olio.xml_et as rqet
 import resqpy.organize as rqo
-import resqpy.well
 import resqpy.well._trajectory as rqt
 import resqpy.well._wellbore_marker as rqwbm
 import resqpy.well.well_utils as rqwu

--- a/resqpy/well/blocked_well_frame.py
+++ b/resqpy/well/blocked_well_frame.py
@@ -4,7 +4,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-import math as maths
 import numpy as np
 
 import resqpy.property as rqp

--- a/tests/unit_tests/fault/test_fault_connection_set.py
+++ b/tests/unit_tests/fault/test_fault_connection_set.py
@@ -12,7 +12,6 @@ import resqpy.model as rq
 import resqpy.property as rqp
 import resqpy.organize as rqo
 import resqpy.olio.transmission as rqtr
-import resqpy.grid_surface as rqgs
 import resqpy.olio.uuid as bu
 
 

--- a/tests/unit_tests/fault/test_fault_interpretation.py
+++ b/tests/unit_tests/fault/test_fault_interpretation.py
@@ -1,8 +1,5 @@
-import pytest
-
 import resqpy.olio.uuid as uuid
 import resqpy.organize as rqo
-from resqpy.model import Model
 
 
 def test_is_equivalent_no_other(tmp_model):

--- a/tests/unit_tests/grid/conftest.py
+++ b/tests/unit_tests/grid/conftest.py
@@ -8,16 +8,13 @@ import math as maths
 import os
 
 import numpy as np
-import pandas as pd
 
 import resqpy.crs as rqc
 import resqpy.grid as grr
 import resqpy.model as rq
 import resqpy.olio.uuid as bu
-import resqpy.olio.vector_utilities as vec
 import resqpy.olio.xml_et as rqet
 import resqpy.rq_import as rqi
-import resqpy.well as rqw
 
 from inspect import getsourcefile
 

--- a/tests/unit_tests/grid/test_defined_geometry.py
+++ b/tests/unit_tests/grid/test_defined_geometry.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import resqpy.model as rq
 import resqpy.grid as grr

--- a/tests/unit_tests/grid/test_faults.py
+++ b/tests/unit_tests/grid/test_faults.py
@@ -1,6 +1,5 @@
 import resqpy.grid._faults as f
 import numpy as np
-from resqpy.model import Model
 
 
 # yapf: disable

--- a/tests/unit_tests/grid/test_parametric_line_geometry.py
+++ b/tests/unit_tests/grid/test_parametric_line_geometry.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import numpy as np
 

--- a/tests/unit_tests/multiprocessing/test_function_multiprocessing.py
+++ b/tests/unit_tests/multiprocessing/test_function_multiprocessing.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import numpy as np
 

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -1,10 +1,7 @@
 from typing import Tuple
 import numpy as np
 
-import resqpy.model as rq
 import resqpy.property as rqp
-import resqpy.olio.xml_et as rqet
-import resqpy.olio.uuid as bu
 from resqpy.model import Model
 from resqpy.grid import RegularGrid
 from resqpy.surface import Surface, PointSet

--- a/tests/unit_tests/olio/test_box_utilities.py
+++ b/tests/unit_tests/olio/test_box_utilities.py
@@ -1,7 +1,6 @@
 # test olio box_utilities functions
 
 import numpy as np
-import pytest
 
 import resqpy.olio.box_utilities as bx
 

--- a/tests/unit_tests/olio/test_factors.py
+++ b/tests/unit_tests/olio/test_factors.py
@@ -1,7 +1,5 @@
 # tests functions in resqpy.olio.factors module
 
-import pytest
-
 import resqpy.olio.factors as f
 
 

--- a/tests/unit_tests/olio/test_fine_coarse.py
+++ b/tests/unit_tests/olio/test_fine_coarse.py
@@ -1,7 +1,6 @@
 # tests for resqpy.olio.fine_coarse class and functions
 
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal
 
 import resqpy.olio.fine_coarse as rqfc

--- a/tests/unit_tests/olio/test_olio_grid_functions.py
+++ b/tests/unit_tests/olio/test_olio_grid_functions.py
@@ -2,11 +2,9 @@ import os
 import numpy as np
 import pytest
 
-from resqpy.olio.grid_functions import left_right_foursome, infill_block_geometry, resequence_nexus_corp, random_cell, determine_corp_ijk_handedness, determine_corp_extent, translate_corp, triangles_for_cell_faces, actual_pillar_shape, columns_to_nearest_split_face
+from resqpy.olio.grid_functions import left_right_foursome, infill_block_geometry, resequence_nexus_corp, random_cell, determine_corp_ijk_handedness, determine_corp_extent, translate_corp, triangles_for_cell_faces, actual_pillar_shape
 import resqpy.model as rq
 import resqpy.grid as grr
-from resqpy.lines import Polyline
-from resqpy.derived_model import add_faults
 from resqpy.olio.random_seed import seed
 
 

--- a/tests/unit_tests/olio/test_olio_write_data.py
+++ b/tests/unit_tests/olio/test_olio_write_data.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import resqpy.olio.write_data as wd
 from pytest_mock import MockerFixture
 

--- a/tests/unit_tests/olio/test_simple_lines.py
+++ b/tests/unit_tests/olio/test_simple_lines.py
@@ -1,4 +1,3 @@
-import math as maths
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 

--- a/tests/unit_tests/olio/test_transmission.py
+++ b/tests/unit_tests/olio/test_transmission.py
@@ -4,7 +4,6 @@ import math as maths
 import os
 
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal
 
 import resqpy.grid as grr

--- a/tests/unit_tests/olio/test_triangulation.py
+++ b/tests/unit_tests/olio/test_triangulation.py
@@ -1,6 +1,5 @@
 import math as maths
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal
 
 import resqpy.crs as rqc
@@ -8,7 +7,6 @@ import resqpy.lines as rql
 import resqpy.model as rq
 import resqpy.olio.triangulation as tri
 import resqpy.olio.vector_utilities as vec
-import resqpy.surface as rqs
 from resqpy.olio.random_seed import seed
 
 

--- a/tests/unit_tests/olio/test_write_hdf5.py
+++ b/tests/unit_tests/olio/test_write_hdf5.py
@@ -1,7 +1,5 @@
-import pytest
 import os
 import numpy as np
-import h5py
 from numpy.testing import assert_array_almost_equal
 
 import resqpy.grid as grr

--- a/tests/unit_tests/olio/test_xml_et.py
+++ b/tests/unit_tests/olio/test_xml_et.py
@@ -1,4 +1,3 @@
-import pytest
 import math as maths
 
 import resqpy.well as rqw

--- a/tests/unit_tests/property/test_attribute_property_set.py
+++ b/tests/unit_tests/property/test_attribute_property_set.py
@@ -1,7 +1,6 @@
 import math as maths
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
 
 import resqpy.property as rqp
 import resqpy.olio.uuid as bu

--- a/tests/unit_tests/property/test_unstructured_grid_properties.py
+++ b/tests/unit_tests/property/test_unstructured_grid_properties.py
@@ -2,11 +2,9 @@ import math as maths
 import os
 
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal
 
 import resqpy.model as rq
-import resqpy.olio.uuid as bu
 import resqpy.property as rqp
 import resqpy.unstructured as rug
 from resqpy.crs import Crs

--- a/tests/unit_tests/surface/test_surface_patches.py
+++ b/tests/unit_tests/surface/test_surface_patches.py
@@ -1,12 +1,10 @@
 import math as maths
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-import os
 import resqpy.model as rq
 import resqpy.crs as rqc
 import resqpy.surface as rqs
 import resqpy.weights_and_measures as wam
-import resqpy.olio.uuid as bu
 
 import pytest
 

--- a/tests/unit_tests/surface/test_tri_mesh_stencil.py
+++ b/tests/unit_tests/surface/test_tri_mesh_stencil.py
@@ -1,5 +1,3 @@
-import pytest
-
 import os
 import numpy as np
 from numpy.testing import assert_array_almost_equal

--- a/tests/unit_tests/test_crs.py
+++ b/tests/unit_tests/test_crs.py
@@ -3,7 +3,6 @@
 import os
 import math as maths
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal
 
 import resqpy.crs as rqc

--- a/tests/unit_tests/time_series/test_time_duration.py
+++ b/tests/unit_tests/time_series/test_time_duration.py
@@ -1,5 +1,4 @@
 import pytest
-import datetime as dt
 
 from resqpy.time_series import TimeDuration
 

--- a/tests/unit_tests/unstructured/test_unstructured.py
+++ b/tests/unit_tests/unstructured/test_unstructured.py
@@ -2,7 +2,6 @@ import math as maths
 import os
 
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose, assert_array_almost_equal
 
 import resqpy.crs as rqc

--- a/tests/unit_tests/well/test_blocked_well.py
+++ b/tests/unit_tests/well/test_blocked_well.py
@@ -9,7 +9,6 @@ import pandas as pd
 from numpy.testing import assert_array_almost_equal
 import pytest
 
-import resqpy
 import resqpy.model as rq
 import resqpy.crs as rqc
 import resqpy.grid as grr

--- a/tests/unit_tests/well/test_s_bend.py
+++ b/tests/unit_tests/well/test_s_bend.py
@@ -17,7 +17,6 @@ import resqpy.grid as grr
 import resqpy.model as rq
 import resqpy.olio.uuid as bu
 import resqpy.olio.vector_utilities as vec
-import resqpy.olio.xml_et as rqet
 import resqpy.rq_import as rqi
 import resqpy.well as rqw
 


### PR DESCRIPTION
A rather trivial edit, to help reduce occurrence of circular imports.

- Removes all unused imports
- Enables the linting rule "F401"

Although the diff is large, it was generated almost entirely mechanically with ruff, so it's simple to re-create.

```bash
ruff check --select=F401 --fix
```

The only case that requires manual attention is when an object is imported into a module, with the intention that is available there to be re-imported somewhere else. In particular:
- `xml_et.py` : exposes variables from `lxml.etree`
- `__init__.py` files: import objects from private modules to be re-exported. Fix is to add them to the `__all__` list of public variables.