### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+---
+
+version: 2
+updates:
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    versioning-strategy: lockfile-only
+    schedule:
+      interval: "daily"  # Initial high freq for testing, will reset to "monthly" once we confirm it works
+      day: "tuesday"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "quarterly"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Add dependabot config to scan for new dependencies and open MRs with and updates lockfile.

Reference: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates

We'll probably want this running "monthly" or "quarterly" frequency, but proposing running it "daily" to start with so we can test and verify the behaviour.