### PR TITLE
Allow configuration of numba cache via environment variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,8 @@ module = [
     "numpy",
     "lasio",
     "h5py",
-    "lxml"
+    "lxml",
+    "numba"
 ]
 ignore_missing_imports = true
 

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -6,7 +6,7 @@ log = logging.getLogger(__name__)
 
 import numpy as np
 import warnings
-from numba import njit, prange  # type: ignore
+from numba import prange
 from typing import Tuple, Union, Dict
 
 import resqpy.crs as rqc
@@ -18,6 +18,7 @@ import resqpy.olio.box_utilities as bx
 import resqpy.olio.intersection as meet
 import resqpy.olio.uuid as bu
 import resqpy.olio.vector_utilities as vec
+from resqpy.olio.numba_compat import njit
 
 # note: resqpy.grid_surface._grid_surface_cuda will be imported by the find_faces_to_represent_surface() function if needed
 

--- a/resqpy/olio/intersection.py
+++ b/resqpy/olio/intersection.py
@@ -5,10 +5,10 @@ import logging
 log = logging.getLogger(__name__)
 
 import numpy as np
-from numba import njit  # type: ignore
 from typing import Union
 
 import resqpy.olio.vector_utilities as vec
+from resqpy.olio.numba_compat import njit
 
 
 def line_plane_intersect(line_p, line_v, triangle):

--- a/resqpy/olio/numba_compat.py
+++ b/resqpy/olio/numba_compat.py
@@ -1,0 +1,34 @@
+"""Thin wrapper around numba.njit that optionally enables numba caching.
+
+Cache behaviour can be controlled via enviornment varibales:
+
+    RESQPY_NUMBA_CACHE :
+        Set to "true" or "TRUE" to enable or on-disk caching for resqpy functions
+        which are decorated by njit. If unset, caching is disabled.
+
+For more info, see <https://numba.readthedocs.io/en/stable/developer/caching.html>.
+"""
+import os
+
+from numba import njit as _numba_njit
+
+# Accept "TRUE" or "true"
+ENABLE_NUMBA_CACHE = os.environ.get("RESQPY_NUMBA_CACHE", "false").lower().startswith("t")
+
+
+def njit(*args, **kwargs):
+    """Drop-in replacement for numba.njit that sets "cache" kwarg according to a global config.
+
+    If "cache" is defined in the decorator, that takes priority.
+    
+    Supports both decorator forms, with or without brackets:
+    - `@njit`
+    - `@njit(parallel = True)`
+    """
+    kwargs.setdefault('cache', ENABLE_NUMBA_CACHE)
+    if args and callable(args[0]):
+        # bare decorator: @njit applied directly to a function
+        func, *rest = args
+        return _numba_njit(func, *rest, **kwargs)
+    # parametrised decorator: @njit(...) returning a decorator
+    return _numba_njit(*args, **kwargs)

--- a/resqpy/olio/triangulation.py
+++ b/resqpy/olio/triangulation.py
@@ -8,7 +8,6 @@ from typing import Tuple
 import math as maths
 import numpy as np
 from scipy.spatial import Delaunay  # type: ignore
-from numba import njit  # type: ignore
 from typing import Optional
 
 import resqpy.crs as rqc
@@ -16,6 +15,7 @@ import resqpy.lines as rql
 import resqpy.model as rq
 import resqpy.olio.intersection as meet
 import resqpy.olio.vector_utilities as vec
+from resqpy.olio.numba_compat import njit
 
 # _ccw_t() no longer needed: triangle vertices maintained in anti-clockwise order throughout
 # def _ccw_t(p, t):   # puts triangle vertex indices into anti-clockwise order, in situ

--- a/resqpy/olio/vector_utilities.py
+++ b/resqpy/olio/vector_utilities.py
@@ -13,9 +13,9 @@ log = logging.getLogger(__name__)
 import math as maths
 from typing import Tuple, Optional
 
-import numba  
+import numba
 import numpy as np
-from numba import prange  
+from numba import prange
 
 from resqpy.olio.numba_compat import njit
 

--- a/resqpy/olio/vector_utilities.py
+++ b/resqpy/olio/vector_utilities.py
@@ -11,10 +11,13 @@ import logging
 log = logging.getLogger(__name__)
 
 import math as maths
-import numpy as np
-import numba  # type: ignore
-from numba import njit, prange  # type: ignore
 from typing import Tuple, Optional
+
+import numba  
+import numpy as np
+from numba import prange  
+
+from resqpy.olio.numba_compat import njit
 
 
 def radians_from_degrees(deg):


### PR DESCRIPTION
If `RESQPY_NUMBA_CACHE=TRUE`, enable numba caching. If unset, the cache is not enabled, which is numba's default behaviour if the `cache` keyword is not passed.

Caching leads to a significant speedup on first use on startup - it can lead to around ~30% speedup in other projects' test suites. However, we probably will wish to disable the cache when developing njit-decorated functions, to ensure that we don't use stale compiled artifacts.

Having this available as an environment variable makes it easier to experiment downstream. The default behaviour of resqpy is unchanged.