### PR TITLE
Add yapf:disable comments for data blocks

### DIFF
--- a/resqpy/grid/_points_functions.py
+++ b/resqpy/grid/_points_functions.py
@@ -103,12 +103,14 @@ def set_cached_points_from_property(grid,
     # invalidate anything cached that is derived from geometry
     grid.geometry_defined_for_all_pillars_cached = None
     grid.geometry_defined_for_all_cells_cached = None
+    # yapf: disable
     for attr in ('array_unsplit_points', 'array_corner_points', 'array_centre_point', 'array_thickness', 'array_volume',
                  'array_half_cell_t', 'array_k_transmissibility', 'array_j_transmissibility',
                  'array_i_transmissibility', 'fgcs', 'array_fgcs_transmissibility', 'pgcs',
                  'array_pgcs_transmissibility', 'kgcs', 'array_kgcs_transmissibility'):
         if hasattr(grid, attr):
             delattr(grid, attr)
+    # yapf: enable
 
     if set_inactive:
         if active_property_uuid is None:
@@ -967,16 +969,20 @@ def centre_point(grid, cell_kji0 = None, cache_centre_array = False):
                                                                  points[1:, grid.pillars_for_column[j, i, 1, 1], :])
         else:
             if grid.k_gaps:
+                # yapf: disable
                 grid.array_centre_point[:, :, :, :] = 0.125 * (
                     points[grid.k_raw_index_array, :-1, :-1, :] + points[grid.k_raw_index_array, :-1, 1:, :] +
                     points[grid.k_raw_index_array, 1:, :-1, :] + points[grid.k_raw_index_array, 1:, 1:, :] +
                     points[grid.k_raw_index_array + 1, :-1, :-1, :] + points[grid.k_raw_index_array + 1, :-1, 1:, :] +
                     points[grid.k_raw_index_array + 1, 1:, :-1, :] + points[grid.k_raw_index_array + 1, 1:, 1:, :])
+                # yapf: enable
             else:
+                # yapf: disable
                 grid.array_centre_point[:, :, :, :] = 0.125 * (points[:-1, :-1, :-1, :] + points[:-1, :-1, 1:, :] +
                                                                points[:-1, 1:, :-1, :] + points[:-1, 1:, 1:, :] +
                                                                points[1:, :-1, :-1, :] + points[1:, :-1, 1:, :] +
                                                                points[1:, 1:, :-1, :] + points[1:, 1:, 1:, :])
