### PR TITLE
Maint: update docs dependencies from Sphinx 5 to Sphinx 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pytest.xml
 docs/_build
 docs/_autosummary
 docs/html
+docs/pdf
 
 # Build artifacts
 build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
   skip: [poetry-lock]  # Often fails on pre-commit.ci due to network issues
+  autoupdate_schedule: quarterly
 
 repos:
   - repo: https://github.com/python-poetry/poetry

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.14"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -94,7 +94,8 @@ Development environment setup
 Code Style
 ----------
 
-We use the yapf auto-formatter with the style configured in the repository. 
+We use the pre-commit framework to run linting and formatting checks.
+
 Most IDEs allow you to configure a formatter to run automatically when you save
 a file. Alternatively, you can run the following command before commiting any
 changes:
@@ -102,7 +103,7 @@ changes:
 .. code-block:: bash
 
    # Reformat all python files in the repository
-   yapf -ir .
+   pre-commit run --all-files
 
 Please try to write code according to the
 `PEP8 Python style guide <https://www.python.org/dev/peps/pep-0008/>`_, which
@@ -176,29 +177,21 @@ There are several command line options that can be appended, for example:
 Static analysis
 ^^^^^^^^^^^^^^^
 
-We use `flake8 <https://flake8.pycqa.org/en/latest/user/invocation.html>`_ to
-scan for obvious code errors. This is automatically run part as part of the CI
+We use `ruff>` to scan for obvious code errors. This is automatically run part as part of the CI
 tests, and can also be run locally with:
 
 .. code:: bash
 
-    flake8 .
+    ruff check
 
 The configuration of which
 `error codes <https://gist.github.com/sharkykh/c76c80feadc8f33b129d846999210ba3>`_
