### PR TITLE
MAINT: Better cleanup of temporary test files

### DIFF
--- a/.github/actions/prepare-poetry/action.yml
+++ b/.github/actions/prepare-poetry/action.yml
@@ -43,9 +43,13 @@ runs:
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-1
-     
+    
+    - name: Verify lockfile
+      run: poetry check --lock
+      shell: bash
+
     - name: Install dependencies and library
       # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-      run: poetry install --no-interaction
+      run: poetry sync --no-interaction
       shell: bash
   

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [poetry-lock]  # Often fails on pre-commit.ci due to network issues
+
 repos:
   - repo: https://github.com/python-poetry/poetry
     rev: '2.4.1'

--- a/resqpy/multi_processing/wrappers/grid_surface_mp.py
+++ b/resqpy/multi_processing/wrappers/grid_surface_mp.py
@@ -20,7 +20,7 @@ import resqpy.olio.uuid as bu
 
 def find_faces_to_represent_surface_regular_wrapper(
         index: int,
-        parent_tmp_dir: str,
+        parent_tmp_dir: str | Path,
         use_index_as_realisation: bool,
         grid_epc: str,
         grid_uuid: Union[UUID, str],
@@ -55,7 +55,7 @@ def find_faces_to_represent_surface_regular_wrapper(
 
     arguments:
         index (int): the index of the function call from the multiprocessing function
-        parent_tmp_dir (str): the parent temporary directory path from the multiprocessing function
+        parent_tmp_dir (str or Path): the parent temporary directory path from the multiprocessing function
         use_index_as_realisation (bool): if True, uses the index number as the realization number on
             the property collection
         grid_epc (str): epc file path where the grid is saved

--- a/resqpy/multi_processing/wrappers/mesh_mp.py
+++ b/resqpy/multi_processing/wrappers/mesh_mp.py
@@ -17,7 +17,7 @@ import resqpy.multi_processing as rqmp
 
 def mesh_from_regular_grid_column_property_wrapper(
     index: int,
-    parent_tmp_dir: str,
+    parent_tmp_dir: str | Path,
     grid_epc: str,
     grid_uuid: Union[UUID, str],
     prop_uuids: List[Union[UUID, str]],
@@ -26,7 +26,7 @@ def mesh_from_regular_grid_column_property_wrapper(
 
     arguments:
         index (int): the index of the function call from the multiprocessing function
-        parent_tmp_dir (str): the parent temporary directory path from the multiprocessing function
+        parent_tmp_dir (str or Path): the parent temporary directory path from the multiprocessing function
         grid_epc (str): epc file path where the grid is saved
         grid_uuid (UUID or str): UUID (universally unique identifier) of the regular grid object
         prop_uuids (list of UUID or str): a list of the property uuids used to create each Mesh

--- a/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
+++ b/tests/unit_tests/multiprocessing/test_grid_surface_mp.py
@@ -1,4 +1,6 @@
 from typing import Tuple
+from pathlib import Path
+
 import numpy as np
 
 import resqpy.property as rqp
@@ -12,7 +14,8 @@ from resqpy.olio.random_seed import seed
 seed(83469613)
 
 
-def test_find_faces_to_represent_surface_regular_wrapper(small_grid_and_surface: Tuple[RegularGrid, Surface]):
+def test_find_faces_to_represent_surface_regular_wrapper(small_grid_and_surface: Tuple[RegularGrid, Surface],
+                                                         tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -25,7 +28,7 @@ def test_find_faces_to_represent_surface_regular_wrapper(small_grid_and_surface:
 
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(input_index,
-                                                                                          "tmp_dir",
+                                                                                          tmp_path,
                                                                                           use_index_as_realisation,
                                                                                           grid_epc,
                                                                                           grid_uuid,
@@ -50,7 +53,8 @@ def test_find_faces_to_represent_surface_regular_wrapper(small_grid_and_surface:
     assert len(uuid_list) == 7
 
 
-def test_find_faces_to_represent_surface_regular_wrapper_point_set(small_grid_and_surface: Tuple[RegularGrid, Surface]):
+def test_find_faces_to_represent_surface_regular_wrapper_point_set(small_grid_and_surface: Tuple[RegularGrid, Surface],
+                                                                   tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -68,7 +72,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_point_set(small_grid_an
 
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(input_index,
-                                                                                          "tmp_dir",
+                                                                                          tmp_path,
                                                                                           use_index_as_realisation,
                                                                                           grid_epc,
                                                                                           grid_uuid,
@@ -95,7 +99,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_point_set(small_grid_an
 
 
 def test_find_faces_to_represent_surface_regular_wrapper_random_agitation(small_grid_and_surface: Tuple[RegularGrid,
-                                                                                                        Surface]):
+                                                                                                        Surface],
+                                                                          tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -108,7 +113,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_random_agitation(small_
 
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(input_index,
-                                                                                          "tmp_dir",
+                                                                                          tmp_path,
                                                                                           use_index_as_realisation,
                                                                                           grid_epc,
                                                                                           grid_uuid,
@@ -133,8 +138,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_random_agitation(small_
     assert len(uuid_list) == 7
 
 
-def test_find_faces_to_represent_surface_regular_wrapper_properties(small_grid_and_surface: Tuple[RegularGrid,
-                                                                                                  Surface]):
+def test_find_faces_to_represent_surface_regular_wrapper_properties(small_grid_and_surface: Tuple[RegularGrid, Surface],
+                                                                    tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -149,7 +154,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties(small_grid_a
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -176,8 +181,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties(small_grid_a
     assert len(uuid_list) == 9
 
 
-def test_find_faces_to_represent_surface_extended_bisector(small_grid_and_extended_surface: Tuple[RegularGrid,
-                                                                                                  Surface]):
+def test_find_faces_to_represent_surface_extended_bisector(small_grid_and_extended_surface: Tuple[RegularGrid, Surface],
+                                                           tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_extended_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -192,7 +197,7 @@ def test_find_faces_to_represent_surface_extended_bisector(small_grid_and_extend
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -219,7 +224,8 @@ def test_find_faces_to_represent_surface_extended_bisector(small_grid_and_extend
 
 
 def test_find_faces_to_represent_surface_regular_wrapper_properties_flange(small_grid_and_surface: Tuple[RegularGrid,
-                                                                                                         Surface]):
+                                                                                                         Surface],
+                                                                           tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -234,7 +240,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties_flange(small
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -262,7 +268,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties_flange(small
 
 
 def test_find_faces_to_represent_surface_regular_wrapper_flange_radius(small_grid_and_surface: Tuple[RegularGrid,
-                                                                                                     Surface]):
+                                                                                                     Surface],
+                                                                       tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -277,7 +284,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_flange_radius(small_gri
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -306,7 +313,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_flange_radius(small_gri
 
 
 def test_find_faces_to_represent_surface_extended_bisector_use_pack(small_grid_and_extended_surface: Tuple[RegularGrid,
-                                                                                                           Surface]):
+                                                                                                           Surface],
+                                                                    tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_extended_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -321,7 +329,7 @@ def test_find_faces_to_represent_surface_extended_bisector_use_pack(small_grid_a
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -354,7 +362,7 @@ def test_find_faces_to_represent_surface_extended_bisector_use_pack(small_grid_a
 
 
 def test_find_faces_to_represent_surface_regular_wrapper_flange_radius_saucer_noreorient(
-        small_grid_and_surface: Tuple[RegularGrid, Surface]):
+        small_grid_and_surface: Tuple[RegularGrid, Surface], tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -369,7 +377,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_flange_radius_saucer_no
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -400,7 +408,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_flange_radius_saucer_no
 
 
 def test_find_faces_to_represent_surface_regular_wrapper_flange_radius_saucer_reorient(
-        small_grid_and_surface: Tuple[RegularGrid, Surface]):
+        small_grid_and_surface: Tuple[RegularGrid, Surface], tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -415,7 +423,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_flange_radius_saucer_re
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -445,7 +453,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_flange_radius_saucer_re
     assert len(uuid_list) == 10
 
 
-def test_find_faces_to_represent_surface_regular_wrapper_patchwork(small_grid_and_surface: Tuple[RegularGrid, Surface]):
+def test_find_faces_to_represent_surface_regular_wrapper_patchwork(small_grid_and_surface: Tuple[RegularGrid, Surface],
+                                                                   tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_surface
     grid_epc = surface_epc = grid.model.epc_file
@@ -502,7 +511,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_patchwork(small_grid_an
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -535,7 +544,8 @@ def test_find_faces_to_represent_surface_regular_wrapper_patchwork(small_grid_an
 
 
 def test_find_faces_to_represent_surface_extended_patchwork(small_grid_and_extended_surface: Tuple[RegularGrid,
-                                                                                                   Surface]):
+                                                                                                   Surface],
+                                                            tmp_path: Path):
     # Arrange
     grid, surface = small_grid_and_extended_surface
     assert surface.model is grid.model
@@ -592,7 +602,7 @@ def test_find_faces_to_represent_surface_extended_patchwork(small_grid_and_exten
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,
@@ -622,7 +632,7 @@ def test_find_faces_to_represent_surface_extended_patchwork(small_grid_and_exten
 
 
 def test_find_faces_to_represent_surface_regular_wrapper_properties_triangles(
-        small_grid_and_surface_nonrandom: Tuple[RegularGrid, Surface]):
+        small_grid_and_surface_nonrandom: Tuple[RegularGrid, Surface], tmp_path):
     # Arrange
     grid, surface = small_grid_and_surface_nonrandom
     grid_epc = surface_epc = grid.model.epc_file
@@ -637,7 +647,7 @@ def test_find_faces_to_represent_surface_regular_wrapper_properties_triangles(
     # Act
     index, success, epc_file, uuid_list = find_faces_to_represent_surface_regular_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         use_index_as_realisation,
         grid_epc,
         grid_uuid,

--- a/tests/unit_tests/multiprocessing/test_mesh_mp.py
+++ b/tests/unit_tests/multiprocessing/test_mesh_mp.py
@@ -1,10 +1,11 @@
+from pathlib import Path
+
 from resqpy.model import Model
 from resqpy.surface import Mesh
 from resqpy.multi_processing.wrappers import mesh_mp
-from resqpy.multi_processing._multiprocessing import rm_tree
 
 
-def test_mesh_from_regular_grid_column_property_wrapper(small_grid_with_properties):
+def test_mesh_from_regular_grid_column_property_wrapper(small_grid_with_properties, tmp_path: Path):
     # Arrange
     grid, prop_uuids = small_grid_with_properties
     grid_epc = grid.model.epc_file
@@ -19,13 +20,12 @@ def test_mesh_from_regular_grid_column_property_wrapper(small_grid_with_properti
         uuid_list,
     ) = mesh_mp.mesh_from_regular_grid_column_property_wrapper(
         input_index,
-        "tmp_dir",
+        tmp_path,
         grid_epc,
         grid_uuid,
         prop_uuids,
     )
     model = Model(epc_file = epc_file)
-    rm_tree("tmp_dir")
 
     # Assert
     assert success is True


### PR DESCRIPTION
Use the `tmp_path` fixture to ensure temporary wrapper.epc files are created and cleaned up in the standard clean manner, rather than appearing in the current working directory

Supporting minor change: the `poetry lock` check is occasionally failing when running on pre-commit.ci, due to a flaky network connection with PyPI. So, moving that check to run under GH actions instead, as part of the poetry env install.