+                # yapf: enable
         if cell_kji0 is None:
             return grid.array_centre_point
         return grid.array_centre_point[cell_kji0[0], cell_kji0[1],

--- a/resqpy/olio/consolidation.py
+++ b/resqpy/olio/consolidation.py
@@ -14,6 +14,7 @@ import resqpy.time_series as rqt
 # the following list contains those RESQML classes with equivalence methods in their resqpy class
 # it is lightly ordered with earlier classes having no dependence on classes later in the list
 
+# yapf: disable
 consolidatable_list = [
     'OrganizationFeature', 'GeobodyFeature', 'BoundaryFeature', 'FrontierFeature', 'GeologicUnitFeature',
     'FluidBoundaryFeature', 'RockFluidUnitFeature', 'TectonicBoundaryFeature', 'GeneticBoundaryFeature',
@@ -27,6 +28,7 @@ ordering_list = consolidatable_list + [
     'IjkGridRepresentation', 'BlockedWellboreRepresentation', 'TriangulatedSetRepresentation', 'Grid2dRepresentation',
     'PointSetRepresentation'
 ]
+# yapf: enable
 # todo: add to this list as other classes gain an is_equivalent() method
 
 

--- a/resqpy/organize/structural_organization_interpretation.py
+++ b/resqpy/organize/structural_organization_interpretation.py
@@ -4,11 +4,13 @@ from resqpy.olio.base import BaseResqpy
 
 valid_ordering_criteria = ('age', 'apparent depth', 'measured depth')
 
+# yapf: disable
 valid_contact_relationships = ("frontier feature to frontier feature", "genetic boundary to frontier feature",
                                "genetic boundary to genetic boundary", "genetic boundary to tectonic boundary",
                                "stratigraphic unit to frontier feature", "stratigraphic unit to stratigraphic unit",
                                "tectonic boundary to frontier feature", "tectonic boundary to genetic boundary",
                                "tectonic boundary to tectonic boundary")
+# yapf: enable
 
 
 class StructuralOrganizationInterpretation(BaseResqpy):

--- a/resqpy/property/property_collection.py
+++ b/resqpy/property/property_collection.py
@@ -305,9 +305,11 @@ class PropertyCollection():
                                              maximum, facet, facet_type, points)
         null_value, const_value = pcap._add_part_to_dict_get_null_constvalue_points(xml_node, continuous, points)
 
+        # yapf: disable
         self.dict[part] = (realization, support_uuid, uuid, xml_node, continuous, count, indexable, property_kind,
                            facet_type, facet, citation_title, time_series_uuid, time_index, minimum, maximum, uom,
                            string_lookup_uuid, property_kind_uuid, extra_metadata, null_value, const_value, points)
+        # yapf: enable
 
     def add_parts_list_to_dict(self, parts_list):
         """Add all the parts named in the parts list to the dictionary for this collection.

--- a/resqpy/weights_and_measures/nexus_units.py
+++ b/resqpy/weights_and_measures/nexus_units.py
@@ -36,10 +36,12 @@ def nexus_uom_for_quantity(nexus_unit_system, quantity, english_volume_flavour =
     nexus_unit_system = nexus_unit_system.upper()
     assert nexus_unit_system in ['METRIC', 'METKG/CM2', 'METBAR', 'LAB', 'ENGLISH']
     # todo: add other quantities as needed
+    # yapf: disable
     assert quantity in [
         'length', 'area', 'volume', 'volume per volume', 'permeability rock', 'rock permeability', 'time',
         'thermodynamic temperature', 'mass per volume', 'pressure', 'volume per time'
     ]
+    # yapf: enable
     if quantity == 'permeability rock':
         quantity = 'rock permeability'
 

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -2517,10 +2517,12 @@ class BlockedWell(BaseResqpy):
 
         if extra_columns_list:
             for extra in extra_columns_list:
+                # yapf: disable
                 assert extra.upper() in [
                     'GRID', 'ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'SKIN', 'RADW', 'PPERF', 'RADB',
                     'WI', 'WBC', 'STAT'
                 ]
+                # yapf: enable
                 column_list.append(extra.upper())
         else:
             add_as_properties = use_properties = False
@@ -3212,10 +3214,12 @@ class BlockedWell(BaseResqpy):
                                             cell_kji0, row_ci_list, ci):
         """Append the row of data corresponding to the interval to the dataframe."""
 
+        # yapf: disable
         column_names = [
             'GRID', 'RADW', 'SKIN', 'ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'STAT', 'PPERF', 'RADB',
             'WI', 'WBC'
         ]
+        # yapf: enable
         column_values = [
             grid_name, radw, skin, angla, anglv, length, kh, xyz[2], md, xyz[0], xyz[1], stat, part_perf_fraction, radb,
             wi, wbc
@@ -3341,10 +3345,12 @@ class BlockedWell(BaseResqpy):
 
     @staticmethod
     def __is_float_column(col_name):
+        # yapf: disable
         if col_name.upper() in [
                 'ANGLA', 'ANGLV', 'LENGTH', 'KH', 'DEPTH', 'MD', 'X', 'Y', 'SKIN', 'RADW', 'RADB', 'PPERF'
         ]:
             return True
+        # yapf: enable
         return False
 
     @staticmethod

--- a/resqpy/well/_md_datum.py
+++ b/resqpy/well/_md_datum.py
@@ -14,11 +14,13 @@ import resqpy.olio.xml_et as rqet
 from resqpy.olio.base import BaseResqpy
 from resqpy.olio.xml_namespaces import curly_namespace as ns
 
+# yapf: disable
 valid_md_reference_list = [
     "ground level", "kelly bushing", "mean sea level", "derrick floor", "casing flange", "arbitrary point",
     "crown valve", "rotary bushing", "rotary table", "sea floor", "lowest astronomical tide", "mean higher high water",
     "mean high water", "mean lower low water", "mean low water", "mean tide level", "kickoff point"
 ]
+# yapf: enable
 
 # todo: could require/maintain DeviationSurvey mds in same units as md datum object's crs vertical units?
 

--- a/resqpy/well/_wellbore_marker.py
+++ b/resqpy/well/_wellbore_marker.py
@@ -65,10 +65,12 @@ class WellboreMarker():
         """
         # verify that marker type is valid
         if marker_type is not None:
+            # yapf: disable
             assert marker_type in ([
                 "fault", "geobody", "horizon", "gas down to", "oil down to", "water down to", "gas up to", "oil up to",
                 "water up to", "free water contact", "gas oil contact", "gas water contact", "water oil contact", "seal"
             ]), "invalid marker type specified"
+            # yapf: enable
 
         self.model = parent_model
         self.wellbore_frame = parent_frame

--- a/tests/unit_tests/grid/test_face_functions.py
+++ b/tests/unit_tests/grid/test_face_functions.py
@@ -16,7 +16,8 @@ def test_face_centre_axis_0(basic_regular_grid: Grid):
     expected_face_centres = np.array([[[[50.0, 25.0, 0.0], [150.0, 25.0, 0.0]],
                                        [[50.0, 75.0, 0.0], [150.0, 75.0, 0.0]]],
                                       [[[50.0, 25.0, 20.0], [150.0, 25.0, 20.0]],
-                                       [[50.0, 75.0, 20.0], [150.0, 75.0, 20.0]]]])  # yapf: enable
+                                       [[50.0, 75.0, 20.0], [150.0, 75.0, 20.0]]]])
+    # yapf: enable
 
     # Act & Assert
     face_centre = ff.face_centre(basic_regular_grid, cell, axis, zero_or_one)