-are checked by default is configured in the repo in
-`setup.cfg <https://github.com/bp/resqpy/blob/master/setup.cfg>`_.
+are checked by default is configured in the repo in `pyproject.toml``
 
 By default in resqpy:
 
 * ``F-`` Logical errors (i.e. bugs) are enabled
 * ``E-`` Style checks (i.e. PEP8 compliance) are disabled
-
-You can test for PEP8 compliance by running flake8 with further error codes:
-
-.. code:: bash
-
-    flake8 . –select=F,E2,E3,E4,E7
 
 Documentation
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,24 +98,46 @@ autoclasstoc_sections = [
     "other-methods",
 ]
 
-# ---- Patch autoclasstoc to fix a sphinx warning ------------------------------
-
-# autoclasstoc 1.7.0 appends a trailing decorative `transition` node to every class (see autoclasstoc.utils.make_toc)
-# this is rejected by recent Sphinx/docutils, as transition nodes must be a direct child of <document> or <section> nodes.
-# So, patch autoclasstoc to remove this problematic node.
+# ---- Patch autoclasstoc -------------------------------------------------------
 
 import autoclasstoc.utils as _autoclasstoc_utils
 from docutils import nodes as _docutils_nodes
 
-_orig_make_toc = _autoclasstoc_utils.make_toc
+
+def _skip_node(self, node):
+    pass
 
 
-def _make_toc_without_transition(*args, **kwargs):
-    toc_nodes = _orig_make_toc(*args, **kwargs)
-    return [n for n in toc_nodes if not isinstance(n, _docutils_nodes.transition)]
+def setup(app):
 
+    # autoclasstoc appends a trailing decorative `transition` node to every
+    # class (see autoclasstoc.utils.make_toc). Recent Sphinx/docutils reject
+    # this, as transition nodes must be a direct child of a <document> or
+    # <section> node, so strip it out.
+    _orig_make_toc = _autoclasstoc_utils.make_toc
 
-_autoclasstoc_utils.make_toc = _make_toc_without_transition
+    def _make_toc_without_transition(*args, **kwargs):
+        toc_nodes = _orig_make_toc(*args, **kwargs)
+        return [n for n in toc_nodes if not isinstance(n, _docutils_nodes.transition)]
+
+    _autoclasstoc_utils.make_toc = _make_toc_without_transition
+
+    # autoclasstoc registers two custom nodes "details" & "details_summary",
+    # which are only implemented for HTML. Tell the LaTex builder to ignore
+    # them.
+    from autoclasstoc.nodes import details, details_summary
+
+    for _node in (details, details_summary):
+        app.add_node(
+            _node,
+            override = True,
+            html = _node.html,
+            latex = (_skip_node, _skip_node),
+            text = (_skip_node, _skip_node),
+            man = (_skip_node, _skip_node),
+            texinfo = (_skip_node, _skip_node),
+        )
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,14 @@ autosummary_generate_overwrite = True
 
 napoleon_use_rtype = False  # More legible
 autodoc_member_order = 'bysource'
+
+# Tell napolean to treat names like `uuid` as literals, rather than a cross-references
+napoleon_preprocess_types = True
+napoleon_type_aliases = {
+    'uuid': '``uuid``',
+    'UUID': '``uuid``',
+    'root': '``root``',
+}
 # napoleon_numpy_docstring = False  # Force consistency, leave only Google
 autodoc_mock_imports = ['cupy']
 extensions = [
@@ -89,6 +97,25 @@ autoclasstoc_sections = [
     "common-methods",
     "other-methods",
 ]
+
+# ---- Patch autoclasstoc to fix a sphinx warning ------------------------------
+
+# autoclasstoc 1.7.0 appends a trailing decorative `transition` node to every class (see autoclasstoc.utils.make_toc)
+# this is rejected by recent Sphinx/docutils, as transition nodes must be a direct child of <document> or <section> nodes.
+# So, patch autoclasstoc to remove this problematic node.
+
+import autoclasstoc.utils as _autoclasstoc_utils
+from docutils import nodes as _docutils_nodes
+
+_orig_make_toc = _autoclasstoc_utils.make_toc
+
+
+def _make_toc_without_transition(*args, **kwargs):
+    toc_nodes = _orig_make_toc(*args, **kwargs)
+    return [n for n in toc_nodes if not isinstance(n, _docutils_nodes.transition)]
+
+
+_autoclasstoc_utils.make_toc = _make_toc_without_transition
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ autosummary_generate_overwrite = True
 napoleon_use_rtype = False  # More legible
 autodoc_member_order = 'bysource'
 # napoleon_numpy_docstring = False  # Force consistency, leave only Google
-
+autodoc_mock_imports = ['cupy']
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
@@ -97,8 +97,6 @@ html_theme = 'sphinx_rtd_theme'
 # Override table width restrictions
 # See https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
 html_static_path = ['_static']
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-    ],
-}
+html_css_files = [
+    'theme_overrides.css',  # override wide tables in RTD theme
+]

--- a/docs/requirements-extras.txt
+++ b/docs/requirements-extras.txt
@@ -1,3 +1,3 @@
-autoclasstoc==1.3.0
-sphinx==5.3.0
-sphinx_rtd_theme<1.0.0
+autoclasstoc==1.7.0
+sphinx==9.1.0
+sphinx_rtd_theme==3.1.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,15 @@
 
 [[package]]
 name = "alabaster"
-version = "0.7.16"
+version = "1.0.0"
 description = "A light, configurable Sphinx theme"
 optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
+python-versions = ">=3.10"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
-    {file = "alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"},
-    {file = "alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65"},
+    {file = "alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"},
+    {file = "alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e"},
 ]
 
 [[package]]
@@ -57,23 +58,25 @@ files = [
 
 [[package]]
 name = "autoclasstoc"
-version = "1.3.0"
+version = "1.7.0"
 description = "Add a succinct TOC to auto-documented classes."
 optional = false
-python-versions = "~=3.6"
-groups = ["dev"]
+python-versions = ">=3.6"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
-    {file = "autoclasstoc-1.3.0-py2.py3-none-any.whl", hash = "sha256:e7319d782f1e7b4cb80fedfc33c04fe1bb31603abfeffa5aaf9dba1d2faf2e45"},
-    {file = "autoclasstoc-1.3.0.tar.gz", hash = "sha256:a9f7ef65c509274ac2de3bb588ba0edf381af54ad98dc5044db130a40eed872f"},
+    {file = "autoclasstoc-1.7.0-py3-none-any.whl", hash = "sha256:00d7f8450d9fb043a500a0ac5fe9cda3699d51d68211f183178734f14df526ec"},
+    {file = "autoclasstoc-1.7.0.tar.gz", hash = "sha256:93a604be070a1f0ab19b0a0dd9d03d3fb16377da8a7a49ed8919692ef882775a"},
 ]
 
 [package.dependencies]
 docutils = "*"
+more_itertools = "*"
 sphinx = ">=3.0"
 
 [package.extras]
 docs = ["sphinx (>=3.1)", "sphinx_rtd_theme"]
-tests = ["coveralls", "pytest", "pytest-cov"]
+tests = ["coverage[toml]", "coverage_enable_subprocess", "lxml", "parametrize_from_file", "pytest", "pytest_tmp_files", "re_assert", "tox"]
 
 [[package]]
 name = "babel"
@@ -81,7 +84,8 @@ version = "2.18.0"
 description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
     {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
@@ -119,7 +123,8 @@ version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
     {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
@@ -143,7 +148,8 @@ version = "3.4.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
     {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
@@ -282,12 +288,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
-markers = "sys_platform == \"win32\""
+groups = ["dev", "docs"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {dev = "sys_platform == \"win32\"", docs = "sys_platform == \"win32\" and python_version >= \"3.12\""}
 
 [[package]]
 name = "coverage"
@@ -437,14 +443,15 @@ files = [
 
 [[package]]
 name = "docutils"
-version = "0.16"
+version = "0.22.4"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-groups = ["dev"]
+python-versions = ">=3.9"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
-    {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
-    {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
+    {file = "docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"},
+    {file = "docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968"},
 ]
 
 [[package]]
@@ -576,7 +583,8 @@ version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -591,7 +599,8 @@ version = "2.0.0"
 description = "Get image size from headers (BMP/PNG/JPEG/JPEG2000/GIF/TIFF/SVG/Netpbm/WebP/AVIF/HEIC/HEIF)"
 optional = false
 python-versions = "<3.15,>=3.10"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96"},
     {file = "imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3"},
@@ -615,7 +624,8 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -949,7 +959,8 @@ version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -1040,6 +1051,19 @@ files = [
     {file = "markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e"},
     {file = "markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8"},
     {file = "markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"},
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
+files = [
+    {file = "more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192"},
+    {file = "more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d"},
 ]
 
 [[package]]
@@ -1403,11 +1427,12 @@ version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
+markers = {docs = "python_version >= \"3.12\""}
 
 [[package]]
 name = "pandas"
@@ -1685,11 +1710,12 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
+markers = {docs = "python_version >= \"3.12\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -1893,7 +1919,8 @@ version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
@@ -1908,6 +1935,19 @@ urllib3 = ">=1.26,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
+
+[[package]]
+name = "roman-numerals"
+version = "4.1.0"
+description = "Manipulate well-formed Roman numerals"
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
+files = [
+    {file = "roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7"},
+    {file = "roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2"},
+]
 
 [[package]]
 name = "ruff"
@@ -2198,7 +2238,8 @@ version = "3.1.1"
 description = "This package provides 36 stemmers for 34 languages generated from Snowball algorithms."
 optional = false
 python-versions = ">=3.3"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"},
     {file = "snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260"},
@@ -2218,57 +2259,56 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "5.3.0"
+version = "9.1.0"
 description = "Python documentation generator"
 optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
+python-versions = ">=3.12"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
-    {file = "Sphinx-5.3.0.tar.gz", hash = "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"},
-    {file = "sphinx-5.3.0-py3-none-any.whl", hash = "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d"},
+    {file = "sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978"},
+    {file = "sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb"},
 ]
 
 [package.dependencies]
-alabaster = ">=0.7,<0.8"
-babel = ">=2.9"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.14,<0.20"
+alabaster = ">=0.7.14"
+babel = ">=2.13"
+colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
+docutils = ">=0.21,<0.23"
 imagesize = ">=1.3"
-Jinja2 = ">=3.0"
-packaging = ">=21.0"
-Pygments = ">=2.12"
-requests = ">=2.5.0"
-snowballstemmer = ">=2.0"
-sphinxcontrib-applehelp = "*"
-sphinxcontrib-devhelp = "*"
-sphinxcontrib-htmlhelp = ">=2.0.0"
-sphinxcontrib-jsmath = "*"
-sphinxcontrib-qthelp = "*"
-sphinxcontrib-serializinghtml = ">=1.1.5"
-
-[package.extras]
-docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-bugbear", "flake8-comprehensions", "flake8-simplify", "isort", "mypy (>=0.981)", "sphinx-lint", "types-requests", "types-typed-ast"]
-test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast ; python_version < \"3.8\""]
+Jinja2 = ">=3.1"
+packaging = ">=23.0"
+Pygments = ">=2.17"
+requests = ">=2.30.0"
+roman-numerals = ">=1.0.0"
+snowballstemmer = ">=2.2"
+sphinxcontrib-applehelp = ">=1.0.7"
+sphinxcontrib-devhelp = ">=1.0.6"
+sphinxcontrib-htmlhelp = ">=2.0.6"
+sphinxcontrib-jsmath = ">=1.0.1"
+sphinxcontrib-qthelp = ">=1.0.6"
+sphinxcontrib-serializinghtml = ">=1.1.9"
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "0.5.2"
+version = "3.1.0"
 description = "Read the Docs theme for Sphinx"
 optional = false
-python-versions = "*"
-groups = ["dev"]
+python-versions = ">=3.8"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
-    {file = "sphinx_rtd_theme-0.5.2-py2.py3-none-any.whl", hash = "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"},
-    {file = "sphinx_rtd_theme-0.5.2.tar.gz", hash = "sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a"},
+    {file = "sphinx_rtd_theme-3.1.0-py2.py3-none-any.whl", hash = "sha256:1785824ae8e6632060490f67cf3a72d404a85d2d9fc26bce3619944de5682b89"},
+    {file = "sphinx_rtd_theme-3.1.0.tar.gz", hash = "sha256:b44276f2c276e909239a4f6c955aa667aaafeb78597923b1c60babc76db78e4c"},
 ]
 
 [package.dependencies]
-docutils = "<0.17"
-sphinx = "*"
+docutils = ">0.18,<0.23"
+sphinx = ">=6,<10"
+sphinxcontrib-jquery = ">=4,<5"
 
 [package.extras]
-dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client"]
+dev = ["bump2version", "transifex-client", "twine", "wheel"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -2276,7 +2316,8 @@ version = "2.0.0"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5"},
     {file = "sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1"},
@@ -2293,7 +2334,8 @@ version = "2.0.0"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2"},
     {file = "sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad"},
@@ -2310,7 +2352,8 @@ version = "2.1.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8"},
     {file = "sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9"},
@@ -2322,12 +2365,29 @@ standalone = ["Sphinx (>=5)"]
 test = ["html5lib", "pytest"]
 
 [[package]]
+name = "sphinxcontrib-jquery"
+version = "4.1"
+description = "Extension to include jQuery on newer Sphinx releases"
+optional = false
+python-versions = ">=2.7"
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
+files = [
+    {file = "sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a"},
+    {file = "sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae"},
+]
+
+[package.dependencies]
+Sphinx = ">=1.8"
+
+[[package]]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 optional = false
 python-versions = ">=3.5"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
     {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
@@ -2342,7 +2402,8 @@ version = "2.0.0"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb"},
     {file = "sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab"},
@@ -2359,7 +2420,8 @@ version = "2.0.0"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331"},
     {file = "sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"},
@@ -2508,7 +2570,8 @@ version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["docs"]
+markers = "python_version >= \"3.12\""
 files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
@@ -2558,4 +2621,4 @@ tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.15"
-content-hash = "f9cfc0f80307d8ed51ca905e261996cceace8b454bb857f5c2b0a52b3bc40ff7"
+content-hash = "9b00fd0f1569aecb8ebb46a587ca71825019c15b9e809bb865c976478d2a97e7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2621,4 +2621,4 @@ tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.15"
-content-hash = "9b00fd0f1569aecb8ebb46a587ca71825019c15b9e809bb865c976478d2a97e7"
+content-hash = "bf6117678337d7ecfbe3f2136c731c928fe3ba204b317ea7b5a5baad8282b9da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,12 @@ types-lxml = ">=2026.2.16"
 h5py-stubs = ">=0.1.2"
 pandas-stubs = {version = ">=3.0.3", python = ">=3.11"}
 scipy-stubs = {version = ">=1.17.1", python = ">=3.11"}
-# docs: keep consistent with docs/requirements-extras.txt
-Sphinx = "==5.3.0"
-autoclasstoc = "==1.3.0"
-sphinx-rtd-theme = "<1"
+
+[tool.poetry.group.docs.dependencies]
+# Keep consistent with docs/requirements-extras.txt
+Sphinx = {version = "==9.1.0", python = ">=3.12"}
+autoclasstoc = {version = "==1.7.0", python = ">=3.12"}
+sphinx-rtd-theme = {version = "==3.1.0", python = ">=3.12"}
 
 [tool.poetry.requires-plugins]
 poetry-dynamic-versioning = { version = ">=1.0,<2.0", extras = ["plugin"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,12 +130,11 @@ select = [
 ]
 ignore = [
     "F841",  # local variable assigned but never used: sometimes deliberate
-    # pydocstyle exceptions for Google-style docstrings:
-    "D203", "D204", "D213", "D215", "D400", "D401", "D404", "D406", "D407",
-    "D408", "D409", "D413",
     # Further pydocstyle exceptions for relatively unimportant issues:
     "D202", "D210", "D402", "D405", "D415", "D417",
 ]
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 # Do not check docstrings for the tests or docs directories.

--- a/resqpy/grid/_grid.py
+++ b/resqpy/grid/_grid.py
@@ -657,7 +657,7 @@ class Grid(BaseResqpy):
 
         notes:
            this code has the concept of a 'main' grid for a model, which resqml does not; it is vaguely
-              equivalent to a 'root' grid in a simulation model
+           equivalent to a 'root' grid in a simulation model;
            the write_active argument should generally be set to the same value as that passed to the write_hdf5... method;
            the RESQML standard allows the geometry to be omitted for a grid, controlled here by the write_geometry argument;
            the explicit geometry may be omitted for regular grids, in which case the arrays should not be written to the hdf5

--- a/resqpy/grid/_regular_grid.py
+++ b/resqpy/grid/_regular_grid.py
@@ -725,13 +725,14 @@ class RegularGrid(grr_g.Grid):
 
         see docstring for Grid.create_xml()
 
-        additional argument:
+        arguments:
            add_cell_length_properties (boolean, default True): if True, 3 constant property arrays with cells as
               indexable element are created to hold the lengths of the primary axes of the cells; the xml is
               created for the properties and they are added to the model (no hdf5 write needed)
-           use_lattice (boolean, default True): if True, a geometry node is created with a Point3dLatticeArray;
+           use_lattice (boolean, default True): if True, a geometry node is created with a Point3dLatticeArray
 
-        note:
+        notes:
+           this method has additional arguments beyond those of Grid.create_xml();
            if the regular grid has been instatiated using the as_irregular_grid mode, a lattice will not be used,
            regardless of the use_lattice argument;
            if using a lattice representation, the write_geomety argument is ignored and a lattice geometry will

--- a/resqpy/grid_surface/_find_faces.py
+++ b/resqpy/grid_surface/_find_faces.py
@@ -508,7 +508,7 @@ def find_faces_to_represent_surface_regular_dense_optimised(grid,
                                                             n_batches = 20):
     """Returns a grid connection set containing those cell faces which are deemed to represent the surface.
 
-    argumants:
+    arguments:
         grid (RegularGrid): the grid for which to create a grid connection set representation of the surface;
            must be aligned, ie. I with +x, J with +y, K with +z and local origin of (0.0, 0.0, 0.0)
         surface (Surface): the surface to be intersected with the grid
@@ -887,7 +887,7 @@ def find_faces_to_represent_surface_regular_optimised(grid,
                                                       direction = 'IJK'):
     """Returns a grid connection set containing those cell faces which are deemed to represent the surface.
 
-    argumants:
+    arguments:
         grid (RegularGrid): the grid for which to create a grid connection set representation of the surface;
            must be aligned, ie. I with +x, J with +y, K with +z and local origin of (0.0, 0.0, 0.0)
         surface (Surface): the surface to be intersected with the grid

--- a/resqpy/lines/_polyline.py
+++ b/resqpy/lines/_polyline.py
@@ -221,7 +221,7 @@ class Polyline(rql_c._BasePolyline):
 
     @classmethod
     def for_regular_polygon(cls, model, n, radius, centre_xyz, crs_uuid, title):
-        """`Returns a closed polyline representing a regular polygon in xy plane.
+        """Returns a closed polyline representing a regular polygon in xy plane.
 
         arguments:
            model (Model): the model for which the new polyline is intended
@@ -234,7 +234,7 @@ class Polyline(rql_c._BasePolyline):
         returns:
            a new closed Polyline representing a regular polygon in the xy plane
 
-        notee:
+        notes:
            z values are all set to the z value of the centre point;
            one vertex will have an x value identical to the centre and a positive y offset (due north usually);
            this method does not write to hdf5 nor create xml for the new polyline

--- a/resqpy/rq_import/_import_nexus.py
+++ b/resqpy/rq_import/_import_nexus.py
@@ -114,7 +114,7 @@ def import_nexus(
           only relevant if vdb_file is not None; see also vdb_property_list
         - vdb_recurrent_properties (bool, default False): if True, recurrent vdb properties are imported;
           only relevant if vdb_file is not None; see also vdb_property_list
-        - timestep_selection (str, default 'all): 'first', 'last', 'first and last', 'all',
+        - timestep_selection (str, default 'all'): 'first', 'last', 'first and last', 'all',
           or list of ints being reporting timestep numbers; ignored if vdb_recurrent_properties is False
         - use_compressed_time_series (bool, default True): generates reduced time series containing
           timesteps with recurrent properties from vdb, rather than full nexus summary time series

--- a/resqpy/rq_import/_import_vdb_all_grids.py
+++ b/resqpy/rq_import/_import_vdb_all_grids.py
@@ -67,7 +67,7 @@ def import_vdb_all_grids(resqml_file_root,
         - vdb_recurrent_properties (bool, default False): if True, recurrent vdb properties are imported;
           only relevant if vdb_file is not None; see also vdb_property_list
         - decoarsen (bool, default True): where ICOARSE is present, redistribute data to uncoarse cells
-        - timestep_selection (str, default 'all): 'first', 'last', 'first and last', 'all', or list of ints
+        - timestep_selection (str, default 'all'): 'first', 'last', 'first and last', 'all', or list of ints
           being reporting timestep numbers to include; ignored if vdb_recurrent_properties is False
         - create_property_set (bool, default False): if True a resqml PropertySet is created
         - vdb_property_list (list of str, optional): list of vdb static and/or recurrent properties to

--- a/resqpy/surface/_surface.py
+++ b/resqpy/surface/_surface.py
@@ -358,10 +358,10 @@ class Surface(rqsb.BaseSurface):
               arrays are returned
 
         returns:
-           tuple (triangles, points):
-              triangles (int array of shape[:, 3]): integer indices into points array,
-                 being the nodes of the corners of the triangles;
-              points (float array of shape[:, 3]): flat array of xyz points, indexed by triangles
+           tuple (triangles, points) where
+           triangles is an int array of shape (N, 3) holding integer indices into the points array,
+           being the nodes of the corners of the triangles, and
+           points is a float array of shape (M, 3) being a flat array of xyz points, indexed by triangles
 
         :meta common:
         """