@@ -32,7 +33,8 @@ def test_face_centre_axis_1(basic_regular_grid: Grid):
     expected_face_centres = np.array([[[[50.0, 50.0, 10.0], [150.0, 50.0, 10.0]],
                                        [[50.0, 100.0, 10.0], [150.0, 100.0, 10.0]]],
                                       [[[50.0, 50.0, 30.0], [150.0, 50.0, 30.0]],
-                                       [[50.0, 100.0, 30.0], [150.0, 100.0, 30.0]]]])  # yapf: enable
+                                       [[50.0, 100.0, 30.0], [150.0, 100.0, 30.0]]]])
+    # yapf: enable
 
     # Act & Assert
     face_centre = ff.face_centre(basic_regular_grid, cell, axis, zero_or_one)
@@ -66,15 +68,16 @@ def test_face_centre_invalid_axis(example_model_with_properties: Model):
         ff.face_centre(grid, cell, axis, zero_or_one)
 
 
+# yapf: disable
 @pytest.mark.parametrize(
     "cell, expected_face_centres",
-    # yapf: disable
     [((0, 0, 0), np.array([[[50.0, 25.0, 0.0], [50.0, 25.0, 20.0]],
                            [[50.0, 0.0, 10.0], [50.0, 50.0, 10.0]],
                            [[0.0, 25.0, 10.0], [100.0, 25.0, 10.0]]])),
      ((1, 1, 1), np.array([[[150.0, 75.0, 20.0], [150.0, 75.0, 40.0]],
                            [[150.0, 50.0, 30.0], [150.0, 100.0, 30.0]],
-                           [[100.0, 75.0, 30.0], [200.0, 75.0, 30.0]]]))])  # yapf: enable
+                           [[100.0, 75.0, 30.0], [200.0, 75.0, 30.0]]]))])
+# yapf: enable
 def test_face_centres_kji_01(basic_regular_grid: Grid, cell, expected_face_centres):
     # Act & Assert
     face_centres = ff.face_centres_kji_01(basic_regular_grid, cell)

--- a/tests/unit_tests/olio/test_fine_coarse.py
+++ b/tests/unit_tests/olio/test_fine_coarse.py
@@ -62,8 +62,10 @@ def test_fine_coarse_functions():
         (1.0, 0.5, 0.5, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 0.5, 0.5, 1.0),
         dtype = float)
     assert_array_almost_equal(fct.proportions_for_axis(1), ep)
+    # yapf: disable
     ep = np.array((0.5, 0.5, 1.0 / 3, 1.0 / 3, 1.0 / 3, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25,
                    0.25, 0.25, 1.0 / 3, 1.0 / 3, 1.0 / 3, 0.5, 0.5),
                   dtype = float)
+    # yapf: enable
     assert_array_almost_equal(fct.proportions_for_axis(2), ep)
     # todo: add test of tartan refinement in exponential mode

--- a/tests/unit_tests/olio/test_olio_grid_functions.py
+++ b/tests/unit_tests/olio/test_olio_grid_functions.py
@@ -102,11 +102,13 @@ def test_left_right_foursome_error_handling():
 def test_resequence_nexus_corp():
 
     # --------- Arrange ----------
+    # yapf: disable
     corner_points = np.array([[[[[[[0., 0., 0.], [10., 0., 0.]], [[10., -10., 0.], [0., -10., 0.]]],
                                  [[[0., 0., 10.], [10., 0., 10.]], [[10., -10., 10.], [0., -10., 10.]]]]]]])
 
     expected_result = np.array([[[[[[[0., 0., 0.], [10., 0., 0.]], [[0., -10., 0.], [10., -10., 0.]]],
                                    [[[0., 0., 10.], [10., 0., 10.]], [[0., -10., 10.], [10., -10., 10.]]]]]]])
+    # yapf: enable
 
     # --------- Act ----------
     resequence_nexus_corp(corner_points = corner_points)
@@ -171,8 +173,10 @@ def test_random_cell(tmp_path):
 
 def test_triangles_for_cell_faces():
     # --------- Arrange----------
+    # yapf: disable
     corner_points = np.array([[[[0., 0., 0.], [10., 0., 0.]], [[0., -10., 0.], [10., -10., 0.]]],
                               [[[0., 0., 10.], [10., 0., 10.]], [[0., -10., 10.], [10., -10., 10.]]]])
+    # yapf: enable
     # --------- Act----------
     tri = triangles_for_cell_faces(cp = corner_points)
     # face centre points
@@ -238,11 +242,13 @@ def test_actual_pillar_shape(tmp_path):
 def test_determine_corp_ijk_handedness():
 
     # --------- Arrange----------
+    # yapf: disable
     corner_points_right = np.array([[[[[[[0., 0., 0.], [10., 0., 0.]], [[0., -10., 0.], [10., -10., 0.]]],
                                        [[[0., 0., 10.], [10., 0., 10.]], [[0., -10., 10.], [10., -10., 10.]]]]]]])
 
     corner_points_left = np.array([[[[[[[0., 0., 0.], [10., 0., 0.]], [[0., 10., 0.], [10., 10., 0.]]],
                                       [[[0., 0., 10.], [10., 0., 10.]], [[0., 10., 10.], [10., 10., 10.]]]]]]])
+    # yapf: enable
 
     # --------- Act----------
     handedness_right = determine_corp_ijk_handedness(corner_points = corner_points_right)
@@ -272,8 +278,8 @@ def test_determine_corp_extent(tmp_path):
     assert [nk, nj, ni] == [4, 3, 2]
 
 