--- a/resqpy/well/_blocked_well.py
+++ b/resqpy/well/_blocked_well.py
@@ -346,8 +346,8 @@ class BlockedWell(BaseResqpy):
         """Returns numpy int array of shape (N, 2, 2) being pairs of face (axis, polarity) pairs, to go with cell_kji0_array().
 
         notes:
-           each of the N rows in the returned array is of the form:
-              ((entry_face_axis, entry_face_polarity), (exit_face_axis, exit_face_polarity))
+           each of the N rows in the returned array is of the form
+           ((entry_face_axis, entry_face_polarity), (exit_face_axis, exit_face_polarity));
            where the axis values are in the range 0 to 2 for k, j & i respectively, and
            the polarity values are zero for the 'negative' face and 1 for the 'positive' face;
            exit values may be -1 to indicate TD within the cell (ie. no exit point)
@@ -973,7 +973,7 @@ class BlockedWell(BaseResqpy):
            - the min_length and min_kh limits apply to individual cell intervals and thus depend on cell size;
            - the water and oil saturation limits are for saturations at a single time and affect whether the interval
              is included in the dataframe
-           – to turn perforations off and on over time create a time series dependent bunch of boolean properties on
+           - to turn perforations off and on over time create a time series dependent bunch of boolean properties on
              the blocked well, with title 'STAT' or local property kind 'well connection open';
            - the saturation limits do not stop deeper intervals with qualifying saturations from being included;
            - the k0_list, perforation_list and region_list arguments should be set to None to disable the

--- a/resqpy/well/_deviation_survey.py
+++ b/resqpy/well/_deviation_survey.py
@@ -202,7 +202,7 @@ class DeviationSurvey(BaseResqpy):
                         represented_interp = None):
         """Load MD, aximuth & inclination data from an ascii deviation survey file.
 
-        qrguments:
+        arguments:
            parent_model (model.Model): the parent resqml model
            deviation_survey_file (string): the filename of an ascii file holding the deviation survey data
            comment_character (string): the character to be treated as introducing comments


### PR DESCRIPTION
 Closes #921

- Updates the Sphinx version used to build docs, which are now quite old.
  - Bumps Sphinx v5 -> v9,  rtd-theme v0 -> v3
  - Updates the `.readthedocs.yaml` to build on ubuntu 24 /python 3.14 , rather than ubuntu 22 / python 3.11
  - Bump the pinned `docs/requirements-extras.txt` to match the poetry lockfile
  - Updates `docs/conf.py` to get it working with recent Sphinx, patching [autoclasstoc](https://github.com/kalekundert/autoclasstoc)
- Simplify the relevant pydocstyle linter settings in `pyproject.toml` by specifying the "convention" setting
- Fixes a whole bunch of typos and formatting things in docstrings that were giving warnings
- Updates the contributing guide to suggest "precommit" and "ruff check" rather than the old "flake8"

The docs can be previewed on this feature build: <https://resqpy.readthedocs.io/en/docs/>