+# yapf: disable
 @pytest.mark.parametrize(
-    # yapf: disable
     'x_shift, y_shift, expected_result',
     [(2, 0,
       np.array([[[[[[[2.001, 0.001, 0.001], [12.001, 0.001, 0.001]], [[2.001, -10.001, 0.001], [12.001, -10.001, 0.001]]

--- a/tests/unit_tests/olio/test_vector_utilities.py
+++ b/tests/unit_tests/olio/test_vector_utilities.py
@@ -524,9 +524,11 @@ def test_mesh_points_in_triangle():
 
 def test_points_in_polygons():
     # note: order of returned rows is not specified and could change, causing this (and other) tests to wrongly fail
+    # yapf: disable
     polygons = np.array([[(0.0, 4.0), (0.0, 8.0), (4.0, 8.0), (4.0, 4.0),
                           (2.0, 6.0)], [(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (2.0, 2.0), (0.0, 4.0)]],
                         dtype = float)
+    # yapf: enable
     points = np.array([(1.0, 2.5), (2.0, 2.5), (1.0, 1.0), (-1.0, 1.0), (3.5, 3.0), (0.1, -0.1)], dtype = float)
     within = vec.points_in_polygons(points, polygons, 3)
     assert len(within) == 3

--- a/tests/unit_tests/property/test_property.py
+++ b/tests/unit_tests/property/test_property.py
@@ -1521,10 +1521,12 @@ def test_basic_static_property_parts_perm_multiple_facet(example_model_with_prop
             assert pc.citation_title_for_part(actual) == name
 
 
+# yapf: disable
 @pytest.mark.parametrize('name_list,expected_none', [(['KI', 'KJ', 'KK'], [False, False, False]),
                                                      (['KX', 'KY', 'KZ'], [False, False, False]),
                                                      (['PERMI', 'PERMJ', 'PERMK'], [False, False, False]),
                                                      (['PERMX', 'PERMY', 'PERMZ'], [False, False, False])])
+# yapf: enable
 def test_basic_static_property_parts_perm_multiple_name(example_model_with_properties, name_list, expected_none):
     # Arrange
     model = example_model_with_properties

--- a/tests/unit_tests/rq_import/test_import_vdb_ensemble.py
+++ b/tests/unit_tests/rq_import/test_import_vdb_ensemble.py
@@ -21,6 +21,7 @@ def test_default_args(tmp_path):
     parts_expected = [('ContinuousProperty', 123), ('DiscreteProperty', 15), ('EpcExternalPartReference', 1),
                       ('IjkGridRepresentation', 1), ('LocalDepth3dCrs', 1), ('PropertyKind', 2), ('PropertySet', 7),
                       ('TimeSeries', 1)]
+    # yapf: disable
     pk_list_expected = [
         'IGRID', 'TNSC', 'cell length', 'code', 'depth', 'fluid volume', 'index', 'permeability thickness',
         'pore volume', 'pressure', 'rock volume', 'saturation', 'thickness', 'transmissibility'
@@ -29,6 +30,7 @@ def test_default_args(tmp_path):
         'MDEP', 'DEADCELL', 'SG', 'IGRID', 'OIP', 'SO', 'WIP', 'KID', 'GIP', 'DAD', 'DZN', 'TX', 'KH', 'SW', 'UID',
         'DXC', 'DZC', 'BV', 'TZ', 'P', 'PVR', 'UNPACK', 'DYC', 'TNSC', 'TY'
     }
+    # yapf: enable
 
     # Act
     import_vdb_ensemble(epc_file, ensemble_dir)

--- a/tests/unit_tests/surface/test_tri_mesh_stencil.py
+++ b/tests/unit_tests/surface/test_tri_mesh_stencil.py
@@ -55,10 +55,12 @@ def test_gaussian_pattern():
         pattern,
         (1.0, 0.97197327, 0.89251862, 0.77426368, 0.6345548, 0.49131274, 0.35938137, 0.24834861, 0.16213491, 0.1))
     pattern = tms._gaussian_pattern(15, 5.0)
+    # yapf: disable
     assert_array_almost_equal(
         pattern,
         (1.0, 9.38215596e-1, 7.74837429e-1, 5.63279351e-1, 3.60447789e-1, 2.03032796e-1, 1.00668900e-1, 4.39369336e-2,
          1.68798841e-2, 5.70840102e-3, 1.69927937e-3, 4.45266876e-4, 1.02702565e-4, 2.08519889e-5, 3.72665317e-6))
+    # yapf: enable
 
 
 def test_tri_mesh_stencil_init_normalize_none():

--- a/tests/unit_tests/well/test_s_bend.py
+++ b/tests/unit_tests/well/test_s_bend.py
@@ -247,12 +247,14 @@ def test_s_bend_fn(tmp_path, epc = None):
     bw_4.create_xml()
     assert bw_4.cell_count == 26
     assert len(bw_4.cell_indices) == bw_4.cell_count
+    # yapf: disable
     np.testing.assert_array_equal(
         bw_4.cell_indices,
         np.array([
             2402, 1802, 1852, 652, 52, 153, 753, 803, 2003, 2603, 2653, 2703, 2103, 903, 904, 304, 354, 454, 1054, 2254,
             2304, 2904, 2905, 2955, 2355, 1155
         ]))
+    # yapf: enable
 
     # derive a faulted version of the grid
 


### PR DESCRIPTION
A tiny housekeeping change: adds a few yapf:disable and yapf:enable comments around data blocks. No change for the current code, but if we run `ruff format` in future, these blocks will not be changed.

Proposing as a separate PR just to keep any future "ruff format" MR a simple one-command change.